### PR TITLE
docs(strategy): benchmark narrative + positioning + hosted-demo/WASM drafts

### DIFF
--- a/docs/benchmark_narrative_draft.md
+++ b/docs/benchmark_narrative_draft.md
@@ -1,70 +1,148 @@
-# Draft: gigastt Performance Narrative (fix/benchmark-methodology)
+# Benchmark Narrative — DRAFT (for review; NOT yet in README)
 
-> This draft is written before the full 4×4 cross-domain benchmark finishes.
-> It will be finalized once `benchmark/run_full_suite.sh` completes and the
-> actual WER/RTF numbers are inserted into README.md / README_RU.md.
+**Status:** draft · **Date:** 2026-06-13 · Part D of the benchmark-expansion design.
 
-## Headline options
+This is the review stop-point before any README/README_RU change. Numbers for the
+**existing four engines** come from the committed 1000-sample renormalized matrix
+(`benchmark/results_full/renorm_summary.md` for WER + 95% CI;
+`benchmark/results_full/detailed_analysis.md` for per-domain RTF). Numbers marked
+**`pending`** require a full run of the newly-added runners (Vosk 0.54,
+faster-whisper-turbo, T-one) and of the new axes (punctuation, hallucinations,
+footprint) — see "What's still pending" at the end.
 
-**Option A — if data confirm gigastt leads on spontaneous/far-field:**
-> On-device Russian speech recognition with the best local WER on
-> spontaneous and far-field speech.
+All measurements were taken on an Apple **M1**, CPU execution provider, INT8 where
+applicable. WER is computed with failures counted as 100% WER and ITN
+renormalization applied; 95% bootstrap CIs (1000 iterations).
 
-**Option B — if data show mixed leadership:**
-> Rust-native, real-time Russian speech recognition with sub-200 ms latency,
-> hardware acceleration, and a 6× smaller model footprint than Whisper/Vosk.
+---
 
-## Key claims to support with numbers
+## 1. Accuracy by domain (WER %, 95% CI)
 
-1. **No single engine wins every domain.** Vosk’s 1.3 GB Kaldi model with a
-   strong LM dominates clean read speech (Golos crowd). gigastt’s 230 MB
-   GigaAM v3 is competitive there and leads on far-field commands.
-2. **gigastt is the strongest local option for streaming/far-field use-cases**
-   because it is the only Rust-native engine with real-time WebSocket,
-   CoreML/CUDA/NNAPI acceleration, and INT8 quantization.
-3. **Whisper-based engines catch up on spontaneous/noisy domains** but are
-   3–4× slower and 12× larger than gigastt.
+Domains: **Clean read** = `golos_crowd_1k` · **Far-field** = `golos_farfield` ·
+**Phone** = `openstt_calls` · **YouTube** = `openstt_youtube`.
 
-## Proposed README Performance section
+| Engine | Model | Clean read | Far-field | Phone calls | YouTube |
+|---|---|---|---|---|---|
+| **gigastt** | GigaAM v3 (INT8) | 8.60 (7.51–9.66) | **5.90 (5.09–6.83)** | **19.28 (17.88–20.67)** | **11.35 (10.32–12.31)** |
+| Vosk 0.42 | vosk-model-ru-0.42 | **4.82 (4.03–5.60)** | 13.93 (12.49–15.47) | 38.57 (36.72–40.64) | 20.65 (19.38–21.98) |
+| whisper.cpp | Large v3 | 15.26 (13.74–16.71) | 17.91 (16.29–19.57) | 32.73 (30.69–34.91) | 22.61 (20.97–24.20) |
+| faster-whisper | Large v3 (INT8) | 15.53 (13.94–17.10) | 17.34 (15.62–19.07) | 24.93 (23.32–26.57) | 15.45 (14.15–16.62) |
+| Vosk 0.54 | vosk-model-ru-0.54 | `pending` | `pending` | `pending` | `pending` |
+| faster-whisper-turbo | Large v3 turbo | `pending` | `pending` | `pending` | `pending` |
+| T-one | voicekit-team/T-one | `pending` | `pending` | `pending` | `pending` |
 
-```markdown
-## Performance
+**Reading of the existing four:** gigastt leads on **3 of 4** domains — far-field,
+phone, and YouTube — by a wide margin (far-field 5.90 vs Vosk's 13.93; phone 19.28
+vs 38.57; YouTube 11.35 vs 20.65). **Vosk 0.42 wins clean read** (4.82 vs 8.60) and
+this should be stated plainly. The Whisper engines trail on every domain here.
 
-| Metric | Value |
-|---|---|
-| **WER (Russian, clean read)** | TBD% (1 000 Golos crowd samples, TBD words, 95% CI) |
-| **WER (Russian, far-field)** | TBD% (1 000 Golos farfield samples, TBD words, 95% CI) |
-| **WER (Russian, phone calls)** | TBD% (1 000 OpenSTT calls samples, TBD words, 95% CI) |
-| **WER (Russian, YouTube)** | TBD% (1 000 OpenSTT YouTube samples, TBD words, 95% CI) |
-| **INT8 vs FP32** | 0% WER degradation (verified on Golos crowd) |
-| **Latency (16s audio, M1)** | ~700 ms |
-| **Memory (RSS)** | ~560 MB |
-| **Model size** | 851 MB (FP32) / 222 MB (INT8) |
+> Open question the new runners answer: **Vosk 0.54** (Zipformer2) is the real
+> modern Vosk and is reported ≈6% on Common Voice ru — it may narrow or change the
+> clean-read story. **T-one** is purpose-built for telephony and is the engine most
+> likely to contest gigastt's phone-call lead. Both are why this table must be
+> re-run before any "we lead" claim.
 
-### Cross-ASR by domain (1 000-sample slices, CPU)
+---
 
-| Engine | Clean read | Far-field | Phone calls | YouTube | RTF | Size |
-|---|---|---|---|---|---|---|
-| Vosk | TBD% | TBD% | TBD% | TBD% | TBDx | 1.3 GB |
-| gigastt | TBD% | TBD% | TBD% | TBD% | TBDx | 230 MB |
-| whisper.cpp | TBD% | TBD% | TBD% | TBD% | TBDx | ~3 GB |
-| faster-whisper | TBD% | TBD% | TBD% | TBD% | TBDx | ~3 GB |
+## 2. Speed (RTF, lower = faster; M1 CPU)
 
-> **Take-away:** Vosk remains the accuracy king on clean studio speech, but
-> gigastt is the best balance of accuracy, speed, size, and streaming
-> capability for real-world Russian ASR.
-```
+RTF = processing time / audio duration, per domain.
 
