### PR TITLE
deps: bump polyvoice from 0.6.5 to 0.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,16 +1557,15 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyvoice"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddba9bcafacb1e7b968576b8ecc848a1ae6647c5e1364e58fcd9a0a61ab8462"
+checksum = "8530447af32850811ec4d69837c703040b90a1d712b96ff1e2d1ec6a464398ca"
 dependencies = [
  "anyhow",
  "crossbeam-queue",
  "fastrand",
  "hound",
  "ndarray",
- "num-complex",
  "ort",
  "realfft",
  "serde",

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -37,7 +37,7 @@ rubato = "3.0"
 symphonia = { version = "0.6", features = ["aac", "isomp4", "mp3", "ogg", "flac", "pcm", "wav"] }
 bytes = "1"
 prost = "0.14"
-polyvoice = { version = "0.6.5", features = ["onnx"], optional = true }
+polyvoice = { version = "0.6.7", features = ["onnx"], optional = true }
 parking_lot = "0.12"
 libc = "0.2"
 


### PR DESCRIPTION
## Summary
- Bumps `polyvoice` from 0.6.5 to 0.6.7 (latest patch release).
- API-compatible with the 0.6 `Pipeline`/`StreamingPipeline` diarization code merged in #29 — no source changes required, only the version floor + lockfile.
- 0.6.6/0.6.7 are internal CI/tooling releases (cargo-machete, nextest) for the polyvoice crate; no public API surface changed.

## Test plan
- [x] `cargo build --workspace` (default `diarization` feature) — clean
- [x] `cargo clippy -p gigastt-core --features diarization` — warning-free
- [x] `cargo test -p gigastt-core --features diarization --lib` — 116 passed
- [ ] CI green (expect only the known `Semver Checks` false-failure: `--all-features` hits the coreml/cuda `compile_error!` in rustdoc)