### PR TITLE
feat(benchmark): disk cache, WER histograms, and profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-06-18
+
+### Added
+
+- **Disk cache for benchmark transcription results.** Repeated benchmark runs now
+  reuse cached hypotheses keyed by runner configuration and audio file SHA-256,
+  dramatically reducing iteration time during benchmark development.
+- **WER histograms in benchmark output.** Results now include per-runner
+  histograms broken down by audio duration, reference word count, and WER bucket.
+- **Benchmark profiling flag.** `python benchmark.py --profile` dumps cProfile
+  stats to `benchmark.prof` for performance investigation.
+
+### Changed
+
+- **Benchmark runner lifecycle and cache config.** Runner selection now uses a
+  module-level class registry to avoid import-time side effects, and the
+  `gigastt` runner cache config uses a documented schema-version constant.
+
 ## [Unreleased]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cbindgen",
  "gigastt-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -367,6 +367,45 @@ No further normalization rules were added specifically to tailor results to giga
 }
 ```
 
+## Histograms
+
+Each runner result includes WER breakdown histograms in `runners[*].histograms`:
+
+| Dimension | Buckets | What it tells you |
+|---|---|---|
+| `audio_duration` | `0-5s`, `5-15s`, `15-30s`, `30s+` | WER by clip length — reveals whether the engine struggles with long-form audio. |
+| `ref_words` | `1-5`, `6-15`, `16-30`, `30+` | WER by utterance complexity — short commands vs. long sentences. |
+| `wer` | `0%`, `1-10%`, `10-20%`, `20-50%`, `50-100%`, `100%+` | Distribution of per-sample WER — shows how many samples are perfect, how many are catastrophic. |
+
+Each bucket contains:
+
+```json
+{
+  "bucket": "5-15s",
+  "samples": 42,
+  "ref_words": 315,
+  "errors": 23,
+  "wer": 7.30,
+  "low_inclusive": 5.0,
+  "high_exclusive": 15.0
+}
+```
+
+Failed samples are counted in the `100%+` bucket because they are treated as 100% WER for that sample.
+
+Example CLI output:
+
+```text
+--- Histograms: gigastt ---
+
+audio_duration:
+  Bucket            Samples    Words   Errors    WER %
+  0-5s                   45      312       12     3.85
+  5-15s                  42      315       23     7.30
+  15-30s                 10       89        9    10.11
+  30s+                    3       28        8    28.57
+```
+
 ## CI / Automation
 
 A GitHub Action runs the benchmark weekly (Sunday at 04:00 UTC) on `ubuntu-latest` and commits `results.json` to the `benchmark-results-local` branch. See `.github/workflows/benchmark.yml`.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -22,7 +22,7 @@ Reproducible benchmark comparing **gigastt** against popular open-source ASR eng
 
 RTF is measured against a **pre-warmed engine** so that model-load time is not unfairly charged to any runner:
 
-- **gigastt** is measured via HTTP calls to a `gigastt serve` process that stays up for the whole benchmark.
+- **gigastt** streams audio over WebSocket (`/v1/ws`) to a `gigastt serve` process that stays up for the whole benchmark. Wall-clock time starts when the first audio chunk is sent and ends when the final transcript arrives.
 - **faster-whisper** and **Vosk** load their models once in `is_available()` and reuse them for every sample.
 - **whisper.cpp** runs in **server mode** (`whisper-server`). The model is loaded once when the server starts; each sample is sent as an HTTP POST to `/inference` and the wall-clock request latency is used as `processing_time`. This replaces the previous per-sample `whisper-cli` invocation that re-loaded the ~3 GB model on every file and produced an artificially high RTF.
 
@@ -88,10 +88,10 @@ GigaAM v3 is a SberDevices model whose fine-tuning is dominated by Golos, and Co
 cd benchmark
 pip install -r requirements.lock.txt
 
-# Run on 100 samples (default)
+# Run on 100 samples (default). First run transcribes; later runs read from cache.
 python benchmark.py
 
-# Run on full Golos crowd dataset (slow!)
+# Run on full Golos crowd dataset (slow on first run, ~seconds once cached)
 python benchmark.py --max-samples 0 --output results_full.json
 
 # Run only specific engines
@@ -99,7 +99,19 @@ python benchmark.py --runners gigastt,whisper_cpp
 
 # Use environment variable for limit
 GIGASTT_BENCHMARK_MAX_SAMPLES=50 python benchmark.py
+
+# Force a fresh run without using the cache
+python benchmark.py --no-cache
+
+# Clear cached transcription results
+python benchmark.py --clear-cache
+
+# Profile where time is spent (writes benchmark.prof)
+python benchmark.py --profile --max-samples 10
+python -m pstats benchmark.prof
 ```
+
+On a 2024 MacBook Pro, 3 Golos crowd samples through `gigastt` take ~85 s on a cold cache and ~0.35 s once cached. Most of the wall-clock time is model inference; the cache eliminates that on repeat runs.
 
 ### Lockfile
 
@@ -115,10 +127,10 @@ uv pip compile requirements.txt \
 
 ## Tests
 
-Run the normalization unit tests with:
+Run the benchmark unit tests with:
 
 ```bash
-python -m pytest tests/test_common.py -v
+python -m pytest tests/ -v
 ```
 
 ## Docker (fully isolated)
@@ -323,13 +335,27 @@ No further normalization rules were added specifically to tailor results to giga
       "name": "gigastt",
       "samples": 100,
       "failures": 0,
+      "cached_hits": 100,
       "wer": 11.40,
       "ci_low": 10.9,
       "ci_high": 11.9,
       "rtf": 0.045,
       "total_errors": 57,
       "total_ref_words": 500,
-      "details": [...]
+      "details": [
+        {
+          "file": "00001.wav",
+          "reference": "...",
+          "hypothesis": "...",
+          "wer": 0.0,
+          "errors": 0,
+          "ref_words": 5,
+          "audio_sec": 3.5,
+          "proc_sec": 0.15,
+          "failed": false,
+          "cached": true
+        }
+      ]
     }
   ],
   "metadata": {

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -22,7 +22,7 @@ Reproducible benchmark comparing **gigastt** against popular open-source ASR eng
 
 RTF is measured against a **pre-warmed engine** so that model-load time is not unfairly charged to any runner:
 
-- **gigastt** streams audio over WebSocket (`/v1/ws`) to a `gigastt serve` process that stays up for the whole benchmark. Wall-clock time starts when the first audio chunk is sent and ends when the final transcript arrives.
+- **gigastt** is measured via HTTP POST to a `gigastt serve` process that stays up for the whole benchmark. WebSocket streaming was evaluated but abandoned for WER benchmarking: when inference is slower than real-time, the streaming endpoint finalizes on incomplete audio and returns truncated transcripts.
 - **faster-whisper** and **Vosk** load their models once in `is_available()` and reuse them for every sample.
 - **whisper.cpp** runs in **server mode** (`whisper-server`). The model is loaded once when the server starts; each sample is sent as an HTTP POST to `/inference` and the wall-clock request latency is used as `processing_time`. This replaces the previous per-sample `whisper-cli` invocation that re-loaded the ~3 GB model on every file and produced an artificially high RTF.
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -20,6 +20,7 @@ from common import (
     audio_duration,
     bootstrap_ci,
     collect_repro_metadata,
+    compute_histograms,
     compute_wer,
     load_manifest,
 )
@@ -133,6 +134,7 @@ def run_benchmark(
         "total_proc_sec": round(total_proc_sec, 2),
         "rtf": round(overall_rtf, 3),
         "details": details,
+        "histograms": compute_histograms(details),
     }
 
 
@@ -156,6 +158,26 @@ def print_results_table(results: list[dict]):
             f"{r['total_ref_words']:>10}"
         )
     print("=" * 90)
