### PR TITLE
ci(release): drop Intel-Mac (macos-13) target to unblock v2.1.0 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,11 @@ jobs:
             # "Install aarch64 cross-linker" step). Relies on a prebuilt
             # aarch64 onnxruntime being fetched by `ort` (download-binaries);
             # fail-fast: false isolates this target if that ever regresses.
-          - name: macos-x86_64-cpu
-            os: macos-13
-            target: x86_64-apple-darwin
-            features: ""
-            asset_suffix: x86_64-apple-darwin
-            cuda: false
-            # macos-13 is the last Intel-based runner. No `coreml` — Intel Macs
-            # have no Neural Engine, so the CPU EP is used.
+          # x86_64-apple-darwin (Intel Mac) is intentionally omitted: GitHub is
+          # retiring the macos-13 Intel runners and they no longer schedule — the
+          # job sat queued 1.5h+ without ever starting, blocking the whole release.
+          # Intel-Mac users install via `cargo install gigastt` (builds from
+          # source). Re-add an Intel entry if hosted Intel runners return.
           - name: windows-x86_64-cpu
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ benchmark against current Russian-ASR engines, and a reworked README.
   faster-whisper-turbo, and **T-one** (greedy + production beam+LM) on clean read,
   far-field, phone calls and YouTube — with WER + 95% CI, RTF, footprint and an explicit
   training-contamination caveat. See [`docs/benchmarks.md`](docs/benchmarks.md).
-- **Release platform matrix expanded** to `x86_64-pc-windows-msvc`,
-  `x86_64-apple-darwin` (Intel) and `aarch64-unknown-linux-gnu` (cross-compiled), with
-  matching Homebrew coverage.
+- **Release platform matrix expanded** to `x86_64-pc-windows-msvc` and
+  `aarch64-unknown-linux-gnu` (cross-compiled), with matching Homebrew coverage.
+  (Prebuilt `x86_64-apple-darwin` Intel-Mac tarballs were dropped: GitHub's
+  `macos-13` Intel runners are being retired and no longer schedule. Intel-Mac
+  users install via `cargo install gigastt`.)
 - **Benchmark data licensing** — `benchmark/DATA_LICENSE` + root `NOTICE` carve the
   benchmark transcripts (Open STT CC BY-NC 4.0; Golos Sber Public License) out of the
   project's MIT grant.


### PR DESCRIPTION
GitHub is retiring the `macos-13` Intel runners — the `macos-x86_64-cpu` job sat **queued 1.5h+ without ever starting**, blocking the whole v2.1.0 binary release (`publish` needs every matrix job to succeed). The target was newly added in 2.1.0 and has never built successfully.

Drop `x86_64-apple-darwin` so the 4 working platforms ship now:
- Linux x86_64, Linux aarch64 (cross), macOS Apple Silicon, Windows x86_64

Intel-Mac users keep `cargo install gigastt` (builds from source). CHANGELOG 2.1.0 platform line softened to match. Re-add an Intel entry if hosted Intel runners return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)