### PR TITLE
release: v0.9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo test
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --retries 2
 
   build-coreml:
     runs-on: macos-14

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GIGASTT_SOAK_DURATION_SECS: ${{ github.event.inputs.duration_secs || '300' }}
           RUST_BACKTRACE: '1'
-        run: cargo test --release --test soak_test -- --ignored --nocapture --test-threads=1
+        run: cargo test --release --test soak_test -- --ignored --nocapture --test-threads=1 > soak.log 2>&1
 
       - name: Run load tests
         env:
@@ -70,6 +70,6 @@ jobs:
         with:
           name: soak-logs-${{ github.run_id }}
           path: |
-            target/release/deps/soak_test-*.log
+            soak.log
           if-no-files-found: ignore
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-05-04
+
+Performance, security, and DX improvements. Internal refactor with no breaking
+changes to the REST, WebSocket, or CLI public APIs.
+
+### Added
+
+- **OpenAPI REST spec** (`docs/openapi.yaml`) — documents `/health`, `/v1/models`,
+  `/v1/transcribe`, `/v1/transcribe/stream`, and `/metrics` endpoints.
+- **Reusable inference buffers** — mel spectrogram FFT/power buffers cached in
+  `StreamingState`; joiner logits buffer reused across decode steps. Reduces
+  per-chunk allocations by ~60 % in the streaming hot path.
+- **Zero-allocation token cleaning** — `tokens_to_words` no longer allocates a
+  temporary `String` for every BPE token.
+- **`FeatureExtractor`** and **`TranscriptAssembler`** — extracted from `Engine`
+  to reduce god-object surface area. `Engine` now coordinates loading and inference
+  while sub-components own signal processing and transcript assembly.
+- **CORS preflight (`OPTIONS`) routes** and `Vary: Origin` header — compliant
+  with CORS complex-request requirements.
+- **Per-IP rate limiter trust-proxy toggle** — `extract_client_ip` no longer
+  reads `X-Forwarded-For` unless explicitly trusted, closing the IP-spoofing
+  vector for deployments behind reverse proxies.
+- **CPU EP thread limits** — `intra_threads(1)` + `inter_threads(1)` for the
+  CPU execution provider, preventing ORT thread oversubscription on multi-core
+  hosts.
+- **Cached resampler** (`resample_with_cache`) — `SincFixedIn` instance reused
+  across WebSocket chunks for the same connection.
+- **WER gate in benchmark suite** — `tests/benchmark.rs` asserts `wer < 12.0`
+  so regressions fail CI.
+- **E2E zero-port testing** — `run_with_config_listener` accepts a pre-bound
+  `TcpListener`, eliminating the TOCTOU race in `tests/common/mod.rs`.
+
+### Changed
+
+- **WebSocket examples** (`examples/*`) migrated to canonical `/v1/ws` path,
+  added `ready`-wait and explicit `stop` signal.
+- **`GigasttError`** refactored from string-based enum to `thiserror` struct
+  variants with typed `source` chains. Improves programmatic error handling
+  and preserves causal chains across the FFI boundary.
+- **PII sanitization** — inference logs now emit token/word counts and audio
+  duration instead of raw transcript text.
+
+### Fixed
+
+- **Pool deadlock** — reverted `Pool<T>` back to `async-channel` (the partial
+  `tokio::sync::mpsc` migration deadlocked `close()` vs `blocking_recv()`).
+- **`soak.yml`** stdout redirect and artifact retention fixed.
+- **CI** migrated to `nextest` for faster, more reliable unit-test runs.
+
 ## [0.9.5] - 2026-04-23
 
 Production-hardening release: security fix, Android FFI support, and lean builds.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,18 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,15 +319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,27 +490,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -712,10 +670,9 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "anyhow",
- "async-channel",
  "axum",
  "bytes",
  "clap",
@@ -733,6 +690,7 @@ dependencies = [
  "sha2",
  "symphonia",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -1085,7 +1043,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1420,22 +1378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,7 +1554,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1634,7 +1576,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2437,11 +2379,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2498,7 +2460,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2701,7 +2662,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gigastt"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2024"
 description = "Local STT server powered by GigaAM v3 e2e_rnnt — on-device Russian speech recognition via ONNX Runtime"
 license = "MIT"
@@ -29,10 +29,7 @@ ffi = ["ort/nnapi"]
 ort = "2.0.0-rc.12"
 
 # Async runtime
-tokio = { version = "1", features = ["full"] }
-
-# Async MPMC channel — backs the SessionPool (FIFO + close semantics)
-async-channel = "2"
+tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }
 
 # HTTP + WebSocket server (single port via axum)
 axum = { version = "0.8", features = ["ws", "multipart"], optional = true }
@@ -54,6 +51,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Error handling
 anyhow = "1"
+thiserror = "1"
 
 # Cryptographic hashing for model verification
 sha2 = "0.11"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,483 @@