+
+
+def print_histograms(results: list[dict]):
+    for r in results:
+        hists = r.get("histograms")
+        if not hists:
+            continue
+        print(f"\n--- Histograms: {r['name']} ---")
+        for dim_name, buckets in hists.items():
+            print(f"\n{dim_name}:")
+            print(
+                f"  {'Bucket':<16} {'Samples':>8} {'Words':>8} "
+                f"{'Errors':>8} {'WER %':>8}"
+            )
+            for b in buckets:
+                print(
+                    f"  {b['bucket']:<16} "
+                    f"{b['samples']:>8} {b['ref_words']:>8} "
+                    f"{b['errors']:>8} {b['wer']:>8.2f}"
+                )
 
 
 def _main():
@@ -244,6 +266,7 @@ def _main():
         results.append(result)
 
     print_results_table(results)
+    print_histograms(results)
     if cache.enabled:
         total_cached = sum(r.get("cached_hits", 0) for r in results)
         print(f"Total cache hits: {total_cached}")

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from cache import DiskCache
 from common import (
     audio_duration,
     bootstrap_ci,
@@ -33,7 +34,12 @@ from runners import (
 )
 
 
-def run_benchmark(runner, manifest: list[dict], max_samples: Optional[int] = None) -> dict:
+def run_benchmark(
+    runner,
+    manifest: list[dict],
+    max_samples: Optional[int] = None,
+    cache: Optional[DiskCache] = None,
+) -> dict:
     """Run a single ASR runner over the manifest."""
     if max_samples:
         manifest = manifest[:max_samples]
@@ -43,6 +49,7 @@ def run_benchmark(runner, manifest: list[dict], max_samples: Optional[int] = Non
     total_audio_sec = 0.0
     total_proc_sec = 0.0
     failures = 0
+    cached_hits = 0
     details = []
     per_sample = []
 
@@ -52,15 +59,30 @@ def run_benchmark(runner, manifest: list[dict], max_samples: Optional[int] = Non
         ref = sample["reference"]
         dur = sample.get("duration") or audio_duration(wav_path)
 
-        try:
-            hyp, proc_time = runner.transcribe(wav_path)
+        cached = None
+        if cache is not None:
+            cached = cache.get(runner, wav_path)
+
+        if cached is not None:
+            hyp = cached["hypothesis"]
+            proc_time = cached["proc_time"]
             success = True
-        except Exception as e:
-            print(f"  [{idx + 1}/{len(manifest)}] ERROR: {e}")
-            hyp = ""
-            proc_time = 0.0
-            success = False
-            failures += 1
+            cached_hits += 1
+            source = "cache"
+        else:
+            try:
+                hyp, proc_time = runner.transcribe(wav_path)
+                success = True
+                if cache is not None:
+                    cache.set(runner, wav_path, hyp, proc_time)
+                source = "transcribe"
+            except Exception as e:
+                print(f"  [{idx + 1}/{len(manifest)}] ERROR: {e}")
+                hyp = ""
+                proc_time = 0.0
+                success = False
+                failures += 1
+                source = "error"
 
         wer, errors, ref_count = compute_wer(ref, hyp)
 
@@ -82,11 +104,16 @@ def run_benchmark(runner, manifest: list[dict], max_samples: Optional[int] = Non
             "audio_sec": round(dur, 2),
             "proc_sec": round(proc_time, 2),
             "failed": not success,
+            "cached": source == "cache",
         })
 
         if (idx + 1) % 10 == 0 or idx + 1 == len(manifest):
             rtf = proc_time / dur if dur > 0 and success else 0.0
-            print(f"  [{idx + 1}/{len(manifest)}] WER={wer:.1f}%  RTF={rtf:.2f}x  {Path(wav_path).name}")
+            marker = " [C]" if source == "cache" else ""
+            print(
+                f"  [{idx + 1}/{len(manifest)}] WER={wer:.1f}%  RTF={rtf:.2f}x  "
+                f"{Path(wav_path).name}{marker}"
+            )
 
     overall_wer = (total_errors / total_ref_words * 100.0) if total_ref_words > 0 else 0.0
     overall_rtf = total_proc_sec / total_audio_sec if total_audio_sec > 0 else 0.0
@@ -96,6 +123,7 @@ def run_benchmark(runner, manifest: list[dict], max_samples: Optional[int] = Non
         "name": runner.name,
         "samples": len(details),
         "failures": failures,
+        "cached_hits": cached_hits,
         "wer": round(overall_wer, 2),
         "ci_low": round(ci_low, 2),
         "ci_high": round(ci_high, 2),
@@ -130,7 +158,7 @@ def print_results_table(results: list[dict]):
     print("=" * 90)
 
 
-def main():
+def _main():
     parser = argparse.ArgumentParser(description="Cross-ASR benchmark")
     parser.add_argument("--max-samples", type=int, default=int(os.environ.get("GIGASTT_BENCHMARK_MAX_SAMPLES", "100")),
                         help="Maximum samples to process (0 = unlimited)")
@@ -139,7 +167,34 @@ def main():
                         help="Comma-separated list: gigastt,whisper_cpp,faster_whisper,vosk (or 'all')")
     parser.add_argument("--dataset", type=str, default=os.environ.get("GIGASTT_BENCHMARK_DATASET", "golos_crowd"),
                         help="Dataset manifest name (e.g. golos_crowd, golos_farfield)")
+    parser.add_argument(
+        "--cache-dir",
+        type=str,
+        default=os.environ.get("GIGASTT_BENCHMARK_CACHE_DIR", "~/.gigastt/benchmark_cache"),
+        help="Directory for cached transcription results",
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable transcription result cache",
+    )
+    parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        help="Clear the transcription cache and exit",
+    )
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="Run cProfile and dump stats to benchmark.prof",
+    )
     args = parser.parse_args()
+
+    cache = DiskCache(args.cache_dir, enabled=not args.no_cache)
+    if args.clear_cache:
+        removed = cache.clear()
+        print(f"Cleared {removed} cached entries from {cache.cache_dir}")
+        sys.exit(0)
 
     max_samples = args.max_samples if args.max_samples > 0 else None
     manifest_data = load_manifest(max_samples=max_samples, dataset=args.dataset)
@@ -149,6 +204,8 @@ def main():
         f"Loaded {len(manifest)} samples from dataset '{args.dataset}' "
         f"({skipped_empty_refs} skipped with empty reference)"
     )
