### PR TITLE
fix(release): aarch64 libstdc++ for ARM-Linux cross-build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,12 +99,13 @@ jobs:
           fi
 
       # aarch64-unknown-linux-gnu is cross-compiled on an x86_64 runner; cargo
-      # needs the GNU cross-linker and the matching linker env var.
+      # needs the GNU cross-linker plus the aarch64 libstdc++ (g++-*), since
+      # onnxruntime/polyvoice link `-lstdc++`, and the matching linker env var.
       - name: Install aarch64 cross-linker
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         shell: bash
         run: |
-          sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
 
       - name: Install CUDA toolkit


### PR DESCRIPTION
v2.1.0 release build failed on aarch64-unknown-linux-gnu (`ld: cannot find -lstdc++`). Add `g++-aarch64-linux-gnu` to the cross-linker step. crates.io is already published; this unblocks the GitHub binary release. 🤖 Generated with [Claude Code](https://claude.com/claude-code)