-## Methodology summary to keep
+| Engine | Clean read | Far-field | Phone calls | YouTube |
+|---|---|---|---|---|
+| Vosk 0.42 | **0.035** | **0.029** | **0.029** | **0.029** |
+| gigastt | 0.157 | 0.164 | 0.212 | 0.158 |
+| whisper.cpp | 0.357 | 0.556 | 0.624 | 0.765 |
+| faster-whisper | 1.187 | 1.604 | 2.312 | 1.879 |
+| Vosk 0.54 / turbo / T-one | `pending` | `pending` | `pending` | `pending` |
 
-- Pre-warmed engines for RTF.
-- Failures counted as 100% WER.
-- Bootstrap 95% CI.
-- Decode params documented.
-- Dataset licenses: Sber Public License (Golos), CC BY-NC 4.0 (OpenSTT).
+**Reading:** Vosk is the fastest by far (~0.03) but pays in accuracy on hard audio.
+gigastt is the fastest *accurate* engine (~0.16–0.21, comfortably real-time on CPU).
+faster-whisper is **slower than real-time** on CPU (>1.0 RTF) across all domains.
 
-## Next step
+---
 
-After `run_full_suite.sh` finishes, replace all `TBD` placeholders above,
-update README.md / README_RU.md, and choose headline Option A or B based on
-which claim the data actually support.
+## 3. Streaming latency (true incremental streaming)
+
+Only gigastt exposes genuine token-by-token WebSocket streaming. Measured on
+`golos_00.wav` (4.0 s), audio fed in real time, timer from connection.
+
+| Engine | TTFP (time-to-first-partial) | Finalization lag | Streaming? |
+|---|---|---|---|
+| gigastt (CPU) | ~782 ms | ~3449 ms | yes (`/v1/ws`) |
+| gigastt (CoreML) | ~693 ms | ~4041 ms | yes |
+| whisper.cpp | — | — | no true streaming (chunked offline) |
+| faster-whisper | — | — | no true streaming |
+| Vosk (server) | `pending` | `pending` | yes (vosk-server) |
+
+**Honest framing (do NOT revert to "sub-200ms"):** gigastt's TTFP is **~0.7–0.8 s**,
+not sub-200ms. The decode is a sliding-window re-decode over an offline RNN-T, so
+"streaming" means *buffered/chunked over an offline model*, not a natively streaming
+acoustic model. The architectural win to claim is *"true incremental partials from a
+single embedded binary"* vs Whisper's no-streaming — not a latency number gigastt
+doesn't hit. Vosk-server and T-one (300 ms chunks) are genuine streaming designs and
+must be measured before any latency-leadership claim.
+
+---
+
+## 4. Footprint
+
+| Engine | Model on disk | Peak RSS (cold) | Cold-start |
+|---|---|---|---|
+| gigastt | **225 MB** (INT8; 851 MB FP32) | `pending` | `pending` |
+| Vosk 0.42 | ~1.3 GB | `pending` | `pending` |
+| faster-whisper | Large v3 ≈1.5 GB (INT8) | `pending` | `pending` |
+| whisper.cpp | Large v3 ≈3 GB | `pending` | `pending` |
+| T-one | `pending` | `pending` | `pending` |
+
+`benchmark_footprint.py` fills peak RSS + cold-start. The on-disk number is gigastt's
+strongest single stat: **~6× smaller than Vosk, ~13× smaller than whisper.cpp**, which
+is what makes it embeddable.
+
+---
+
+## 5. New axes (structure only — `pending` numbers)
+
+- **Punctuation / capitalization F1** (`benchmark_punctuation.py`, Common Voice ru):
+  measures whether an engine restores `.,!?` and capitalization. ⚠️ Caveat to verify:
+  GigaAM v3 e2e_rnnt likely emits **lowercase, unpunctuated** text — so gigastt may
+  score *low* here, same as Vosk. Report honestly; this is a column where the Whisper
+  engines probably win. Do not spin it.
+- **Hallucinations on non-speech** (`benchmark_hallucinations.py`, MUSAN noise/music):
+  inserted words per minute on audio with no speech. Whisper models are known to
+  hallucinate on silence; this is a plausible gigastt/Vosk advantage. `pending`.
+
+---
+
+## 6. Two positioning theses (pick after the full re-run)
+
+**Thesis A — "Best local accuracy on *hard* Russian speech" (data currently supports this).**
+On the committed matrix gigastt already leads far-field, phone, and YouTube at ~6×
+smaller footprint and real-time CPU speed. Frame: *the smallest engine that wins on
+the speech that actually matters in production — far-field commands, noisy phone
+calls, spontaneous video — conceding only clean studio read-speech to Vosk.* Risk:
+T-one may take telephony; Vosk 0.54 may shift the picture. Only claim after the re-run.
+
+**Thesis B — "Streaming + footprint + Rust-native embeddability" (robust regardless of WER).**
+Frame on the axes that don't depend on winning WER: true incremental streaming (vs
+Whisper's none), ~225 MB single static binary, C-ABI FFI for Android/mobile, hardened
+server (rate-limit / origin allowlist / graceful drain), MIT-clean code *and* weights.
+This is the defensible niche from the competitive analysis and survives even if a
+competitor wins a WER column.
+
+**Recommendation:** lead with **B** (it's true today and unbreakable), and add the
+specific A claims *per domain* once the re-run confirms them against Vosk 0.54 + T-one.
+
+---
+
+## What's still pending (blocks publishing to README)
+
+1. Full run of **Vosk 0.54**, **faster-whisper-turbo**, **T-one** on all 4 domains
+   (WER + RTF). Requires: confirm `vosk-model-ru-0.54` id on alphacephei; `pip install
+   torch transformers` + confirm T-one's exact HF/processor API; ~GBs of downloads;
+   a several-hour run → **needs an agreed time window**.
+2. `benchmark_footprint.py` + `benchmark_punctuation.py` + `benchmark_hallucinations.py`
+   actual numbers (smoke first, ≤50 samples).
+3. Vosk-server streaming latency for a fair streaming comparison.
+4. Only then: update the README cross-domain table + write the final, single
+   positioning paragraph.

--- a/docs/hosted-demo-wasm-design.md
+++ b/docs/hosted-demo-wasm-design.md
@@ -1,0 +1,177 @@
+# Zero-Friction Trial: Hosted Demo vs In-Browser WASM
+
+**Status:** DRAFT for human review
+**Date:** 2026-06-13
+**Scope:** Design only. Nothing here changes README, README_RU, or any code. This document evaluates two paths for closing the "no zero-friction trial" gap and recommends one to pursue first.
+
+---
+
+## Problem statement
+
+Today every way to try gigastt requires downloading the ~850 MB model (~225 MB INT8 encoder + decoder + joiner) and building or running the server locally. There is no hosted demo and no in-browser path. An evaluator who wants to answer one question — *"how good is this at Russian speech?"* — cannot, without a multi-step local install. For a pre-traction, solo-maintained project, that friction is the difference between a casual GitHub visitor becoming a user and bouncing.
+
+The audit's recommendation: stand up a **hosted mic → transcript demo** so anyone can speak Russian into their browser and watch the transcript appear, with no install. WASM (run the model entirely client-side) is raised as an alternative worth assessing honestly.
+
+This doc designs both and picks one.
+
+---
+
+## Option 1 — Hosted mic → transcript demo
+
+A static web page captures microphone audio in the browser, downsamples it to 16 kHz PCM16, and streams it over the **existing** gigastt WebSocket endpoint (`/v1/ws`) to a hosted instance of the server. Partial and final transcripts stream back and render live. The server is unchanged — this is purely a deployment + thin frontend exercise.
+
+### Why this is low-effort
+
+The server already does the hard part. From `crates/gigastt-core/src/protocol/mod.rs` and `crates/gigastt/src/server/ws.rs`:
+
+- **WebSocket streaming exists** at `/v1/ws`. The client sends raw PCM16 binary frames; the server emits `Ready`, `Partial`, and `Final` JSON messages (`ServerMessage` enum). `PROTOCOL_VERSION = "1.0"`.
+- **Sample-rate negotiation exists.** A `Configure { sample_rate }` message (must precede the first audio frame) accepts 8/16/24/44.1/48 kHz; the server resamples to 16 kHz internally via rubato. The browser can capture at 48 kHz and let the server resample, or downsample client-side to 16 kHz to cut bandwidth ~3×.
+- **Abuse controls exist.** Per-IP token-bucket rate limiting (`--rate-limit-per-minute`, `--rate-limit-burst`), a wall-clock session cap (`--max-session-secs`, default 3600 — for a demo, set this *low*, e.g. 30–60 s), idle timeout (`--idle-timeout-secs`), pool-saturation backpressure (WS error carries `retry_after_ms`), and an origin allowlist (`--allow-origin`).
+- **Metrics exist** (`--metrics` → Prometheus `/metrics`) for watching abuse/load.
+
+So Option 1 is roughly: **(a)** a ~150-line static HTML/JS page, **(b)** a container deployment of the binary that already exists (the project already ships `Dockerfile`), **(c)** correct flags.
+
+### Architecture
+
+```
+Browser (static page, any CDN/host)
+  navigator.mediaDevices.getUserMedia({ audio })
+    -> AudioContext / AudioWorklet
+       -> Float32 @ 48 kHz  --(downsample)-->  Int16 PCM @ 16 kHz
+  WebSocket  wss://demo.<host>/v1/ws
+    1. send  {"type":"configure","sample_rate":16000}
+    2. send  <binary PCM16 frames, ~100-250 ms each>
+    <- {"type":"ready", ...}
+    <- {"type":"partial", "text": "..."}   (interim, may change)
+    <- {"type":"final",   "text": "..."}   (utterance complete)
+  Render partial in grey, promote to black on final.
+
+Hosted gigastt server (the existing binary, in a container)
+  gigastt serve --bind-all \
+    --allow-origin https://demo.<host> \
+    --rate-limit-per-minute 20 --rate-limit-burst 5 \
+    --max-session-secs 45 \
+    --metrics
+```
+
+**Frontend specifics**
+- Use `getUserMedia` + an `AudioWorkletNode` (preferred over the deprecated `ScriptProcessorNode`) to pull Float32 PCM. Linear-resample 48 kHz → 16 kHz (or request a 16 kHz context where supported) and convert to little-endian Int16 (`sample * 0x7FFF`, clamped). Send each ~100–250 ms chunk as a binary WS frame.
+- The server carries trailing odd PCM16 bytes across frames (V1-25), so chunk sizes don't need to be even — but keeping them even avoids the edge case entirely.
+- TLS is required: browsers only grant mic access on secure contexts (`https://` / `wss://`), and most hosts terminate TLS for you.
+
+**Backend specifics — required flags**
+- `--bind-all` (or `GIGASTT_ALLOW_BIND_ANY=1`): the server binds loopback-only by default; a hosted instance must listen on `0.0.0.0`. (The provided `Dockerfile` already passes `--bind-all`.)
+- `--allow-origin https://demo.<host>`: lock cross-origin WS upgrades to the demo page's origin. Do **not** use `--cors-allow-any` in production-facing demo.
+- `--rate-limit-per-minute` + `--rate-limit-burst`: cap connections per IP. `/health` is exempt.
+- `--max-session-secs 30..60`: critical. The default 3600 is wrong for a public demo — a single silent socket could pin a pool slot for an hour. A short cap closes idle/abusive sockets fast.
+- `--metrics`: enable so you can watch `gigastt_http_requests_total` and spot abuse.
+- Consider lowering `--pool-size` to match the host's CPU; each concurrent stream needs a pooled session triplet.
+
+### Hosting recommendation
+
+Constraints: solo dev, pre-traction, wants cheap/free, model is 225 MB INT8 (fits typical free-tier disk), needs a long-lived process that holds a WebSocket (rules out pure serverless/edge-function platforms that don't support stateful WS well), CPU-only inference is fine for a demo.
+
+| Option | Free/cheap tier | WS support | Disk for 225 MB model | Cold start | Notes |
+|---|---|---|---|---|---|
+| **Hugging Face Spaces (Docker SDK)** | Free CPU tier | Yes (full HTTP server) | Yes | Sleeps when idle; wakes on hit (seconds) | **Recommended.** Audience-fit: HF is where Russian-ASR evaluators already are; the GigaAM model itself lives on HF. Docker Spaces run an arbitrary container — drop the existing `Dockerfile`. Free, no credit card. Idle-sleep is fine for a demo (label "first request wakes the box"). |
+| **Fly.io** | Small always-on/scale-to-zero VM, low cost | Yes | Yes (volume) | scale-to-zero wake ~seconds | Strong #2. Real VM, full control, global anycast. Not strictly free but cheap; `fly.toml` + the existing Dockerfile. Good if HF Spaces' sleep behavior or CPU is too constrained. |
+| **Render** | Free web service (sleeps after inactivity) | Yes | Yes | Wake from sleep can be slow (tens of seconds) on free tier | Workable; free tier sleep/wake is the roughest of the three. |
+| **Small VPS** (Hetzner/Fly machine/etc.) | ~€4/mo | Yes | Yes | None (always on) | Most control, no cold start, but you own ops/TLS/patching. Overkill pre-traction. |
+
+**Recommendation: Hugging Face Spaces (Docker SDK) first.** Rationale: zero cost, no card, reuses the existing `Dockerfile` almost verbatim, and — uniquely — it places the demo in front of exactly the audience evaluating Russian ASR models (HF model hub). The model can be baked into the image (the repo already supports `GIGASTT_BAKE_MODEL=1`, ~1.1 GB image) to avoid a cold download, or pulled on boot. Fly.io is the fallback if Spaces' free CPU/idle-sleep proves too limiting under real traffic.
+
+**Cold-start note.** On INT8 + CoreML the encoder is fast, but hosted demos run **CPU-only** (no Neural Engine, no CUDA on free tiers). First inference also pays the one-time INT8 quantization unless the image ships a pre-quantized encoder — bake it (`gigastt quantize` at build time, or `GIGASTT_BAKE_MODEL=1`) so the container starts warm. The server already exposes `Engine::warmup()` and calls it before serving, so steady-state latency is fine; the concern is only the first cold boot after idle-sleep. Label it.
+
+### Privacy framing (non-negotiable)
+
+gigastt's entire pitch is **on-device, no cloud, no API keys, full privacy.** A hosted demo *inverts* that — audio leaves the user's machine and is transcribed on a server you operate. This must be stated plainly on the page and in any link to it, or it actively undermines the project's core message. Suggested copy:
+
+> ⚠️ **This hosted demo is the one exception to gigastt's on-device promise.** Your microphone audio is streamed to a public server to show transcription quality without an install. It is processed in memory and not stored. For real use, run gigastt locally — your audio never leaves your machine.
+
+Operationally back that up: the server holds audio only in memory (no transcript/audio persistence exists in the codebase — keep it that way), and the short `--max-session-secs` cap limits exposure.
+
+### Abuse controls (summary)
+
+Already in the binary, just enable them: per-IP rate limit, short max-session cap, idle timeout, pool backpressure (503 + `Retry-After` on REST, `retry_after_ms` on WS), origin allowlist. Additionally: put the host's own edge/CDN rate limiting in front if available, and keep `--metrics` on to watch for abuse. A demo doesn't need auth, but a per-IP daily cap (host-level) is worth adding if it gets popular.
+
+### Concrete next steps (Option 1)
+
+1. Write the static page (`getUserMedia` + AudioWorklet → 16 kHz PCM16 → WS, render partial/final). ~1 day.
+2. Add a Spaces-friendly container entrypoint with the demo flags above (the existing `Dockerfile` is 90% there; main change is the flag set and a short `--max-session-secs`). ~0.5 day.
+3. Bake the pre-quantized model into the image to kill cold-start (`GIGASTT_BAKE_MODEL=1`). ~0.5 day.
+4. Deploy to HF Spaces (Docker SDK), set the page origin in `--allow-origin`, smoke-test mic → transcript end-to-end on Chrome + Safari. ~0.5 day.
+5. Add the privacy banner and a prominent "this is a cloud demo; run locally for privacy" note. ~trivial.
+
+**Total: ~2–3 focused days.** No server code changes required.
+
+---
+
+## Option 2 — In-browser WASM (no server)
+
+Run the whole pipeline (mel features → Conformer encoder → RNN-T decode loop) client-side via WebAssembly, so there is no server at all and the on-device/no-cloud promise is preserved even in the demo.
+
+Two sub-paths exist, and they are very different in feasibility:
+
+### Path A — compile the `ort` Rust crate to WASM and reuse `gigastt-core`
+
+**Verdict: not viable today as a drop-in.** Findings:
+
+- `ort` (pyke) is a **wrapper around Microsoft's ONNX Runtime C/C++ library** ([pykeio/ort](https://github.com/pykeio/ort)). gigastt pins `ort` `2.0.0-rc.12`, which wraps ONNX Runtime 1.26 ([crates.io/ort](https://crates.io/crates/ort), [docs.rs/ort](https://docs.rs/ort)). To run in a browser, ONNX Runtime itself must be compiled to WASM (via Emscripten) — you cannot link the native desktop library.
+- The project's stated air-gapped/offline build path uses `ort`'s `load-dynamic` feature. **`load-dynamic` cannot work in WASM**: it `dlopen`s the shared library at runtime, and the browser sandbox has no `dlopen`/`LoadLibrary` equivalent ([pykeio/ort DeepWiki — Installation & Setup](https://deepwiki.com/pykeio/ort/2.1-installation-and-setup)).
+- `ort`'s actual WASM story is its **`alternative-backend`** feature + `ort::set_api()`, which disables linking the native library and wires in a backend exposing `OrtGetApiBase` ([pykeio/ort DeepWiki](https://deepwiki.com/pykeio/ort/2.1-installation-and-setup)). This is an advanced, sparsely-documented path. `wasm32-unknown-unknown` "does not (easily) support interop with C/C++ code," so the realistic target is `wasm32-unknown-emscripten` ([rustc book — wasm32-unknown-emscripten](https://doc.rust-lang.org/beta/rustc/platform-support/wasm32-unknown-emscripten.html)). The only WASM usage visible in `ort`'s ecosystem is one third-party OCR project (retto) — not the streaming-ASR shape gigastt needs, and not a documented, supported recipe.
+- Even if it linked, `gigastt-core`'s WASM build would inherit its whole native dependency tree (symphonia, rubato, threading model, file I/O in `model/mod.rs`), much of which assumes a native environment. This is a port, not a recompile.
+
+**Effort/risk for Path A:** high effort, high risk, poorly-trodden. Not appropriate pre-traction.
+
+### Path B — ONNX Runtime Web (JS/WASM) + reimplement the decode loop in JS
+
+This is the *realistic* WASM path, and it is the one whisper.cpp's demo and transformers.js actually use — neither runs a Rust crate; both run ONNX Runtime compiled to WASM and drive it from JS.
+
+- **ONNX Runtime Web** compiles the native CPU engine to WASM via Emscripten, with SIMD + multi-threaded backends and a WebGPU EP (since ORT 1.7) for GPU acceleration ([onnxruntime.ai — Build for web](https://onnxruntime.ai/docs/build/web.html), [Using WebGPU](https://onnxruntime.ai/docs/tutorials/web/ep-webgpu.html)). Non-SIMD / non-threaded builds are being dropped since v1.19 — **SIMD + threads are the assumed baseline** ([onnxruntime-web npm](https://www.npmjs.com/package/onnxruntime-web)).
+- **transformers.js** runs Whisper entirely in-browser on top of ONNX Runtime Web, with a WebGPU path and a WASM fallback, streaming from the mic via `MediaRecorder` + chunking ([HF — Transformers.js](https://huggingface.co/docs/transformers.js/index), [xenova/whisper-web](https://github.com/xenova/whisper-web), [blog.rasc.ch](https://blog.rasc.ch/2025/01/transformers-js-speech.html)). This proves the *pattern* — but transformers.js ships a pipeline for Whisper's architecture; it would **not** decode GigaAM's RNN-T out of the box.
+- **whisper.cpp WASM** ([ggml.ai/whisper.cpp](https://ggml.ai/whisper.cpp/), [whisper.cpp/examples/whisper.wasm](https://github.com/ggml-org/whisper.cpp/tree/master/examples/whisper.wasm)) documents the real-world constraints, which apply equally to gigastt-in-WASM:
+
+What Path B would require gigastt to build:
+1. **A JS/TS reimplementation of `gigastt-core`'s non-ONNX logic** — the 64-bin/FFT=320/hop=160 HTK mel front-end (`features.rs`), the BPE tokenizer (`tokenizer.rs`, 1025 tokens), and the **RNN-T greedy decode loop** (`decode.rs`) that threads decoder+joiner state. ORT Web only runs the three ONNX graphs; the loop that calls encoder → decoder → joiner and manages blank/state is gigastt's own code and must be rewritten in JS. This is the bulk of the work and the main risk.
+2. **The three ONNX models served to the browser.** Encoder INT8 is ~225 MB. That is a large client download and a large memory footprint.
+
+#### The hard constraints (from the WASM ASR ecosystem)
+
+- **Model size / memory.** whisper.cpp's WASM demo caps out at the `small` model "inclusive… beyond that memory and performance are unsatisfactory," and notes a base model "~140 MB compressed, 400 MB+ in memory during inference" ([whisper.cpp discussion #533](https://github.com/ggml-org/whisper.cpp/discussions/533)). gigastt's 225 MB INT8 encoder is in the danger zone: a ~225 MB download plus expanded runtime memory, on every visitor, every cold load. **Firefox cannot load files >256 MB — use Chrome** ([ggml.ai/whisper.cpp](https://ggml.ai/whisper.cpp/)). Caching (Cache API / IndexedDB) helps repeat visits but not the first.
+- **Cross-origin isolation is mandatory for threads.** WASM multi-threading needs `SharedArrayBuffer`, which every browser gates behind **COOP `same-origin` + COEP `require-corp`** headers ([TestMu — WASM threads](https://www.testmuai.com/learning-hub/wasm-threads-browser-support/), [whisper.cpp examples](https://github.com/ggml-org/whisper.cpp/tree/master/examples/whisper.wasm)). Setting COEP breaks loading of any non-opted-in cross-origin asset — a real deployment headache. (HF Spaces can set these headers; a plain static host may not.)
+- **SIMD required, performance modest.** The WASM CPU path needs SIMD; even so, whisper.cpp reports only "x2–x3 real-time for tiny/base on a modern CPU" ([ggml.ai/whisper.cpp](https://ggml.ai/whisper.cpp/)). WebGPU is dramatically faster (one background-removal benchmark: ~550× vs single-thread no-SIMD on an M3 Max — [IMG.LY](https://img.ly/blog/browser-background-removal-using-onnx-runtime-webgpu/)), but WebGPU is still experimental, browser-gated (Chrome/Edge solid, Firefox default mid-2024, Safari catching up — [onnxruntime.ai WebGPU](https://onnxruntime.ai/docs/tutorials/web/ep-webgpu.html)), and the GigaAM graphs may hit unsupported ops, forcing partial CPU fallback.
+
+#### Path B verdict
+
+**Partially realistic, but not pre-traction.** It is technically achievable — the ORT-Web + JS-decode-loop pattern is proven by transformers.js and whisper.cpp — but for gigastt specifically it means **porting the mel front-end, tokenizer, and RNN-T decode loop to JavaScript**, shipping a **225 MB model to every browser**, and managing **COOP/COEP + SIMD/threads + WebGPU-op-coverage** caveats. That is a multi-week effort with real "does GigaAM's RNN-T even decode acceptably in JS at usable speed?" risk, and the privacy win (no server) is the *only* thing it buys over Option 1 — at ~10× the effort.
+
+**Effort/risk:** Path A — not viable (high risk). Path B — feasible but multi-week, medium-high risk, large per-visitor download.
+
+---
+
+## Recommendation
+
+**Pursue Option 1 (hosted mic → transcript demo) first. Defer WASM.**
+
+Reasoning, biased toward the lowest-effort credible win for a pre-traction solo project:
+
+1. **Effort asymmetry is enormous.** Option 1 is ~2–3 days with **zero server code changes** — the WS streaming, rate limiting, session cap, origin allowlist, and metrics already exist; it's a thin frontend + a container deploy of the existing binary. Option 2 (the only viable variant, Path B) is multi-week and requires reimplementing the mel front-end, tokenizer, and RNN-T decode loop in JS.
+2. **It directly closes the audited gap.** "Anyone can try Russian transcription in-browser with no install" is satisfied the moment the hosted demo is live.
+3. **Audience fit.** Hosting on HF Spaces puts the demo in front of the exact people evaluating Russian ASR, next to where the GigaAM model already lives — free, no card, reuses the existing `Dockerfile`.
+4. **The one real cost is the privacy-message tension, and it's manageable** with explicit labeling ("this hosted demo is the one cloud exception; run locally for privacy") plus the already-short-able `--max-session-secs` cap and in-memory-only processing.
+5. **WASM's only advantage over the hosted demo is preserving the no-cloud promise in the demo itself** — genuinely on-brand, but not worth ~10× the effort and a 225 MB per-visitor download before the project has traction. Revisit Path B (ORT-Web + JS decode loop) *after* traction, ideally targeting WebGPU and possibly a smaller/distilled encoder to get the download under the practical browser ceiling.
+
+**Suggested sequencing:** ship Option 1 now; file a tracked "WASM in-browser demo (ORT-Web + JS RNN-T decode loop)" item as a post-traction stretch, with the open question recorded: *can GigaAM v3 RNN-T decode acceptably in-browser, and can the 225 MB encoder be shrunk to fit the practical browser download/memory ceiling?*
+
+---
+
+## Sources
+
+WASM / ort / in-browser ASR claims above are drawn from:
+
+- pyke `ort` crate & WASM constraints: [github.com/pykeio/ort](https://github.com/pykeio/ort), [crates.io/crates/ort](https://crates.io/crates/ort), [docs.rs/ort](https://docs.rs/ort), [pykeio/ort DeepWiki — Installation & Setup](https://deepwiki.com/pykeio/ort/2.1-installation-and-setup)
+- Rust WASM targets: [rustc book — wasm32-unknown-unknown](https://doc.rust-lang.org/beta/rustc/platform-support/wasm32-unknown-unknown.html), [rustc book — wasm32-unknown-emscripten](https://doc.rust-lang.org/beta/rustc/platform-support/wasm32-unknown-emscripten.html)
+- ONNX Runtime Web (SIMD/threads/WebGPU): [onnxruntime.ai — Build for web](https://onnxruntime.ai/docs/build/web.html), [onnxruntime.ai — WebGPU EP](https://onnxruntime.ai/docs/tutorials/web/ep-webgpu.html), [onnxruntime-web on npm](https://www.npmjs.com/package/onnxruntime-web), [IMG.LY — WebGPU background removal benchmark](https://img.ly/blog/browser-background-removal-using-onnx-runtime-webgpu/)
+- transformers.js / Whisper in-browser: [HF — Transformers.js](https://huggingface.co/docs/transformers.js/index), [xenova/whisper-web](https://github.com/xenova/whisper-web), [blog.rasc.ch — Speech recognition with Transformers.js](https://blog.rasc.ch/2025/01/transformers-js-speech.html)
+- whisper.cpp WASM (constraints, model size, COOP/COEP, SIMD, perf): [ggml.ai/whisper.cpp](https://ggml.ai/whisper.cpp/), [whisper.cpp/examples/whisper.wasm](https://github.com/ggml-org/whisper.cpp/tree/master/examples/whisper.wasm), [whisper.cpp discussion #533](https://github.com/ggml-org/whisper.cpp/discussions/533)
+- WASM threads / SharedArrayBuffer / cross-origin isolation: [TestMu — WASM threads, Atomics, COOP/COEP](https://www.testmuai.com/learning-hub/wasm-threads-browser-support/)

--- a/docs/positioning-draft.md
+++ b/docs/positioning-draft.md
@@ -1,0 +1,114 @@
+# Positioning — DRAFT (for review; NOT yet in README)
+
+**Status:** draft · **Date:** 2026-06-13 · Strategic positioning (audit findings #29/#31/#42).
+
+Task 02 already removed the *false/unmeasured* claims from the README. This doc is the
+next step the audit flagged but no task closed: **forward positioning** — what gigastt
+should actively claim, who it's for, and how it stands against the specific competitors
+a knowledgeable Russian-ASR engineer reaches for. Pre-traction (≈10★, ≈500 downloads),
+so every skeptical reader matters; the goal is a niche that is *true today* and survives
+a competitor winning any single WER column.
+
+---
+
+## 1. The problem with current positioning
+
+- **Too many personas.** The README addresses ~5 broad audiences (voice assistants,
+  transcription apps, call-center, accessibility, embedded). At a narrow FFI/embedded
+  niche with one model, that breadth reads as unfocused and invites comparison on axes
+  gigastt loses (clean-read WER vs Vosk, multilingual vs Whisper/Parakeet).
+- **No stance vs the closest competitors.** The comparison table lists
+  whisper.cpp / faster-whisper / Vosk / sherpa / Cloud — but **not** the three projects
+  that actually overlap gigastt's pitch: `onnx-asr`, `transcribe-rs`, and **T-one**.
+  Silence there looks like avoidance.
+
+---
+
+## 2. The niche (the honest one-liner)
+
+> **Embeddable on-device Russian STT for Rust and mobile apps** — one static binary or
+> one crate, no Python, no cloud, on the SOTA open Russian model (GigaAM v3), with a
+> hardened streaming server and a C-ABI FFI.
+
+Everything in the README should ladder up to *that*. Drop the broad-assistant framing
+as the headline; keep concrete use-cases as examples *under* the niche.
+
+**Lead axes (true today, see `benchmark_narrative_draft.md` Thesis B):**
+single static binary (~225 MB) · true incremental WebSocket streaming · C-ABI FFI for
+Android/mobile · hardened server (rate-limit / origin allowlist / graceful drain /
+metrics) · MIT-clean **code *and* weights** · accuracy leadership on far-field /
+telephony / spontaneous (3 of 4 domains, pending re-run vs Vosk 0.54 + T-one).
+
+**Axes to stop competing on as headline:** clean-read WER (Vosk wins), multilingual
+(Whisper/Parakeet win), "only Rust-native" (false — see transcribe-rs), raw latency
+numbers (TTFP is ~0.7 s, not sub-200 ms).
+
+---
+
+## 3. Head-to-head positioning (concede honestly, differentiate sharply)
+
+### vs `onnx-asr` (istupakov, ~331★) — the strongest adjacent competitor
+- **What it is:** a pip-installable Python *library*; GigaAM v2/v3 (CTC+RNNT), many EPs
+  (CUDA/TensorRT/CoreML/DirectML/ROCm/WebGPU), Win/Linux/macOS x86+Arm, no protoc.
+- **Concede:** for a Python pipeline or notebook, `onnx-asr` is the easier, broader,
+  more-backends choice. Say so.
+- **Differentiate:** gigastt is a **deployable hardened server + an embeddable native
+  binary/FFI**, not a library you wire up. No Python runtime; one artifact; production
+  ops (backpressure, drain, rate-limit, metrics) built in. *gigastt is what you ship;
+  onnx-asr is what you prototype with.*
+- **Action:** add `onnx-asr` to the comparison and to the acknowledgments framing —
+  ceding Python pipelines explicitly is more credible than omitting it.
+
+### vs `transcribe-rs` (MIT, ~208★) — kills the "only Rust-native" claim
+- **What it is:** Rust-native GigaAM v3 with CoreML/CUDA/int8 *today*.
+- **Concede:** gigastt is **not** the only Rust-native GigaAM v3 option. Remove that
+  claim everywhere (task 02 dropped "only Rust-native"; keep it gone).
+- **Differentiate:** transcribe-rs is a transcription *library/CLI*; gigastt is a
+  **server + FFI + mobile** story (WebSocket streaming, Android cdylib, hardened HTTP).
+  Compete on the *server/embedded* surface, not on "Rust-native" as a bare fact.
+
+### vs **T-one** (T-Bank, Apache-2.0) — the telephony specialist
+- **What it is:** purpose-built streaming CTC-Conformer (300 ms chunks), Apache on code
+  *and* weights, production-hardened in a bank; strong on call-center / named entities.
+- **Concede:** for pure Russian telephony streaming, T-one is purpose-built and may beat
+  gigastt on calls (pending the head-to-head run; published T-one numbers are vs
+  GigaAM-RNNT-**v2**, not v3 — so this is genuinely open).
+- **Differentiate:** gigastt is **general-domain + embeddable** (far-field, video, calls
+  on one model) with a single-binary/FFI deployment; T-one is telephony-focused. Position
+  as *the embeddable generalist*, and let the re-run decide the telephony column honestly.
+
+### vs Whisper (whisper.cpp / faster-whisper)
+- Already in the table. Keep: gigastt is far faster (real-time CPU vs >1.0 RTF for
+  faster-whisper) and ~13× smaller, and leads RU WER on every measured domain. Whisper's
+  edge is multilingual — out of gigastt's niche.
+
+### vs Vosk
+- Concede clean-read accuracy (4.82 vs 8.60) and raw RTF. Win on far-field/telephony/
+  YouTube accuracy + ~6× smaller footprint + streaming partials. (pending Vosk 0.54.)
+
+---
+
+## 4. Persona narrowing (from ~5 broad → 2 sharp)
+
+**Primary:** Rust / mobile developers embedding offline Russian STT — one crate or one
+`cdylib`, no Python, no cloud (privacy/compliance), small footprint.
+
+**Secondary:** self-hosters who want a private, hardened Russian STT *server* (WebSocket
++ REST + SSE) they can run on a loopback or a VPS without sending audio to a cloud API.
+
+Everything else (general voice assistants, accessibility, etc.) becomes an *example* of
+those two, not a separate headline persona.
+
+---
+
+## 5. Concrete next edits (after review, separate task)
+
+1. README headline → the niche one-liner (§2); demote the broad-assistant framing.
+2. Add `onnx-asr`, `transcribe-rs`, `T-one` to the competitor table / prose with the
+   honest concede/differentiate lines above.
+3. Collapse the persona list to the two in §4.
+4. Keep the latency framing honest (~0.7 s TTFP; no sub-200 ms).
+5. Cross-check against `benchmark_narrative_draft.md` so positioning and numbers agree.
+
+> This is messaging strategy, not measured fact — it must be reconciled with the full
+> re-run numbers (Vosk 0.54 + T-one) before any of it lands in the README.


### PR DESCRIPTION
Strategic-backlog drafts (review docs — **none touch README/README_RU or code**):

- **`benchmark_narrative_draft.md`** (Part D): replaces the stale all-TBD stub (it still floated *sub-200ms*) with the committed 1000-sample renorm matrix — WER+CI, per-domain RTF, honest ~0.7s TTFP, footprint; new engines/axes marked `pending`; two data-keyed positioning theses.
- **`positioning-draft.md`**: narrow ~5 personas → the embeddable Rust/mobile niche; explicit honest stance vs `onnx-asr` / `transcribe-rs` / **T-one**.
- **`hosted-demo-wasm-design.md`**: hosted mic→transcript demo (recommended: HF Spaces Docker, ~2-3 days, no server-code change) vs in-browser WASM (ort→wasm not viable; ONNX-Runtime-Web feasible but multi-week). Sourced.

Validation done alongside: the merged benchmark infra (#48) was smoke-run on 20 golos_crowd samples — gigastt 9.17% / RTF 0.146, vosk 1.83%, faster-whisper 10.09%, 0 failures — confirming the new runner registration path works end-to-end.

These are decision-input drafts; reconcile with a full re-run (Vosk 0.54 + T-one) before any README change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)