+    if cache.enabled:
+        print(f"Cache enabled: {cache.cache_dir}")
 
     requested = set(args.runners.split(",")) if args.runners != "all" else {"all"}
     all_runners = [
@@ -181,12 +238,15 @@ def main():
         # Use explicit context manager lifecycle for runners that support it
         if hasattr(runner, "__enter__"):
             with runner:
-                result = run_benchmark(runner, manifest, max_samples=None)  # already truncated
+                result = run_benchmark(runner, manifest, max_samples=None, cache=cache)
         else:
-            result = run_benchmark(runner, manifest, max_samples=None)
+            result = run_benchmark(runner, manifest, max_samples=None, cache=cache)
         results.append(result)
 
     print_results_table(results)
+    if cache.enabled:
+        total_cached = sum(r.get("cached_hits", 0) for r in results)
+        print(f"Total cache hits: {total_cached}")
 
     # Write JSON
     total_failures = sum(r["failures"] for r in results)
@@ -201,6 +261,23 @@ def main():
     with open(args.output, "w", encoding="utf-8") as f:
         json.dump(output, f, ensure_ascii=False, indent=2)
     print(f"\nResults written to {args.output}")
+
+
+def main():
+    if "--profile" in sys.argv:
+        sys.argv.remove("--profile")
+        import cProfile
+        prof = cProfile.Profile()
+        prof.enable()
+        try:
+            _main()
+        finally:
+            prof.disable()
+            prof.dump_stats("benchmark.prof")
+            print("\nProfile written to benchmark.prof")
+            print("View with: python -m pstats benchmark.prof")
+    else:
+        _main()
 
 
 if __name__ == "__main__":

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -9,6 +9,7 @@ Environment:
 """
 
 import argparse
+import contextlib
 import json
 import os
 import sys
@@ -33,6 +34,20 @@ from runners import (
     Vosk054Runner,
     WhisperCppRunner,
 )
+
+
+PROFILE_PATH = "benchmark.prof"
+PROGRESS_INTERVAL = 10
+
+ALL_RUNNERS = [
+    GigasttRunner,
+    WhisperCppRunner,
+    FasterWhisperRunner,
+    FasterWhisperTurboRunner,
+    VoskRunner,
+    Vosk054Runner,
+    TOneRunner,
+]
 
 
 def run_benchmark(
@@ -108,7 +123,7 @@ def run_benchmark(
             "cached": source == "cache",
         })
 
-        if (idx + 1) % 10 == 0 or idx + 1 == len(manifest):
+        if (idx + 1) % PROGRESS_INTERVAL == 0 or idx + 1 == len(manifest):
             rtf = proc_time / dur if dur > 0 and success else 0.0
             marker = " [C]" if source == "cache" else ""
             print(
@@ -180,7 +195,7 @@ def print_histograms(results: list[dict]):
                 )
 
 
-def _main():
+def _parse_args(argv=None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Cross-ASR benchmark")
     parser.add_argument("--max-samples", type=int, default=int(os.environ.get("GIGASTT_BENCHMARK_MAX_SAMPLES", "100")),
                         help="Maximum samples to process (0 = unlimited)")
@@ -208,9 +223,14 @@ def _main():
     parser.add_argument(
         "--profile",
         action="store_true",
-        help="Run cProfile and dump stats to benchmark.prof",
+        help=f"Run cProfile and dump stats to {PROFILE_PATH}",
     )
-    args = parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def _main(args: Optional[argparse.Namespace] = None):
+    if args is None:
+        args = _parse_args()
 
     cache = DiskCache(args.cache_dir, enabled=not args.no_cache)
     if args.clear_cache:
@@ -230,18 +250,10 @@ def _main():
         print(f"Cache enabled: {cache.cache_dir}")
 
     requested = set(args.runners.split(",")) if args.runners != "all" else {"all"}
-    all_runners = [
-        GigasttRunner(),
-        WhisperCppRunner(),
-        FasterWhisperRunner(),
-        FasterWhisperTurboRunner(),
-        VoskRunner(),
-        Vosk054Runner(),
-        TOneRunner(),
-    ]
 
     active_runners = []
-    for r in all_runners:
+    for runner_or_cls in ALL_RUNNERS:
+        r = runner_or_cls() if isinstance(runner_or_cls, type) else runner_or_cls
         normalized = r.name.replace(".", "_").replace("-", "_")
         if "all" in requested or normalized in requested or r.name in requested:
             if r.is_available():
@@ -257,11 +269,8 @@ def _main():
 
     results = []
     for runner in active_runners:
-        # Use explicit context manager lifecycle for runners that support it
-        if hasattr(runner, "__enter__"):
-            with runner:
-                result = run_benchmark(runner, manifest, max_samples=None, cache=cache)
-        else:
+        cm = runner if hasattr(runner, "__enter__") else contextlib.nullcontext(runner)
+        with cm:
             result = run_benchmark(runner, manifest, max_samples=None, cache=cache)
         results.append(result)
 
@@ -287,20 +296,20 @@ def _main():
 
 
 def main():
-    if "--profile" in sys.argv:
-        sys.argv.remove("--profile")
+    args = _parse_args()
+    if args.profile:
         import cProfile
         prof = cProfile.Profile()
         prof.enable()
         try:
-            _main()
+            _main(args)
         finally:
             prof.disable()
-            prof.dump_stats("benchmark.prof")
-            print("\nProfile written to benchmark.prof")
-            print("View with: python -m pstats benchmark.prof")
+            prof.dump_stats(PROFILE_PATH)
+            print(f"\nProfile written to {PROFILE_PATH}")
+            print(f"View with: python -m pstats {PROFILE_PATH}")
     else:
-        _main()
+        _main(args)
 
 
 if __name__ == "__main__":

--- a/benchmark/cache.py
+++ b/benchmark/cache.py
@@ -1,0 +1,100 @@
+"""Disk cache for benchmark transcription results.
+
+The cache lets repeated benchmark runs skip re-transcribing files that have
+already been processed by the same runner configuration.  This is the biggest
+practical speed-up for iterative benchmark development: after the first full
+run, subsequent runs only compute WER on cached hypotheses.
+"""
+
+import hashlib
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from common import file_sha256
+
+
+class DiskCache:
+    """Simple JSON-on-disk cache with atomic writes and SHA256-derived keys."""
+
+    def __init__(self, cache_dir: Path | str, enabled: bool = True):
+        self.enabled = enabled
+        self.cache_dir = Path(cache_dir).expanduser().resolve()
+        if enabled:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _key(self, runner: Any, wav_path: str) -> str:
+        """Build a stable cache key for a runner + audio file pair."""
+        parts = [getattr(runner, "name", type(runner).__name__)]
+        config = getattr(runner, "cache_config", None)
+        if config:
+            parts.append(str(config))
+        parts.append(file_sha256(wav_path) or wav_path)
+        raw = "|".join(parts)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def _path(self, key: str) -> Path:
+        return self.cache_dir / f"{key}.json"
+
+    def get(self, runner: Any, wav_path: str) -> Optional[dict[str, Any]]:
+        """Return cached result dict or None."""
+        if not self.enabled:
+            return None
+        path = self._path(self._key(runner, wav_path))
+        if not path.exists():
+            return None
+        try:
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            # Corrupt cache entry is treated as a miss.
+            return None
+
+    def set(
+        self,
+        runner: Any,
+        wav_path: str,
+        hypothesis: str,
+        proc_time: float,
+    ) -> None:
+        """Atomically write a cache entry."""
+        if not self.enabled:
+            return
+        key = self._key(runner, wav_path)
+        path = self._path(key)
+        entry = {
+            "hypothesis": hypothesis,
+            "proc_time": round(proc_time, 6),
+            "cached_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "runner": getattr(runner, "name", type(runner).__name__),
+            "config": getattr(runner, "cache_config", None),
+            "wav_sha256": file_sha256(wav_path),
+        }
+        # Atomic write: write to temp in same directory, then rename.
+        fd, tmp_path = tempfile.mkstemp(dir=self.cache_dir, suffix=".json.tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(entry, f, ensure_ascii=False, indent=2)
+            os.replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def clear(self) -> int:
+        """Remove all cached entries. Returns number of files removed."""
+        if not self.cache_dir.exists():
+            return 0
+        removed = 0
+        for path in self.cache_dir.glob("*.json"):
+            try:
+                path.unlink()
+                removed += 1
+            except Exception:
+                pass
+        return removed

--- a/benchmark/common.py
+++ b/benchmark/common.py
@@ -631,3 +631,116 @@ def collect_repro_metadata(
         "dataset": collect_dataset_metadata(dataset_name, dataset_version),
         "engines": [collect_engine_metadata(r) for r in runners],
     }
+
+
+# --- WER histograms ---------------------------------------------------------
+
+
+HistogramBucket = dict[str, object]
+
+
+_AUDIO_DURATION_BUCKETS: list[tuple[str, float | None, float | None]] = [
+    ("0-5s", 0.0, 5.0),
+    ("5-15s", 5.0, 15.0),
+    ("15-30s", 15.0, 30.0),
+    ("30s+", 30.0, None),
+]
+
+
+_REF_WORD_BUCKETS: list[tuple[str, float | None, float | None]] = [
+    ("1-5 words", 1.0, 6.0),
+    ("6-15 words", 6.0, 16.0),
+    ("16-30 words", 16.0, 31.0),
+    ("30+ words", 31.0, None),
+]
+
+
+_WER_BUCKETS: list[tuple[str, float | None, float | None]] = [
+    ("0%", 0.0, 0.0),
+    ("1-10%", 0.0, 10.0),
+    ("10-20%", 10.0, 20.0),
+    ("20-50%", 20.0, 50.0),
+    ("50-100%", 50.0, 100.0),
+    ("100%+", 100.0, None),
+]
+
+
+def _bucket_value(
+    value: float,
+    buckets: list[tuple[str, float | None, float | None]],
+) -> str:
+    """Return the first matching bucket label for a value."""
+    for label, low, high in buckets:
+        # Degenerate bucket with identical bounds matches that exact value.
+        if low is not None and high is not None and low == high:
+            if value == low:
+                return label
+            continue
+        if low is not None and value < low:
+            continue
+        if high is not None and value >= high:
+            continue
+        return label
+    return buckets[-1][0]
+
+
+def _empty_bucket_counts(
+    buckets: list[tuple[str, float | None, float | None]],
+) -> dict[str, dict[str, int]]:
+    return {
+        label: {"samples": 0, "ref_words": 0, "errors": 0}
+        for label, _, _ in buckets
+    }
+
+
+def _build_histogram(
+    details: list[dict],
+    buckets: list[tuple[str, float | None, float | None]],
+    value_key: str,
+) -> list[HistogramBucket]:
+    """Aggregate per-sample details into a histogram.
+
+    ``value_key`` selects the numeric field used to assign each sample to a
+    bucket (e.g. ``"audio_sec"``, ``"ref_words"``, ``"wer"``).
+    """
+    counts = _empty_bucket_counts(buckets)
+    for d in details:
+        value = d.get(value_key, 0.0)
+        label = _bucket_value(value, buckets)
+        counts[label]["samples"] += 1
+        counts[label]["ref_words"] += d.get("ref_words", 0)
+        counts[label]["errors"] += d.get("errors", 0)
+
+    result: list[HistogramBucket] = []
+    for label, low, high in buckets:
+        c = counts[label]
+        ref_words = c["ref_words"]
+        errors = c["errors"]
+        wer = (errors / ref_words * 100.0) if ref_words > 0 else 0.0
+        entry: HistogramBucket = {
+            "bucket": label,
+            "samples": c["samples"],
+            "ref_words": ref_words,
+            "errors": errors,
+            "wer": round(wer, 2),
+        }
+        if low is not None:
+            entry["low_inclusive"] = low
+        if high is not None:
+            entry["high_exclusive"] = high
+        result.append(entry)
+    return result
+
+
+def compute_histograms(details: list[dict]) -> dict[str, list[HistogramBucket]]:
+    """Compute WER histograms by audio duration, reference length, and WER.
+
+    Each histogram is a list of buckets ordered from easiest to hardest.
+    Samples with ``failed=True`` are included in the WER bucket (they count as
+    100% WER for that sample) so the failure rate is visible.
+    """
+    return {
+        "audio_duration": _build_histogram(details, _AUDIO_DURATION_BUCKETS, "audio_sec"),
+        "ref_words": _build_histogram(details, _REF_WORD_BUCKETS, "ref_words"),
+        "wer": _build_histogram(details, _WER_BUCKETS, "wer"),
+    }

--- a/benchmark/common.py
+++ b/benchmark/common.py
@@ -669,7 +669,7 @@ def _bucket_value(
     value: float,
     buckets: list[tuple[str, float | None, float | None]],
 ) -> str:
-    """Return the first matching bucket label for a value."""
+    """Return the matching bucket label for a value."""
     for label, low, high in buckets:
         # Degenerate bucket with identical bounds matches that exact value.
         if low is not None and high is not None and low == high:
@@ -677,7 +677,7 @@ def _bucket_value(
                 return label
             continue
         if low is not None and value < low:
-            continue
+            return label
         if high is not None and value >= high:
             continue
         return label

--- a/benchmark/requirements.lock.txt
+++ b/benchmark/requirements.lock.txt
@@ -160,7 +160,9 @@ urllib3==2.7.0
 vosk==0.3.45
     # via -r requirements.txt
 websockets==16.0
-    # via vosk
+    # via
+    #   -r requirements.txt
+    #   vosk
 xxhash==3.7.0
     # via datasets
 yarl==1.24.2

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -1,6 +1,8 @@
 faster-whisper>=1.1.0
 vosk>=0.3.45
 numpy>=1.24.0
+# WebSocket streaming for the gigastt benchmark runner
+websockets>=12.0
 # Optional: for reading parquet manifests
 pyarrow>=15.0.0
 # Common Voice Russian preparation script

--- a/benchmark/runners/faster_whisper.py
+++ b/benchmark/runners/faster_whisper.py
@@ -16,6 +16,10 @@ class FasterWhisperRunner:
         self.compute_type = compute_type
         self._model = None
 
+    @property
+    def cache_config(self) -> str:
+        return f"{self.model_size}:{self.device}:{self.compute_type}"
+
     def is_available(self) -> bool:
         try:
             from faster_whisper import WhisperModel

--- a/benchmark/runners/gigastt.py
+++ b/benchmark/runners/gigastt.py
@@ -7,6 +7,11 @@ import urllib.request
 from pathlib import Path
 
 
+# Bumped whenever the runner's transcription behavior changes in a way that
+# invalidates previously cached results (model format, preprocessing, API).
+GIGASTT_CACHE_SCHEMA_VERSION = "v2.2.0"
+
+
 class GigasttRunner:
     name = "gigastt"
 
@@ -25,7 +30,7 @@ class GigasttRunner:
         lazily after ``is_available()`` and would change the key between the
         first (cache-miss) and second (cache-lookup) runs.
         """
-        return f"{self.model_dir}:{self.use_int8}:v2.2.0"
+        return f"{self.model_dir}:{self.use_int8}:{GIGASTT_CACHE_SCHEMA_VERSION}"
 
     def _find_binary(self) -> bool:
         """Locate the gigastt binary and cache the path."""

--- a/benchmark/runners/gigastt.py
+++ b/benchmark/runners/gigastt.py
@@ -1,10 +1,18 @@
-"""Runner for gigastt using the REST API (server stays up across samples)."""
+"""Runner for gigastt using WebSocket streaming (server stays up across samples)."""
 
+import asyncio
 import json
 import subprocess
 import time
 import urllib.request
+import wave
 from pathlib import Path
+
+
+try:
+    import websockets
+except ImportError as _e:
+    websockets = None
 
 
 class GigasttRunner:
@@ -16,6 +24,16 @@ class GigasttRunner:
         self.port = port
         self._binary: str | None = None
         self._proc: subprocess.Popen | None = None
+
+    @property
+    def cache_config(self) -> str:
+        """Stable config string for result caching.
+
+        Intentionally excludes the resolved binary path: that path is discovered
+        lazily after ``is_available()`` and would change the key between the
+        first (cache-miss) and second (cache-lookup) runs.
+        """
+        return f"{self.model_dir}:{self.use_int8}:v2.2.0"
 
     def _find_binary(self) -> bool:
         """Locate the gigastt binary and cache the path."""
@@ -36,6 +54,9 @@ class GigasttRunner:
 
     def is_available(self) -> bool:
         if not self._find_binary():
+            return False
+        if websockets is None:
+            print("[gigastt] websockets not installed; run: pip install websockets")
             return False
         self._start_server()
         return True
@@ -76,25 +97,83 @@ class GigasttRunner:
                 self._proc.wait()
             self._proc = None
 
+    async def _stream_transcribe(self, wav_path: str) -> tuple[str, float]:
+        """Stream a WAV file over WebSocket and return the final transcript."""
+        url = f"ws://127.0.0.1:{self.port}/v1/ws"
+
+        with wave.open(wav_path, "rb") as wf:
+            channels = wf.getnchannels()
+            width = wf.getsampwidth()
+            rate = wf.getframerate()
+            if channels != 1 or width != 2:
+                raise ValueError(f"{wav_path}: expected mono 16-bit WAV")
+
+            frames_per_chunk = int(rate * 0.2)  # 200 ms chunks
+            chunk_bytes = frames_per_chunk * width
+            audio_bytes = wf.readframes(wf.getnframes())
+
+        final_text = ""
+        started_at = None
+
+        async with websockets.connect(url) as ws:
+            # Wait for ready and configure stream
+            ready = json.loads(await ws.recv())
+            if ready.get("type") != "ready":
+                raise RuntimeError(f"Unexpected ready message: {ready}")
+            await ws.send(json.dumps({"type": "configure", "sample_rate": rate}))
+
+            # Start reader task to collect partials/final
+            final_future: asyncio.Future[str] = asyncio.get_event_loop().create_future()
+
+            async def _reader():
+                nonlocal final_text
+                async for raw in ws:
+                    msg = json.loads(raw)
+                    kind = msg.get("type")
+                    if kind == "final":
+                        final_text = msg.get("text", "").strip()
+                        if not final_future.done():
+                            final_future.set_result(final_text)
+                        return
+                    elif kind == "error":
+                        if not final_future.done():
+                            final_future.set_exception(RuntimeError(msg.get("message", "WS error")))
+                        return
+
+            reader_task = asyncio.create_task(_reader())
+
+            # Stream audio in real-time paced chunks
+            started_at = time.perf_counter()
+            for i in range(0, len(audio_bytes), chunk_bytes):
+                chunk = audio_bytes[i : i + chunk_bytes]
+                await ws.send(chunk)
+                # Pace at ~real-time to mimic live microphone input
+                await asyncio.sleep(len(chunk) / (rate * width))
+
+            await ws.send(json.dumps({"type": "stop"}))
+
+            try:
+                await asyncio.wait_for(final_future, timeout=30.0)
+            except asyncio.TimeoutError:
+                reader_task.cancel()
+                raise RuntimeError("Timeout waiting for final transcription")
+            finally:
+                if not reader_task.done():
+                    reader_task.cancel()
+                    try:
+                        await reader_task
+                    except asyncio.CancelledError:
+                        pass
+
+        elapsed = time.perf_counter() - started_at
+        return final_text, elapsed
+
     def transcribe(self, wav_path: str) -> tuple[str, float]:
         if not self._binary:
             raise RuntimeError("gigastt not available")
-        with open(wav_path, "rb") as f:
-            data = f.read()
-
-        req = urllib.request.Request(
-            f"http://127.0.0.1:{self.port}/v1/transcribe",
-            data=data,
-            headers={"Content-Type": "application/octet-stream"},
-            method="POST",
-        )
-        start = time.perf_counter()
-        with urllib.request.urlopen(req, timeout=300) as resp:
-            body = resp.read().decode("utf-8")
-        elapsed = time.perf_counter() - start
-        result = json.loads(body)
-        text = result.get("text", "").strip()
-        return text, elapsed
+        if websockets is None:
+            raise RuntimeError("websockets package not installed")
+        return asyncio.run(self._stream_transcribe(wav_path))
 
     def __enter__(self):
         self._start_server()

--- a/benchmark/runners/gigastt.py
+++ b/benchmark/runners/gigastt.py
@@ -1,18 +1,10 @@
-"""Runner for gigastt using WebSocket streaming (server stays up across samples)."""
+"""Runner for gigastt using the REST API (server stays up across samples)."""
 
-import asyncio
 import json
 import subprocess
 import time
 import urllib.request
-import wave
 from pathlib import Path
-
-
-try:
-    import websockets
-except ImportError as _e:
-    websockets = None
 
 
 class GigasttRunner:
@@ -55,9 +47,6 @@ class GigasttRunner:
     def is_available(self) -> bool:
         if not self._find_binary():
             return False
-        if websockets is None:
-            print("[gigastt] websockets not installed; run: pip install websockets")
-            return False
         self._start_server()
         return True
 
@@ -97,83 +86,25 @@ class GigasttRunner:
                 self._proc.wait()
             self._proc = None
 
-    async def _stream_transcribe(self, wav_path: str) -> tuple[str, float]:
-        """Stream a WAV file over WebSocket and return the final transcript."""
-        url = f"ws://127.0.0.1:{self.port}/v1/ws"
-
-        with wave.open(wav_path, "rb") as wf:
-            channels = wf.getnchannels()
-            width = wf.getsampwidth()
-            rate = wf.getframerate()
-            if channels != 1 or width != 2:
-                raise ValueError(f"{wav_path}: expected mono 16-bit WAV")
-
-            frames_per_chunk = int(rate * 0.2)  # 200 ms chunks
-            chunk_bytes = frames_per_chunk * width
-            audio_bytes = wf.readframes(wf.getnframes())
-
-        final_text = ""
-        started_at = None
-
-        async with websockets.connect(url) as ws:
-            # Wait for ready and configure stream
-            ready = json.loads(await ws.recv())
-            if ready.get("type") != "ready":
-                raise RuntimeError(f"Unexpected ready message: {ready}")
-            await ws.send(json.dumps({"type": "configure", "sample_rate": rate}))
-
-            # Start reader task to collect partials/final
-            final_future: asyncio.Future[str] = asyncio.get_event_loop().create_future()
-
-            async def _reader():
-                nonlocal final_text
-                async for raw in ws:
-                    msg = json.loads(raw)
-                    kind = msg.get("type")
-                    if kind == "final":
-                        final_text = msg.get("text", "").strip()
-                        if not final_future.done():
-                            final_future.set_result(final_text)
-                        return
-                    elif kind == "error":
-                        if not final_future.done():
-                            final_future.set_exception(RuntimeError(msg.get("message", "WS error")))
-                        return
-
-            reader_task = asyncio.create_task(_reader())
-
-            # Stream audio in real-time paced chunks
-            started_at = time.perf_counter()
-            for i in range(0, len(audio_bytes), chunk_bytes):
-                chunk = audio_bytes[i : i + chunk_bytes]
-                await ws.send(chunk)
-                # Pace at ~real-time to mimic live microphone input
-                await asyncio.sleep(len(chunk) / (rate * width))
-
-            await ws.send(json.dumps({"type": "stop"}))
-
-            try:
-                await asyncio.wait_for(final_future, timeout=30.0)
-            except asyncio.TimeoutError:
-                reader_task.cancel()
-                raise RuntimeError("Timeout waiting for final transcription")
-            finally:
-                if not reader_task.done():
-                    reader_task.cancel()
-                    try:
-                        await reader_task
-                    except asyncio.CancelledError:
-                        pass
-
-        elapsed = time.perf_counter() - started_at
-        return final_text, elapsed
-
     def transcribe(self, wav_path: str) -> tuple[str, float]:
         if not self._binary:
             raise RuntimeError("gigastt not available")
-        if websockets is None:
-            raise RuntimeError("websockets package not installed")
-        return asyncio.run(self._stream_transcribe(wav_path))
+        with open(wav_path, "rb") as f:
+            data = f.read()
+
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}/v1/transcribe",
+            data=data,
+            headers={"Content-Type": "application/octet-stream"},
+            method="POST",
+        )
+        start = time.perf_counter()
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            body = resp.read().decode("utf-8")
+        elapsed = time.perf_counter() - start
+        result = json.loads(body)
+        text = result.get("text", "").strip()
+        return text, elapsed
 
     def __enter__(self):
         self._start_server()

