### PR TITLE
ci(homebrew): drop Intel-Mac from formula + unblock repin

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -52,17 +52,15 @@ jobs:
           VERSION="${TAG#v}"
           gh release download "$TAG" --pattern 'SHA256SUMS.txt' --dir . --clobber
           MAC_ARM=$(awk -v a="gigastt-${VERSION}-aarch64-apple-darwin.tar.gz"     '$2==a{print $1}' SHA256SUMS.txt)
-          MAC_X86=$(awk -v a="gigastt-${VERSION}-x86_64-apple-darwin.tar.gz"      '$2==a{print $1}' SHA256SUMS.txt)
           LIN_X86=$(awk -v a="gigastt-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" '$2==a{print $1}' SHA256SUMS.txt)
           LIN_ARM=$(awk -v a="gigastt-${VERSION}-aarch64-unknown-linux-gnu.tar.gz" '$2==a{print $1}' SHA256SUMS.txt)
-          if [ -z "$MAC_ARM" ] || [ -z "$MAC_X86" ] || [ -z "$LIN_X86" ] || [ -z "$LIN_ARM" ]; then
+          if [ -z "$MAC_ARM" ] || [ -z "$LIN_X86" ] || [ -z "$LIN_ARM" ]; then
             echo "::error ::SHA256SUMS.txt is missing one of the expected assets" >&2
             cat SHA256SUMS.txt >&2
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "mac_arm=$MAC_ARM" >> "$GITHUB_OUTPUT"
-          echo "mac_x86=$MAC_X86" >> "$GITHUB_OUTPUT"
           echo "linux_x86=$LIN_X86" >> "$GITHUB_OUTPUT"
           echo "linux_arm=$LIN_ARM" >> "$GITHUB_OUTPUT"
 
@@ -71,7 +69,6 @@ jobs:
         env:
           VERSION: ${{ steps.shas.outputs.version }}
           MAC_ARM: ${{ steps.shas.outputs.mac_arm }}
-          MAC_X86: ${{ steps.shas.outputs.mac_x86 }}
           LINUX_X86: ${{ steps.shas.outputs.linux_x86 }}
           LINUX_ARM: ${{ steps.shas.outputs.linux_arm }}
         run: |
@@ -80,7 +77,6 @@ jobs:
           import os, re, pathlib
           version = os.environ['VERSION']
           mac = os.environ['MAC_ARM']
-          mac_x86 = os.environ['MAC_X86']
           lin = os.environ['LINUX_X86']
           lin_arm = os.environ['LINUX_ARM']
           p = pathlib.Path('Formula/gigastt.rb')
@@ -97,11 +93,6 @@ jobs:
               text, count=1, flags=re.S,
           )
           text = re.sub(
-              r'(x86_64-apple-darwin\.tar\.gz"\s+sha256 ")[0-9a-f]{64}(")',
-              lambda m: m.group(1) + mac_x86 + m.group(2),
-              text, count=1, flags=re.S,
-          )
-          text = re.sub(
               r'(aarch64-unknown-linux-gnu\.tar\.gz"\s+sha256 ")[0-9a-f]{64}(")',
               lambda m: m.group(1) + lin_arm + m.group(2),
               text, count=1, flags=re.S,
@@ -114,11 +105,6 @@ jobs:
           text = re.sub(
               r'releases/download/v[0-9][0-9a-zA-Z.\-+]*/gigastt-[0-9][0-9a-zA-Z.\-+]*-x86_64-unknown-linux-gnu\.tar\.gz',
               f'releases/download/v{version}/gigastt-{version}-x86_64-unknown-linux-gnu.tar.gz',
-              text, count=1,
-          )
-          text = re.sub(
-              r'releases/download/v[0-9][0-9a-zA-Z.\-+]*/gigastt-[0-9][0-9a-zA-Z.\-+]*-x86_64-apple-darwin\.tar\.gz',
-              f'releases/download/v{version}/gigastt-{version}-x86_64-apple-darwin.tar.gz',
               text, count=1,
           )
           text = re.sub(

--- a/Formula/gigastt.rb
+++ b/Formula/gigastt.rb
@@ -16,14 +16,11 @@ class Gigastt < Formula
   license "MIT"
 
   on_macos do
+    # Apple Silicon only — GitHub retired the macos-13 Intel runners, so there is
+    # no prebuilt x86_64-apple-darwin tarball. Intel Macs: `cargo install gigastt`.
     if Hardware::CPU.arm?
       url "https://github.com/ekhodzitsky/gigastt/releases/download/v2.0.14/gigastt-2.0.14-aarch64-apple-darwin.tar.gz"
       sha256 "abbbbf46c4faea56afa3d44a3c0b202b8b4f375d9047b1a14ec10844a519f223"
-    elsif Hardware::CPU.intel?
-      # sha256 is a placeholder; .github/workflows/homebrew.yml overwrites it
-      # from SHA256SUMS.txt after the first release carrying this target.
-      url "https://github.com/ekhodzitsky/gigastt/releases/download/v2.0.14/gigastt-2.0.14-x86_64-apple-darwin.tar.gz"
-      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
     end
   end
 


### PR DESCRIPTION
Follow-up to #64 (dropped the x86_64-apple-darwin release target). The repin workflow hard-required the Intel-Mac asset (`exit 1` if missing), so every repin would now fail. Removes Intel-Mac from `homebrew.yml` (SHA extraction/check/rewrite) and the `on_macos` Intel branch in `Formula/gigastt.rb`. macOS = Apple Silicon; Linux x64 + ARM64 unchanged. Intel-Mac users `cargo install gigastt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)