### PR TITLE
fix(benchmark): de-risk new competitor runners (Vosk 0.54 fixed via sherpa-onnx, T-one API corrected)

### DIFF
--- a/benchmark/runners/t_one.py
+++ b/benchmark/runners/t_one.py
@@ -1,67 +1,75 @@
-"""Runner for T-one (``voicekit-team/T-one``) — T-Bank's streaming CTC Conformer.
+"""Runner for T-one (``t-tech/T-one``) — T-Bank's streaming CTC Conformer (Apache-2.0).
 
-T-one is Apache-2.0 (code *and* weights) and purpose-built for Russian telephony /
-call-center streaming — exactly the niche gigastt targets, which is why it belongs
-in the comparison. This runner loads it via ``transformers`` + ``torch`` as a
-Wav2Vec2-style CTC model.
+T-one is purpose-built for Russian telephony / call-center streaming — exactly the
+niche gigastt targets, which is why it belongs in the comparison. It ships its **own**
+inference package ``tone``; it is NOT a generic ``transformers`` model (the HF repo
+``t-tech/T-one`` declares a custom ``ToneForCTC`` architecture). The documented offline
+path is::
 
-Best-effort by design: the exact processor / model classes and HF repo id should be
-confirmed against the T-one model card before a full run (override the repo with
-``BENCHMARK_TONE_MODEL``). Until ``torch`` + ``transformers`` + the weights are
-present, ``is_available()`` returns ``False`` and the suite skips T-one. All heavy
-imports are lazy so importing this module never fails.
+    from tone import StreamingCTCPipeline, read_audio
+    pipeline = StreamingCTCPipeline.from_hugging_face()      # pulls t-tech/T-one
+    text = pipeline.forward_offline(read_audio("clip.wav"))
+
+Install (pulls torch)::
+
+    uv pip install "git+https://github.com/voicekit-team/T-one.git"
+
+Until ``tone`` is importable, ``is_available()`` returns ``False`` and the suite skips
+T-one. All heavy imports are lazy so importing this module never fails.
 """
 
-import os
 import time
-import wave
 
 
 class TOneRunner:
     name = "t-one"
 
-    def __init__(self, model_id: str | None = None, device: str = "cpu"):
-        self.model_id = model_id or os.environ.get("BENCHMARK_TONE_MODEL", "voicekit-team/T-one")
+    def __init__(self, device: str | None = None):
         self.device = device
-        self._model = None
-        self._processor = None
+        self._pipeline = None
 
     def is_available(self) -> bool:
         try:
-            import torch  # noqa: F401
-            import transformers  # noqa: F401
+            import tone  # noqa: F401
             return True
         except Exception as e:
-            print(f"[t-one] Not available: {e}")
+            print(
+                "[t-one] Not available (install: "
+                "uv pip install 'git+https://github.com/voicekit-team/T-one.git'): "
+                f"{e}"
+            )
             return False
 
     def _load(self):
-        if self._model is None:
-            from transformers import AutoModelForCTC, AutoProcessor
-            print(f"[t-one] Loading {self.model_id} ...")
-            self._processor = AutoProcessor.from_pretrained(self.model_id)
-            self._model = AutoModelForCTC.from_pretrained(self.model_id).to(self.device).eval()
-        return self._model, self._processor
+        if self._pipeline is None:
+            from tone import StreamingCTCPipeline
+            print("[t-one] Loading StreamingCTCPipeline from t-tech/T-one ...")
+            self._pipeline = StreamingCTCPipeline.from_hugging_face()
+        return self._pipeline
 
-    def _read_wav_16k_mono(self, wav_path: str):
-        import numpy as np
-
-        with wave.open(wav_path, "rb") as wf:
-            if wf.getnchannels() != 1 or wf.getsampwidth() != 2 or wf.getframerate() != 16000:
-                raise ValueError("T-one runner expects 16kHz mono 16-bit WAV")
-            frames = wf.readframes(wf.getnframes())
-        return np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+    @staticmethod
+    def _extract_text(result) -> str:
+        """``forward_offline`` returns phrase objects (or strings); join defensively."""
+        if isinstance(result, str):
+            return result
+        parts = []
+        for item in result or []:
+            if isinstance(item, str):
+                parts.append(item)
+            else:
+                parts.append(
+                    getattr(item, "text", None)
+                    or getattr(item, "transcription", None)
+                    or str(item)
+                )
+        return " ".join(p for p in parts if p).strip()
 
     def transcribe(self, wav_path: str) -> tuple[str, float]:
-        import torch
+        from tone import read_audio
 
-        model, processor = self._load()
-        audio = self._read_wav_16k_mono(wav_path)
+        pipeline = self._load()
+        audio = read_audio(wav_path)
         start = time.perf_counter()
-        inputs = processor(audio, sampling_rate=16000, return_tensors="pt")
-        with torch.no_grad():
-            logits = model(inputs.input_values.to(self.device)).logits
-        pred_ids = torch.argmax(logits, dim=-1)
-        text = processor.batch_decode(pred_ids)[0]
+        result = pipeline.forward_offline(audio)
         elapsed = time.perf_counter() - start
-        return text.strip().lower(), elapsed
+        return self._extract_text(result).lower(), elapsed

--- a/benchmark/runners/vosk_054.py
+++ b/benchmark/runners/vosk_054.py
@@ -1,34 +1,89 @@
-"""Runner for Vosk 0.54 — NOTE: NOT a drop-in for the Kaldi vosk-api.
+"""Runner for Vosk 0.54 (Zipformer2) via sherpa-onnx.
 
-De-risk finding (2026-06-14): ``vosk-model-ru-0.54`` on alphacephei is a **Zipformer2
-ONNX** bundle — it ships ``am-onnx/``, ``decode-onnx.py``, ``lang/``, ``lm/`` and is
-*not* a Kaldi model. ``vosk.Model()`` rejects it ("Folder does not contain model
-files"), so this runner cannot reuse the 0.42 ``KaldiRecognizer`` path. Integrating
-0.54 needs an onnxruntime backend (its bundled ``decode-onnx.py``) or sherpa-onnx,
-both of which support Zipformer2 ONNX models.
+``vosk-model-ru-0.54`` is NOT a Kaldi model — it is a sherpa-onnx **offline
+transducer** (``am-onnx/{encoder,decoder,joiner}.onnx`` + ``lang/tokens.txt``),
+exactly as the bundle's own ``decode-onnx.py`` shows
+(``sherpa_onnx.OfflineRecognizer.from_transducer(...)``). So this runner uses the
+``sherpa-onnx`` package, not the vosk-api.
 
-Until that backend is wired, ``is_available()`` returns ``False`` so the full suite
-skips Vosk 0.54 cleanly instead of recording 100% failures. Tracked as a follow-up.
+That encoder→decoder→joiner ONNX transducer is the same pattern the author's native
+Rust engines implement (``voxrs/src/inference/zipformer.rs``, ``siamstt``); sherpa-onnx
+is the quickest path for the Python benchmark. The decode config below mirrors the
+model's own ``decode-onnx.py`` (modified beam search, max_active_paths=10).
+
+Install: ``uv pip install sherpa-onnx``. Until present, ``is_available()`` returns
+False and the suite skips Vosk 0.54.
 """
 
 import os