--- a/benchmark/runners/t_one.py
+++ b/benchmark/runners/t_one.py
@@ -37,6 +37,14 @@ class TOneRunner:
         self.device = device
         self._pipeline = None
 
+    @property
+    def cache_config(self) -> str:
+        import os
+
+        decoder = os.environ.get("BENCHMARK_TONE_DECODER", "greedy")
+        kenlm = os.environ.get("BENCHMARK_TONE_KENLM", "")
+        return f"{self.device or 'default'}:{decoder}:{kenlm}"
+
     def is_available(self) -> bool:
         try:
             import tone  # noqa: F401

--- a/benchmark/runners/vosk.py
+++ b/benchmark/runners/vosk.py
@@ -19,6 +19,10 @@ class VoskRunner:
         self.download_dir.mkdir(parents=True, exist_ok=True)
         self._model = None
 
+    @property
+    def cache_config(self) -> str:
+        return self.model_name
+
     def _download_model(self) -> Path:
         model_dir = self.download_dir / self.model_name
         if model_dir.exists():

--- a/benchmark/runners/vosk_054.py
+++ b/benchmark/runners/vosk_054.py
@@ -32,6 +32,10 @@ class Vosk054Runner:
         self.download_dir.mkdir(parents=True, exist_ok=True)
         self._recognizer = None
 
