### PR TITLE
fix: Docker images build again — MSRV 1.88, docker-build CI jobs, cache rework

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,13 +18,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check -p gigastt-ffi
 
   build-android:
@@ -37,13 +34,10 @@ jobs:
           targets: aarch64-linux-android
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-android-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: android
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-ndk
         run: cargo install cargo-ndk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,9 +641,22 @@ jobs:
     runs-on: ubuntu-latest
     name: Docker Build (CPU)
     timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
+      # The layer cache lives in ghcr.io (free for public repos), keeping the
+      # 10 GB Actions cache budget untouched. GITHUB_TOKEN grants packages:read
+      # on PRs (forks included), so warm reads work everywhere; writes happen
+      # on main pushes only. An unreadable cache ref is a soft warning — the
+      # build goes cold, it never fails.
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: .
@@ -651,8 +664,8 @@ jobs:
           push: false
           load: true
           tags: gigastt:ci
-          cache-from: type=gha,scope=docker-cpu
-          cache-to: type=gha,mode=max,scope=docker-cpu
+          cache-from: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:cpu
+          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:cpu,mode=max' || '' }}
       - name: Smoke test (--version)
         run: |
           docker run --rm gigastt:ci --version | tee version.out
@@ -666,6 +679,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Docker Build (${{ matrix.name }})
     timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -683,14 +699,18 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h /
       - uses: docker/setup-buildx-action@v3
+      # Layer cache in ghcr.io — rationale in docker-build above. This job is
+      # main-push-only, so the cache is always written back.
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: .
           file: ./${{ matrix.dockerfile }}
           push: false
           tags: gigastt-${{ matrix.name }}:ci