+import time
+import urllib.request
+import wave
+import zipfile
+from pathlib import Path
 
-from .vosk import VoskRunner
 
-
-class Vosk054Runner(VoskRunner):
+class Vosk054Runner:
     name = "vosk-0.54"
 
     def __init__(self, model_name: str | None = None, download_dir: str | None = None):
-        if model_name is None:
-            model_name = os.environ.get("BENCHMARK_VOSK054_MODEL", "vosk-model-ru-0.54")
-        super().__init__(model_name=model_name, download_dir=download_dir)
+        self.model_name = model_name or os.environ.get("BENCHMARK_VOSK054_MODEL", "vosk-model-ru-0.54")
+        self.download_dir = Path(download_dir) if download_dir else Path.home() / ".cache" / "vosk"
+        self.download_dir.mkdir(parents=True, exist_ok=True)
+        self._recognizer = None
 
     def is_available(self) -> bool:
-        # vosk-model-ru-0.54 is a Zipformer2 ONNX bundle, not a Kaldi model the
-        # vosk-api can load. Skip until a sherpa-onnx / onnxruntime backend is wired.
-        print(
-            "[vosk-0.54] Not available: vosk-model-ru-0.54 is a Zipformer2 ONNX model, "
-            "not loadable by vosk-api; needs a sherpa-onnx/onnxruntime backend (follow-up)."
-        )
-        return False
+        try:
+            import sherpa_onnx  # noqa: F401
+            return True
+        except Exception as e:
+            print(f"[vosk-0.54] Not available (install: uv pip install sherpa-onnx): {e}")
+            return False
+
+    def _download_model(self) -> Path:
+        model_dir = self.download_dir / self.model_name
+        if model_dir.exists():
+            return model_dir
+        url = f"https://alphacephei.com/vosk/models/{self.model_name}.zip"
+        zip_path = self.download_dir / f"{self.model_name}.zip"
+        print(f"[vosk-0.54] Downloading {url} ...")
+        urllib.request.urlretrieve(url, zip_path)
+        with zipfile.ZipFile(zip_path, "r") as z:
+            z.extractall(self.download_dir)
+        return model_dir
+
+    def _load(self):
+        if self._recognizer is None:
+            import sherpa_onnx
+
+            d = self._download_model()
+            am = d / "am-onnx"
+            self._recognizer = sherpa_onnx.OfflineRecognizer.from_transducer(
+                encoder=str(am / "encoder.onnx"),
+                decoder=str(am / "decoder.onnx"),
+                joiner=str(am / "joiner.onnx"),
+                tokens=str(d / "lang" / "tokens.txt"),
+                num_threads=1,
+                provider="cpu",
+                sample_rate=16000,
+                dither=3e-5,
+                max_active_paths=10,
+                decoding_method="modified_beam_search",
+            )
+        return self._recognizer
+
+    def transcribe(self, wav_path: str) -> tuple[str, float]:
+        import numpy as np
+
+        recognizer = self._load()
+        with wave.open(wav_path, "rb") as wf:
+            if wf.getnchannels() != 1 or wf.getsampwidth() != 2 or wf.getframerate() != 16000:
+                raise ValueError("vosk-0.54 runner expects 16kHz mono 16-bit WAV")
+            frames = wf.readframes(wf.getnframes())
+        samples = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+        start = time.perf_counter()
+        stream = recognizer.create_stream()
+        stream.accept_waveform(16000, samples)
+        recognizer.decode_stream(stream)
+        elapsed = time.perf_counter() - start
+        return stream.result.text.strip().lower(), elapsed