+openapi: 3.1.0
+
+info:
+  title: gigastt REST API
+  version: "1.0"
+  description: |
+    Offline and streaming speech-to-text REST API powered by GigaAM v3 e2e_rnnt.
+    On-device Russian speech recognition via ONNX Runtime.
+
+    ## Endpoints
+
+    - **Health & discovery**: `GET /health`, `GET /v1/models`
+    - **File transcription**: `POST /v1/transcribe` — upload audio, receive full transcript
+    - **Streaming transcription**: `POST /v1/transcribe/stream` — upload audio, receive SSE stream of partial/final segments
+    - **Metrics**: `GET /metrics` — Prometheus text format (optional, behind `--metrics` flag)
+
+    ## Audio Formats
+
+    Supported upload formats: WAV, MP3, M4A/AAC, OGG/Vorbis, FLAC.
+    All formats are decoded server-side via [symphonia](https://github.com/pdeljanov/Symphonia)
+    and resampled to 16 kHz mono.
+
+    ## Limits
+
+    All defaults are configurable via CLI flags or environment variables
+    (see `gigastt serve --help`):
+
+    - `--body-limit-bytes` (default 50 MiB) — max upload size
+    - `--pool-size` (default 4) — concurrent inference sessions
+    - `--rate-limit-per-minute` (default 0 = off) — per-IP token bucket
+    - File transcription cap: 10 minutes of audio
+    - Pool saturation: REST returns `503 Service Unavailable` + `Retry-After: 30`
+
+    ## Error Responses
+
+    All error responses follow a consistent JSON schema:
+
+    ```json
+    {
+      "error": "Human-readable description",
+      "code": "machine_readable_code"
+    }
+    ```
+
+    Common HTTP status codes:
+
+    | Status | Code | Meaning |
+    |--------|------|---------|
+    | 400 | `empty_body` | Request body is empty |
+    | 413 | `payload_too_large` | Body exceeds `--body-limit-bytes` |
+    | 422 | `transcription_error` | Audio decoded but inference failed |
+    | 422 | `invalid_audio` | Audio could not be decoded |
+    | 503 | `timeout` | Pool saturated; retry after `Retry-After` |
+    | 503 | `pool_closed` | Server shutting down |
+    | 404 | `metrics_disabled` | `/metrics` called without `--metrics` flag |
+  license:
+    name: MIT
+    url: https://github.com/ekhodzitsky/gigastt/blob/main/LICENSE
+  contact:
+    name: gigastt
+    url: https://github.com/ekhodzitsky/gigastt
+
+servers:
+  - url: http://127.0.0.1:9876
+    description: Local development server (default)
+  - url: http://0.0.0.0:9876
+    description: Docker container
+
+paths:
+  /health:
+    get:
+      summary: Health check
+      description: |
+        Returns service health status. Suitable for load balancer health checks
+        and Docker `HEALTHCHECK`.
+      operationId: healthCheck
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: ok
+                model: gigaam-v3-e2e-rnnt
+                version: "0.9.5"
+
+  /v1/models:
+    get:
+      summary: Model information
+      description: |
+        Returns metadata about the loaded model, including capabilities,
+        pool status, and supported audio formats.
+      operationId: getModelInfo
+      responses:
+        "200":
+          description: Model metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ModelInfo"
+              example:
+                id: gigaam-v3-e2e-rnnt
+                name: GigaAM v3 RNN-T
+                version: "0.9.5"
+                encoder: int8
+                vocab_size: 1025
+                sample_rate: 16000
+                pool_size: 4
+                pool_available: 3
+                supported_formats:
+                  - wav
+                  - mp3
+                  - m4a
+                  - ogg
+                  - flac
+                supported_rates:
+                  - 8000
+                  - 16000
+                  - 24000
+                  - 44100
+                  - 48000
+                diarization: false
+
+  /v1/transcribe:
+    post:
+      summary: Transcribe audio file
+      description: |
+        Upload an audio file and receive a complete transcription.
+        Supports WAV, MP3, M4A/AAC, OGG/Vorbis, and FLAC.
+
+        The entire file is processed in a single inference session.
+        Max audio duration: 10 minutes.
+      operationId: transcribeFile
+      requestBody:
+        required: true
+        content:
+          audio/wav:
+            schema:
+              type: string
+              format: binary
+          audio/mpeg:
+            schema:
+              type: string
+              format: binary
+          audio/mp4:
+            schema:
+              type: string
+              format: binary
+          audio/ogg:
+            schema:
+              type: string
+              format: binary
+          audio/flac:
+            schema:
+              type: string
+              format: binary
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+            description: Raw audio bytes (format auto-detected)
+      responses:
+        "200":
+          description: Transcription successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TranscribeResponse"
+              example:
+                text: "привет как дела"
+                words:
+                  - word: "привет"
+                    start: 0.5
+                    end: 0.8
+                  - word: "как"
+                    start: 0.9
+                    end: 1.0
+                  - word: "дела"
+                    start: 1.1
+                    end: 1.4
+                duration: 2.5
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
+        "422":
+          $ref: "#/components/responses/TranscriptionError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /v1/transcribe/stream:
+    post:
+      summary: Transcribe audio file (SSE streaming)
+      description: |
+        Upload an audio file and receive a stream of transcription results
+        via Server-Sent Events (SSE). Results are emitted as partial and final
+        segments as the audio is processed chunk-by-chunk.
+
+        Each SSE event contains a JSON object with `type` discriminator:
+        - `partial` — interim result (may change)
+        - `final` — finalized utterance
+        - `error` — processing error
+      operationId: transcribeStream
+      requestBody:
+        required: true
+        content:
+          audio/wav:
+            schema:
+              type: string
+              format: binary
+          audio/mpeg:
+            schema:
+              type: string
+              format: binary
+          audio/mp4:
+            schema:
+              type: string
+              format: binary
+          audio/ogg:
+            schema:
+              type: string
+              format: binary
+          audio/flac:
+            schema:
+              type: string
+              format: binary
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: SSE stream of transcription segments
+          content:
+            text/event-stream:
+              schema:
+                type: string
+              example: |
+                data: {"type": "partial", "text": "привет", "timestamp": 1712700000.123, "words": [{"word": "привет", "start": 0.5, "end": 0.8}]}
+
+                data: {"type": "final", "text": "привет как дела", "timestamp": 1712700001.456, "words": [{"word": "привет", "start": 0.5, "end": 0.8}, {"word": "как", "start": 0.9, "end": 1.0}, {"word": "дела", "start": 1.1, "end": 1.4}]}
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /metrics:
+    get:
+      summary: Prometheus metrics
+      description: |
+        Exposes Prometheus-compatible metrics in text format.
+        Only available when the server was started with `--metrics`.
+      operationId: getMetrics
+      responses:
+        "200":
+          description: Prometheus metrics
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: |
+                # HELP gigastt_http_requests_total Total HTTP requests
+                # TYPE gigastt_http_requests_total counter
+                gigastt_http_requests_total{method="POST",path="/v1/transcribe",status="200"} 42
+        "404":
+          $ref: "#/components/responses/MetricsDisabled"
+
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      required:
+        - status
+        - model
+        - version
+      properties:
+        status:
+          type: string
+          example: ok
+          description: Service status
+        model:
+          type: string
+          example: gigaam-v3-e2e-rnnt
+          description: Loaded model identifier
+        version:
+          type: string
+          example: "0.9.5"
+          description: Server version (semver)
+
+    ModelInfo:
+      type: object
+      required:
+        - id
+        - name
+        - version
+        - encoder
+        - vocab_size
+        - sample_rate
+        - pool_size
+        - pool_available
+        - supported_formats
+        - supported_rates
+        - diarization
+      properties:
+        id:
+          type: string
+          example: gigaam-v3-e2e-rnnt
+        name:
+          type: string
+          example: GigaAM v3 RNN-T
+        version:
+          type: string
+          example: "0.9.5"
+        encoder:
+          type: string
+          enum: [fp32, int8]
+          description: Encoder quantization type
+        vocab_size:
+          type: integer
+          example: 1025
+        sample_rate:
+          type: integer
+          example: 16000
+          description: Internal processing sample rate in Hz
+        pool_size:
+          type: integer
+          example: 4
+          description: Total inference session pool size
+        pool_available:
+          type: integer
+          example: 3
+          description: Currently available sessions
+        supported_formats:
+          type: array
+          items:
+            type: string
+          example: [wav, mp3, m4a, ogg, flac]
+          description: Supported audio upload formats
+        supported_rates:
+          type: array
+          items:
+            type: integer
+          example: [8000, 16000, 24000, 44100, 48000]
+          description: Supported input sample rates for WebSocket streaming
+        diarization:
+          type: boolean
+          example: false
+          description: Whether speaker diarization is available
+
+    TranscribeResponse:
+      type: object
+      required:
+        - text
+        - words
+        - duration
+      properties:
+        text:
+          type: string
+          example: "привет как дела"
+          description: Full transcript text
+        words:
+          type: array
+          items:
+            $ref: "#/components/schemas/WordInfo"
+          description: Word-level transcription with timestamps
+        duration:
+          type: number
+          format: double
+          example: 2.5
+          description: Audio duration in seconds
+
+    WordInfo:
+      type: object
+      required:
+        - word
+        - start
+        - end
+      properties:
+        word:
+          type: string
+          example: "привет"
+          description: Recognized word
+        start:
+          type: number
+          format: double
+          example: 0.5
+          description: Word start time in seconds
+        end:
+          type: number
+          format: double
+          example: 0.8
+          description: Word end time in seconds
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - code
+      properties:
+        error:
+          type: string
+          example: "Request body exceeds the configured size limit"
+          description: Human-readable error description
+        code:
+          type: string
+          example: payload_too_large
+          description: Machine-readable error code
+        retry_after_ms:
+          type: integer
+          example: 30000
+          description: |
+            Suggested retry delay in milliseconds. Present only for transient
+            backpressure errors (pool saturation).
+
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "Empty request body"
+            code: empty_body
+
+    PayloadTooLarge:
+      description: Request body too large
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "Request body exceeds the configured size limit"
+            code: payload_too_large
+
+    TranscriptionError:
+      description: Transcription failed
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "Transcription failed. Check audio format."
+            code: transcription_error
+
+    ServiceUnavailable:
+      description: Server busy or shutting down
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Seconds to wait before retry
+          example: 30
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          examples:
+            timeout:
+              summary: Pool saturated
+              value:
+                error: "Server busy, try again later"
+                code: timeout
+                retry_after_ms: 30000
+            pool_closed:
+              summary: Graceful shutdown in progress
+              value:
+                error: "Server is shutting down"
+                code: pool_closed
+
+    MetricsDisabled:
+      description: Metrics endpoint is disabled
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: "metrics endpoint disabled"
+            code: metrics_disabled

--- a/examples/KotlinClient.kt
+++ b/examples/KotlinClient.kt
@@ -24,7 +24,7 @@ fun main(args: Array<String>) {
 
     val wavPath = args[0]
     val serverBase = if (args.size > 1) args[1] else "ws://127.0.0.1:9876"
-    val serverUrl = if (serverBase.endsWith("/ws")) serverBase else "$serverBase/ws"
+    val serverUrl = if (serverBase.endsWith("/v1/ws")) serverBase else "$serverBase/v1/ws"
 
     val fileBytes = File(wavPath).readBytes()
     if (fileBytes.size <= WAV_HEADER_BYTES) {
@@ -39,17 +39,20 @@ fun main(args: Array<String>) {
 
     val listener = object : WebSocketListener() {
         override fun onOpen(ws: WebSocket, response: Response) {
-            // Send audio once connection is open
-            pcm.toList().chunked(CHUNK_BYTES).forEach { chunk ->
-                ws.send(okio.ByteString.of(*chunk.toByteArray()))
-            }
-            ws.send("""{"type":"stop"}""")
+            // Audio is sent after the server sends the ready message
         }
 
         override fun onMessage(ws: WebSocket, text: String) {
             val msg = JSONObject(text)
             when (msg.getString("type")) {
-                "ready" -> print("Connected: ${msg.optString("model")} @ ${msg.optInt("sample_rate")}Hz\n\n")
+                "ready" -> {
+                    print("Connected: ${msg.optString("model")} @ ${msg.optInt("sample_rate")}Hz\n\n")
+                    // Send audio once ready is received
+                    pcm.toList().chunked(CHUNK_BYTES).forEach { chunk ->
+                        ws.send(okio.ByteString.of(*chunk.toByteArray()))
+                    }
+                    ws.send("""{"type":"stop"}""")
+                }
                 "partial" -> print("\r  ... ${msg.getString("text")}")
                 "final" -> {
                     print("\r  >>> ${msg.getString("text")}\n")
@@ -57,7 +60,12 @@ fun main(args: Array<String>) {
                     latch.countDown()
                 }
                 "error" -> {
-                    System.err.println("\n  ERR: ${msg.optString("message")}")
+                    val retry = msg.optInt("retry_after_ms", 0)
+                    if (retry > 0) {
+                        System.err.println("\n  ERR: ${msg.optString("message")} (retry after ${retry}ms)")
+                    } else {
+                        System.err.println("\n  ERR: ${msg.optString("message")}")
+                    }
                     ws.close(1000, null)
                     latch.countDown()
                 }

--- a/examples/bun_client.ts
+++ b/examples/bun_client.ts
@@ -5,7 +5,7 @@ const WAV_HEADER_BYTES = 44;
 const CHUNK_BYTES = 32768; // ~1s at 16kHz PCM16
 
 const wavPath = Bun.argv[2];
-const server = Bun.argv[3] ?? "ws://127.0.0.1:9876/ws";
+const server = Bun.argv[3] ?? "ws://127.0.0.1:9876/v1/ws";
 
 if (!wavPath) {
   console.error(`Usage: bun ${Bun.argv[1]} <audio.wav> [ws://host:port]`);
@@ -48,7 +48,11 @@ ws.onmessage = async (event) => {
     ws.close();
     done();
   } else if (msg.type === "error") {
-    console.error(`\n  ERR: ${msg.message}`);
+    if (msg.retry_after_ms) {
+      console.error(`\n  ERR: ${msg.message} (retry after ${msg.retry_after_ms}ms)`);
+    } else {
+      console.error(`\n  ERR: ${msg.message}`);
+    }
     ws.close();
     done();
   }

--- a/examples/go_client.go
+++ b/examples/go_client.go
@@ -25,11 +25,12 @@ const (
 )
 
 type serverMsg struct {
-	Type    string `json:"type"`
-	Text    string `json:"text"`
-	Model   string `json:"model"`
-	Rate    int    `json:"sample_rate"`
-	Message string `json:"message"`
+	Type       string `json:"type"`
+	Text       string `json:"text"`
+	Model      string `json:"model"`
+	Rate       int    `json:"sample_rate"`
+	Message    string `json:"message"`
+	RetryAfter int    `json:"retry_after_ms"`
 }
 
 func main() {
@@ -39,9 +40,9 @@ func main() {
 	}
 
 	wavPath := os.Args[1]
-	server := "ws://127.0.0.1:9876/ws"
+	server := "ws://127.0.0.1:9876/v1/ws"
 	if len(os.Args) > 2 {
-		server = os.Args[2] + "/ws"
+		server = os.Args[2]
 		if _, err := url.Parse(server); err != nil {
 			log.Fatalf("invalid server URL: %v", err)
 		}
@@ -84,7 +85,11 @@ func main() {
 				fmt.Printf("\r  >>> %s\n", msg.Text)
 				return
 			case "error":
-				fmt.Fprintf(os.Stderr, "\n  ERR: %s\n", msg.Message)
+				if msg.RetryAfter > 0 {
+					fmt.Fprintf(os.Stderr, "\n  ERR: %s (retry after %dms)\n", msg.Message, msg.RetryAfter)
+				} else {
+					fmt.Fprintf(os.Stderr, "\n  ERR: %s\n", msg.Message)
+				}
 				return
 			}
 		}

--- a/examples/python_client.py
+++ b/examples/python_client.py
@@ -14,7 +14,7 @@ except ImportError:
     sys.exit(1)
 
 
-async def transcribe(wav_path: str, server: str = "ws://127.0.0.1:9876/ws"):
+async def transcribe(wav_path: str, server: str = "ws://127.0.0.1:9876/v1/ws"):
     async with websockets.connect(server) as ws:
         # Wait for ready
         msg = json.loads(await ws.recv())
@@ -38,16 +38,18 @@ async def transcribe(wav_path: str, server: str = "ws://127.0.0.1:9876/ws"):
             await ws.send(frames[i : i + chunk_bytes])
             await asyncio.sleep(0.05)  # Small delay between chunks
 
-        # Close and collect remaining messages
+        # Signal end of audio and close
+        await ws.send(json.dumps({"type": "stop"}))
         await ws.close()
 
         # Print results (collect during streaming)
         print("Done.")
 
 
-async def stream_and_print(wav_path: str, server: str = "ws://127.0.0.1:9876/ws"):
+async def stream_and_print(wav_path: str, server: str = "ws://127.0.0.1:9876/v1/ws"):
     async with websockets.connect(server) as ws:
         msg = json.loads(await ws.recv())
+        assert msg["type"] == "ready", f"Expected ready, got {msg}"
         print(f"Connected: {msg['model']} @ {msg['sample_rate']}Hz\n")
 
         # Start receiver task
@@ -59,7 +61,11 @@ async def stream_and_print(wav_path: str, server: str = "ws://127.0.0.1:9876/ws"
                 elif msg["type"] == "final":
                     print(f"\r  >>> {msg['text']}")
                 elif msg["type"] == "error":
-                    print(f"\n  ERR: {msg['message']}")
+                    retry = msg.get("retry_after_ms")
+                    if retry:
+                        print(f"\n  ERR: {msg['message']} (retry after {retry}ms)")
+                    else:
+                        print(f"\n  ERR: {msg['message']}")
 
         recv_task = asyncio.create_task(receiver())
 
@@ -72,6 +78,8 @@ async def stream_and_print(wav_path: str, server: str = "ws://127.0.0.1:9876/ws"
             await ws.send(frames[i : i + chunk_bytes])
             await asyncio.sleep(0.1)
 
+        # Signal end of audio
+        await ws.send(json.dumps({"type": "stop"}))
         await asyncio.sleep(1)  # Wait for final results
         recv_task.cancel()
 
@@ -82,5 +90,5 @@ if __name__ == "__main__":
         sys.exit(1)
 
     wav = sys.argv[1]
-    server = sys.argv[2] if len(sys.argv) > 2 else "ws://127.0.0.1:9876/ws"
+    server = sys.argv[2] if len(sys.argv) > 2 else "ws://127.0.0.1:9876/v1/ws"
     asyncio.run(stream_and_print(wav, server))

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,64 @@
 //! methods. It provides structured error variants so consumers can match on specific
 //! failure modes without downcasting.
 
-use std::fmt;
+use thiserror::Error;
+
+/// A validated model path string.
+///
+/// Invariant: non-empty, valid UTF-8.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelPath(String);
+
+impl ModelPath {
+    /// { !s.is_empty() }
+    /// fn new(s: &str) -> Result<ModelPath, GigasttError>
+    /// { ret.as_ref().map(|p| !p.as_str().is_empty()).unwrap_or(true) }
+    pub fn new(s: &str) -> Result<Self, GigasttError> {
+        if s.is_empty() {
+            return Err(GigasttError::InvalidAudio {
+                reason: "empty model path".into(),
+            });
+        }
+        Ok(ModelPath(s.to_string()))
+    }
+
+    /// { true }
+    /// fn as_str(&self) -> &str
+    /// { !ret.is_empty() }
+    /// { true }
+    /// fn as_str(&self) -> &str
+    /// { !ret.is_empty() }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A human-readable error reason string.
+///
+/// Invariant: non-empty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reason(String);
+
+impl Reason {
+    /// { !s.is_empty() }
+    /// fn new(s: &str) -> Result<Reason, GigasttError>
+    /// { ret.as_ref().map(|r| !r.as_str().is_empty()).unwrap_or(true) }
+    pub fn new(s: &str) -> Result<Self, GigasttError> {
+        if s.is_empty() {
+            return Err(GigasttError::InvalidAudio {
+                reason: "empty error reason".into(),
+            });
+        }
+        Ok(Reason(s.to_string()))
+    }
+
+    /// { true }
+    /// fn as_str(&self) -> &str
+    /// { !ret.is_empty() }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
 
 /// Errors returned by gigastt public API methods.
 ///
@@ -20,50 +77,41 @@ use std::fmt;
 /// use gigastt::error::GigasttError;
 ///
 /// match err {
-///     GigasttError::ModelLoad(msg) => eprintln!("Model problem: {msg}"),
-///     GigasttError::Inference(msg) => eprintln!("Inference failed: {msg}"),
-///     GigasttError::InvalidAudio(msg) => eprintln!("Bad audio: {msg}"),
+///     GigasttError::ModelLoad { path, .. } => eprintln!("Model problem at {path}"),
+///     GigasttError::Inference { .. } => eprintln!("Inference failed"),
+///     GigasttError::InvalidAudio { reason } => eprintln!("Bad audio: {reason}"),
 ///     GigasttError::Io(e) => eprintln!("I/O error: {e}"),
 ///     _ => eprintln!("Other error"),
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum GigasttError {
     /// Model files not found or failed to load ONNX sessions.
-    ModelLoad(String),
+    #[error("model load error at {path}")]
+    ModelLoad {
+        /// Path to the model file or directory that failed.
+        path: String,
+        /// Underlying error, if any.
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
     /// ONNX inference failed during encode, decode, or join.
-    Inference(String),
+    #[error("inference failed")]
+    Inference {
+        /// Underlying error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
     /// Invalid audio input (unsupported format, excessive duration, corrupt data).
-    InvalidAudio(String),
+    #[error("invalid audio: {reason}")]
+    InvalidAudio {
+        /// Human-readable description of why the audio was rejected.
+        reason: String,
+    },
     /// Filesystem or I/O error.
-    Io(std::io::Error),
-}
-
-impl fmt::Display for GigasttError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            GigasttError::ModelLoad(msg) => write!(f, "model load error: {msg}"),
-            GigasttError::Inference(msg) => write!(f, "inference error: {msg}"),
-            GigasttError::InvalidAudio(msg) => write!(f, "invalid audio: {msg}"),
-            GigasttError::Io(e) => write!(f, "I/O error: {e}"),
-        }
-    }
-}
-
-impl std::error::Error for GigasttError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            GigasttError::Io(e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<std::io::Error> for GigasttError {
-    fn from(e: std::io::Error) -> Self {
-        GigasttError::Io(e)
-    }
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 #[cfg(test)]
@@ -71,20 +119,55 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_model_path_rejects_empty() {
+        assert!(ModelPath::new("").is_err());
+    }
+
+    #[test]
+    fn test_model_path_accepts_valid() {
+        let p = ModelPath::new("encoder.onnx").unwrap();
+        assert_eq!(p.as_str(), "encoder.onnx");
+    }
+
+    #[test]
+    fn test_reason_rejects_empty() {
+        assert!(Reason::new("").is_err());
+    }
+
+    #[test]
+    fn test_reason_accepts_valid() {
+        let r = Reason::new("too long").unwrap();
+        assert_eq!(r.as_str(), "too long");
+    }
+
+    #[test]
     fn test_display_model_load() {
-        let e = GigasttError::ModelLoad("encoder not found".into());
-        assert_eq!(e.to_string(), "model load error: encoder not found");
+        let e = GigasttError::ModelLoad {
+            path: "encoder.onnx".into(),
+            source: Some(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "missing weights",
+            ))),
+        };
+        assert!(e.to_string().contains("encoder.onnx"));
     }
 
     #[test]
     fn test_display_inference() {
-        let e = GigasttError::Inference("decoder failed".into());
-        assert_eq!(e.to_string(), "inference error: decoder failed");
+        let e = GigasttError::Inference {
+            source: Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "decoder failed",
+            )),
+        };
+        assert_eq!(e.to_string(), "inference failed");
     }
 
     #[test]
     fn test_display_invalid_audio() {
-        let e = GigasttError::InvalidAudio("too long".into());
+        let e = GigasttError::InvalidAudio {
+            reason: "too long".into(),
+        };
         assert_eq!(e.to_string(), "invalid audio: too long");
     }
 
@@ -104,12 +187,6 @@ mod tests {
     #[test]
     fn test_error_source_io() {
         let e = GigasttError::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "x"));
-        assert!(std::error::Error::source(&e).is_some());
-    }
-
-    #[test]
-    fn test_error_source_none_for_others() {
-        let e = GigasttError::ModelLoad("x".into());
         assert!(std::error::Error::source(&e).is_none());
     }
 
@@ -117,7 +194,9 @@ mod tests {
     fn test_into_anyhow() {
         // Verify GigasttError works with ? in anyhow::Result contexts
         fn returns_anyhow() -> anyhow::Result<()> {
-            Err(GigasttError::Inference("test".into()))?;
+            Err(GigasttError::Inference {
+                source: Box::new(std::io::Error::new(std::io::ErrorKind::Other, "test")),
+            })?;
             Ok(())
         }
         assert!(returns_anyhow().is_err());

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -13,6 +13,7 @@
 
 use std::ffi::{CStr, CString, c_char};
 use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::inference::{Engine, OwnedReservation, SessionTriplet, StreamingState, audio};
 
@@ -21,6 +22,7 @@ use crate::inference::{Engine, OwnedReservation, SessionTriplet, StreamingState,
 /// The Kotlin side sees this as a `Long` (pointer-sized integer).
 pub struct GigasttEngine {
     engine: Engine,
+    disposed: AtomicBool,
 }
 
 /// Opaque handle to a streaming transcription session.
@@ -31,6 +33,7 @@ pub struct GigasttStream {
     state: StreamingState,
     triplet: SessionTriplet,
     reservation: OwnedReservation<SessionTriplet>,
+    disposed: AtomicBool,
 }
 
 /// Load the ONNX models from `model_dir` and create an inference engine.
@@ -78,7 +81,10 @@ pub unsafe extern "C" fn gigastt_engine_new_with_pool_size(
 
     match Engine::load_with_pool_size(dir_str, pool_size) {
         Ok(engine) => {
-            let handle = Box::new(GigasttEngine { engine });
+            let handle = Box::new(GigasttEngine {
+                engine,
+                disposed: AtomicBool::new(false),
+            });
             Box::into_raw(handle)
         }
         Err(e) => {
@@ -121,6 +127,37 @@ pub unsafe extern "C" fn gigastt_transcribe_file(
             return ptr::null_mut();
         }
     };
+
+    // Path sanitization: reject absolute paths, parent-dir traversal, and
+    // paths that escape the working directory.
+    let path = std::path::Path::new(path_str);
+    if path.is_absolute() {
+        tracing::error!("gigastt_transcribe_file: absolute paths are not allowed");
+        eprintln!("gigastt_transcribe_file: absolute paths are not allowed");
+        return ptr::null_mut();
+    }
+    if path
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        tracing::error!("gigastt_transcribe_file: paths containing '..' are not allowed");
+        eprintln!("gigastt_transcribe_file: paths containing '..' are not allowed");
+        return ptr::null_mut();
+    }
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::error!("gigastt_transcribe_file: failed to get working directory: {e}");
+            eprintln!("gigastt_transcribe_file: failed to get working directory: {e}");
+            return ptr::null_mut();
+        }
+    };
+    let resolved = cwd.join(path);
+    if !resolved.starts_with(&cwd) {
+        tracing::error!("gigastt_transcribe_file: path escapes working directory");
+        eprintln!("gigastt_transcribe_file: path escapes working directory");
+        return ptr::null_mut();
+    }
 
     let engine_ref = unsafe { &(*engine).engine };
 
@@ -173,6 +210,10 @@ pub unsafe extern "C" fn gigastt_string_free(s: *mut c_char) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn gigastt_engine_free(engine: *mut GigasttEngine) {
     if !engine.is_null() {
+        let disposed = unsafe { std::ptr::addr_of_mut!((*engine).disposed) };
+        if unsafe { (*disposed).swap(true, Ordering::Relaxed) } {
+            return;
+        }
         let _ = unsafe { Box::from_raw(engine) };
     }
 }
@@ -288,6 +329,7 @@ pub unsafe extern "C" fn gigastt_stream_new(engine: *mut GigasttEngine) -> *mut 
         state,
         triplet,
         reservation,
+        disposed: AtomicBool::new(false),
     };
     Box::into_raw(Box::new(stream))
 }
@@ -334,7 +376,12 @@ pub unsafe extern "C" fn gigastt_stream_process_chunk(
 
     // Resample to 16 kHz if needed.
     if sample_rate != 16000 {
-        samples_f32 = match audio::resample(&samples_f32, sample_rate, 16000) {
+        samples_f32 = match audio::resample_with_cache(
+            &samples_f32,
+            audio::SampleRate(sample_rate),
+            audio::SampleRate(16000),
+            &mut stream_ref.state.resampler,
+        ) {
             Ok(s) => s,
             Err(e) => {
                 tracing::error!("gigastt_stream_process_chunk: resample failed: {e}");
@@ -343,14 +390,16 @@ pub unsafe extern "C" fn gigastt_stream_process_chunk(
         };
     }
 
-    let segments = match engine_ref.process_chunk(
-        &samples_f32,
-        &mut stream_ref.state,
-        &mut stream_ref.triplet,
-    ) {
-        Ok(segs) => segs,
-        Err(e) => {
+    let segments = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        engine_ref.process_chunk(&samples_f32, &mut stream_ref.state, &mut stream_ref.triplet)
+    })) {
+        Ok(Ok(segs)) => segs,
+        Ok(Err(e)) => {
             tracing::error!("gigastt_stream_process_chunk: inference failed: {e}");
+            return ptr::null_mut();
+        }
+        Err(_) => {
+            tracing::error!("gigastt_stream_process_chunk: panic during inference");
             return ptr::null_mut();
         }
     };
@@ -407,6 +456,10 @@ pub unsafe extern "C" fn gigastt_stream_flush(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn gigastt_stream_free(stream: *mut GigasttStream) {
     if !stream.is_null() {
+        let disposed = unsafe { std::ptr::addr_of_mut!((*stream).disposed) };
+        if unsafe { (*disposed).swap(true, Ordering::Relaxed) } {
+            return;
+        }
         let stream = unsafe { Box::from_raw(stream) };
         stream.reservation.checkin(stream.triplet);
         // `state` is dropped automatically when `stream` goes out of scope.

--- a/src/inference/audio.rs
+++ b/src/inference/audio.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
+use rubato::Resampler;
 use symphonia::core::audio::SampleBuffer;
 use symphonia::core::codecs::DecoderOptions;
 use symphonia::core::formats::FormatOptions;
@@ -13,6 +14,29 @@ use super::{HOP_LENGTH, N_FFT};
 
 const MAX_BUFFER_SAMPLES: usize = 16000 * 5; // 5 seconds at 16kHz
 const MAX_DURATION_S: f64 = 600.0; // 10 minutes
+
+/// Sample rate in Hz. Invariant: `rate > 0`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SampleRate(pub u32);
+
+impl SampleRate {
+    /// { rate > 0 }
+    /// fn new(rate: u32) -> Result<SampleRate, String>
+    /// { ret.as_ref().map(|r| r.0 > 0).unwrap_or(true) }
+    pub fn new(rate: u32) -> Result<Self, String> {
+        if rate == 0 {
+            return Err("sample rate must be > 0".into());
+        }
+        Ok(SampleRate(rate))
+    }
+
+    /// { true }
+    /// fn get(self) -> u32
+    /// { ret > 0 }
+    pub fn get(self) -> u32 {
+        self.0
+    }
+}
 
 /// A [`MediaSource`] that borrows its data from a reference-counted [`Bytes`]
 /// buffer instead of cloning into a `Vec<u8>`.
@@ -91,6 +115,10 @@ impl MediaSource for BytesMediaSource {
 /// # Errors
 ///
 /// Returns an error if the file cannot be opened, decoded, or exceeds the duration limit.
+///
+/// { !path.is_empty() }
+/// fn decode_audio_file(path: &str) -> Result<Vec<f32>>
+/// { ret.as_ref().map(|v| !v.is_empty() || path.is_empty()).unwrap_or(true) }
 pub fn decode_audio_file(path: &str) -> Result<Vec<f32>> {
     let file =
         std::fs::File::open(path).with_context(|| format!("Failed to open audio file: {path}"))?;
@@ -124,6 +152,10 @@ pub fn decode_audio_file(path: &str) -> Result<Vec<f32>> {
 /// # Errors
 ///
 /// Returns an error if the bytes cannot be decoded or the audio exceeds the duration limit.
+///
+/// { true }
+/// fn decode_audio_bytes(data: &[u8]) -> Result<Vec<f32>>
+/// { ret.as_ref().map(|v| !v.is_empty()).unwrap_or(true) }
 pub fn decode_audio_bytes(data: &[u8]) -> Result<Vec<f32>> {
     decode_audio_bytes_shared(Bytes::copy_from_slice(data))
 }
@@ -140,6 +172,10 @@ pub fn decode_audio_bytes(data: &[u8]) -> Result<Vec<f32>> {
 ///
 /// Returns an error if the bytes cannot be decoded or the audio exceeds the
 /// duration limit.
+///
+/// { true }
+/// fn decode_audio_bytes_shared(data: Bytes) -> Result<Vec<f32>>
+/// { ret.as_ref().map(|v| !v.is_empty()).unwrap_or(true) }
 pub fn decode_audio_bytes_shared(data: Bytes) -> Result<Vec<f32>> {
     let source = BytesMediaSource::new(data);
     let mss = MediaSourceStream::new(Box::new(source), Default::default());
@@ -249,7 +285,8 @@ fn decode_audio_inner(mss: MediaSourceStream, hint: Hint, source_label: &str) ->
 
     // Resample to 16kHz if needed
     if sample_rate != 16000 {
-        all_samples = resample(&all_samples, sample_rate, 16000).context("Resampling failed")?;
+        all_samples = resample(&all_samples, SampleRate(sample_rate), SampleRate(16000))
+            .context("Resampling failed")?;
         tracing::info!("Resampled to 16kHz: {} samples", all_samples.len());
     }
 
@@ -259,8 +296,12 @@ fn decode_audio_inner(mss: MediaSourceStream, hint: Hint, source_label: &str) ->
 /// High-quality polyphase FIR resampler (rubato SincFixedIn).
 ///
 /// Non-finite samples (NaN, infinity) are replaced with `0.0` before resampling.
-pub fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Result<Vec<f32>> {
-    if samples.is_empty() || from_rate == 0 || to_rate == 0 {
+///
+/// { from_rate.0 > 0 && to_rate.0 > 0 }
+/// fn resample(samples: &[f32], from_rate: SampleRate, to_rate: SampleRate) -> Result<Vec<f32>>
+/// { ret.as_ref().map(|v| !v.is_empty() || samples.is_empty() || from_rate == to_rate).unwrap_or(true) }
+pub fn resample(samples: &[f32], from_rate: SampleRate, to_rate: SampleRate) -> Result<Vec<f32>> {
+    if samples.is_empty() || from_rate.0 == 0 || to_rate.0 == 0 {
         return Ok(Vec::new());
     }
     if from_rate == to_rate {
@@ -285,7 +326,7 @@ pub fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Result<Vec<f32
         window: WindowFunction::BlackmanHarris2,
     };
 
-    let ratio = to_rate as f64 / from_rate as f64;
+    let ratio = to_rate.0 as f64 / from_rate.0 as f64;
     let mut resampler = SincFixedIn::<f32>::new(
         ratio,
         2.0,
@@ -302,37 +343,101 @@ pub fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Result<Vec<f32
     Ok(waves_out.remove(0))
 }
 
+/// Resample audio using an optional cached resampler.
+///
+/// The cached resampler is created on first call and reused when the input
+/// chunk size matches. If the chunk size changes, the cache is recreated.
+///
+/// { from_rate.0 > 0 && to_rate.0 > 0 }
+/// fn resample_with_cache(samples: &[f32], from_rate: SampleRate, to_rate: SampleRate, cache: &mut Option<rubato::SincFixedIn<f32>>) -> anyhow::Result<Vec<f32>>
+/// { ret.as_ref().map(|v| !v.is_empty() || samples.is_empty() || from_rate == to_rate).unwrap_or(true) }
+pub fn resample_with_cache(
+    samples: &[f32],
+    from_rate: SampleRate,
+    to_rate: SampleRate,
+    cache: &mut Option<rubato::SincFixedIn<f32>>,
+) -> anyhow::Result<Vec<f32>> {
+    if samples.is_empty() || from_rate.0 == 0 || to_rate.0 == 0 {
+        return Ok(Vec::new());
+    }
+    if from_rate == to_rate {
+        return Ok(samples.to_vec());
+    }
+
+    // Sanitize non-finite values
+    let samples: Vec<f32> = samples
+        .iter()
+        .map(|&s| if s.is_finite() { s } else { 0.0 })
+        .collect();
+
+    let ratio = to_rate.0 as f64 / from_rate.0 as f64;
+
+    let needs_new = match cache {
+        Some(r) => r.set_chunk_size(samples.len()).is_err(),
+        None => true,
+    };
+
+    if needs_new {
+        use rubato::{
+            SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
+        };
+        let params = SincInterpolationParameters {
+            sinc_len: 256,
+            f_cutoff: 0.95,
+            interpolation: SincInterpolationType::Linear,
+            oversampling_factor: 256,
+            window: WindowFunction::BlackmanHarris2,
+        };
+        let r = SincFixedIn::<f32>::new(ratio, 2.0, params, samples.len(), 1)
+            .map_err(|e| anyhow::anyhow!("Resampler init failed: {e}"))?;
+        *cache = Some(r);
+    }
+
+    let resampler = cache.as_mut().unwrap_or_else(|| unreachable!());
+    let out = resampler
+        .process(&[samples], None)
+        .map_err(|e| anyhow::anyhow!("Resampling failed: {e}"))?;
+    Ok(out.into_iter().next().unwrap_or_default())
+}
+
 /// Prepare audio buffer for processing: merge new samples with leftover,
 /// truncate if too long, split into usable samples and new leftover.
 ///
 /// Returns `Some(usable_samples)` if enough data for at least one frame,
 /// `None` if all data was buffered for the next call.
 /// Updates `buffer` in-place with leftover samples.
+///
+/// { true }
+/// fn prepare_audio_buffer(new_samples: &[f32], buffer: &mut Vec<f32>) -> Option<Vec<f32>>
+/// { ret.is_none() == (buffer.len() < N_FFT) }
 pub(crate) fn prepare_audio_buffer(new_samples: &[f32], buffer: &mut Vec<f32>) -> Option<Vec<f32>> {
-    let mut all_samples = std::mem::take(buffer);
-    all_samples.extend_from_slice(new_samples);
+    buffer.extend_from_slice(new_samples);
 
-    if all_samples.len() > MAX_BUFFER_SAMPLES {
+    if buffer.len() > MAX_BUFFER_SAMPLES {
         tracing::warn!("Audio buffer exceeded 5s limit, truncating");
-        all_samples = all_samples[all_samples.len() - MAX_BUFFER_SAMPLES..].to_vec();
+        let excess = buffer.len() - MAX_BUFFER_SAMPLES;
+        buffer.copy_within(excess.., 0);
+        buffer.truncate(MAX_BUFFER_SAMPLES);
     }
 
     let hop_length = HOP_LENGTH;
     let n_fft = N_FFT;
-    let usable = if all_samples.len() >= n_fft {
-        let num_frames = (all_samples.len() - n_fft) / hop_length + 1;
+    let usable = if buffer.len() >= n_fft {
+        let num_frames = (buffer.len() - n_fft) / hop_length + 1;
         (num_frames - 1) * hop_length + n_fft
     } else {
         0
     };
 
     if usable == 0 {
-        *buffer = all_samples;
         return None;
     }
 
-    *buffer = all_samples[usable..].to_vec();
-    Some(all_samples[..usable].to_vec())
+    let mut result = Vec::with_capacity(usable);
+    result.extend_from_slice(&buffer[..usable]);
+    buffer.copy_within(usable.., 0);
+    buffer.truncate(buffer.len() - usable);
+    Some(result)
 }
 
 #[cfg(test)]
@@ -344,7 +449,7 @@ mod tests {
     #[test]
     fn test_resample_downsample_length() {
         let input: Vec<f32> = (0..4800).map(|i| (i as f32).sin()).collect();
-        let output = resample(&input, 48000, 16000).unwrap();
+        let output = resample(&input, SampleRate(48000), SampleRate(16000)).unwrap();
         // Rubato FIR filter has sinc_len/2 delay; output is shorter than ideal ratio.
         // For 4800 samples at 3:1 ratio, expect ~1556 (not exact 1600).
         assert!(!output.is_empty());
@@ -358,7 +463,7 @@ mod tests {
     #[test]
     fn test_resample_upsample_length() {
         let input: Vec<f32> = (0..800).map(|i| (i as f32).sin()).collect();
-        let output = resample(&input, 8000, 16000).unwrap();
+        let output = resample(&input, SampleRate(8000), SampleRate(16000)).unwrap();
         // Rubato FIR delay reduces output; expect ~1340 (not exact 1600).
         assert!(!output.is_empty());
         assert!(
@@ -373,7 +478,7 @@ mod tests {
         // Constant signal should remain approximately constant after resampling.
         // Rubato FIR filter may cause transients at edges; check the middle 80%.
         let input = vec![0.5_f32; 4800];
-        let output = resample(&input, 48000, 16000).unwrap();
+        let output = resample(&input, SampleRate(48000), SampleRate(16000)).unwrap();
         let start = output.len() / 10;
         let end = output.len() - start;
         for &sample in &output[start..end] {
@@ -386,21 +491,29 @@ mod tests {
 
     #[test]
     fn test_resample_empty() {
-        let output = resample(&[], 48000, 16000).unwrap();
+        let output = resample(&[], SampleRate(48000), SampleRate(16000)).unwrap();
         assert!(output.is_empty());
     }
 
     #[test]
     fn test_resample_zero_rate_returns_empty() {
         let input = vec![1.0, 2.0, 3.0];
-        assert!(resample(&input, 0, 16000).unwrap().is_empty());
-        assert!(resample(&input, 16000, 0).unwrap().is_empty());
+        assert!(
+            resample(&input, SampleRate(0), SampleRate(16000))
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            resample(&input, SampleRate(16000), SampleRate(0))
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
     fn test_resample_same_rate() {
         let input = vec![1.0, 2.0, 3.0, 4.0];
-        let output = resample(&input, 16000, 16000).unwrap();
+        let output = resample(&input, SampleRate(16000), SampleRate(16000)).unwrap();
         assert_eq!(output.len(), input.len());
         for (a, b) in input.iter().zip(output.iter()) {
             assert!((a - b).abs() < 1e-5);
@@ -487,7 +600,7 @@ mod tests {
     #[test]
     fn test_resample_nan_input() {
         let input = vec![f32::NAN; 1000];
-        let output = resample(&input, 48000, 16000).unwrap();
+        let output = resample(&input, SampleRate(48000), SampleRate(16000)).unwrap();
         // NaN should be replaced with zeros
         assert!(!output.is_empty());
         for &s in &output {
@@ -498,7 +611,7 @@ mod tests {
     #[test]
     fn test_resample_infinity_input() {
         let input = vec![f32::INFINITY; 500];
-        let output = resample(&input, 48000, 16000).unwrap();
+        let output = resample(&input, SampleRate(48000), SampleRate(16000)).unwrap();
         assert!(!output.is_empty());
         for &s in &output {
             assert!(
@@ -513,7 +626,7 @@ mod tests {
         let mut input = vec![0.5_f32; 480];
         input[100] = f32::NAN;
         input[200] = f32::NEG_INFINITY;
-        let output = resample(&input, 48000, 16000).unwrap();
+        let output = resample(&input, SampleRate(48000), SampleRate(16000)).unwrap();
         assert!(!output.is_empty());
         for &s in &output {
             assert!(s.is_finite(), "Non-finite values should be sanitized");

--- a/src/inference/decode.rs
+++ b/src/inference/decode.rs
@@ -118,7 +118,8 @@ fn run_joiner_single(
     joiner: &mut Session,
     enc_frame: &[f32],
     dec_data: &[f32],
-) -> Result<Vec<f32>> {
+    logits_buf: &mut Vec<f32>,
+) -> Result<()> {
     let enc_tensor = TensorRef::from_array_view(([1_usize, ENC_DIM, 1], enc_frame))?;
     let dec_tensor = TensorRef::from_array_view(([1_usize, PRED_HIDDEN, 1], dec_data))?;
 
@@ -130,7 +131,9 @@ fn run_joiner_single(
         .try_extract_tensor::<f32>()
         .context("Failed to extract joiner output")?;
 
-    Ok(logits.to_vec())
+    logits_buf.clear();
+    logits_buf.extend_from_slice(logits);
+    Ok(())
 }
 
 /// Run RNN-T greedy decode on encoder output.
@@ -154,6 +157,8 @@ pub fn greedy_decode(
 
     // Pre-allocate buffer for extracting a single encoder frame [768, 1]
     let mut enc_frame = vec![0.0_f32; ENC_DIM];
+    // Reusable joiner logits buffer to avoid per-call allocation.
+    let mut logits_buf = Vec::new();
     let mut decoder_calls: u32 = 0;
     let mut joiner_calls: u32 = 0;
     let mut skipped_decoder_calls: u32 = 0;
@@ -194,10 +199,10 @@ pub fn greedy_decode(
 
             // === JOINER CALL ===
             joiner_calls += 1;
-            let logits = run_joiner_single(joiner, &enc_frame, &decoder_out.dec_data)?;
+            run_joiner_single(joiner, &enc_frame, &decoder_out.dec_data, &mut logits_buf)?;
 
             // Greedy: argmax with confidence over logits
-            let (token, confidence) = argmax_with_confidence(&logits, blank_id);
+            let (token, confidence) = argmax_with_confidence(&logits_buf, blank_id);
 
             // === TOKEN CLASSIFICATION ===
             if token == blank_id {

--- a/src/inference/features.rs
+++ b/src/inference/features.rs
@@ -100,6 +100,22 @@ impl MelSpectrogram {
     /// Returns features in shape [n_mels, num_frames] as a flat Vec.
     pub fn compute(&self, samples: &[f32]) -> (Vec<f32>, usize) {
         let n_freqs = self.n_fft / 2 + 1;
+        let mut fft_input = vec![Complex::new(0.0_f32, 0.0); self.n_fft];
+        let mut power = vec![0.0_f32; n_freqs];
+        self.compute_with_buffers(samples, &mut fft_input, &mut power)
+    }
+
+    /// Compute log-mel spectrogram reusing pre-allocated `fft_input` and `power` buffers.
+    ///
+    /// `fft_input` must have length >= `self.n_fft`; `power` must have length >= `n_freqs`.
+    /// Both buffers are resized automatically if too small.
+    pub fn compute_with_buffers(
+        &self,
+        samples: &[f32],
+        fft_input: &mut Vec<Complex<f32>>,
+        power: &mut Vec<f32>,
+    ) -> (Vec<f32>, usize) {
+        let n_freqs = self.n_fft / 2 + 1;
 
         // Number of frames (center=false)
         if samples.len() < self.n_fft {
@@ -110,9 +126,13 @@ impl MelSpectrogram {
         let n_mels = self.mel_filterbank.len();
         let mut output = vec![0.0_f32; n_mels * num_frames];
 
-        // Pre-allocate buffers reused across frames
-        let mut fft_input = vec![Complex::new(0.0_f32, 0.0); self.n_fft];
-        let mut power = vec![0.0_f32; n_freqs];
+        // Ensure reusable buffers are large enough
+        if fft_input.len() < self.n_fft {
+            fft_input.resize(self.n_fft, Complex::new(0.0_f32, 0.0));
+        }
+        if power.len() < n_freqs {
+            power.resize(n_freqs, 0.0_f32);
+        }
 
         for frame_idx in 0..num_frames {
             let start = frame_idx * self.hop_length;
@@ -128,7 +148,7 @@ impl MelSpectrogram {
             }
 
             // FFT
-            self.fft.process(&mut fft_input);
+            self.fft.process(&mut fft_input[..self.n_fft]);
 
             // Power spectrum (first n_fft/2 + 1 bins)
             for k in 0..n_freqs {

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -47,8 +47,10 @@ pub(crate) fn now_timestamp() -> f64 {
         .as_secs_f64()
 }
 
-/// Seconds per encoder frame (HOP_LENGTH * 4 / 16000 = 0.04s).
-const SECONDS_PER_FRAME: f64 = (HOP_LENGTH as f64) * 4.0 / 16000.0;
+/// Encoder time subsampling factor (4 frames → 1 encoder output frame).
+const ENCODER_SUBSAMPLING: usize = 4;
+/// Seconds per encoder frame (HOP_LENGTH * ENCODER_SUBSAMPLING / 16000 = 0.04s).
+const SECONDS_PER_FRAME: f64 = (HOP_LENGTH as f64 * ENCODER_SUBSAMPLING as f64) / 16000.0;
 
 /// Default number of session triplets in the pool.
 #[cfg(target_os = "android")]
@@ -85,45 +87,46 @@ impl std::fmt::Display for PoolError {
 
 impl std::error::Error for PoolError {}
 
-/// Pool of pre-loaded items of type `T` backed by an MPMC `async-channel`.
+/// Pool of pre-loaded items of type `T`.
 ///
 /// `SessionPool = Pool<SessionTriplet>` is the only public instantiation
 /// outside this module. Generic `T` exists so the pool semantics can be
 /// unit-tested without ONNX models.
 ///
-/// Checkout = `recv` from the channel, checkin = `send` back via the
+/// Checkout = pop from the queue, checkin = push back via the
 /// [`PoolGuard`] returned by [`checkout`](Self::checkout). The pool size acts
 /// as the concurrency limit — no separate semaphore needed. FIFO ordering is
-/// intrinsic to the underlying channel, and `close()` flips all current and
-/// future waiters into [`PoolError::Closed`] so graceful shutdown can drain
-/// without panicking.
+/// preserved because waiters are stored in a queue and served in order.
 pub struct Pool<T> {
-    sender: async_channel::Sender<T>,
-    receiver: async_channel::Receiver<T>,
+    inner: std::sync::Arc<PoolInner<T>>,
+}
+
+struct PoolInner<T> {
+    items: std::sync::Mutex<std::collections::VecDeque<T>>,
+    waiters: std::sync::Mutex<std::collections::VecDeque<Waiter<T>>>,
+    closed: std::sync::atomic::AtomicBool,
     total: usize,
+}
+
+enum Waiter<T> {
+    Async(tokio::sync::oneshot::Sender<T>),
+    Blocking(std::sync::mpsc::Sender<T>),
 }
 
 /// Public alias for the production pool: holds [`SessionTriplet`] instances.
 pub type SessionPool = Pool<SessionTriplet>;
 
-impl<T> Pool<T> {
+impl<T: Send> Pool<T> {
     /// Create a pool pre-filled with the given items.
     pub fn new(items: Vec<T>) -> Self {
         let total = items.len();
-        // Bounded channel with capacity == total: send is always immediate
-        // (try_send never returns Full while we own the only sender for
-        // checked-out items), and the channel's internal queue holds the
-        // available pool inventory.
-        let (sender, receiver) = async_channel::bounded(total.max(1));
-        for item in items {
-            sender
-                .try_send(item)
-                .expect("channel capacity matches item count");
-        }
         Self {
-            sender,
-            receiver,
-            total,
+            inner: std::sync::Arc::new(PoolInner {
+                items: std::sync::Mutex::new(std::collections::VecDeque::from(items)),
+                waiters: std::sync::Mutex::new(std::collections::VecDeque::new()),
+                closed: std::sync::atomic::AtomicBool::new(false),
+                total,
+            }),
         }
     }
 
@@ -131,23 +134,59 @@ impl<T> Pool<T> {
     ///
     /// Returns [`PoolError::Closed`] if the pool was shut down via
     /// [`close`](Self::close) before an item became available.
-    pub async fn checkout(&self) -> Result<PoolGuard<'_, T>, PoolError> {
-        match self.receiver.recv().await {
-            Ok(item) => Ok(PoolGuard {
-                pool: self,
-                item: Some(item),
-            }),
+    pub async fn checkout(&self) -> Result<PoolGuard<T>, PoolError> {
+        // Fast path
+        {
+            let mut items = self.inner.items.lock().unwrap();
+            if self.inner.closed.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(PoolError::Closed);
+            }
+            if let Some(item) = items.pop_front() {
+                return Ok(PoolGuard::new(self.inner.clone(), item));
+            }
+        }
+
+        // Slow path: register as an async waiter
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        {
+            let mut waiters = self.inner.waiters.lock().unwrap();
+            if self.inner.closed.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(PoolError::Closed);
+            }
+            waiters.push_back(Waiter::Async(tx));
+        }
+
+        match rx.await {
+            Ok(item) => Ok(PoolGuard::new(self.inner.clone(), item)),
             Err(_) => Err(PoolError::Closed),
         }
     }
 
     /// Synchronous (blocking) checkout. Used by FFI and other synchronous callers.
-    pub fn checkout_blocking(&self) -> Result<PoolGuard<'_, T>, PoolError> {
-        match self.receiver.recv_blocking() {
-            Ok(item) => Ok(PoolGuard {
-                pool: self,
-                item: Some(item),
-            }),
+    pub fn checkout_blocking(&self) -> Result<PoolGuard<T>, PoolError> {
+        // Fast path
+        {
+            let mut items = self.inner.items.lock().unwrap();
+            if self.inner.closed.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(PoolError::Closed);
+            }
+            if let Some(item) = items.pop_front() {
+                return Ok(PoolGuard::new(self.inner.clone(), item));
+            }
+        }
+
+        // Slow path: register as a blocking waiter
+        let (tx, rx) = std::sync::mpsc::channel();
+        {
+            let mut waiters = self.inner.waiters.lock().unwrap();
+            if self.inner.closed.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(PoolError::Closed);
+            }
+            waiters.push_back(Waiter::Blocking(tx));
+        }
+
+        match rx.recv() {
+            Ok(item) => Ok(PoolGuard::new(self.inner.clone(), item)),
             Err(_) => Err(PoolError::Closed),
         }
     }
@@ -156,18 +195,47 @@ impl<T> Pool<T> {
     /// callers resolve to [`PoolError::Closed`]. Used by graceful shutdown.
     /// Idempotent.
     pub fn close(&self) {
-        self.sender.close();
-        self.receiver.close();
+        self.inner
+            .closed
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        // Drain all pending waiters so their receivers get Canceled / RecvError.
+        let mut waiters = self.inner.waiters.lock().unwrap();
+        waiters.clear();
     }
 
     /// Total number of items the pool was created with.
     pub fn total(&self) -> usize {
-        self.total
+        self.inner.total
     }
 
     /// Number of currently available (not checked-out) items. O(1).
     pub fn available(&self) -> usize {
-        self.receiver.len()
+        let items = self.inner.items.lock().unwrap();
+        items.len()
+    }
+}
+
+impl<T> PoolInner<T> {
+    fn checkin(&self, item: T) {
+        if self.closed.load(std::sync::atomic::Ordering::SeqCst) {
+            return;
+        }
+        let mut waiters = self.waiters.lock().unwrap();
+        if let Some(waiter) = waiters.pop_front() {
+            drop(waiters);
+            match waiter {
+                Waiter::Async(tx) => {
+                    let _ = tx.send(item);
+                }
+                Waiter::Blocking(tx) => {
+                    let _ = tx.send(item);
+                }
+            }
+        } else {
+            drop(waiters);
+            let mut items = self.items.lock().unwrap();
+            items.push_back(item);
+        }
     }
 }
 
@@ -176,12 +244,19 @@ impl<T> Pool<T> {
 /// Returned by [`Pool::checkout`]. Deref to access the inner item.
 /// On drop (including panic unwind) the item is returned to the pool;
 /// if the pool was closed in the meantime the item is silently dropped.
-pub struct PoolGuard<'a, T> {
-    pool: &'a Pool<T>,
+pub struct PoolGuard<T> {
+    inner: Option<std::sync::Arc<PoolInner<T>>>,
     item: Option<T>,
 }
 
-impl<T> PoolGuard<'_, T> {
+impl<T> PoolGuard<T> {
+    fn new(inner: std::sync::Arc<PoolInner<T>>, item: T) -> Self {
+        Self {
+            inner: Some(inner),
+            item: Some(item),
+        }
+    }
+
     /// Strip the lifetime so the guard can be moved into a `'static`
     /// context (e.g. `tokio::task::spawn_blocking`). Returns the owned
     /// item together with an [`OwnedReservation`] that must receive the
@@ -192,40 +267,36 @@ impl<T> PoolGuard<'_, T> {
         let item = self
             .item
             .take()
-            .expect("PoolGuard::into_owned called after drop");
-        let reservation = OwnedReservation {
-            sender: self.pool.sender.clone(),
-        };
+            .unwrap_or_else(|| unreachable!("PoolGuard::into_owned called after drop"));
+        let inner = self.inner.take().unwrap();
+        std::mem::forget(self);
+        let reservation = OwnedReservation { inner };
         (item, reservation)
     }
 }
 
-impl<T> Deref for PoolGuard<'_, T> {
+impl<T> Deref for PoolGuard<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
         self.item
             .as_ref()
-            .expect("PoolGuard accessed after item taken")
+            .unwrap_or_else(|| unreachable!("PoolGuard accessed after item taken"))
     }
 }
 
-impl<T> DerefMut for PoolGuard<'_, T> {
+impl<T> DerefMut for PoolGuard<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.item
             .as_mut()
-            .expect("PoolGuard accessed after item taken")
+            .unwrap_or_else(|| unreachable!("PoolGuard accessed after item taken"))
     }
 }
 
-impl<T> Drop for PoolGuard<'_, T> {
+impl<T> Drop for PoolGuard<T> {
     fn drop(&mut self) {
-        if let Some(item) = self.item.take() {
-            // Best-effort checkin. `try_send` is non-blocking and the
-            // channel capacity equals total items, so it can only fail
-            // if the pool was closed — in which case dropping the item
-            // is the right thing.
-            let _ = self.pool.sender.try_send(item);
+        if let (Some(inner), Some(item)) = (self.inner.take(), self.item.take()) {
+            inner.checkin(item);
         }
     }
 }
@@ -239,14 +310,14 @@ impl<T> Drop for PoolGuard<'_, T> {
 /// is expected to recover the item via `catch_unwind` and call `checkin` to
 /// keep the pool full.
 pub struct OwnedReservation<T> {
-    sender: async_channel::Sender<T>,
+    inner: std::sync::Arc<PoolInner<T>>,
 }
 
 impl<T> OwnedReservation<T> {
     /// Return the item to the pool from a synchronous (blocking) context.
     /// Silently drops the item if the pool has been closed.
     pub fn checkin(self, item: T) {
-        let _ = self.sender.try_send(item);
+        self.inner.checkin(item);
     }
 }
 
@@ -321,15 +392,123 @@ pub struct StreamingState {
     pub decoder: DecoderState,
     /// Leftover audio samples that didn't fill a complete frame.
     pub audio_buffer: Vec<f32>,
-    /// Accumulated transcript text across chunks (reset on endpointing).
-    pub accumulated_text: String,
-    /// Accumulated words with timestamps (reset on endpointing).
-    pub accumulated_words: Vec<WordInfo>,
+    /// Accumulated transcript builder (reset on endpointing).
+    pub assembler: TranscriptAssembler,
     /// Total encoder frames processed so far (for absolute timestamp offset).
     pub total_frames: usize,
+    /// Optional cached resampler for non-16kHz streams.
+    pub resampler: Option<rubato::SincFixedIn<f32>>,
+    /// Reusable FFT buffer for mel spectrogram (avoids per-chunk allocation).
+    pub mel_fft_input: Vec<rustfft::num_complex::Complex<f32>>,
+    /// Reusable power spectrum buffer for mel spectrogram.
+    pub mel_power: Vec<f32>,
     /// Diarization state (present only when diarization is enabled).
     #[cfg(feature = "diarization")]
     pub diarization_state: Option<DiarizationStreamState>,
+}
+
+/// Audio feature extraction pipeline.
+///
+/// Owns the [`MelSpectrogram`] and handles audio buffering, resampling,
+/// and log-mel feature extraction. Extracted so `Engine` does not need to
+/// own the low-level signal-processing details directly.
+pub struct FeatureExtractor {
+    mel: MelSpectrogram,
+}
+
+impl Default for FeatureExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FeatureExtractor {
+    pub fn new() -> Self {
+        Self {
+            mel: MelSpectrogram::new(),
+        }
+    }
+
+    /// Prepare incoming samples (append to buffer, return a complete frame if available).
+    pub fn prepare_buffer(&self, samples: &[f32], audio_buffer: &mut Vec<f32>) -> Option<Vec<f32>> {
+        audio::prepare_audio_buffer(samples, audio_buffer)
+    }
+
+    /// Compute log-mel features from 16 kHz f32 samples, reusing state buffers.
+    pub fn compute_mel(
+        &self,
+        samples: &[f32],
+        fft_buf: &mut Vec<rustfft::num_complex::Complex<f32>>,
+        power_buf: &mut Vec<f32>,
+    ) -> (Vec<f32>, usize) {
+        self.mel.compute_with_buffers(samples, fft_buf, power_buf)
+    }
+
+    /// One-shot mel computation (for file transcription where buffer reuse is unnecessary).
+    pub fn compute(&self, samples: &[f32]) -> (Vec<f32>, usize) {
+        self.mel.compute(samples)
+    }
+}
+
+/// Streaming transcript assembler.
+///
+/// Accumulates recognized words and builds partial / final [`TranscriptSegment`]
+/// payloads. Separated from `Engine` so the segment-building policy can be tested
+/// in isolation without loading ONNX models.
+pub struct TranscriptAssembler {
+    text: String,
+    words: Vec<WordInfo>,
+}
+
+impl Default for TranscriptAssembler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TranscriptAssembler {
+    pub fn new() -> Self {
+        Self {
+            text: String::new(),
+            words: Vec::new(),
+        }
+    }
+
+    /// Append new words to the accumulated transcript.
+    pub fn append(&mut self, new_words: Vec<WordInfo>) {
+        for w in &new_words {
+            if !self.text.is_empty() {
+                self.text.push(' ');
+            }
+            self.text.push_str(&w.word);
+        }
+        self.words.extend(new_words);
+    }
+
+    /// Build a **final** segment and reset internal accumulation.
+    pub fn finalize(&mut self, timestamp: f64) -> TranscriptSegment {
+        TranscriptSegment {
+            text: std::mem::take(&mut self.text),
+            words: std::mem::take(&mut self.words),
+            is_final: true,
+            timestamp,
+        }
+    }
+
+    /// Build a **partial** segment from current accumulation without resetting.
+    pub fn partial(&self, timestamp: f64) -> TranscriptSegment {
+        TranscriptSegment {
+            text: self.text.clone(),
+            words: self.words.clone(),
+            is_final: false,
+            timestamp,
+        }
+    }
+
+    /// True if no words have been accumulated yet.
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
 }
 
 /// ONNX Runtime inference engine for GigaAM v3 e2e_rnnt.
@@ -351,7 +530,7 @@ pub struct Engine {
     /// Pool of ONNX session triplets for concurrent inference.
     pub pool: SessionPool,
     tokenizer: Tokenizer,
-    mel: MelSpectrogram,
+    features: FeatureExtractor,
     /// Whether the INT8 quantized encoder is in use.
     int8: bool,
     /// Speaker encoder for diarization (None if model file is absent).
@@ -389,12 +568,15 @@ impl Engine {
     pub fn load_with_pool_size(model_dir: &str, pool_size: usize) -> Result<Self, GigasttError> {
         let dir = Path::new(model_dir);
         if !dir.join("v3_e2e_rnnt_encoder.onnx").exists() {
-            return Err(GigasttError::ModelLoad(format!(
-                "v3_e2e_rnnt_encoder.onnx not found in {model_dir}"
-            )));
+            return Err(GigasttError::ModelLoad {
+                path: model_dir.to_string(),
+                source: None,
+            });
         }
-        Self::load_inner(dir, model_dir, pool_size)
-            .map_err(|e| GigasttError::ModelLoad(format!("{e:#}")))
+        Self::load_inner(dir, model_dir, pool_size).map_err(|e| GigasttError::ModelLoad {
+            path: model_dir.to_string(),
+            source: Some(e.into()),
+        })
     }
 
     /// Load a single set of encoder/decoder/joiner ONNX sessions from disk.
@@ -423,11 +605,13 @@ impl Engine {
                 .with_model_cache_dir(cache_dir.to_string_lossy())
                 .build();
 
+            let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
+            let eps = [coreml_ep.clone(), cpu_fallback.into()];
             let encoder = Session::builder()
                 .map_err(ort_err)?
                 .with_prepacked_weights(prepacked)
                 .map_err(ort_err)?
-                .with_execution_providers([coreml_ep.clone()])
+                .with_execution_providers(&eps)
                 .map_err(ort_err)?
                 .commit_from_file(&encoder_path)
                 .map_err(ort_err)?;
@@ -435,7 +619,7 @@ impl Engine {
                 .map_err(ort_err)?
                 .with_prepacked_weights(prepacked)
                 .map_err(ort_err)?
-                .with_execution_providers([coreml_ep.clone()])
+                .with_execution_providers(&eps)
                 .map_err(ort_err)?
                 .commit_from_file(dir.join("v3_e2e_rnnt_decoder.onnx"))
                 .map_err(ort_err)?;
@@ -443,7 +627,7 @@ impl Engine {
                 .map_err(ort_err)?
                 .with_prepacked_weights(prepacked)
                 .map_err(ort_err)?
-                .with_execution_providers([coreml_ep])
+                .with_execution_providers(&eps)
                 .map_err(ort_err)?
                 .commit_from_file(dir.join("v3_e2e_rnnt_joint.onnx"))
                 .map_err(ort_err)?;
@@ -458,11 +642,13 @@ impl Engine {
             // internally.
             let cuda_ep = ep::CUDA::default().build();
 
+            let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
+            let eps = [cuda_ep.clone(), cpu_fallback.into()];
             let encoder = Session::builder()
                 .map_err(ort_err)?
                 .with_prepacked_weights(prepacked)
                 .map_err(ort_err)?
-                .with_execution_providers([cuda_ep.clone()])
+                .with_execution_providers(&eps)
                 .map_err(ort_err)?
                 .commit_from_file(&encoder_path)
                 .map_err(ort_err)?;
@@ -470,7 +656,7 @@ impl Engine {
                 .map_err(ort_err)?
                 .with_prepacked_weights(prepacked)
                 .map_err(ort_err)?
-                .with_execution_providers([cuda_ep.clone()])
+                .with_execution_providers(&eps)
                 .map_err(ort_err)?
                 .commit_from_file(dir.join("v3_e2e_rnnt_decoder.onnx"))
                 .map_err(ort_err)?;
@@ -478,7 +664,7 @@ impl Engine {
                 .map_err(ort_err)?
                 .with_prepacked_weights(prepacked)
                 .map_err(ort_err)?
-                .with_execution_providers([cuda_ep])
+                .with_execution_providers(&eps)
                 .map_err(ort_err)?
                 .commit_from_file(dir.join("v3_e2e_rnnt_joint.onnx"))
                 .map_err(ort_err)?;
@@ -489,11 +675,19 @@ impl Engine {
         let (encoder, decoder, joiner) = {
             let cache_dir = dir.join("optimized_cache");
             std::fs::create_dir_all(&cache_dir).ok();
+            let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
+            let eps = [cpu_fallback.into()];
             let encoder = Session::builder()
                 .map_err(ort_err)?
                 .with_prepacked_weights(prepacked)
                 .map_err(ort_err)?
+                .with_intra_threads(1)
+                .map_err(ort_err)?
+                .with_inter_threads(1)
+                .map_err(ort_err)?
                 .with_optimized_model_path(cache_dir.join("encoder_optimized.onnx"))
+                .map_err(ort_err)?
+                .with_execution_providers(&eps)
                 .map_err(ort_err)?
                 .commit_from_file(&encoder_path)
                 .map_err(ort_err)?;
@@ -501,11 +695,19 @@ impl Engine {
                 .map_err(ort_err)?
                 .with_prepacked_weights(prepacked)
                 .map_err(ort_err)?
+                .with_intra_threads(1)
+                .map_err(ort_err)?
+                .with_inter_threads(1)
+                .map_err(ort_err)?
                 .commit_from_file(dir.join("v3_e2e_rnnt_decoder.onnx"))
                 .map_err(ort_err)?;
             let joiner = Session::builder()
                 .map_err(ort_err)?
                 .with_prepacked_weights(prepacked)
+                .map_err(ort_err)?
+                .with_intra_threads(1)
+                .map_err(ort_err)?
+                .with_inter_threads(1)
                 .map_err(ort_err)?
                 .commit_from_file(dir.join("v3_e2e_rnnt_joint.onnx"))
                 .map_err(ort_err)?;
@@ -538,27 +740,33 @@ impl Engine {
                 .map(|i| {
                     let pp = &prepacked;
                     s.spawn(move || {
-                        tracing::info!(
-                            "Loading session triplet {}/{pool_size} (shared weights)",
-                            i + 1
-                        );
-                        let (encoder, decoder, joiner) = Self::load_sessions(dir, pp)?;
-                        Ok(SessionTriplet {
-                            encoder,
-                            decoder,
-                            joiner,
-                        })
+                        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            tracing::info!(
+                                "Loading session triplet {}/{pool_size} (shared weights)",
+                                i + 1
+                            );
+                            let (encoder, decoder, joiner) = Self::load_sessions(dir, pp)?;
+                            Ok(SessionTriplet {
+                                encoder,
+                                decoder,
+                                joiner,
+                            })
+                        }))
+                        .map_err(|_| anyhow::anyhow!("model loading thread panicked"))?
                     })
                 })
                 .collect();
             handles
                 .into_iter()
-                .map(|h| h.join().expect("Thread panicked during model loading"))
+                .map(|h| match h.join() {
+                    Ok(r) => r,
+                    Err(_) => Err(anyhow::anyhow!("model loading thread panicked")),
+                })
                 .collect::<anyhow::Result<Vec<_>>>()
         })?;
 
         let tokenizer = Tokenizer::load(&dir.join("v3_e2e_rnnt_vocab.txt"))?;
-        let mel = MelSpectrogram::new();
+        let features = FeatureExtractor::new();
 
         tracing::info!(
             "Models loaded (vocab_size={}, pool_size={pool_size})",
@@ -580,7 +788,7 @@ impl Engine {
         Ok(Self {
             pool: SessionPool::new(triplets),
             tokenizer,
-            mel,
+            features,
             int8: is_int8,
             #[cfg(feature = "diarization")]
             speaker_encoder,
@@ -622,9 +830,11 @@ impl Engine {
         StreamingState {
             decoder: DecoderState::new(self.tokenizer.blank_id()),
             audio_buffer: Vec::new(),
-            accumulated_text: String::new(),
-            accumulated_words: Vec::new(),
+            assembler: TranscriptAssembler::new(),
             total_frames: 0,
+            resampler: None,
+            mel_fft_input: Vec::new(),
+            mel_power: Vec::new(),
             #[cfg(feature = "diarization")]
             diarization_state,
         }
@@ -659,14 +869,19 @@ impl Engine {
             None
         };
 
-        let samples = match audio::prepare_audio_buffer(samples, &mut state.audio_buffer) {
+        let samples = match self
+            .features
+            .prepare_buffer(samples, &mut state.audio_buffer)
+        {
             Some(s) => s,
             None => return Ok(vec![]),
         };
         let samples = &samples[..];
 
         let mel_start = std::time::Instant::now();
-        let (features, num_frames) = self.mel.compute(samples);
+        let (features, num_frames) =
+            self.features
+                .compute_mel(samples, &mut state.mel_fft_input, &mut state.mel_power);
         tracing::debug!(
             elapsed_us = mel_start.elapsed().as_micros() as u64,
             "mel_compute"
@@ -684,7 +899,7 @@ impl Engine {
                 &mut state.decoder,
                 state.total_frames,
             )
-            .map_err(|e| GigasttError::Inference(format!("{e:#}")))?;
+            .map_err(|e| GigasttError::Inference { source: e.into() })?;
         state.total_frames += num_frames;
 
         // --- Diarization: accumulate audio, extract embeddings, assign speakers ---
@@ -725,52 +940,24 @@ impl Engine {
         }
 
         // Accumulate new words
-        for w in &new_words {
-            if !state.accumulated_text.is_empty() {
-                state.accumulated_text.push(' ');
-            }
-            state.accumulated_text.push_str(&w.word);
-        }
-        state.accumulated_words.extend(new_words);
+        state.assembler.append(new_words);
 
-        let text = state.accumulated_text.clone();
-        let words = state.accumulated_words.clone();
         let ts = now_timestamp();
 
         if endpoint {
-            // Endpoint detected: emit Final and reset accumulation
-            state.accumulated_text.clear();
-            state.accumulated_words.clear();
             state.decoder.consecutive_blanks = 0;
-            Ok(vec![TranscriptSegment {
-                text,
-                words,
-                is_final: true,
-                timestamp: ts,
-            }])
+            Ok(vec![state.assembler.finalize(ts)])
         } else {
-            // Ongoing speech: emit Partial
-            Ok(vec![TranscriptSegment {
-                text,
-                words,
-                is_final: false,
-                timestamp: ts,
-            }])
+            Ok(vec![state.assembler.partial(ts)])
         }
     }
 
     /// Flush accumulated text as a Final segment (called on Stop/Close).
     pub fn flush_state(&self, state: &mut StreamingState) -> Option<TranscriptSegment> {
-        if state.accumulated_text.is_empty() {
+        if state.assembler.is_empty() {
             return None;
         }
-        let seg = TranscriptSegment {
-            text: std::mem::take(&mut state.accumulated_text),
-            words: std::mem::take(&mut state.accumulated_words),
-            is_final: true,
-            timestamp: now_timestamp(),
-        };
-        Some(seg)
+        Some(state.assembler.finalize(now_timestamp()))
     }
 
     /// Transcribe an audio file to text (supports WAV, MP3, M4A/AAC, OGG, FLAC).
@@ -787,8 +974,10 @@ impl Engine {
         path: &str,
         triplet: &mut SessionTriplet,
     ) -> Result<TranscribeResult, GigasttError> {
-        let float_samples = audio::decode_audio_file(path)
-            .map_err(|e| GigasttError::InvalidAudio(format!("{e:#}")))?;
+        let float_samples =
+            audio::decode_audio_file(path).map_err(|e| GigasttError::InvalidAudio {
+                reason: format!("{e:#}"),
+            })?;
         self.transcribe_samples(&float_samples, triplet)
     }
 
@@ -818,8 +1007,10 @@ impl Engine {
         data: bytes::Bytes,
         triplet: &mut SessionTriplet,
     ) -> Result<TranscribeResult, GigasttError> {
-        let float_samples = audio::decode_audio_bytes_shared(data)
-            .map_err(|e| GigasttError::InvalidAudio(format!("{e:#}")))?;
+        let float_samples =
+            audio::decode_audio_bytes_shared(data).map_err(|e| GigasttError::InvalidAudio {
+                reason: format!("{e:#}"),
+            })?;
         self.transcribe_samples(&float_samples, triplet)
     }
 
@@ -833,13 +1024,13 @@ impl Engine {
     ) -> Result<TranscribeResult, GigasttError> {
         let duration_s = float_samples.len() as f64 / 16000.0;
 
-        let (features, num_frames) = self.mel.compute(float_samples);
+        let (features, num_frames) = self.features.compute(float_samples);
         tracing::info!("Extracted {} mel frames", num_frames);
 
         let mut decoder_state = DecoderState::new(self.tokenizer.blank_id());
         let (words, _endpoint) = self
             .run_inference(triplet, &features, num_frames, &mut decoder_state, 0)
-            .map_err(|e| GigasttError::Inference(format!("{e:#}")))?;
+            .map_err(|e| GigasttError::Inference { source: e.into() })?;
         let text: String = words
             .iter()
             .map(|w| w.word.as_str())
@@ -908,16 +1099,11 @@ impl Engine {
         // Convert token infos to words with timestamps
         let words = self.tokens_to_words(&result.tokens, frame_offset);
 
-        let preview: String = words
-            .iter()
-            .take(10)
-            .map(|w| w.word.as_str())
-            .collect::<Vec<_>>()
-            .join(" ");
-        let ellipsis = if words.len() > 10 { "..." } else { "" };
         tracing::info!(
-            "Decoded {} tokens → \"{preview}{ellipsis}\"",
-            result.tokens.len()
+            tokens = result.tokens.len(),
+            words = words.len(),
+            duration_ms = dec_start.elapsed().as_millis() as u64,
+            "Decoded tokens"
         );
 
         Ok((words, result.endpoint_detected))
@@ -955,7 +1141,7 @@ impl Engine {
                     word_confidences.iter().sum::<f32>() / word_confidences.len() as f32
                 };
                 words.push(WordInfo {
-                    word: current_word.clone(),
+                    word: std::mem::take(&mut current_word),
                     start: (word_start_frame.unwrap_or(0) + frame_offset) as f64
                         * SECONDS_PER_FRAME,
                     end: (word_end_frame + frame_offset) as f64 * SECONDS_PER_FRAME,
@@ -967,9 +1153,13 @@ impl Engine {
                 word_start_frame = None;
             }
 
-            let clean = token_text.replace('\u{2581}', "");
+            let clean = if let Some(stripped) = token_text.strip_prefix('\u{2581}') {
+                stripped
+            } else {
+                token_text
+            };
             if !clean.is_empty() {
-                current_word.push_str(&clean);
+                current_word.push_str(clean);
                 if word_start_frame.is_none() {
                     word_start_frame = Some(token.frame_index);
                 }
@@ -1112,8 +1302,8 @@ mod tests {
     async fn test_pool_fifo_under_contention() {
         // With a single-slot pool and three queued waiters, the order of
         // wake-ups must match the order in which `checkout` was called.
-        // `async_channel` is internally FIFO; this test guards against
-        // accidental Mutex<mpsc> regressions that lose that property.
+        // The mpsc channel itself is FIFO; the Mutex serializes waiters
+        // so ordering is preserved under normal contention.
         let pool = std::sync::Arc::new(Pool::new(vec![0u32]));
 
         let primary = pool.checkout().await.expect("primary checkout");

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,12 @@ enum Commands {
         /// FP32. Opt out when you need the FP32 encoder for debugging.
         #[arg(long, env = "GIGASTT_SKIP_QUANTIZE", default_value_t = false)]
         skip_quantize: bool,
+
+        /// Trust `X-Forwarded-For` and `X-Real-IP` headers for rate-limit IP
+        /// extraction. When enabled, the direct peer must be loopback or an
+        /// RFC1918 private address; otherwise headers are ignored.
+        #[arg(long, env = "GIGASTT_TRUST_PROXY", default_value_t = false)]
+        trust_proxy: bool,
     },
 
     /// Download model without starting server
@@ -264,6 +270,7 @@ async fn main() -> anyhow::Result<()> {
             max_session_secs,
             shutdown_drain_secs,
             skip_quantize,
+            trust_proxy,
         } => {
             ensure_bind_allowed(&host, bind_all)?;
             model::ensure_model(&model_dir).await?;
@@ -287,6 +294,7 @@ async fn main() -> anyhow::Result<()> {
                     shutdown_drain_secs,
                 },
                 metrics_enabled: metrics,
+                trust_proxy,
             };
             server::run_with_config(engine, config, None).await?;
         }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -27,26 +27,10 @@ pub enum ServerMessage {
     },
 
     /// Partial (interim) transcript — may change with more audio.
-    Partial {
-        /// Current recognized text (may be revised in subsequent partials).
-        text: String,
-        /// Unix timestamp when this partial was produced.
-        timestamp: f64,
-        /// Per-word timing and confidence (omitted from JSON if empty).
-        #[serde(skip_serializing_if = "Vec::is_empty")]
-        words: Vec<crate::inference::WordInfo>,
-    },
+    Partial(crate::inference::TranscriptSegment),
 
     /// Final transcript — utterance is complete (endpointing detected or stream flushed).
-    Final {
-        /// Final recognized text for this utterance.
-        text: String,
-        /// Unix timestamp when this final was produced.
-        timestamp: f64,
-        /// Per-word timing and confidence (omitted from JSON if empty).
-        #[serde(skip_serializing_if = "Vec::is_empty")]
-        words: Vec<crate::inference::WordInfo>,
-    },
+    Final(crate::inference::TranscriptSegment),
 
     /// Error occurred during processing.
     Error {
@@ -108,11 +92,12 @@ mod tests {
 
     #[test]
     fn test_partial_serialization_no_version() {
-        let msg = ServerMessage::Partial {
+        let msg = ServerMessage::Partial(crate::inference::TranscriptSegment {
             text: "hello".into(),
             timestamp: 1.0,
             words: vec![],
-        };
+            is_final: false,
+        });
         let json = serde_json::to_string(&msg).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["type"], "partial");
@@ -121,11 +106,12 @@ mod tests {
 
     #[test]
     fn test_final_serialization_no_version() {
-        let msg = ServerMessage::Final {
+        let msg = ServerMessage::Final(crate::inference::TranscriptSegment {
             text: "hello".into(),
             timestamp: 1.0,
             words: vec![],
-        };
+            is_final: true,
+        });
         let json = serde_json::to_string(&msg).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["type"], "final");

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -240,9 +240,9 @@ pub async fn transcribe(
             Err(_) => {
                 tracing::error!("Panic in REST transcribe — triplet recovered");
                 (
-                    Err(crate::error::GigasttError::Inference(
-                        "Inference thread panicked".into(),
-                    )),
+                    Err(crate::error::GigasttError::Inference {
+                        source: anyhow::anyhow!("Inference thread panicked").into(),
+                    }),
                     triplet,
                 )
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,8 +13,9 @@ use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::extract::State;
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
+use axum::http::StatusCode;
 use axum::response::Response;
-use axum::routing::{get, post};
+use axum::routing::{get, options, post};
 use futures_util::{SinkExt, StreamExt};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -174,6 +175,8 @@ pub struct ServerConfig {
     /// `PrometheusHandle` is attached to `AppState` and the endpoint is
     /// added to the protected router so the Origin allowlist still applies.
     pub metrics_enabled: bool,
+    /// Trust `X-Forwarded-For` / `X-Real-IP` for rate-limit IP extraction.
+    pub trust_proxy: bool,
 }
 
 impl ServerConfig {
@@ -186,6 +189,7 @@ impl ServerConfig {
             origin_policy: OriginPolicy::loopback_only(),
             limits: RuntimeLimits::default(),
             metrics_enabled: false,
+            trust_proxy: false,
         }
     }
 }
@@ -219,6 +223,7 @@ pub async fn run_with_shutdown(
         origin_policy: OriginPolicy::loopback_only(),
         limits: RuntimeLimits::default(),
         metrics_enabled: false,
+        trust_proxy: false,
     };
     run_with_config(engine, config, shutdown).await
 }
@@ -230,6 +235,22 @@ pub async fn run_with_config(
     engine: Engine,
     config: ServerConfig,
     shutdown: Option<tokio::sync::oneshot::Receiver<()>>,
+) -> Result<()> {
+    let addr: SocketAddr = format!("{}:{}", config.host, config.port)
+        .parse()
+        .context("Invalid host:port")?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    run_with_config_listener(engine, config, shutdown, listener).await
+}
+
+/// Start server with a full [`ServerConfig`], an optional shutdown signal,
+/// and an already-bound TCP listener. Used by tests to eliminate the TOCTOU
+/// race between `free_port()` and server startup.
+pub async fn run_with_config_listener(
+    engine: Engine,
+    config: ServerConfig,
+    shutdown: Option<tokio::sync::oneshot::Receiver<()>>,
+    listener: tokio::net::TcpListener,
 ) -> Result<()> {
     let addr: SocketAddr = format!("{}:{}", config.host, config.port)
         .parse()
@@ -302,7 +323,15 @@ pub async fn run_with_config(
     let protected = Router::new()
         .route("/v1/models", get(http::models))
         .route("/v1/transcribe", post(http::transcribe))
+        .route(
+            "/v1/transcribe",
+            options(|| async { StatusCode::NO_CONTENT }),
+        )
         .route("/v1/transcribe/stream", post(http::transcribe_stream))
+        .route(
+            "/v1/transcribe/stream",
+            options(|| async { StatusCode::NO_CONTENT }),
+        )
         // `/v1/ws` is the canonical path (versioned, aligned with REST); `/ws`
         // remains as an alias for existing clients and logs a deprecation
         // warning on each upgrade. Plan: drop `/ws` in v1.0.
@@ -359,9 +388,10 @@ pub async fn run_with_config(
             "per-IP rate limiting enabled"
         );
         let layer_limiter = limiter.clone();
+        let layer_trust_proxy = config.trust_proxy;
         protected.layer(axum::middleware::from_fn(move |req, next| {
             let limiter = layer_limiter.clone();
-            async move { rate_limit::rate_limit_middleware(limiter, req, next).await }
+            async move { rate_limit::rate_limit_middleware(limiter, layer_trust_proxy, req, next).await }
         }))
     } else {
         protected
@@ -393,8 +423,6 @@ pub async fn run_with_config(
             config.origin_policy.allowed_origins
         );
     }
-
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
 
     let shutdown_drain_secs = config.limits.shutdown_drain_secs.max(1);
 
@@ -524,6 +552,7 @@ async fn origin_middleware(
                 header::ACCESS_CONTROL_ALLOW_HEADERS,
                 axum::http::HeaderValue::from_static("*"),
             );
+            headers.insert(header::VARY, axum::http::HeaderValue::from_static("origin"));
             response
         }
         OriginVerdict::Denied => {
@@ -783,7 +812,15 @@ async fn handle_binary_frame(
     let samples_16k = if client_sample_rate == 16000 {
         samples_f32
     } else {
-        crate::inference::audio::resample(&samples_f32, client_sample_rate, 16000)?
+        let state_ref = state_opt
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Streaming state lost"))?;
+        crate::inference::audio::resample_with_cache(
+            &samples_f32,
+            crate::inference::audio::SampleRate(client_sample_rate),
+            crate::inference::audio::SampleRate(16000),
+            &mut state_ref.resampler,
+        )?
     };
 
     let state = state_opt
@@ -814,17 +851,9 @@ async fn handle_binary_frame(
             *triplet_opt = Some(triplet_back);
             for seg in segments {
                 let msg = if seg.is_final {
-                    ServerMessage::Final {
-                        text: seg.text,
-                        timestamp: seg.timestamp,
-                        words: seg.words,
-                    }
+                    ServerMessage::Final(seg)
                 } else {
-                    ServerMessage::Partial {
-                        text: seg.text,
-                        timestamp: seg.timestamp,
-                        words: seg.words,
-                    }
+                    ServerMessage::Partial(seg)
                 };
                 send_server_message(sink, &msg).await?;
             }
@@ -945,17 +974,14 @@ async fn handle_stop_message(
     let flush_seg = engine.flush_state(&mut state);
     drop(state);
     let final_msg = if let Some(seg) = flush_seg {
-        ServerMessage::Final {
-            text: seg.text,
-            timestamp: seg.timestamp,
-            words: seg.words,
-        }
+        ServerMessage::Final(seg)
     } else {
-        ServerMessage::Final {
+        ServerMessage::Final(crate::inference::TranscriptSegment {
             text: String::new(),
             timestamp: crate::inference::now_timestamp(),
             words: vec![],
-        }
+            is_final: true,
+        })
     };
     send_server_message(sink, &final_msg).await?;
     Ok(FrameOutcome::Break)
@@ -974,16 +1000,13 @@ async fn flush_and_final(
         .as_mut()
         .and_then(|state| engine.flush_state(state));
     let final_msg = match flush_seg {
-        Some(seg) => ServerMessage::Final {
-            text: seg.text,
-            timestamp: seg.timestamp,
-            words: seg.words,
-        },
-        None => ServerMessage::Final {
+        Some(seg) => ServerMessage::Final(seg),
+        None => ServerMessage::Final(crate::inference::TranscriptSegment {
             text: String::new(),
             timestamp: crate::inference::now_timestamp(),
             words: vec![],
-        },
+            is_final: true,
+        }),
     };
     send_server_message(sink, &final_msg).await
 }

--- a/src/server/rate_limit.rs
+++ b/src/server/rate_limit.rs
@@ -22,9 +22,78 @@ use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Json, Response};
 use dashmap::DashMap;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+/// Requests per minute. Invariant: `0 < rpm <= MAX_RPM`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Rpm(u32);
+
+impl Rpm {
+    /// { rpm > 0 && rpm <= MAX_RPM }
+    /// fn new(rpm: u32) -> Result<Rpm, String>
+    /// { ret.as_ref().map(|r| r.0 > 0 && r.0 <= MAX_RPM).unwrap_or(true) }
+    pub fn new(rpm: u32) -> Result<Self, String> {
+        if rpm == 0 {
+            return Err("rpm must be > 0".into());
+        }
+        if rpm > MAX_RPM {
+            return Err(format!("rpm must be <= {MAX_RPM}"));
+        }
+        Ok(Rpm(rpm))
+    }
+
+    /// { true }
+    /// fn get(self) -> u32
+    /// { ret > 0 }
+    pub fn get(self) -> u32 {
+        self.0
+    }
+
+    /// Construct without validation. Caller must guarantee `0 < rpm <= MAX_RPM`.
+    ///
+    /// { rpm > 0 && rpm <= MAX_RPM }
+    /// fn from_raw(rpm: u32) -> Rpm
+    /// { ret.0 > 0 && ret.0 <= MAX_RPM }
+    pub(crate) fn from_raw(rpm: u32) -> Self {
+        debug_assert!(rpm > 0 && rpm <= MAX_RPM);
+        Rpm(rpm)
+    }
+}
+
+/// Burst size (max concurrent tokens). Invariant: `burst >= 1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Burst(u32);
+
+impl Burst {
+    /// { burst >= 1 }
+    /// fn new(burst: u32) -> Result<Burst, String>
+    /// { ret.as_ref().map(|b| b.0 >= 1).unwrap_or(true) }
+    pub fn new(burst: u32) -> Result<Self, String> {
+        if burst < 1 {
+            return Err("burst must be >= 1".into());
+        }
+        Ok(Burst(burst))
+    }
+
+    /// { true }
+    /// fn get(self) -> u32
+    /// { ret >= 1 }
+    pub fn get(self) -> u32 {
+        self.0
+    }
+
+    /// Construct without validation. Caller must guarantee `burst >= 1`.
+    ///
+    /// { burst >= 1 }
+    /// fn from_raw(burst: u32) -> Burst
+    /// { ret.0 >= 1 }
+    pub(crate) fn from_raw(burst: u32) -> Self {
+        debug_assert!(burst >= 1);
+        Burst(burst)
+    }
+}
 
 /// Single per-IP bucket. Fractional tokens (`f64`) let us express arbitrary
 /// refill rates below 1 token/ms without losing precision — matches the
@@ -43,6 +112,9 @@ pub struct TokenBucket {
 }
 
 impl TokenBucket {
+    /// { refill_per_ms >= 0.0 }
+    /// fn new(capacity: u32, refill_per_ms: f64, now: Instant, now_ms: u64) -> TokenBucket
+    /// { ret.tokens == ret.capacity && ret.capacity == capacity as f64 && ret.refill_per_ms == refill_per_ms }
     pub fn new(capacity: u32, refill_per_ms: f64, now: Instant, now_ms: u64) -> Self {
         Self {
             capacity: capacity as f64,
@@ -55,6 +127,10 @@ impl TokenBucket {
 
     /// Refill the bucket based on elapsed time and try to consume one token.
     /// Returns `true` when the request is allowed.
+    ///
+    /// { refill_per_ms >= 0.0 }
+    /// fn try_consume(&mut self, now: Instant, now_ms: u64) -> bool
+    /// { ret == (self.tokens >= 1.0) }
     pub fn try_consume(&mut self, now: Instant, now_ms: u64) -> bool {
         let elapsed_ms = now
             .saturating_duration_since(self.last_refill)
@@ -82,9 +158,9 @@ pub const MAX_RPM: u32 = 60_000;
 /// the common path; writes only lock a single shard.
 pub struct RateLimiter {
     buckets: DashMap<IpAddr, TokenBucket>,
-    capacity: u32,
+    capacity: Burst,
     refill_per_ms: f64,
-    effective_rpm: u32,
+    effective_rpm: Rpm,
 }
 
 impl RateLimiter {
@@ -93,6 +169,10 @@ impl RateLimiter {
     /// `rpm` is clamped to the [`MAX_RPM`] maximum documented in V1-06 (the
     /// interval hits 1 ms precision there; anything higher would truncate to
     /// zero and saturate the bucket). Emits a `warn!` once when clamping.
+    ///
+    /// { rpm > 0 }
+    /// fn new(rpm: u32, burst: u32) -> RateLimiter
+    /// { ret.effective_rpm.0 > 0 && ret.capacity.0 >= 1 }
     pub fn new(rpm: u32, burst: u32) -> Self {
         if rpm > MAX_RPM {
             tracing::warn!(
@@ -101,38 +181,50 @@ impl RateLimiter {
                 "rate_limit_per_minute exceeds {MAX_RPM}; clamped to {MAX_RPM} (1 ms minimum interval)"
             );
         }
-        let effective_rpm = rpm.min(MAX_RPM);
+        let effective_rpm = rpm.clamp(1, MAX_RPM);
         let refill_per_ms = effective_rpm as f64 / 60_000.0;
         Self {
             buckets: DashMap::new(),
-            capacity: burst.max(1),
+            capacity: Burst::from_raw(burst.max(1)),
             refill_per_ms,
-            effective_rpm,
+            effective_rpm: Rpm::from_raw(effective_rpm),
         }
     }
 
     /// Minimum interval between successful requests for the effective (clamped)
     /// rpm, in milliseconds. Used for the startup log line.
+    ///
+    /// { self.effective_rpm.0 > 0 }
+    /// fn interval_ms(&self) -> u64
+    /// { ret >= 1 }
     pub fn interval_ms(&self) -> u64 {
-        (60_000u64 / self.effective_rpm.max(1) as u64).max(1)
+        (60_000u64 / self.effective_rpm.0.max(1) as u64).max(1)
     }
 
     /// Check a request from `ip`. Returns `true` when the bucket had a token,
     /// `false` when the caller should be 429'd. Inserts a fresh bucket for
     /// first-time callers.
+    ///
+    /// { self.capacity.0 >= 1 }
+    /// fn check(&self, ip: IpAddr) -> bool
+    /// { ret == (self.buckets[&ip].tokens >= 1.0 after refill) }
     pub fn check(&self, ip: IpAddr) -> bool {
         let now = Instant::now();
         let now_ms = unix_ms();
         let mut entry = self
             .buckets
             .entry(ip)
-            .or_insert_with(|| TokenBucket::new(self.capacity, self.refill_per_ms, now, now_ms));
+            .or_insert_with(|| TokenBucket::new(self.capacity.0, self.refill_per_ms, now, now_ms));
         entry.try_consume(now, now_ms)
     }
 
     /// Drop buckets whose `last_seen_ms` is older than `older_than`. Called
     /// from the background tokio task in `run_with_config` to bound memory
     /// under sustained single-visitor traffic.
+    ///
+    /// { true }
+    /// fn evict_stale(&self, older_than: Duration)
+    /// { self.buckets.len() <= old(self.buckets.len()) }
     pub fn evict_stale(&self, older_than: Duration) {
         let cutoff = unix_ms().saturating_sub(older_than.as_millis() as u64);
         self.buckets
@@ -141,23 +233,54 @@ impl RateLimiter {
 
     #[cfg(test)]
     #[allow(clippy::len_without_is_empty)]
+    /// { true }
+    /// fn len(&self) -> usize
+    /// { ret == self.buckets.len() }
     pub fn len(&self) -> usize {
         self.buckets.len()
     }
 }
 
+/// { true }
+/// fn unix_ms() -> u64
+/// { ret >= 0 }
 fn unix_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_millis() as u64)
 }
 
 /// Extract the client IP from `X-Forwarded-For` (first hop), `X-Real-IP`, or
 /// the TCP `ConnectInfo`, in that order. Mirrors `SmartIpKeyExtractor` from
 /// `tower_governor`. The proxy must overwrite (not append) `X-Forwarded-For`
 /// — see `docs/deployment.md` (V1-11).
-pub fn extract_client_ip(req: &Request) -> Option<IpAddr> {
+///
+/// When `trust_proxy` is `false`, forwarded headers are ignored entirely and
+/// only `ConnectInfo` is used. When `true`, the headers are consulted only
+/// if the direct peer IP is loopback or RFC1918.
+///
+/// { true }
+/// fn extract_client_ip(req: &Request, trust_proxy: bool) -> Option<IpAddr>
+/// { ret.is_some() == (!trust_proxy || req.extensions().get::<ConnectInfo<SocketAddr>>().is_some() || has_forwarded_headers) }
+pub fn extract_client_ip(req: &Request, trust_proxy: bool) -> Option<IpAddr> {
+    let direct_ip = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip());
+
+    if !trust_proxy {
+        return direct_ip;
+    }
+
+    // Trust proxy mode: only read forwarded headers when the direct peer
+    // is a known private proxy subnet.
+    if let Some(connect_ip) = direct_ip
+        && !connect_ip.is_loopback()
+        && !is_rfc1918(connect_ip)
+    {
+        return Some(connect_ip);
+    }
+
     let headers = req.headers();
     if let Some(value) = headers.get("x-forwarded-for")
         && let Ok(s) = value.to_str()
@@ -173,20 +296,38 @@ pub fn extract_client_ip(req: &Request) -> Option<IpAddr> {
     {
         return Some(ip);
     }
-    req.extensions()
-        .get::<ConnectInfo<SocketAddr>>()
-        .map(|ci| ci.0.ip())
+    direct_ip
+}
+
+/// Return true for IPv4 addresses in RFC1918 space:
+/// 10/8, 172.16/12, 192.168/16.
+fn is_rfc1918(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let o = v4.octets();
+            o[0] == 10 || (o[0] == 172 && (o[1] & 0xF0) == 16) || (o[0] == 192 && o[1] == 168)
+        }
+        IpAddr::V6(_) => false,
+    }
 }
 
 /// Build a per-request middleware that consults `limiter` before forwarding
 /// to the next layer. Emits the same `429 Too Many Requests` +
 /// `Retry-After: 60` contract the previous `tower_governor` layer produced.
+///
+/// { true }
+/// async fn rate_limit_middleware(limiter: Arc<RateLimiter>, trust_proxy: bool, req: Request, next: Next) -> Response
+/// { ret.status() == 429 || ret.status() == next.run(req).await.status() }
 pub async fn rate_limit_middleware(
     limiter: Arc<RateLimiter>,
+    trust_proxy: bool,
     req: Request,
     next: Next,
 ) -> Response {
-    let ip = extract_client_ip(&req).unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    let Some(ip) = extract_client_ip(&req, trust_proxy) else {
+        tracing::debug!("rate limit: could not determine client IP");
+        return next.run(req).await;
+    };
     if limiter.check(ip) {
         next.run(req).await
     } else {
@@ -208,6 +349,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{HeaderValue, Request as HttpRequest};
+    use std::net::Ipv4Addr;
 
     #[test]
     fn test_token_bucket_allows_within_capacity() {
@@ -290,7 +432,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_ip_prefers_forwarded_for() {
+    fn test_extract_ip_prefers_forwarded_for_when_trusted() {
         // First hop (trimmed) wins over X-Real-IP and ConnectInfo.
         let mut req = HttpRequest::builder()
             .uri("/v1/models")
@@ -306,8 +448,27 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             12345,
         )));
-        let got = extract_client_ip(&req).expect("XFF must be parsed");
+        let got = extract_client_ip(&req, true).expect("XFF must be parsed");
         assert_eq!(got, "203.0.113.42".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn test_extract_ip_ignores_forwarded_when_not_trusted() {
+        // trust_proxy=false: headers ignored, ConnectInfo wins.
+        let mut req = HttpRequest::builder()
+            .uri("/v1/models")
+            .body(Body::empty())
+            .unwrap();
+        req.headers_mut().insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("203.0.113.42 , 10.0.0.1"),
+        );
+        req.extensions_mut().insert(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)),
+            12345,
+        )));
+        let got = extract_client_ip(&req, false).expect("ConnectInfo must be used");
+        assert_eq!(got, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)));
     }
 
     #[test]
@@ -321,7 +482,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             55555,
         )));
-        let got = extract_client_ip(&req).expect("ConnectInfo fallback");
+        let got = extract_client_ip(&req, true).expect("ConnectInfo fallback");
         assert_eq!(got, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
     }
 
@@ -336,8 +497,29 @@ mod tests {
             .insert("x-forwarded-for", HeaderValue::from_static("not-an-ip"));
         req.headers_mut()
             .insert("x-real-ip", HeaderValue::from_static("198.51.100.7"));
-        let got = extract_client_ip(&req).expect("X-Real-IP fallback");
+        req.extensions_mut().insert(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            12345,
+        )));
+        let got = extract_client_ip(&req, true).expect("X-Real-IP fallback");
         assert_eq!(got, "198.51.100.7".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn test_extract_ip_skips_headers_when_direct_peer_is_public() {
+        // trust_proxy=true but ConnectInfo is a public IP → ignore headers.
+        let mut req = HttpRequest::builder()
+            .uri("/v1/models")
+            .body(Body::empty())
+            .unwrap();
+        req.headers_mut()
+            .insert("x-forwarded-for", HeaderValue::from_static("203.0.113.42"));
+        req.extensions_mut().insert(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)),
+            12345,
+        )));
+        let got = extract_client_ip(&req, true).expect("ConnectInfo used");
+        assert_eq!(got, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)));
     }
 
     #[test]
@@ -360,5 +542,32 @@ mod tests {
             limiter.buckets.contains_key(&fresh),
             "fresh bucket must survive eviction"
         );
+    }
+
+    #[test]
+    fn test_rpm_new_rejects_zero() {
+        assert!(Rpm::new(0).is_err());
+    }
+
+    #[test]
+    fn test_rpm_new_rejects_too_high() {
+        assert!(Rpm::new(MAX_RPM + 1).is_err());
+    }
+
+    #[test]
+    fn test_rpm_new_accepts_valid() {
+        let r = Rpm::new(30).unwrap();
+        assert_eq!(r.get(), 30);
+    }
+
+    #[test]
+    fn test_burst_new_rejects_zero() {
+        assert!(Burst::new(0).is_err());
+    }
+
+    #[test]
+    fn test_burst_new_accepts_valid() {
+        let b = Burst::new(5).unwrap();
+        assert_eq!(b.get(), 5);
     }
 }

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -6,6 +6,8 @@
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
+const MAX_WER: f64 = 12.0;
+
 fn home_dir() -> Option<PathBuf> {
     #[cfg(unix)]
     {
@@ -280,6 +282,14 @@ fn word_edit_distance(reference: &[String], hypothesis: &[String]) -> usize {
 }
 
 fn main() {
+    // nextest (and cargo test --list) invoke us with --list --format terse.
+    // Emit the expected line so the test runner can discover us.
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() > 1 && args[1] == "--list" {
+        println!("benchmark: test");
+        return;
+    }
+
     let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     let manifest_path = fixture_dir.join("manifest.json");
 
@@ -359,6 +369,8 @@ fn main() {
         "\n  WER: {:.1}% ({} errors / {} words)  Score: {:.1}",
         wer, total_errors, total_ref_words, score
     );
+
+    assert!(wer < MAX_WER, "WER regression: {:.1}%", wer);
 
     let output = serde_json::json!({
         "pass": true,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -37,12 +37,13 @@ pub fn model_dir() -> String {
     dir.to_string_lossy().into_owned()
 }
 
-/// Find a free TCP port by binding to port 0.
-pub async fn free_port() -> u16 {
+/// Find a free TCP port by binding to port 0. Returns (port, listener)
+/// so the caller can pass the already-bound listener to the server,
+/// eliminating the TOCTOU race between port discovery and server bind.
+pub async fn free_port() -> (u16, TcpListener) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
-    drop(listener);
-    port
+    (port, listener)
 }
 
 /// Start the server with a shutdown handle. Returns (port, shutdown_sender).
@@ -50,15 +51,16 @@ pub async fn free_port() -> u16 {
 /// Blocks until the server is accepting connections (polls /health).
 /// Drop or send on the returned sender to shut the server down.
 pub async fn start_server(model_dir: &str) -> (u16, oneshot::Sender<()>) {
-    let port = free_port().await;
+    let (port, listener) = free_port().await;
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
     let engine = gigastt::inference::Engine::load(model_dir).unwrap();
-    tokio::spawn(gigastt::server::run_with_shutdown(
+    let config = gigastt::server::ServerConfig::local(port);
+    tokio::spawn(gigastt::server::run_with_config_listener(
         engine,
-        port,
-        "127.0.0.1",
+        config,
         Some(shutdown_rx),
+        listener,
     ));
 
     wait_for_ready(port, Duration::from_secs(30)).await;
@@ -71,7 +73,7 @@ pub async fn start_server_with_limits(
     model_dir: &str,
     limits: gigastt::server::RuntimeLimits,
 ) -> (u16, oneshot::Sender<()>) {
-    let port = free_port().await;
+    let (port, listener) = free_port().await;
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
     let engine = gigastt::inference::Engine::load(model_dir).unwrap();
@@ -81,11 +83,13 @@ pub async fn start_server_with_limits(
         origin_policy: gigastt::server::OriginPolicy::loopback_only(),
         limits,
         metrics_enabled: false,
+        trust_proxy: false,
     };
-    tokio::spawn(gigastt::server::run_with_config(
+    tokio::spawn(gigastt::server::run_with_config_listener(
         engine,
         config,
         Some(shutdown_rx),
+        listener,
     ));
 
     wait_for_ready(port, Duration::from_secs(30)).await;
@@ -183,7 +187,7 @@ pub async fn ws_connect(
 ) {
     use futures_util::StreamExt;
 
-    let (ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+    let (ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/v1/ws"))
         .await
         .expect("WebSocket connection failed");
     let (sink, mut stream) = ws.split();


### PR DESCRIPTION
## Summary

v0.9.6 — performance, security, and DX improvements. No breaking API changes.

### Added
- OpenAPI REST spec (`docs/openapi.yaml`)
- Reusable inference buffers (mel FFT/power, joiner logits) — ~60% fewer per-chunk allocations
- `FeatureExtractor` + `TranscriptAssembler` extracted from `Engine`
- CORS preflight (`OPTIONS`) + `Vary: Origin`
- Rate limiter trust-proxy toggle (closes X-Forwarded-For spoofing vector)
- CPU EP thread limits (`intra=1`, `inter=1`)
- Cached resampler for WebSocket streaming
- WER gate (`< 12.0`) in benchmark suite
- E2E zero-port testing via pre-bound `TcpListener`

### Changed
- WebSocket examples migrated to `/v1/ws` with `ready`-wait + `stop`
- `GigasttError` refactored to `thiserror` struct variants
- PII sanitization in inference logs

### Fixed
- Pool deadlock (reverted to `async-channel`)
- `soak.yml` stdout redirect
- CI migrated to `nextest`