### PR TITLE
chore(githooks): targeted tests + typos in pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,7 +7,14 @@ cargo fmt --all --check
 echo "[pre-commit] Running clippy..."
 cargo clippy --workspace -- -D warnings -A dead_code
 
-echo "[pre-commit] Running unit tests..."
-cargo test --workspace
+echo "[pre-commit] Running typos..."
+if command -v typos >/dev/null 2>&1; then
+  typos
+else
+  echo "  (typos not installed — skipping; 'brew install typos-cli' or 'cargo install typos-cli' to enable)"
+fi
+
+echo "[pre-commit] Running unit + bin tests (skips the ~2.5h WER benchmark pulled in by a bare 'cargo test --workspace')..."
+cargo test --workspace --lib --bins
 
 echo "[pre-commit] All checks passed."


### PR DESCRIPTION
Makes the pre-commit hook actually usable + catches what slipped past me in #45:
- `cargo test --workspace` → `cargo test --workspace --lib --bins` (a bare `--workspace` pulls in the ~2.5h WER benchmark, making commits impractical).
- Add a `typos` step (gracefully skipped if not installed).

Enable locally with `git config core.hooksPath .githooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)