-          # mode=max also caches the builder stage. The docker scopes plus the
-          # cargo/model caches can exceed the 10 GB repo cache budget; GHA then
-          # evicts LRU entries and builds degrade to cold — they never fail.
-          cache-from: type=gha,scope=docker-${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=docker-${{ matrix.name }}
+          cache-from: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:${{ matrix.name }}
+          cache-to: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:${{ matrix.name }},mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,11 +404,14 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
-    name: MSRV (1.87)
+    name: MSRV (1.88)
     steps:
       - uses: actions/checkout@v4
-      # MSRV floor: edition 2024 needs >=1.85, is_multiple_of needs >=1.87.
-      - uses: dtolnay/rust-toolchain@1.87
+      # MSRV floor: edition 2024 needs >=1.85, is_multiple_of needs >=1.87,
+      # ort 2.0.0-rc.12 declares rust-version 1.88. NB: a warm cargo cache can
+      # mask a too-new dependency MSRV here — the ort 1.88 floor was only
+      # caught by the cold-registry Docker build, while this job stayed green.
+      - uses: dtolnay/rust-toolchain@1.88
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,3 +604,93 @@ jobs:
           files: ./cobertura-e2e.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  docker-changes:
+    # Detects whether a PR touches anything the Docker images are built from,
+    # so `docker-build` only spends a runner when packaging could have changed.
+    runs-on: ubuntu-latest
+    name: Docker Paths
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docker:
+              - 'Dockerfile*'
+              - 'benchmark/Dockerfile'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/**/Cargo.toml'
+              - 'crates/**/build.rs'
+              - 'crates/gigastt-core/proto/**'
+              - 'rust-toolchain.toml'
+
+  docker-build:
+    # Dockerfiles rot silently unless CI builds them: an MSRV drift in the
+    # builder pin and a phantom COPY both shipped unnoticed before this job
+    # existed. PRs build the CPU image only when docker-relevant paths change;
+    # every main push rebuilds it unconditionally as the safety net.
+    needs: docker-changes
+    if: github.event_name == 'push' || needs.docker-changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    name: Docker Build (CPU)
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: gigastt:ci
+          cache-from: type=gha,scope=docker-cpu
+          cache-to: type=gha,mode=max,scope=docker-cpu
+      - name: Smoke test (--version)
+        run: |
+          docker run --rm gigastt:ci --version | tee version.out
+          grep -E '^gigastt [0-9]+\.[0-9]+\.[0-9]+' version.out
+
+  docker-build-extras:
+    # Main push only: the CUDA + benchmark images exist to catch packaging
+    # rot, not to gate PRs. No GPU is needed — the CUDA EP is link-time only;
+    # the build just pulls the multi-GB nvidia base image.
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    name: Docker Build (${{ matrix.name }})
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: cuda
+            dockerfile: Dockerfile.cuda
+          - name: benchmark
+            dockerfile: benchmark/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free disk space
+        # The nvidia/cuda devel base (~8 GB) plus a release target dir plus
+        # the buildx cache export overflow the ~14 GB free on a stock runner.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./${{ matrix.dockerfile }}
+          push: false
+          tags: gigastt-${{ matrix.name }}:ci
+          # mode=max also caches the builder stage. The docker scopes plus the
+          # cargo/model caches can exceed the 10 GB repo cache budget; GHA then
+          # evicts LRU entries and builds degrade to cold — they never fail.
+          cache-from: type=gha,scope=docker-${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,10 @@ jobs:
           components: clippy
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --workspace --all-targets -- -D warnings -A dead_code
 
   unit-tests:
@@ -47,13 +44,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test --workspace --lib --bins
       - uses: taiki-e/install-action@v2
         with:
@@ -68,13 +62,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: brew install protobuf
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo build --release -p gigastt --features coreml
 
       # Runtime smoke (main push only — the model is ~850 MB). Issue #42:
@@ -125,13 +116,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo build --release -p gigastt --features cuda
 
   build-diarization:
@@ -142,13 +130,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo build --release -p gigastt --features diarization
 
   e2e-tests:
@@ -161,13 +146,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache model
         id: cache-model
@@ -194,13 +176,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache model
         id: cache-model
@@ -247,13 +226,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           # coreml+cuda are mutually exclusive; --all-features is impossible.
@@ -270,13 +246,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Default features only — coreml+cuda is a hard compile_error, so
       # `--all-features` is impossible here (unlike single-crate repos).
       - name: Run unit coverage
@@ -351,13 +324,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build docs (deny warnings)
         run: cargo doc --no-deps --workspace
         env:
@@ -374,13 +344,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # coreml+cuda is a hard compile_error and nnapi is Android-only, so the
       # platform execution-provider features are excluded from the powerset.
       - run: cargo hack check --feature-powerset --workspace --exclude-features coreml,cuda,nnapi --locked
@@ -393,13 +360,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo publish --dry-run -p gigastt-core --locked
 
   msrv:
@@ -414,13 +378,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: msrv
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check --workspace --locked
 
   fuzz:
@@ -434,14 +395,11 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-fuzz
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            fuzz/target
-          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: fuzz
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-directories: fuzz/target
       # rust-toolchain.toml pins stable repo-wide; RUSTUP_TOOLCHAIN overrides it
       # so cargo-fuzz's nightly `-Z sanitizer` flags are accepted. Force the gnu
       # target because the musl-built cargo-fuzz binary otherwise defaults to a
@@ -464,13 +422,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Save baseline from main
         # Branch refs are untrusted input — pass them through env vars rather
@@ -543,13 +498,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache model
         id: cache-model

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -30,15 +30,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: actions/cache@v5
+      # Separate shared-key: soak builds --release and must not evict the
+      # debug artefacts that ci.yml's `ci` family populates (and vice-versa).
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          # Scope by profile so --release builds don't evict the --debug
-          # artefacts that ci.yml populates (and vice-versa).
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: release
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache model
         id: cache-model
@@ -87,14 +84,11 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-fuzz
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            fuzz/target
-          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: fuzz
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-directories: fuzz/target
 
       # RUSTUP_TOOLCHAIN overrides the stable pin in rust-toolchain.toml so the
       # nightly `-Z sanitizer` flags are accepted; the explicit gnu target keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MSRV bumped 1.87 → 1.88.** `ort`/`ort-sys` 2.0.0-rc.12 declare
+  `rust-version = "1.88"`, so any cold-registry build on 1.87 (including the
+  Docker images) fails at resolution. The MSRV CI job had stayed green only
+  thanks to a warm cargo cache.
+
+### Fixed
+
+- **All three Docker images build again.** The rot ran deep: builder pins
+  behind the workspace MSRV, missing stubs for the declared
+  `[[bench]]`/`[[test]]` targets in the dependency-cache layer, the real
+  build silently linking against stale dummy rlibs (COPY preserves host
+  mtimes; sources are now touched before the final build), a phantom `proto/`
+  COPY in the benchmark image, missing `pkg-config`/`libssl-dev` for
+  `openssl-sys` (via reqwest native-tls), and base images too old for ort's
+  prebuilt onnxruntime (`__cxa_call_terminate` needs gcc-13 libstdc++ —
+  Debian bookworm→trixie, CUDA Ubuntu 22.04→24.04). Cargo invocations now
+  run `--locked`.
+
+### Added
+
+- **CI builds the Docker images** (`docker-build` jobs): the CPU image plus a
+  `--version` smoke run on every main push and on PRs touching docker-relevant
+  paths; the CUDA and benchmark images on main push.
+
 ## [2.0.14] - 2026-06-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 [workspace.package]
 version = "2.0.14"
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.88"
 license = "MIT"
 repository = "https://github.com/ekhodzitsky/gigastt"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,14 @@
 # Run:   docker run -p 9876:9876 gigastt
 
 # --- Builder stage ---
-FROM rust:1.85-bookworm AS builder
+# Pinned to the workspace MSRV (`rust-version` in Cargo.toml) so the image
+# build doubles as an MSRV check; bump both together. `--locked` keeps the
+# image on the audited Cargo.lock graph — a fresh resolve could pull deps
+# with a newer MSRV (exactly how ort rc.12 silently raised the floor to 1.88).
+# trixie (not bookworm): ort's prebuilt onnxruntime statics are compiled with
+# gcc >= 13 and reference `__cxa_call_terminate` (CXXABI_1.3.15), which
+# bookworm's libstdc++ 12 lacks — the final link fails there.
+FROM rust:1.88-trixie AS builder
 
 # `prost-build` (via build.rs) requires `protoc` at compile time; without it
 # the build aborts with "prost-build failed to compile proto/onnx.proto".
@@ -23,6 +30,8 @@ COPY crates/gigastt-core/build.rs crates/gigastt-core/
 COPY crates/gigastt-core/proto/ crates/gigastt-core/proto/
 COPY crates/gigastt-ffi/Cargo.toml crates/gigastt-ffi/
 COPY crates/gigastt/Cargo.toml crates/gigastt/
+# Every [[bench]]/[[test]] target declared in the manifests must exist on disk
+# for cargo to parse the workspace, hence the extra stubs below.
 RUN mkdir -p crates/gigastt-core/src crates/gigastt-ffi/src crates/gigastt/src/server && \
     echo 'pub mod error; pub mod inference; pub mod model; pub mod onnx_proto; pub mod protocol; pub mod quantize;' > crates/gigastt-core/src/lib.rs && \
     mkdir -p crates/gigastt-core/src/inference crates/gigastt-core/src/model crates/gigastt-core/src/protocol && \
@@ -33,17 +42,28 @@ RUN mkdir -p crates/gigastt-core/src crates/gigastt-ffi/src crates/gigastt/src/s
     touch crates/gigastt/src/server/mod.rs && \
     echo '' > crates/gigastt-ffi/src/lib.rs && \
     echo 'fn main() {}' > crates/gigastt-ffi/build.rs && \
-    cargo build --release -p gigastt && \
+    mkdir -p crates/gigastt-core/benches crates/gigastt/tests && \
+    echo 'fn main() {}' > crates/gigastt-core/benches/mel.rs && \
+    echo 'fn main() {}' > crates/gigastt-core/benches/resample.rs && \
+    echo 'fn main() {}' > crates/gigastt-core/benches/tokenizer.rs && \
+    echo 'fn main() {}' > crates/gigastt/tests/benchmark.rs && \
+    cargo build --release -p gigastt --locked && \
     rm -rf crates/*/src target/release/deps/gigastt* target/release/gigastt*
 
 # Now bring in the actual source and build the real binary.
 COPY crates/ crates/
 
-RUN cargo build --release -p gigastt && \
+# COPY preserves host mtimes (older than the dummy artifacts above), so cargo
+# would consider the dummy-built workspace rlibs fresh and link the real
+# binary against them. Touch the sources to force a rebuild of the workspace
+# crates; the dependency cache stays valid.
+RUN find crates -name '*.rs' -exec touch {} + && \
+    cargo build --release -p gigastt --locked && \
     strip target/release/gigastt
 
 # --- Model bake stage (runs only when GIGASTT_BAKE_MODEL=1) ---
-FROM debian:bookworm-slim AS model-fetcher
+# trixie-slim to match the builder's glibc/libstdc++ (the stage runs the binary).
+FROM debian:trixie-slim AS model-fetcher
 
 ARG GIGASTT_BAKE_MODEL=0
 
@@ -59,7 +79,7 @@ RUN mkdir -p /models && \
     fi
 
 # --- Runtime stage ---
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG GIGASTT_BAKE_MODEL=0
 

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -5,13 +5,17 @@
 # CUDA binary falls back to CPU if no GPU is available at runtime.
 
 # --- Builder stage ---
-FROM nvidia/cuda:12.6.3-devel-ubuntu22.04 AS builder
+# ubuntu24.04 (not 22.04): ort's prebuilt onnxruntime needs gcc >= 13
+# libstdc++ (`__cxa_call_terminate`, CXXABI_1.3.15) — see Dockerfile.
+FROM nvidia/cuda:12.6.3-devel-ubuntu24.04 AS builder
 
-# `protobuf-compiler` feeds prost-build (build.rs); everything else is the
-# baseline toolchain needed to compile the crate + its C deps.
+# `protobuf-compiler` feeds prost-build (build.rs); `pkg-config` + `libssl-dev`
+# feed openssl-sys (reqwest native-tls); the rest is the baseline toolchain.
+# The rustup pin tracks the workspace MSRV (`rust-version` in Cargo.toml);
+# bump both together. `--locked` rationale — see Dockerfile.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl build-essential pkg-config protobuf-compiler && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.85.0 && \
+    apt-get install -y --no-install-recommends curl build-essential pkg-config libssl-dev protobuf-compiler && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0 && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -35,18 +39,27 @@ RUN mkdir -p crates/gigastt-core/src crates/gigastt-ffi/src crates/gigastt/src/s
     touch crates/gigastt/src/server/mod.rs && \
     echo '' > crates/gigastt-ffi/src/lib.rs && \
     echo 'fn main() {}' > crates/gigastt-ffi/build.rs && \
-    cargo build --release -p gigastt --features cuda && \
+    mkdir -p crates/gigastt-core/benches crates/gigastt/tests && \
+    echo 'fn main() {}' > crates/gigastt-core/benches/mel.rs && \
+    echo 'fn main() {}' > crates/gigastt-core/benches/resample.rs && \
+    echo 'fn main() {}' > crates/gigastt-core/benches/tokenizer.rs && \
+    echo 'fn main() {}' > crates/gigastt/tests/benchmark.rs && \
+    cargo build --release -p gigastt --features cuda --locked && \
     rm -rf crates/*/src target/release/deps/gigastt* target/release/gigastt*
 
 COPY crates/ crates/
 
 # ort's download-binaries feature fetches CUDA-enabled ONNX Runtime.
 # copy-dylibs copies libonnxruntime*.so to target/release/.
-RUN cargo build --release -p gigastt --features cuda && \
+# Touch sources so cargo rebuilds the workspace crates instead of reusing the
+# dummy rlibs (COPY preserves older host mtimes — see Dockerfile).
+RUN find crates -name '*.rs' -exec touch {} + && \
+    cargo build --release -p gigastt --features cuda --locked && \
     strip target/release/gigastt
 
 # --- Model bake stage (runs only when GIGASTT_BAKE_MODEL=1) ---
-FROM debian:bookworm-slim AS model-fetcher
+# trixie-slim: new enough glibc to run the ubuntu24.04-built binary.
+FROM debian:trixie-slim AS model-fetcher
 
 ARG GIGASTT_BAKE_MODEL=0
 
@@ -62,7 +75,7 @@ RUN mkdir -p /models && \
     fi
 
 # --- Runtime stage ---
-FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04
+FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
 
 ARG GIGASTT_BAKE_MODEL=0
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/ekhodzitsky/gigastt/blob/main/CHANGELOG.md"><img src="https://img.shields.io/badge/changelog-Keep%20a%20Changelog-orange" alt="Changelog"></a>
     <a href="https://codecov.io/gh/ekhodzitsky/gigastt"><img src="https://codecov.io/gh/ekhodzitsky/gigastt/branch/main/graph/badge.svg" alt="codecov"></a>
     <a href="https://docs.rs/gigastt-core"><img src="https://docs.rs/gigastt-core/badge.svg" alt="docs.rs"></a>
-    <a href="https://github.com/ekhodzitsky/gigastt"><img src="https://img.shields.io/badge/MSRV-1.87-blue.svg" alt="MSRV 1.87"></a>
+    <a href="https://github.com/ekhodzitsky/gigastt"><img src="https://img.shields.io/badge/MSRV-1.88-blue.svg" alt="MSRV 1.88"></a>
     <a href="https://github.com/ekhodzitsky/gigastt/tree/benchmark-results-local"><img src="https://img.shields.io/badge/WER-11.37%25-blue" alt="WER"></a>
     <a href="https://github.com/ekhodzitsky/gigastt/tree/benchmark-results-local"><img src="https://img.shields.io/badge/RTF-0.335x-green" alt="RTF"></a>
     <a href="https://github.com/ekhodzitsky/gigastt/tree/benchmark-results-local"><img src="https://img.shields.io/badge/benchmark-9994%20samples-orange" alt="Benchmark"></a>
@@ -417,7 +417,7 @@ gigastt quantize --force
 | **GPU** | _(integrated, via CoreML)_ | NVIDIA + CUDA 12+ (optional) |
 | **Disk** | ~1.5 GB | ~1.5 GB |
 | **RAM** | ~560 MB | ~560 MB |
-| **Rust** | 1.87+ | 1.87+ |
+| **Rust** | 1.88+ | 1.88+ |
 
 ## Security
 

--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y \
     cmake \
     curl \
     git \
+    pkg-config \
+    libssl-dev \
     protobuf-compiler \
     python3.12 \
     python3.12-venv \
@@ -55,8 +57,7 @@ FROM base AS gigastt-builder
 
 COPY Cargo.toml Cargo.lock /workspace/
 COPY crates/ /workspace/crates/
-COPY proto/ /workspace/proto/
-RUN cargo build --release -p gigastt
+RUN cargo build --release -p gigastt --locked
 
 # =============================================================================
 # Final runtime image
@@ -69,6 +70,12 @@ COPY --from=gigastt-builder /workspace/target/release/gigastt /usr/local/bin/gig
 
 # Copy benchmark sources
 COPY benchmark/ /workspace/benchmark/
+
+# TODO: the bundled-fixtures fallback (common.py manifest_path()) does not work
+# in this image: crates/gigastt/tests/fixtures/ is not copied here, and
+# benchmark.py uses manifest "filename" entries verbatim, so bare names resolve
+# against the CWD. Mount the dataset at /root/.gigastt/benchmarks instead
+# (docker-compose.yml does).
 
 WORKDIR /workspace/benchmark
 

--- a/benchmark/docker-compose.yml
+++ b/benchmark/docker-compose.yml
@@ -5,6 +5,9 @@ services:
       dockerfile: benchmark/Dockerfile
     volumes:
       # Mount model caches so they persist across runs
+      # TODO: ':ro' breaks first-run auto-quantize — `gigastt serve` (spawned by
+      # runners/gigastt.py) writes encoder_int8.onnx into this directory. Run
+      # `gigastt quantize` on the host once, or set GIGASTT_SKIP_QUANTIZE=1.
       - ~/.gigastt/models:/root/.gigastt/models:ro
       - ~/.cache/whisper.cpp:/root/.cache/whisper.cpp
       - ~/.cache/vosk:/root/.cache/vosk

--- a/crates/gigastt/tests/e2e_ws.rs
+++ b/crates/gigastt/tests/e2e_ws.rs
@@ -636,10 +636,10 @@ async fn test_ws_max_session_precheck() {
         let next = tokio::time::timeout(remaining, stream.next()).await;
         match next {
             Ok(Some(Ok(Message::Text(text)))) => {
-                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
-                    if v["code"] == "max_session_duration_exceeded" {
-                        saw_cap_close = true;
-                    }
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text)
+                    && v["code"] == "max_session_duration_exceeded"
+                {
+                    saw_cap_close = true;
                 }
             }
             Ok(Some(Ok(Message::Close(Some(


### PR DESCRIPTION
## Что сломано и починено

Docker никогда не собирался в CI, и упаковка молча сгнила — шесть слоёв:

1. **Пины билдеров отстали от MSRV** (`rust:1.85` / rustup `1.85.0`). Теперь пин = MSRV, сборка образа заодно валидирует MSRV-claim на холодном реестре.
2. **Dummy-слой не создавал файлы объявленных `[[bench]]`/`[[test]]`-таргетов** — cargo отказывался парсить workspace ещё до MSRV-проверки.
3. **Реальная сборка линковалась с dummy-rlib'ами**: `COPY` сохраняет хостовые mtime, cargo считал пустышку `gigastt-core` свежей (`rm` не матчил `libgigastt_core-*.rlib` — префикс `lib`). Фикс — `touch` исходников перед финальной сборкой.
4. **Фантомный `COPY proto/`** в benchmark-образе (каталог живёт в `crates/gigastt-core/proto/` и уже покрыт `COPY crates/`).
5. **`openssl-sys` (через reqwest native-tls)** требует `pkg-config` + `libssl-dev` — добавлены в benchmark- и CUDA-билдеры.
6. **Базы слишком старые для prebuilt onnxruntime из ort**: статика собрана gcc≥13 и ссылается на `__cxa_call_terminate` (CXXABI_1.3.15), которого нет в libstdc++ bookworm (≤1.3.13, проверено) и ubuntu22.04. Базы: bookworm→trixie, CUDA ubuntu22.04→24.04.

Все cargo-вызовы в Dockerfile'ах теперь `--locked` — образ собирает аудированный lock-граф, а не свежий ресолв.

## MSRV 1.87 → 1.88 (требует внимания при ревью)

`ort`/`ort-sys` 2.0.0-rc.12 декларируют `rust-version = "1.88"` — холодная сборка на 1.87 падает даже с `--locked`. Зелёный msrv-джоб был артефактом тёплого cargo-кеша. Даунгрейд ort невозможен (на rc.12 завязан CoreML-фикс #42), поэтому бамп: `Cargo.toml`, msrv-джоб (@1.88 + предупреждение о кеш-маскировке), README-бейдж/таблица, CHANGELOG.

## CI

- `docker-changes` (dorny/paths-filter) → `docker-build` (CPU + smoke `--version`; на PR только при изменении docker-путей, на main push всегда) → `docker-build-extras` (CUDA + benchmark, только main push, с очисткой диска).
- **Кеш-реворк** (Actions cache был заполнен на 9.96/10 GB): docker-слои уехали в ghcr.io (`type=registry`, бесплатно для публичного репо, PR-ы читают через `GITHUB_TOKEN`, запись только с main); cargo-кеши мигрированы на `Swatinem/rust-cache` с `save-if: main` (семейства ci/msrv/fuzz/android/release). Ожидаемое устойчивое состояние ~4 GB. Старые записи умрут по 7-дневному TTL.

## Верификация

- Локально (macOS, Docker Desktop): `docker build -t gigastt .` проходит, `docker run --rm gigastt --version` → `gigastt 2.0.14`; benchmark-образ собирается целиком.
- `Dockerfile.cuda` структурно идентичен CPU; полная сборка подтвердится джобом `docker-build-extras` на первом main push.
- `actionlint` чистый по ci/android/soak.
- Rust-код не менялся; `cargo metadata` парсится, юнит-тесты не затронуты.

Второстепенные изъяны benchmark-контейнера задокументированы TODO-комментариями (fallback на bundled-фикстуры сломан ещё и логикой путей в `benchmark.py`; `:ro`-маунт моделей конфликтует с auto-quantize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)