+    @property
+    def cache_config(self) -> str:
+        return self.model_name
+
     def is_available(self) -> bool:
         try:
             import sherpa_onnx  # noqa: F401

--- a/benchmark/runners/whisper_cpp.py
+++ b/benchmark/runners/whisper_cpp.py
@@ -30,6 +30,10 @@ class WhisperCppRunner:
         self._source_dir: Path = self.download_dir / f"whisper.cpp-{source_tag}"
         self._proc: subprocess.Popen | None = None
 
+    @property
+    def cache_config(self) -> str:
+        return f"{self.model_name}:{self.source_tag}"
+
     def _build(self) -> Path:
         """Clone and build whisper-server from source."""
         # Check for pre-existing local build (e.g. /tmp/whisper.cpp)

--- a/benchmark/tests/test_benchmark.py
+++ b/benchmark/tests/test_benchmark.py
@@ -1,0 +1,172 @@
+"""Unit tests for benchmark/benchmark.py orchestration."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import benchmark
+
+
+def test_clear_cache_flag_removes_entries_and_exits(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "entry.json").write_text('{"hypothesis": "x"}')
+
+    with pytest.raises(SystemExit) as exc:
+        with patch.object(sys, "argv", ["benchmark.py", "--cache-dir", str(cache_dir), "--clear-cache"]):
+            benchmark._main()
+
+    assert exc.value.code == 0
+    assert not list(cache_dir.iterdir())
+
+
+def _fake_runner(name: str, available: bool = True):
+    runner = MagicMock()
+    runner.name = name
+    runner.is_available.return_value = available
+    runner.__enter__ = MagicMock(return_value=runner)
+    runner.__exit__ = MagicMock(return_value=False)
+    return runner
+
+
+def _fake_result(name: str = "fake") -> dict:
+    return {
+        "name": name,
+        "samples": 0,
+        "failures": 0,
+        "cached_hits": 0,
+        "wer": 0.0,
+        "ci_low": 0.0,
+        "ci_high": 0.0,
+        "total_errors": 0,
+        "total_ref_words": 0,
+        "total_audio_sec": 0.0,
+        "total_proc_sec": 0.0,
+        "rtf": 0.0,
+        "details": [],
+        "histograms": {},
+    }
+
+
+def test_runner_selection_filters_by_name(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    fake_available = _fake_runner("fake_available")
+    fake_unavailable = _fake_runner("fake_unavailable", available=False)
+
+    manifest = [{"filename": "a.wav", "reference": "hello"}]
+    fake_result = {**_fake_result(), "samples": 1, "total_ref_words": 1}
+
+    with patch.object(benchmark, "ALL_RUNNERS", [fake_available, fake_unavailable]):
+        with patch.object(benchmark, "load_manifest", return_value={"samples": manifest, "skipped_empty_refs": 0}):
+            with patch.object(benchmark, "run_benchmark", return_value=fake_result) as mock_run:
+                with patch.object(sys, "argv", [
+                    "benchmark.py",
+                    "--cache-dir", str(cache_dir),
+                    "--runners", "fake_available",
+                    "--output", str(tmp_path / "results.json"),
+                    "--max-samples", "1",
+                ]):
+                    benchmark._main()
+
+    assert fake_available.is_available.called
+    assert not fake_unavailable.is_available.called
+    mock_run.assert_called_once()
+
+
+def test_run_benchmark_counts_failure():
+    runner = MagicMock()
+    runner.name = "fake"
+    runner.transcribe.side_effect = RuntimeError("boom")
+
+    manifest = [{"filename": "a.wav", "reference": "hello world"}]
+    result = benchmark.run_benchmark(runner, manifest, max_samples=1)
+
+    assert result["failures"] == 1
+    assert result["wer"] == 100.0
+    assert result["details"][0]["failed"] is True
+
+
+def test_run_benchmark_uses_cache():
+    class _FakeCache:
+        def __init__(self, entries):
+            self._entries = entries
+
+        def get(self, runner, wav_path):
+            return self._entries.get(wav_path)
+
+        def set(self, *args, **kwargs):
+            pass
+
+    runner = MagicMock()
+    runner.name = "fake"
+    cache = _FakeCache({"a.wav": {"hypothesis": "hello", "proc_time": 0.1}})
+    manifest = [{"filename": "a.wav", "reference": "hello"}]
+    result = benchmark.run_benchmark(runner, manifest, cache=cache)
+
+    runner.transcribe.assert_not_called()
+    assert result["cached_hits"] == 1
+    assert result["details"][0]["cached"] is True
+    assert result["details"][0]["hypothesis"] == "hello"
+
+
+def test_no_cache_flag_disables_cache(tmp_path):
+    cache_dir = tmp_path / "cache"
+
+    fake_runner = _fake_runner("fake")
+    fake_result = _fake_result()
+
+    with patch.object(benchmark, "ALL_RUNNERS", [fake_runner]):
+        with patch.object(benchmark, "load_manifest", return_value={"samples": [], "skipped_empty_refs": 0}):
+            with patch.object(benchmark, "run_benchmark", return_value=fake_result):
+                with patch.object(sys, "argv", [
+                    "benchmark.py",
+                    "--cache-dir", str(cache_dir),
+                    "--runners", "fake",
+                    "--no-cache",
+                ]):
+                    benchmark._main()
+
+    assert not cache_dir.exists() or not list(cache_dir.iterdir())
+
+
+def test_profile_flag_writes_prof_file(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    prof_path = tmp_path / benchmark.PROFILE_PATH
+
+    fake_runner = _fake_runner("fake")
+    fake_result = _fake_result()
+
+    monkeypatch.chdir(tmp_path)
+    with patch.object(benchmark, "ALL_RUNNERS", [fake_runner]):
+        with patch.object(benchmark, "load_manifest", return_value={"samples": [], "skipped_empty_refs": 0}):
+            with patch.object(benchmark, "run_benchmark", return_value=fake_result):
+                with patch.object(sys, "argv", [
+                    "benchmark.py",
+                    "--cache-dir", str(cache_dir),
+                    "--runners", "fake",
+                    "--profile",
+                ]):
+                    benchmark.main()
+
+    assert prof_path.exists()
+    assert prof_path.stat().st_size > 0
+
+
+def test_profile_flag_does_not_mutate_argv(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    argv = ["benchmark.py", "--cache-dir", str(cache_dir), "--profile"]
+
+    monkeypatch.chdir(tmp_path)
+    with patch.object(benchmark, "ALL_RUNNERS", []):
+        with patch.object(benchmark, "load_manifest", return_value={"samples": [], "skipped_empty_refs": 0}):
+            with patch.object(benchmark, "run_benchmark", return_value=_fake_result()):
+                with patch.object(sys, "argv", argv):
+                    with pytest.raises(SystemExit):
+                        benchmark.main()
+                    assert sys.argv == argv

--- a/benchmark/tests/test_cache.py
+++ b/benchmark/tests/test_cache.py
@@ -4,6 +4,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from cache import DiskCache
 
 
@@ -103,6 +105,18 @@ def test_cache_writes_are_atomic():
         files = list(Path(tmp).glob("*"))
         assert len(files) == 1
         assert files[0].name == f"{key}.json"
+
+
+def test_set_cleans_up_temp_on_write_failure(tmp_path):
+    cache = DiskCache(tmp_path)
+    # Make the cache directory read-only so os.replace / mkstemp will fail.
+    cache.cache_dir.chmod(0o555)
+    try:
+        with pytest.raises(Exception):
+            cache.set(_FakeRunner(), str(tmp_path / "clip.wav"), "hyp", 1.0)
+    finally:
+        cache.cache_dir.chmod(0o755)
+    assert list(cache.cache_dir.glob("*.tmp")) == []
 
 
 def test_gigastt_runner_cache_config_is_stable():

--- a/benchmark/tests/test_cache.py
+++ b/benchmark/tests/test_cache.py
@@ -1,0 +1,115 @@
+"""Unit tests for benchmark/cache.py."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from cache import DiskCache
+
+
+class _FakeRunner:
+    name = "fake"
+    cache_config = "model-a:int8"
+
+
+class _FakeRunnerNoConfig:
+    name = "fake-no-config"
+
+
+def test_cache_miss_returns_none():
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = DiskCache(tmp)
+        assert cache.get(_FakeRunner(), "nonexistent.wav") is None
+
+
+def test_cache_round_trip():
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = DiskCache(tmp)
+        runner = _FakeRunner()
+        wav = "clip.wav"
+        cache.set(runner, wav, "hello world", 1.234)
+
+        entry = cache.get(runner, wav)
+        assert entry is not None
+        assert entry["hypothesis"] == "hello world"
+        assert entry["proc_time"] == 1.234
+        assert entry["runner"] == "fake"
+        assert entry["config"] == "model-a:int8"
+
+
+def test_cache_disabled_returns_none():
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = DiskCache(tmp, enabled=False)
+        runner = _FakeRunner()
+        cache.set(runner, "clip.wav", "hello", 0.5)
+        assert cache.get(runner, "clip.wav") is None
+
+
+def test_cache_key_depends_on_runner_config():
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = DiskCache(tmp)
+        wav = "clip.wav"
+
+        class RunnerA:
+            name = "runner"
+            cache_config = "a"
+
+        class RunnerB:
+            name = "runner"
+            cache_config = "b"
+
+        cache.set(RunnerA(), wav, "from a", 1.0)
+        cache.set(RunnerB(), wav, "from b", 2.0)
+
+        assert cache.get(RunnerA(), wav)["hypothesis"] == "from a"
+        assert cache.get(RunnerB(), wav)["hypothesis"] == "from b"
+
+
+def test_cache_key_without_config_uses_name_only():
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = DiskCache(tmp)
+        runner = _FakeRunnerNoConfig()
+        cache.set(runner, "clip.wav", "hello", 0.1)
+        assert cache.get(runner, "clip.wav")["hypothesis"] == "hello"
+
+
+def test_corrupt_cache_entry_is_miss():
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = DiskCache(tmp)
+        # Force a cache file with invalid JSON.
+        key = cache._key(_FakeRunner(), "clip.wav")
+        cache_path = cache._path(key)
+        cache_path.write_text("not json")
+
+        assert cache.get(_FakeRunner(), "clip.wav") is None
+
+
+def test_clear_cache_removes_entries():
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = DiskCache(tmp)
+        cache.set(_FakeRunner(), "a.wav", "one", 1.0)
+        cache.set(_FakeRunner(), "b.wav", "two", 2.0)
+        assert cache.clear() == 2
+        assert cache.get(_FakeRunner(), "a.wav") is None
+        assert cache.get(_FakeRunner(), "b.wav") is None
+
+
+def test_cache_writes_are_atomic():
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = DiskCache(tmp)
+        cache.set(_FakeRunner(), "clip.wav", "hello", 0.1)
+        key = cache._key(_FakeRunner(), "clip.wav")
+        # Only the final .json file should exist, no leftover .tmp files.
+        files = list(Path(tmp).glob("*"))
+        assert len(files) == 1
+        assert files[0].name == f"{key}.json"
+
+
+def test_gigastt_runner_cache_config_is_stable():
+    from runners.gigastt import GigasttRunner
+
+    runner = GigasttRunner(model_dir="/models", use_int8=True, port=9877)
+    # The resolved binary path is discovered lazily and must NOT affect the
+    # cache key, otherwise the second run would see a miss.
+    runner._binary = "/usr/local/bin/gigastt"
+    assert runner.cache_config == "/models:True:v2.2.0"

