### PR TITLE
feat(benchmark): modern-competitor runners + footprint axis (infra, no runs)

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -24,8 +24,11 @@ from common import (
 )
 from runners import (
     FasterWhisperRunner,
+    FasterWhisperTurboRunner,
     GigasttRunner,
+    TOneRunner,
     VoskRunner,
+    Vosk054Runner,
     WhisperCppRunner,
 )
 
@@ -152,7 +155,10 @@ def main():
         GigasttRunner(),
         WhisperCppRunner(),
         FasterWhisperRunner(),
+        FasterWhisperTurboRunner(),
         VoskRunner(),
+        Vosk054Runner(),
+        TOneRunner(),
     ]
 
     active_runners = []

--- a/benchmark/benchmark_footprint.py
+++ b/benchmark/benchmark_footprint.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Measure model footprint per engine: file size, peak RSS, and cold-start time.
+
+Footprint is one of gigastt's real advantages (INT8 ~225 MB vs Whisper ~3 GB,
+Vosk 1.3-1.8 GB). For each available runner this records:
+  - on-disk model size (best-effort, engine-specific),
+  - peak resident memory during the first transcription (cold start) and after a
+    couple more (steady state),
+  - cold-start wall time (runner ready -> first transcription done).
+
+Output: ``results_footprint.json``. Smoke-friendly: only a handful of samples are
+used. ``psutil`` is used when available; otherwise it falls back to ``resource``.
+"""
+
+import argparse
+import importlib
+import json
+import os
+import time
+from pathlib import Path
+
+import common
+
+
+def _peak_rss_mb(pid: int | None = None) -> float | None:
+    try:
+        import psutil
+
+        proc = psutil.Process(pid) if pid else psutil.Process()
+        return round(proc.memory_info().rss / (1024 * 1024), 1)
+    except Exception:
+        if pid is not None:
+            return None  # resource can only report this process, not a subprocess
+        try:
+            import resource
+
+            maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            # ru_maxrss is bytes on macOS, KiB on Linux.
+            scale = 1024 * 1024 if os.uname().sysname == "Darwin" else 1024
+            return round(maxrss / scale, 1)
+        except Exception:
+            return None
+
+
+def _model_size_mb(runner) -> float | None:
+    """Best-effort on-disk model size for a runner, if locatable."""
+    name = runner.name
+    home = Path.home()
+    if name.startswith("gigastt"):
+        enc = home / ".gigastt" / "models" / "v3_e2e_rnnt_encoder_int8.onnx"
+        if enc.exists():
+            return round(enc.stat().st_size / (1024 * 1024), 1)
+    if name.startswith("vosk"):
+        model_dir = getattr(runner, "download_dir", None)
+        model_name = getattr(runner, "model_name", None)
+        if model_dir and model_name:
+            d = Path(model_dir) / model_name
+            if d.exists():
+                total = sum(f.stat().st_size for f in d.rglob("*") if f.is_file())
+                return round(total / (1024 * 1024), 1)
+    return None
+
+
+def measure_runner(runner, samples: list[dict]) -> dict:
+    start = time.perf_counter()
+    runner.transcribe(samples[0]["filename"])  # cold start = model load + inference
+    cold_start_s = time.perf_counter() - start
+
+    sub = getattr(runner, "_proc", None)
+    pid = sub.pid if sub is not None else None
+    peak_cold = _peak_rss_mb(pid)
+
+    for s in samples[1:3]:
+        try:
+            runner.transcribe(s["filename"])
+        except Exception:
+            pass
+    peak_steady = _peak_rss_mb(pid)
+
+    return {
+        "name": runner.name,
+        "model_size_mb": _model_size_mb(runner),
+        "cold_start_sec": round(cold_start_s, 2),
+        "peak_rss_mb_cold": peak_cold,
+        "peak_rss_mb_steady": peak_steady,
+    }
+
+
+def _load_runner_classes() -> list:
+    candidates = [
+        "GigasttRunner",
+        "GigasttCoreMLRunner",
+        "FasterWhisperRunner",
+        "FasterWhisperTurboRunner",
+        "WhisperCppRunner",
+        "VoskRunner",
+        "Vosk054Runner",
+        "TOneRunner",
+    ]
+    classes = []
+    for name in candidates:
+        try:
+            classes.append(getattr(importlib.import_module("runners"), name))
+        except Exception as e:
+            print(f"[benchmark_footprint] Skipping {name}: {e}")
+    return classes
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Model footprint benchmark")
+    parser.add_argument("--dataset", default=os.environ.get("GIGASTT_BENCHMARK_DATASET", "golos_crowd"))
+    parser.add_argument("--max-samples", type=int, default=3, help="Samples for cold/steady measurement")
+    parser.add_argument("--output", default="results_footprint.json")
+    parser.add_argument("--runners", default="all", help="Comma-separated runner names")
+    args = parser.parse_args()
+
+    runner_classes = _load_runner_classes()
+    manifest_data = common.load_manifest(max_samples=args.max_samples, dataset=args.dataset)
+    samples = manifest_data["samples"]
+    if not samples:
+        print("No samples available; cannot measure footprint.")
+        return
+
+    all_runners = [cls() for cls in runner_classes]
+    requested = set(args.runners.split(",")) if args.runners != "all" else {"all"}
+    active = [r for r in all_runners if "all" in requested or r.name in requested]
+
+    results = []
+    for runner in active:
+        if not runner.is_available():
+            print(f"Skipping {runner.name} (not available)")
+            continue
+        print(f"\n=== {runner.name} ===")
+        try:
+            if hasattr(runner, "__exit__"):
+                with runner:
+                    results.append(measure_runner(runner, samples))
+            else:
+                results.append(measure_runner(runner, samples))
+        except Exception as e:
+            print(f"[{runner.name}] footprint measurement failed: {e}")
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump({"dataset": args.dataset, "runners": results}, f, ensure_ascii=False, indent=2)
+    print(f"\nResults written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/benchmark_hallucinations.py
+++ b/benchmark/benchmark_hallucinations.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Measure hallucination rate on non-speech audio (MUSAN)."""
+
+import argparse
+import json
+import os
+import subprocess
+import time
+import urllib.request
+import wave
+import zipfile
+from pathlib import Path
+
+import common
+
+
+MUSAN_URL = "http://www.openslr.org/resources/17/musan.tar.gz"
+
+
+def download_musan(cache_dir: Path) -> Path:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    archive = cache_dir / "musan.tar.gz"
+    if not archive.exists():
+        print(f"Downloading MUSAN from {MUSAN_URL} ...")
+        urllib.request.urlretrieve(MUSAN_URL, archive)
+    extracted = cache_dir / "musan"
+    if not extracted.exists():
+        print("Extracting MUSAN ...")
+        subprocess.run(["tar", "-xzf", str(archive), "-C", str(cache_dir)], check=True)
+    return extracted
+
+
+def collect_non_speech_clips(musan_dir: Path, max_clips: int = 100) -> list[Path]:
+    clips = []
+    for sub in ("noise", "music"):
+        path = musan_dir / sub
+        if path.exists():
+            clips.extend(sorted(path.rglob("*.wav")))
+    return clips[:max_clips]
+
+
+def count_words(text: str) -> int:
+    return len(text.split())
+
+
+def audio_duration(wav_path: Path) -> float:
+    with wave.open(str(wav_path), "rb") as w:
+        return w.getnframes() / w.getframerate()
+
+
+def evaluate_runner(runner, clips: list[Path]) -> dict:
+    total_words = 0
+    total_minutes = 0.0
+    for clip in clips:
+        try:
+            hyp, _ = runner.transcribe(str(clip))
+        except Exception as e:
+            print(f"[{runner.name}] error on {clip}: {e}")
+            hyp = ""
+        total_words += count_words(hyp)
+        total_minutes += audio_duration(clip) / 60.0
+    wpm = total_words / total_minutes if total_minutes > 0 else 0.0
+    return {
+        "name": runner.name,
+        "clips": len(clips),
+        "words_inserted": total_words,
+        "audio_minutes": round(total_minutes, 2),
+        "words_per_minute": round(wpm, 2),
+    }
+
+
+def _load_runner_classes() -> list:
+    """Load runner classes dynamically, skipping any not yet exported."""
+    import importlib
+
+    candidates = [
+        "GigasttRunner",
+        "FasterWhisperRunner",
+        "FasterWhisperTurboRunner",
+        "WhisperCppRunner",
+        "VoskRunner",
+        "Vosk054Runner",
+        "TOneRunner",
+    ]
+    classes = []
+    for name in candidates:
+        try:
+            cls = getattr(importlib.import_module("runners"), name)
+            classes.append(cls)
+        except Exception as e:
+            print(f"[benchmark_hallucinations] Skipping {name}: {e}")
+    return classes
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Hallucination benchmark on MUSAN non-speech")
+    parser.add_argument("--max-clips", type=int, default=20, help="Non-speech clips to use")
+    parser.add_argument("--cache-dir", default=str(Path.home() / ".cache" / "musan"))
+    parser.add_argument("--output", default="results_hallucinations.json")
+    parser.add_argument("--runners", default="all")
+    args = parser.parse_args()
+
+    runner_classes = _load_runner_classes()
+    musan_dir = download_musan(Path(args.cache_dir))
+    clips = collect_non_speech_clips(musan_dir, max_clips=args.max_clips)
+    print(f"Using {len(clips)} non-speech clips")
+
+    all_runners = [cls() for cls in runner_classes]
+
+    requested = set(args.runners.split(",")) if args.runners != "all" else {"all"}
+    active = [r for r in all_runners if "all" in requested or r.name in requested]
+
+    results = []
+    for runner in active:
+        if not runner.is_available():
+            print(f"Skipping {runner.name} (not available)")
+            continue
+        print(f"\n=== {runner.name} ===")
+        cm = getattr(runner, "__enter__", lambda: runner)
+        cm_exit = getattr(runner, "__exit__", None)
+        if cm_exit:
+            with runner:
+                results.append(evaluate_runner(runner, clips))
+        else:
+            results.append(evaluate_runner(runner, clips))
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump({"runners": results}, f, ensure_ascii=False, indent=2)
+    print(f"\nResults written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/benchmark_punctuation.py
+++ b/benchmark/benchmark_punctuation.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Measure punctuation and capitalization F1 on a dataset with original text."""
+
+import argparse
+import importlib
+import json
+import os
+from pathlib import Path
+
+import common
+
+
+PUNCTUATION_MARKS = set(".,!?;:\"'()[]{}«»—…")
+
+
+def extract_punctuation(text: str) -> list[tuple[int, str]]:
+    """Return (position, mark) for each punctuation char."""
+    return [(i, ch) for i, ch in enumerate(text) if ch in PUNCTUATION_MARKS]
+
+
+def extract_capitalization(text: str) -> list[tuple[int, str]]:
+    """Return (position, char) for each uppercase Cyrillic/Latin letter."""
+    return [(i, ch) for i, ch in enumerate(text) if ch.isupper() and ch.isalpha()]
+
+
+def f1_score(ref_items: list, hyp_items: list) -> dict:
+    ref_set = set(ref_items)
+    hyp_set = set(hyp_items)
+    tp = len(ref_set & hyp_set)
+    fp = len(hyp_set - ref_set)
+    fn = len(ref_set - hyp_set)
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+    return {
+        "precision": round(precision, 3),
+        "recall": round(recall, 3),
+        "f1": round(f1, 3),
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+    }
+
+
+def aggregate(items: list[dict]) -> dict:
+    tp = sum(i["tp"] for i in items)
+    fp = sum(i["fp"] for i in items)
+    fn = sum(i["fn"] for i in items)
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+    return {
+        "precision": round(precision, 3),
+        "recall": round(recall, 3),
+        "f1": round(f1, 3),
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+    }
+
+
+def evaluate_runner(runner, manifest: list[dict]) -> dict:
+    punct_results = []
+    cap_results = []
+    for sample in manifest:
+        ref = sample["reference"]
+        try:
+            hyp, _ = runner.transcribe(sample["filename"])
+        except Exception as e:
+            print(f"[{runner.name}] error on {sample['filename']}: {e}")
+            hyp = ""
+        punct_results.append(f1_score(extract_punctuation(ref), extract_punctuation(hyp)))
+        cap_results.append(f1_score(extract_capitalization(ref), extract_capitalization(hyp)))
+
+    return {
+        "name": runner.name,
+        "samples": len(manifest),
+        "punctuation": aggregate(punct_results),
+        "capitalization": aggregate(cap_results),
+    }
+
+
+def _load_runner_classes() -> list:
+    """Load runner classes dynamically, skipping any not yet exported."""
+    candidates = [
+        "GigasttRunner",
+        "FasterWhisperRunner",
+        "FasterWhisperTurboRunner",
+        "WhisperCppRunner",
+        "VoskRunner",
+        "Vosk054Runner",
+        "TOneRunner",
+    ]
+    classes = []
+    for name in candidates:
+        try:
+            cls = getattr(importlib.import_module("runners"), name)
+            classes.append(cls)
+        except Exception as e:
+            print(f"[benchmark_punctuation] Skipping {name}: {e}")
+    return classes
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Punctuation and capitalization benchmark")
+    default_dataset = os.environ.get("GIGASTT_BENCHMARK_DATASET", "golos_crowd")
+    parser.add_argument("--dataset", default=default_dataset, help="Dataset manifest name")
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=int(os.environ.get("GIGASTT_BENCHMARK_MAX_SAMPLES", "50")),
+        help="Maximum samples (smoke tests default 50)",
+    )
+    parser.add_argument("--output", default="results_punctuation.json")
+    parser.add_argument("--runners", default="all", help="Comma-separated runner names")
+    args = parser.parse_args()
+
+    runner_classes = _load_runner_classes()
+    manifest_data = common.load_manifest(
+        max_samples=args.max_samples if args.max_samples > 0 else None,
+        dataset=args.dataset,
+    )
+    manifest = manifest_data["samples"]
+    print(f"Loaded {len(manifest)} samples for punctuation benchmark")
+
+    all_runners = [cls() for cls in runner_classes]
+
+    requested = set(args.runners.split(",")) if args.runners != "all" else {"all"}
+    active = [r for r in all_runners if "all" in requested or r.name in requested]
+
+    results = []
+    for runner in active:
+        if not runner.is_available():
+            print(f"Skipping {runner.name} (not available)")
+            continue
+        print(f"\n=== {runner.name} ===")
+        cm = getattr(runner, "__enter__", lambda: runner)
+        cm_exit = getattr(runner, "__exit__", None)
+        if cm_exit:
+            with runner:
+                results.append(evaluate_runner(runner, manifest))
+        else:
+            results.append(evaluate_runner(runner, manifest))
+
+    output = {"dataset": args.dataset, "runners": results}
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(output, f, ensure_ascii=False, indent=2)
+    print(f"\nResults written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/runners/__init__.py
+++ b/benchmark/runners/__init__.py
@@ -1,8 +1,20 @@
 """ASR benchmark runners."""
 
-from .gigastt import GigasttRunner
+from .gigastt import GigasttRunner, GigasttCoreMLRunner
 from .whisper_cpp import WhisperCppRunner
 from .faster_whisper import FasterWhisperRunner
+from .faster_whisper_turbo import FasterWhisperTurboRunner
 from .vosk import VoskRunner
+from .vosk_054 import Vosk054Runner
+from .t_one import TOneRunner
 
-__all__ = ["GigasttRunner", "WhisperCppRunner", "FasterWhisperRunner", "VoskRunner"]
+__all__ = [
+    "GigasttRunner",
+    "GigasttCoreMLRunner",
+    "WhisperCppRunner",
+    "FasterWhisperRunner",
+    "FasterWhisperTurboRunner",
+    "VoskRunner",
+    "Vosk054Runner",
+    "TOneRunner",
+]

--- a/benchmark/runners/faster_whisper_turbo.py
+++ b/benchmark/runners/faster_whisper_turbo.py
@@ -1,0 +1,15 @@
+"""Runner for faster-whisper ``large-v3-turbo`` (faster distilled decoder).
+
+A thin specialization of ``FasterWhisperRunner`` with a fixed model size so the
+engine appears as a distinct, stably-named row in the results table instead of
+being toggled via an environment variable.
+"""
+
+from .faster_whisper import FasterWhisperRunner
+
+
+class FasterWhisperTurboRunner(FasterWhisperRunner):
+    name = "faster-whisper-turbo"
+
+    def __init__(self, device: str = "cpu", compute_type: str = "int8"):
+        super().__init__(model_size="large-v3-turbo", device=device, compute_type=compute_type)

--- a/benchmark/runners/gigastt.py
+++ b/benchmark/runners/gigastt.py
@@ -103,3 +103,46 @@ class GigasttRunner:
     def __exit__(self, exc_type, exc, tb):
         self._stop_server()
         return False
+
+
+class GigasttCoreMLRunner(GigasttRunner):
+    """gigastt built with ``--features coreml`` (macOS arm64 / Neural Engine).
+
+    Only available on Apple Silicon; elsewhere ``is_available()`` is ``False``.
+    Point it at a CoreML-built binary via ``BENCHMARK_GIGASTT_COREML_BINARY``;
+    otherwise it falls back to ``target/release/gigastt`` (which must itself be a
+    coreml build). Intended for the footprint / latency comparisons, not the
+    cross-WER table (the transcription is identical to ``gigastt``).
+    """
+
+    name = "gigastt-coreml"
+
+    def __init__(self, model_dir: str | None = None, port: int = 9878):
+        super().__init__(model_dir=model_dir, use_int8=True, port=port)
+
+    @staticmethod
+    def _is_apple_silicon() -> bool:
+        import platform
+
+        return platform.system() == "Darwin" and platform.machine() == "arm64"
+
+    def _find_binary(self) -> bool:
+        import os
+
+        if not self._is_apple_silicon():
+            return False
+        override = os.environ.get("BENCHMARK_GIGASTT_COREML_BINARY")
+        if override:
+            try:
+                subprocess.run([override, "--version"], capture_output=True, check=True)
+                self._binary = override
+                return True
+            except Exception:
+                return False
+        return super()._find_binary()
+
+    def is_available(self) -> bool:
+        if not self._is_apple_silicon():
+            print("[gigastt-coreml] Not available: requires macOS arm64")
+            return False
+        return super().is_available()

--- a/benchmark/runners/t_one.py
+++ b/benchmark/runners/t_one.py
@@ -1,0 +1,67 @@
+"""Runner for T-one (``voicekit-team/T-one``) — T-Bank's streaming CTC Conformer.
+
+T-one is Apache-2.0 (code *and* weights) and purpose-built for Russian telephony /
+call-center streaming — exactly the niche gigastt targets, which is why it belongs
+in the comparison. This runner loads it via ``transformers`` + ``torch`` as a
+Wav2Vec2-style CTC model.
+
+Best-effort by design: the exact processor / model classes and HF repo id should be
+confirmed against the T-one model card before a full run (override the repo with
+``BENCHMARK_TONE_MODEL``). Until ``torch`` + ``transformers`` + the weights are
+present, ``is_available()`` returns ``False`` and the suite skips T-one. All heavy
+imports are lazy so importing this module never fails.
+"""
+
+import os
+import time
+import wave
+
+
+class TOneRunner:
+    name = "t-one"
+
+    def __init__(self, model_id: str | None = None, device: str = "cpu"):
+        self.model_id = model_id or os.environ.get("BENCHMARK_TONE_MODEL", "voicekit-team/T-one")
+        self.device = device
+        self._model = None
+        self._processor = None
+
+    def is_available(self) -> bool:
+        try:
+            import torch  # noqa: F401
+            import transformers  # noqa: F401
+            return True
+        except Exception as e:
+            print(f"[t-one] Not available: {e}")
+            return False
+
+    def _load(self):
+        if self._model is None:
+            from transformers import AutoModelForCTC, AutoProcessor
+            print(f"[t-one] Loading {self.model_id} ...")
+            self._processor = AutoProcessor.from_pretrained(self.model_id)
+            self._model = AutoModelForCTC.from_pretrained(self.model_id).to(self.device).eval()
+        return self._model, self._processor
+
+    def _read_wav_16k_mono(self, wav_path: str):
+        import numpy as np
+
+        with wave.open(wav_path, "rb") as wf:
+            if wf.getnchannels() != 1 or wf.getsampwidth() != 2 or wf.getframerate() != 16000:
+                raise ValueError("T-one runner expects 16kHz mono 16-bit WAV")
+            frames = wf.readframes(wf.getnframes())
+        return np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+
+    def transcribe(self, wav_path: str) -> tuple[str, float]:
+        import torch
+
+        model, processor = self._load()
+        audio = self._read_wav_16k_mono(wav_path)
+        start = time.perf_counter()
+        inputs = processor(audio, sampling_rate=16000, return_tensors="pt")
+        with torch.no_grad():
+            logits = model(inputs.input_values.to(self.device)).logits
+        pred_ids = torch.argmax(logits, dim=-1)
+        text = processor.batch_decode(pred_ids)[0]
+        elapsed = time.perf_counter() - start
+        return text.strip().lower(), elapsed

--- a/benchmark/runners/vosk_054.py
+++ b/benchmark/runners/vosk_054.py
@@ -1,0 +1,21 @@
+"""Runner for Vosk 0.54 (Zipformer2) — a newer Russian model alongside 0.42.
+
+Reuses ``VoskRunner``'s alphacephei ZIP download + ``KaldiRecognizer`` path; only
+the default model name differs, so both Vosk versions show up side-by-side in the
+results table. The exact model id should be confirmed against
+https://alphacephei.com/vosk/models (override with ``BENCHMARK_VOSK054_MODEL``)
+before a full run.
+"""
+
+import os
+
+from .vosk import VoskRunner
+
+
+class Vosk054Runner(VoskRunner):
+    name = "vosk-0.54"
+
+    def __init__(self, model_name: str | None = None, download_dir: str | None = None):
+        if model_name is None:
+            model_name = os.environ.get("BENCHMARK_VOSK054_MODEL", "vosk-model-ru-0.54")
+        super().__init__(model_name=model_name, download_dir=download_dir)


### PR DESCRIPTION
Implements **Part A + B.4/B.5** of the approved design (`docs/superpowers/specs/2026-06-13-benchmark-modern-competitors-design.md`). Infrastructure only — no full benchmark runs.

**New runners** (thin specializations of existing ones):
- `runners/vosk_054.py` — Vosk 0.54 Zipformer2 (alongside the 0.42 default)
- `runners/faster_whisper_turbo.py` — large-v3-turbo
- `runners/t_one.py` — T-Bank **T-one** CTC (Apache-2.0), the purpose-built RU telephony competitor. Best-effort via torch+transformers; `is_available()` degrades gracefully.
- `runners/gigastt.py` → `GigasttCoreMLRunner` (macOS arm64) for footprint/latency.

**New axis:** `benchmark_footprint.py` (model size + peak RSS + cold-start).

**Wiring:** registered in `benchmark.py`; the punctuation/hallucination scripts (already referencing Vosk054/Turbo) now also pick up T-one.

All heavy deps (torch/transformers/numpy/psutil) are **lazy-imported** so `import runners` always succeeds and unavailable engines skip cleanly. Verified: py_compile, `import runners`, instantiate all 8, graceful `is_available()`; the Rust pre-commit hook (fmt/clippy/typos/unit-tests) passed.

⚠️ **Before a real run:** confirm T-one's exact HF/processor API and the `vosk-model-ru-0.54` id against their model cards. Numbers require a separately-agreed full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)