--- a/benchmark/runners/vosk_054.py
+++ b/benchmark/runners/vosk_054.py
@@ -1,10 +1,14 @@
-"""Runner for Vosk 0.54 (Zipformer2) — a newer Russian model alongside 0.42.
+"""Runner for Vosk 0.54 — NOTE: NOT a drop-in for the Kaldi vosk-api.
 
-Reuses ``VoskRunner``'s alphacephei ZIP download + ``KaldiRecognizer`` path; only
-the default model name differs, so both Vosk versions show up side-by-side in the
-results table. The exact model id should be confirmed against
-https://alphacephei.com/vosk/models (override with ``BENCHMARK_VOSK054_MODEL``)
-before a full run.
+De-risk finding (2026-06-14): ``vosk-model-ru-0.54`` on alphacephei is a **Zipformer2
+ONNX** bundle — it ships ``am-onnx/``, ``decode-onnx.py``, ``lang/``, ``lm/`` and is
+*not* a Kaldi model. ``vosk.Model()`` rejects it ("Folder does not contain model
+files"), so this runner cannot reuse the 0.42 ``KaldiRecognizer`` path. Integrating
+0.54 needs an onnxruntime backend (its bundled ``decode-onnx.py``) or sherpa-onnx,
+both of which support Zipformer2 ONNX models.
+
+Until that backend is wired, ``is_available()`` returns ``False`` so the full suite
+skips Vosk 0.54 cleanly instead of recording 100% failures. Tracked as a follow-up.
 """
 
 import os
@@ -19,3 +23,12 @@ class Vosk054Runner(VoskRunner):
         if model_name is None:
             model_name = os.environ.get("BENCHMARK_VOSK054_MODEL", "vosk-model-ru-0.54")
         super().__init__(model_name=model_name, download_dir=download_dir)
+
+    def is_available(self) -> bool:
+        # vosk-model-ru-0.54 is a Zipformer2 ONNX bundle, not a Kaldi model the
+        # vosk-api can load. Skip until a sherpa-onnx / onnxruntime backend is wired.
+        print(
+            "[vosk-0.54] Not available: vosk-model-ru-0.54 is a Zipformer2 ONNX model, "
+            "not loadable by vosk-api; needs a sherpa-onnx/onnxruntime backend (follow-up)."
+        )
+        return False


### PR DESCRIPTION
Bounded de-risk of the runners added in #48 (prep + smoke, no full run). Findings + fixes:

- **Vosk 0.54 — was broken, now works.** `vosk-model-ru-0.54` is NOT a Kaldi model; it's a **sherpa-onnx offline transducer** (`am-onnx/{encoder,decoder,joiner}.onnx` + `lang/tokens.txt`) — its own `decode-onnx.py` uses `sherpa_onnx.OfflineRecognizer.from_transducer`. The Kaldi runner gave 100% failures. Rewrote it to sherpa-onnx (same encoder→decoder→joiner pattern as the author's native Rust engines `voxrs/src/inference/zipformer.rs` + `siamstt`). **Smoke: WER 0.0%, RTF 0.05x, 0 failures.**
- **T-one — API corrected.** Real HF id is `t-tech/T-one` (custom `ToneForCTC` arch), inference via its own `tone` package (`StreamingCTCPipeline.from_hugging_face().forward_offline()`), not transformers. Rewrote the runner; `tone==0.1.0` installs; `is_available()→True`; weights downloading (smoke finishing).
- **faster-whisper-turbo** confirmed a valid size (faster-whisper 1.2.1); smoke downloading.

sherpa-onnx + tone are opt-in deps (graceful skip if absent). This caught two issues a blind full run would have wasted hours on. T-one/turbo full smoke numbers will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)