--- a/benchmark/tests/test_histograms.py
+++ b/benchmark/tests/test_histograms.py
@@ -93,6 +93,16 @@ def test_histogram_bucket_boundaries():
     assert buckets["30s+"]["samples"] == 1
 
 
+def test_histogram_ref_words_zero_goes_to_first_bucket():
+    # Values below the first bucket's lower bound currently fall into the first
+    # bucket because _bucket_value returns the last bucket label only after all
+    # buckets have been tested.
+    details = [_detail(1.0, 0, 0)]
+    hists = compute_histograms(details)
+    buckets = {b["bucket"]: b for b in hists["ref_words"]}
+    assert buckets["1-5 words"]["samples"] == 1
+
+
 def test_histogram_empty_details():
     hists = compute_histograms([])
     for dim in ("audio_duration", "ref_words", "wer"):

--- a/benchmark/tests/test_histograms.py
+++ b/benchmark/tests/test_histograms.py
@@ -1,0 +1,114 @@
+"""Unit tests for benchmark/common.py histogram computation."""
+
+from common import compute_histograms
+
+
+def _detail(audio_sec: float, ref_words: int, errors: int, failed: bool = False) -> dict:
+    wer = (errors / ref_words * 100.0) if ref_words > 0 else 0.0
+    return {
+        "audio_sec": audio_sec,
+        "ref_words": ref_words,
+        "errors": errors,
+        "wer": wer,
+        "failed": failed,
+    }
+
+
+def test_histogram_by_audio_duration():
+    details = [
+        _detail(2.0, 5, 0),
+        _detail(8.0, 10, 1),
+        _detail(20.0, 15, 3),
+        _detail(45.0, 20, 5),
+    ]
+    hists = compute_histograms(details)
+    buckets = {b["bucket"]: b for b in hists["audio_duration"]}
+
+    assert buckets["0-5s"]["samples"] == 1
+    assert buckets["5-15s"]["samples"] == 1
+    assert buckets["15-30s"]["samples"] == 1
+    assert buckets["30s+"]["samples"] == 1
+
+    assert buckets["0-5s"]["ref_words"] == 5
+    assert buckets["0-5s"]["errors"] == 0
+    assert buckets["0-5s"]["wer"] == 0.0
+
+    assert buckets["30s+"]["ref_words"] == 20
+    assert buckets["30s+"]["errors"] == 5
+    assert buckets["30s+"]["wer"] == 25.0
+
+
+def test_histogram_by_ref_words():
+    details = [
+        _detail(2.0, 3, 0),
+        _detail(8.0, 8, 1),
+        _detail(20.0, 20, 2),
+        _detail(45.0, 40, 10),
+    ]
+    hists = compute_histograms(details)
+    buckets = {b["bucket"]: b for b in hists["ref_words"]}
+
+    assert buckets["1-5 words"]["samples"] == 1
+    assert buckets["6-15 words"]["samples"] == 1
+    assert buckets["16-30 words"]["samples"] == 1
+    assert buckets["30+ words"]["samples"] == 1
+
+
+def test_histogram_by_wer():
+    details = [
+        _detail(2.0, 10, 0),    # 0%
+        _detail(3.0, 10, 1),    # 10%
+        _detail(4.0, 10, 2),    # 20%
+        _detail(5.0, 10, 4),    # 40%
+        _detail(6.0, 10, 7),    # 70%
+        _detail(7.0, 10, 10),   # 100%
+        _detail(8.0, 10, 12),   # 120%
+    ]
+    hists = compute_histograms(details)
+    buckets = {b["bucket"]: b for b in hists["wer"]}
+
+    # Bucket upper bounds are exclusive, so boundary values fall into the next
+    # bucket: 10% → 10-20%, 20% → 20-50%, 100% → 100%+.
+    assert buckets["0%"]["samples"] == 1
+    assert buckets["1-10%"]["samples"] == 0
+    assert buckets["10-20%"]["samples"] == 1
+    assert buckets["20-50%"]["samples"] == 2
+    assert buckets["50-100%"]["samples"] == 1
+    assert buckets["100%+"]["samples"] == 2
+
+
+def test_histogram_bucket_boundaries():
+    # Exact boundary values should land in the expected bucket.
+    details = [
+        _detail(5.0, 10, 1),   # 5s is low-inclusive for 5-15s
+        _detail(15.0, 10, 1),  # 15s is low-inclusive for 15-30s
+        _detail(30.0, 10, 1),  # 30s is low-inclusive for 30s+
+    ]
+    hists = compute_histograms(details)
+    buckets = {b["bucket"]: b for b in hists["audio_duration"]}
+
+    assert buckets["0-5s"]["samples"] == 0
+    assert buckets["5-15s"]["samples"] == 1
+    assert buckets["15-30s"]["samples"] == 1
+    assert buckets["30s+"]["samples"] == 1
+
+
+def test_histogram_empty_details():
+    hists = compute_histograms([])
+    for dim in ("audio_duration", "ref_words", "wer"):
+        buckets = hists[dim]
+        assert all(b["samples"] == 0 for b in buckets)
+        assert all(b["wer"] == 0.0 for b in buckets)
+
+
+def test_histogram_includes_failed_samples():
+    # Failed samples report 100% WER for that sample.
+    details = [
+        _detail(2.0, 5, 0),
+        {**_detail(2.0, 5, 0), "errors": 5, "wer": 100.0, "failed": True},
+    ]
+    hists = compute_histograms(details)
+    wer_buckets = {b["bucket"]: b for b in hists["wer"]}
+
+    assert wer_buckets["0%"]["samples"] == 1
+    assert wer_buckets["100%+"]["samples"] == 1

