### PR TITLE
Green CI: rustfmt + typos allowlist for the audit branch

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,6 +6,12 @@
 mis = "mis"
 # "unparseable" — accepted variant of "unparsable".
 unparseable = "unparseable"
+# "ANE" — Apple Neural Engine (CoreML hardware), used in benchmark/latency_note.md.
+ane = "ane"
+# "daa" — substring of the git short SHA `8daa9a9` referenced in latency notes.
+daa = "daa"
+# "eazy" — the artist "G-Eazy" appearing verbatim in an ASR hypothesis transcript.
+eazy = "eazy"
 
 [default.extend-identifiers]
 # "hel\0lo" — intentional test string with embedded NUL byte.

--- a/crates/gigastt-core/src/inference/audio.rs
+++ b/crates/gigastt-core/src/inference/audio.rs
@@ -999,7 +999,10 @@ mod tests {
         let silence: Vec<i16> = vec![0; 16]; // tiny payload — the header is the attack
         // Just above the ceiling: a well-formed header that the clamp must reject.
         let result = decode_audio_bytes(&make_wav_bytes(&silence, MAX_SAMPLE_RATE + 1));
-        assert!(result.is_err(), "sample_rate above MAX_SAMPLE_RATE must be rejected");
+        assert!(
+            result.is_err(),
+            "sample_rate above MAX_SAMPLE_RATE must be rejected"
+        );
         // A grossly inflated rate must also be rejected (not panic / not allocate).
         let result = decode_audio_bytes(&make_wav_bytes(&silence, 1_000_000_000));
         assert!(result.is_err(), "absurd sample_rate must be rejected");
@@ -1008,8 +1011,8 @@ mod tests {
 
 #[cfg(test)]
 mod proptests {
-    use super::*;
     use super::tests::make_wav_bytes;
+    use super::*;
     use proptest::prelude::*;
 
     proptest! {

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1322,9 +1322,7 @@ impl Engine {
         triplet: &mut SessionTriplet,
     ) -> Option<TranscriptSegment> {
         let has_pending = state.pending_samples > 0 && state.audio_buffer.len() >= N_FFT;
-        if has_pending
-            && let Err(e) = self.decode_window(state, triplet)
-        {
+        if has_pending && let Err(e) = self.decode_window(state, triplet) {
             tracing::warn!("finish_stream decode failed: {e:#}");
         }
         self.flush_state(state)

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -315,7 +315,11 @@ async fn stream_to_partial_then_finalize(
         .redirect(reqwest::redirect::Policy::limited(5))
         .build()
         .context("Failed to build HTTP client")?;
-    let response = client.get(url).send().await.context("HTTP request failed")?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .context("HTTP request failed")?;
     let status = response.status();
     if !status.is_success() {
         anyhow::bail!("Download failed for {label}: HTTP {status}");


### PR DESCRIPTION
Follow-up to #45. Two non-blocking CI checks were red after merge:
- **Format:** rustfmt wanted multi-line wrapping in 3 files touched by the audit (audio.rs, inference/mod.rs, model/mod.rs) — applied `cargo fmt`.
- **Typos:** crate-ci/typos flagged 3 legitimate tokens — `ANE` (Apple Neural Engine), `daa` (substring of git SHA `8daa9a9`), `eazy` (the artist *G-Eazy* in an ASR hypothesis) — allowlisted in `.typos.toml`.

Verified locally: `cargo fmt --check`, `cargo build`, `cargo clippy --workspace --all-targets`, and `typos` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)