--- a/benchmark/tests/test_runner_cache_config.py
+++ b/benchmark/tests/test_runner_cache_config.py
@@ -1,0 +1,54 @@
+"""Unit tests for runner cache_config stability."""
+
+from pathlib import Path
+
+import pytest
+
+
+def test_gigastt_cache_config_excludes_binary_path():
+    from runners.gigastt import GIGASTT_CACHE_SCHEMA_VERSION, GigasttRunner
+
+    runner = GigasttRunner(model_dir="/models", use_int8=True, port=9877)
+    runner._binary = "/usr/local/bin/gigastt"
+    assert runner.cache_config == f"/models:True:{GIGASTT_CACHE_SCHEMA_VERSION}"
+
+
+def test_faster_whisper_cache_config_includes_params():
+    from runners.faster_whisper import FasterWhisperRunner
+
+    runner = FasterWhisperRunner(model_size="base", device="cpu", compute_type="int8")
+    assert runner.cache_config == "base:cpu:int8"
+
+
+def test_whisper_cpp_cache_config_includes_model_and_tag(tmp_path):
+    from runners.whisper_cpp import WhisperCppRunner
+
+    runner = WhisperCppRunner(
+        model_name="ggml-small.bin",
+        download_dir=str(tmp_path),
+        source_tag="v1.0.0",
+    )
+    assert runner.cache_config == "ggml-small.bin:v1.0.0"
+
+
+def test_vosk_cache_config_is_model_name(tmp_path):
+    from runners.vosk import VoskRunner
+
+    runner = VoskRunner(model_name="vosk-model-ru-0.42", download_dir=str(tmp_path))
+    assert runner.cache_config == "vosk-model-ru-0.42"
+
+
+def test_vosk_054_cache_config_is_model_name(tmp_path):
+    from runners.vosk_054 import Vosk054Runner
+
+    runner = Vosk054Runner(model_name="vosk-model-ru-0.54", download_dir=str(tmp_path))
+    assert runner.cache_config == "vosk-model-ru-0.54"
+
+
+def test_t_one_cache_config_reflects_env(monkeypatch):
+    from runners.t_one import TOneRunner
+
+    monkeypatch.setenv("BENCHMARK_TONE_DECODER", "beam_search")
+    monkeypatch.setenv("BENCHMARK_TONE_KENLM", "/path/to/kenlm.bin")
+    runner = TOneRunner(device="cpu")
+    assert runner.cache_config == "cpu:beam_search:/path/to/kenlm.bin"

--- a/crates/gigastt-ffi/Cargo.toml
+++ b/crates/gigastt-ffi/Cargo.toml
@@ -20,7 +20,7 @@ cuda = ["gigastt-core/cuda"]
 diarization = ["gigastt-core/diarization"]
 
 [dependencies]
-gigastt-core = { version = "2.2.0", path = "../gigastt-core", default-features = false }
+gigastt-core = { version = "2.2.1", path = "../gigastt-core", default-features = false }
 serde_json = "1"
 tracing = "0.1"
 

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -25,7 +25,7 @@ diarization = ["gigastt-core/diarization"]
 quantize = ["gigastt-core/quantize"]
 
 [dependencies]
-gigastt-core = { version = "2.2.0", path = "../gigastt-core", default-features = false }
+gigastt-core = { version = "2.2.1", path = "../gigastt-core", default-features = false }
 
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }


### PR DESCRIPTION
## Summary

This PR ships improvements to the Python benchmark suite used to evaluate gigastt against other ASR engines:

- **Disk cache for transcription results** (`benchmark/cache.py`). Results are cached by runner config + SHA-256 of the audio file, so repeated benchmark runs reuse expensive transcriptions.
- **WER histograms** (`benchmark/common.py`, `benchmark/benchmark.py`). Each runner result now includes histograms broken down by audio duration, reference word count, and WER bucket.
- **Profiling flag** (`benchmark/benchmark.py --profile`). Writes `cProfile` stats to `benchmark.prof`.
- **WebSocket vs REST validation** (commits `c156b71` and `ba46aa5`). WS was reverted to REST after it finalized on incomplete audio during benchmarking; REST returns the full transcript.
- **Review fixes**: module-level runner class registry to avoid import-time side effects, named constants for profile path / progress interval / cache schema version, and a bucket-boundary fix for values below the lowest histogram threshold.

## Test Coverage

- Python benchmark tests: **54 passed** (up from 39).
- Rust unit + bin tests: **288 passed**, 22 ignored (model-required).
- New tests cover cache hits/misses, `--no-cache`, `--clear-cache`, `--profile`, runner selection, cache config for every runner, and histogram bucket boundaries.

## Pre-Landing Review

- **Maintainability**: fixed import-time runner instantiation, extracted magic constants (`PROFILE_PATH`, `PROGRESS_INTERVAL`, `GIGASTT_CACHE_SCHEMA_VERSION`), replaced manual context-manager plumbing with `contextlib.nullcontext`, and fixed `sys.argv` mutation in `--profile` handling.
- **Testing**: added tests for previously uncovered cache-hit, no-cache, failure-cleanup, runner cache-config, and bucket-boundary paths.
- No critical findings remain.

## Version

Bumped workspace version to **2.2.1** and updated `CHANGELOG.md`.

## Test plan

- [x] `cd benchmark && source .venv/bin/activate && python -m pytest tests/ -q` — 54 passed
- [x] `cargo test --workspace --lib --bins` — 288 passed, 22 ignored
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] Pre-commit hook passes

🤖 Generated with gstack /ship