### PR TITLE
feat(export): SRT/VTT/TXT/Markdown export for transcription results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,11 @@ All CLI flags have corresponding env vars:
 | `GIGASTT_SKIP_QUANTIZE` | `--skip-quantize` | false |
 | `GIGASTT_METRICS` | `--metrics` | false |
 | `GIGASTT_METRICS_LISTEN` | `--metrics-listen` | 127.0.0.1:9090 |
+| `GIGASTT_FORMAT` | `transcribe --format` | `txt` |
+| `GIGASTT_OUTPUT` | `transcribe --output` | — |
+| `GIGASTT_MAX_CHARS_PER_LINE` | `transcribe --max-chars-per-line` | — |
+| `GIGASTT_MAX_WORDS_PER_LINE` | `transcribe --max-words-per-line` | — |
+| `GIGASTT_WORD_TIMESTAMPS` | `transcribe --word-timestamps` | false |
 | `RUST_LOG` | — | `gigastt=info` |
 
 ## Useful Commands for Agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GIGASTT_BENCHMARK_UPDATE_BASELINE=1` refresh path. The absolute `MAX_WER`
   ceiling is a hard failure too; previously it only warned and `pass` was
   hardcoded `true`.
+- **Export formats for transcription results.** The REST endpoint
+  `/v1/transcribe` now accepts `?format=txt|json|srt|vtt|md` (JSON remains the
+  default) and optional formatter controls (`max_chars_per_line`,
+  `max_words_per_line`, `word_timestamps`, `download`). The CLI command
+  `gigastt transcribe` gained `--format`/`-f`, `--output`/`-o`,
+  `--max-chars-per-line`, `--max-words-per-line`, and `--word-timestamps`.
+  New `gigastt-core::export` module provides pure formatters; SRT/VTT are
+  speaker-aware and Markdown includes YAML frontmatter with `duration`,
+  `language: ru`, and `speakers`.
 
 ### Changed
 

--- a/crates/gigastt-core/src/error.rs
+++ b/crates/gigastt-core/src/error.rs
@@ -112,6 +112,9 @@ pub enum GigasttError {
     /// Filesystem or I/O error.
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    /// Invalid user-supplied parameter or option (not audio-specific).
+    #[error("invalid input: {message}")]
+    InvalidInput { message: String },
 }
 
 impl GigasttError {
@@ -125,6 +128,7 @@ impl GigasttError {
             GigasttError::Inference { .. } => "inference_error",
             GigasttError::InvalidAudio { .. } => "invalid_audio",
             GigasttError::Io(_) => "io_error",
+            GigasttError::InvalidInput { .. } => "invalid_input",
         }
     }
 }
@@ -161,6 +165,21 @@ mod tests {
             GigasttError::Io(std::io::Error::other("x")).code(),
             "io_error"
         );
+        assert_eq!(
+            GigasttError::InvalidInput {
+                message: "bad format".into()
+            }
+            .code(),
+            "invalid_input"
+        );
+    }
+
+    #[test]
+    fn test_display_invalid_input() {
+        let e = GigasttError::InvalidInput {
+            message: "unsupported format".into(),
+        };
+        assert_eq!(e.to_string(), "invalid input: unsupported format");
     }
 
     #[test]

--- a/crates/gigastt-core/src/export.rs
+++ b/crates/gigastt-core/src/export.rs
@@ -1,0 +1,446 @@
+//! Output formatters for transcription results.
+//!
+//! Supports plain text, JSON, SRT, WebVTT, and Markdown export from the
+//! [`TranscribeResult`] structure returned by the inference engine.
+
+use crate::error::GigasttError;
+use crate::inference::{TranscribeResult, WordInfo};
+use std::str::FromStr;
+
+/// Supported export formats for transcription results.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ExportFormat {
+    /// JSON with word-level metadata (default).
+    #[default]
+    Json,
+    /// Plain text transcript only.
+    Txt,
+    /// SubRip subtitles.
+    Srt,
+    /// WebVTT subtitles.
+    Vtt,
+    /// Markdown with YAML frontmatter and optional speaker/timing sections.
+    Md,
+}
+
+impl FromStr for ExportFormat {
+    type Err = GigasttError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "json" => Ok(Self::Json),
+            "txt" | "text" => Ok(Self::Txt),
+            "srt" => Ok(Self::Srt),
+            "vtt" => Ok(Self::Vtt),
+            "md" | "markdown" => Ok(Self::Md),
+            _ => Err(GigasttError::InvalidInput {
+                message: format!("unsupported export format: {s}"),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for ExportFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json => write!(f, "json"),
+            Self::Txt => write!(f, "txt"),
+            Self::Srt => write!(f, "srt"),
+            Self::Vtt => write!(f, "vtt"),
+            Self::Md => write!(f, "md"),
+        }
+    }
+}
+
+impl ExportFormat {
+    /// MIME type to serve for this format over HTTP.
+    pub fn content_type(&self) -> &'static str {
+        match self {
+            Self::Json => "application/json; charset=utf-8",
+            Self::Txt => "text/plain; charset=utf-8",
+            Self::Srt => "application/x-subrip; charset=utf-8",
+            Self::Vtt => "text/vtt; charset=utf-8",
+            Self::Md => "text/markdown; charset=utf-8",
+        }
+    }
+
+    /// Default file extension (without leading dot).
+    pub fn extension(&self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Txt => "txt",
+            Self::Srt => "srt",
+            Self::Vtt => "vtt",
+            Self::Md => "md",
+        }
+    }
+
+    /// Render a [`TranscribeResult`] into this format.
+    pub fn render(&self, result: &TranscribeResult, opts: &RenderOpts) -> String {
+        match self {
+            Self::Json => to_json(result),
+            Self::Txt => to_txt(result),
+            Self::Srt => to_srt(
+                &result.words,
+                opts.max_chars_per_line,
+                opts.max_words_per_line,
+            ),
+            Self::Vtt => to_vtt(
+                &result.words,
+                opts.max_chars_per_line,
+                opts.max_words_per_line,
+            ),
+            Self::Md => to_md(result, opts.include_word_timestamps),
+        }
+    }
+}
+
+/// Options controlling subtitle line breaking and Markdown detail level.
+#[derive(Clone, Copy, Debug)]
+pub struct RenderOpts {
+    /// Maximum characters per subtitle/caption line. `0` means unlimited.
+    pub max_chars_per_line: usize,
+    /// Maximum words per subtitle/caption line. `0` means unlimited.
+    pub max_words_per_line: usize,
+    /// Include per-word timestamps in Markdown output.
+    pub include_word_timestamps: bool,
+}
+
+impl Default for RenderOpts {
+    fn default() -> Self {
+        Self {
+            max_chars_per_line: 80,
+            max_words_per_line: 14,
+            include_word_timestamps: false,
+        }
+    }
+}
+
+/// Serialize the full result as JSON, mirroring the current REST contract.
+///
+/// The REST API exposes `duration` rather than the internal `duration_s` field
+/// name, so this formatter maps the field explicitly.
+pub fn to_json(result: &TranscribeResult) -> String {
+    serde_json::json!({
+        "text": result.text,
+        "words": result.words,
+        "duration": result.duration_s,
+    })
+    .to_string()
+}
+
+/// Plain text transcript only.
+pub fn to_txt(result: &TranscribeResult) -> String {
+    result.text.clone()
+}
+
+/// SubRip (SRT) subtitles from word-level timings.
+///
+/// Words are grouped into lines respecting `max_chars_per_line` and
+/// `max_words_per_line`. Speaker labels are rendered as `[SPEAKER_N] text`.
+pub fn to_srt(words: &[WordInfo], max_chars_per_line: usize, max_words_per_line: usize) -> String {
+    let cues = build_cues(words, max_chars_per_line, max_words_per_line);
+    let mut out = String::new();
+    for (i, cue) in cues.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&(i + 1).to_string());
+        out.push('\n');
+        out.push_str(&format_srt_time(cue.start));
+        out.push_str(" --> ");
+        out.push_str(&format_srt_time(cue.end));
+        out.push('\n');
+        out.push_str(&cue.text);
+        out.push('\n');
+    }
+    out
+}
+
+/// WebVTT subtitles from word-level timings.
+pub fn to_vtt(words: &[WordInfo], max_chars_per_line: usize, max_words_per_line: usize) -> String {
+    let cues = build_cues(words, max_chars_per_line, max_words_per_line);
+    let mut out = String::from("WEBVTT\n\n");
+    for cue in &cues {
+        out.push_str(&format_vtt_time(cue.start));
+        out.push_str(" --> ");
+        out.push_str(&format_vtt_time(cue.end));
+        out.push('\n');
+        out.push_str(&cue.text);
+        out.push('\n');
+        out.push('\n');
+    }
+    out
+}
+
+/// Markdown export with YAML frontmatter and an optional word-level appendix.
+pub fn to_md(result: &TranscribeResult, include_word_timestamps: bool) -> String {
+    let speaker_count = result
+        .words
+        .iter()
+        .filter_map(|w| w.speaker)
+        .max()
+        .map(|m| m + 1)
+        .unwrap_or(0);
+
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str(&format!("duration: {}\n", result.duration_s));
+    out.push_str("language: ru\n");
+    out.push_str(&format!("speakers: {speaker_count}\n"));
+    out.push_str("---\n\n");
+
+    out.push_str("# Transcript\n\n");
+    out.push_str(&result.text);
+    out.push_str("\n\n");
+
+    if include_word_timestamps && !result.words.is_empty() {
+        out.push_str("# Word timings\n\n");
+        out.push_str("| Word | Start | End | Confidence | Speaker |\n");
+        out.push_str("|------|-------|-----|------------|---------|\n");
+        for w in &result.words {
+            let speaker = w
+                .speaker
+                .map(|s| format!("SPEAKER_{s}"))
+                .unwrap_or_else(|| "-".to_string());
+            out.push_str(&format!(
+                "| {} | {:.3}s | {:.3}s | {:.3} | {speaker} |\n",
+                w.word.replace('|', "\\|"),
+                w.start,
+                w.end,
+                w.confidence
+            ));
+        }
+    }
+
+    out
+}
+
+/// Internal cue used for SRT/VTT line grouping.
+#[derive(Clone, Debug)]
+struct Cue {
+    start: f64,
+    end: f64,
+    text: String,
+}
+
+/// Group words into caption cues with speaker-aware line breaking.
+fn build_cues(words: &[WordInfo], max_chars: usize, max_words: usize) -> Vec<Cue> {
+    if words.is_empty() {
+        return Vec::new();
+    }
+
+    let mut cues = Vec::new();
+    let mut current = Cue {
+        start: words[0].start,
+        end: words[0].end,
+        text: String::new(),
+    };
+    let mut current_speaker: Option<u32> = None;
+    let mut word_count = 0;
+
+    let flush = |cue: &mut Cue, cues: &mut Vec<Cue>| {
+        if !cue.text.is_empty() {
+            // Trim trailing space left by append_word.
+            cue.text = cue.text.trim_end().to_string();
+            cues.push(cue.clone());
+            cue.text.clear();
+        }
+    };
+
+    for word in words {
+        let speaker_changed = word.speaker != current_speaker;
+        if speaker_changed {
+            flush(&mut current, &mut cues);
+            current.start = word.start;
+            current_speaker = word.speaker;
+            word_count = 0;
+            if let Some(speaker) = word.speaker {
+                current.text.push_str(&format!("[SPEAKER_{speaker}] "));
+            }
+        }
+
+        let would_chars = if current.text.is_empty() {
+            word.word.len()
+        } else {
+            current.text.len() + 1 + word.word.len()
+        };
+        let would_words = word_count + 1;
+
+        let break_line = !current.text.is_empty()
+            && ((max_chars > 0 && would_chars > max_chars)
+                || (max_words > 0 && would_words > max_words));
+
+        if break_line {
+            flush(&mut current, &mut cues);
+            current.start = word.start;
+            current.end = word.end;
+            word_count = 0;
+            if let Some(speaker) = word.speaker {
+                current.text.push_str(&format!("[SPEAKER_{speaker}] "));
+            }
+        }
+
+        if !current.text.is_empty() && !current.text.ends_with(' ') {
+            current.text.push(' ');
+        }
+        current.text.push_str(&word.word);
+        current.end = word.end;
+        word_count += 1;
+    }
+
+    flush(&mut current, &mut cues);
+    cues
+}
+
+fn format_srt_time(seconds: f64) -> String {
+    let total_ms = (seconds.max(0.0) * 1000.0).round() as u64;
+    let ms = total_ms % 1000;
+    let total_s = total_ms / 1000;
+    let s = total_s % 60;
+    let total_m = total_s / 60;
+    let m = total_m % 60;
+    let h = total_m / 60;
+    format!("{h:02}:{m:02}:{s:02},{ms:03}")
+}
+
+fn format_vtt_time(seconds: f64) -> String {
+    let total_ms = (seconds.max(0.0) * 1000.0).round() as u64;
+    let ms = total_ms % 1000;
+    let total_s = total_ms / 1000;
+    let s = total_s % 60;
+    let total_m = total_s / 60;
+    let m = total_m % 60;
+    let h = total_m / 60;
+    format!("{h:02}:{m:02}:{s:02}.{ms:03}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_words() -> Vec<WordInfo> {
+        vec![
+            WordInfo {
+                word: "привет".to_string(),
+                start: 0.0,
+                end: 0.5,
+                confidence: 0.98,
+                speaker: Some(0),
+            },
+            WordInfo {
+                word: "как".to_string(),
+                start: 0.6,
+                end: 0.9,
+                confidence: 0.95,
+                speaker: Some(0),
+            },
+            WordInfo {
+                word: "дела".to_string(),
+                start: 1.0,
+                end: 1.4,
+                confidence: 0.97,
+                speaker: Some(1),
+            },
+        ]
+    }
+
+    fn sample_result() -> TranscribeResult {
+        TranscribeResult {
+            text: "привет как дела".to_string(),
+            words: sample_words(),
+            duration_s: 1.4,
+        }
+    }
+
+    #[test]
+    fn test_to_txt() {
+        let result = sample_result();
+        assert_eq!(to_txt(&result), "привет как дела");
+    }
+
+    #[test]
+    fn test_to_json() {
+        let result = sample_result();
+        let json = to_json(&result);
+        assert!(json.contains("привет как дела"));
+        assert!(json.contains("\"duration\":1.4"));
+    }
+
+    #[test]
+    fn test_to_srt() {
+        let words = sample_words();
+        let srt = to_srt(&words, 80, 14);
+        assert!(srt.contains("00:00:00,000 -->"));
+        assert!(srt.contains("[SPEAKER_0] привет как"));
+        assert!(srt.contains("[SPEAKER_1] дела"));
+        assert!(srt.starts_with("1\n"));
+    }
+
+    #[test]
+    fn test_to_vtt() {
+        let words = sample_words();
+        let vtt = to_vtt(&words, 80, 14);
+        assert!(vtt.starts_with("WEBVTT\n\n"));
+        assert!(vtt.contains("00:00:00.000 -->"));
+        assert!(vtt.contains("[SPEAKER_1] дела"));
+    }
+
+    #[test]
+    fn test_to_md() {
+        let result = sample_result();
+        let md = to_md(&result, true);
+        assert!(md.contains("duration: 1.4"));
+        assert!(md.contains("speakers: 2"));
+        assert!(md.contains("привет как дела"));
+        assert!(md.contains("| Word | Start | End |"));
+    }
+
+    #[test]
+    fn test_format_srt_time() {
+        assert_eq!(format_srt_time(0.0), "00:00:00,000");
+        assert_eq!(format_srt_time(61.123), "00:01:01,123");
+        assert_eq!(format_srt_time(3661.5), "01:01:01,500");
+    }
+
+    #[test]
+    fn test_format_vtt_time() {
+        assert_eq!(format_vtt_time(0.0), "00:00:00.000");
+        assert_eq!(format_vtt_time(61.123), "00:01:01.123");
+    }
+
+    #[test]
+    fn test_export_format_from_str() {
+        assert_eq!(ExportFormat::from_str("srt").unwrap(), ExportFormat::Srt);
+        assert_eq!(ExportFormat::from_str("SRT").unwrap(), ExportFormat::Srt);
+        assert_eq!(
+            ExportFormat::from_str("markdown").unwrap(),
+            ExportFormat::Md
+        );
+        assert!(ExportFormat::from_str("docx").is_err());
+    }
+
+    #[test]
+    fn test_empty_words() {
+        let words: Vec<WordInfo> = Vec::new();
+        assert!(to_srt(&words, 80, 14).is_empty());
+        assert!(to_vtt(&words, 80, 14) == "WEBVTT\n\n");
+    }
+
+    #[test]
+    fn test_line_breaking() {
+        let words: Vec<WordInfo> = (0..20)
+            .map(|i| WordInfo {
+                word: format!("word{i}"),
+                start: i as f64,
+                end: i as f64 + 0.4,
+                confidence: 0.9,
+                speaker: None,
+            })
+            .collect();
+        let srt = to_srt(&words, 40, 5);
+        let cue_count = srt.trim().split("\n\n").count();
+        // 20 words / 5 per line = 4 cues, but exact count depends on chars.
+        assert!(cue_count >= 2);
+    }
+}

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -505,6 +505,25 @@ pub struct WordInfo {
     pub speaker: Option<u32>,
 }
 
+impl WordInfo {
+    /// Create a new [`WordInfo`].
+    pub fn new(
+        word: impl Into<String>,
+        start: f64,
+        end: f64,
+        confidence: f32,
+        speaker: Option<u32>,
+    ) -> Self {
+        Self {
+            word: word.into(),
+            start,
+            end,
+            confidence,
+            speaker,
+        }
+    }
+}
+
 /// Per-connection streaming state that persists across audio chunks.
 ///
 /// Created via [`Engine::create_state`]. Holds the decoder LSTM state, an audio

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod export;
 pub mod inference;
 pub mod model;
 pub mod onnx_proto;

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -1,8 +1,11 @@
+use anyhow::Context;
 use clap::{Parser, Subcommand};
 use gigastt::server;
 use gigastt::server::{OriginPolicy, RuntimeLimits, ServerConfig};
+use gigastt_core::export::{ExportFormat, RenderOpts};
 use gigastt_core::{inference, model};
 use std::net::IpAddr;
+use std::str::FromStr;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
@@ -181,12 +184,32 @@ enum Commands {
 
     /// Transcribe an audio file (offline)
     Transcribe {
-        /// Path to WAV file (PCM16 mono)
+        /// Path to audio file (WAV, M4A, MP3, OGG, FLAC)
         file: String,
 
         /// Model directory
         #[arg(long, default_value_t = model::default_model_dir())]
         model_dir: String,
+
+        /// Export format: json, txt, srt, vtt, md [default: txt]
+        #[arg(short, long, env = "GIGASTT_FORMAT", default_value = "txt")]
+        format: String,
+
+        /// Output file. When omitted, prints to stdout.
+        #[arg(short, long, env = "GIGASTT_OUTPUT")]
+        output: Option<String>,
+
+        /// Maximum characters per subtitle/caption line (SRT/VTT) [default: 80]
+        #[arg(long, env = "GIGASTT_MAX_CHARS_PER_LINE")]
+        max_chars_per_line: Option<usize>,
+
+        /// Maximum words per subtitle/caption line (SRT/VTT) [default: 14]
+        #[arg(long, env = "GIGASTT_MAX_WORDS_PER_LINE")]
+        max_words_per_line: Option<usize>,
+
+        /// Include per-word timestamps in Markdown output
+        #[arg(long, env = "GIGASTT_WORD_TIMESTAMPS", default_value_t = false)]
+        word_timestamps: bool,
     },
 }
 
@@ -465,14 +488,39 @@ async fn main() -> anyhow::Result<()> {
             gigastt_core::quantize::quantize_model(&input, &output)?;
             tracing::info!("Quantized model saved to {}", output.display());
         }
-        Commands::Transcribe { file, model_dir } => {
+        Commands::Transcribe {
+            file,
+            model_dir,
+            format,
+            output,
+            max_chars_per_line,
+            max_words_per_line,
+            word_timestamps,
+        } => {
             model::ensure_model(&model_dir).await?;
             let engine = inference::Engine::load_with_pool_size(&model_dir, 1)?;
             log_rss();
             let mut guard = engine.pool.checkout().await?;
             let result = engine.transcribe_file(&file, &mut guard);
             drop(guard);
-            println!("{}", result?.text);
+            let result = result?;
+
+            let format = ExportFormat::from_str(&format).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let opts = RenderOpts {
+                max_chars_per_line: max_chars_per_line.unwrap_or(80),
+                max_words_per_line: max_words_per_line.unwrap_or(14),
+                include_word_timestamps: word_timestamps,
+            };
+            let rendered = format.render(&result, &opts);
+
+            match output {
+                Some(path) => {
+                    std::fs::write(&path, rendered)
+                        .with_context(|| format!("failed to write {path}"))?;
+                    tracing::info!("Wrote {} export to {path}", format);
+                }
+                None => println!("{rendered}"),
+            }
         }
     }
 
@@ -573,8 +621,72 @@ mod tests {
     fn test_cli_transcribe_parsing() {
         let cli = Cli::parse_from(["gigastt", "transcribe", "audio.wav"]);
         match cli.command {
-            Commands::Transcribe { file, .. } => {
+            Commands::Transcribe {
+                file,
+                format,
+                output,
+                ..
+            } => {
                 assert_eq!(file, "audio.wav");
+                assert_eq!(format, "txt");
+                assert!(output.is_none());
+            }
+            _ => panic!("expected Transcribe"),
+        }
+    }
+
+    #[test]
+    fn test_cli_transcribe_format_and_output() {
+        let cli = Cli::parse_from([
+            "gigastt",
+            "transcribe",
+            "audio.wav",
+            "--format",
+            "srt",
+            "-o",
+            "out.srt",
+        ]);
+        match cli.command {
+            Commands::Transcribe {
+                file,
+                format,
+                output,
+                ..
+            } => {
+                assert_eq!(file, "audio.wav");
+                assert_eq!(format, "srt");
+                assert_eq!(output, Some("out.srt".to_string()));
+            }
+            _ => panic!("expected Transcribe"),
+        }
+    }
+
+    #[test]
+    fn test_cli_transcribe_subtitle_options() {
+        let cli = Cli::parse_from([
+            "gigastt",
+            "transcribe",
+            "audio.wav",
+            "--format",
+            "vtt",
+            "--max-chars-per-line",
+            "60",
+            "--max-words-per-line",
+            "10",
+            "--word-timestamps",
+        ]);
+        match cli.command {
+            Commands::Transcribe {
+                format,
+                max_chars_per_line,
+                max_words_per_line,
+                word_timestamps,
+                ..
+            } => {
+                assert_eq!(format, "vtt");
+                assert_eq!(max_chars_per_line, Some(60));
+                assert_eq!(max_words_per_line, Some(10));
+                assert!(word_timestamps);
             }
             _ => panic!("expected Transcribe"),
         }

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -1,20 +1,22 @@
 //! HTTP handlers for REST API endpoints.
 
 use axum::body::Bytes;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::http::header;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Json, Response};
 use futures_util::StreamExt;
 use futures_util::stream::Stream;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 
 use super::config::{RuntimeLimits, pool_retry_after_ms, pool_retry_after_secs};
 use super::metrics::MetricsRegistry;
+use gigastt_core::export::{ExportFormat, RenderOpts};
 use gigastt_core::inference::Engine;
 
 /// Shared application state for all handlers. Carries runtime limits so the
@@ -108,6 +110,86 @@ pub struct TranscribeResponse {
     pub words: Vec<gigastt_core::inference::WordInfo>,
     /// Duration of the submitted audio in seconds.
     pub duration: f64,
+}
+
+/// Query parameters for `/v1/transcribe` export formatting.
+#[derive(Debug, Default, Deserialize)]
+pub struct ExportParams {
+    /// Export format: `json` (default), `txt`, `srt`, `vtt`, `md`.
+    pub format: Option<String>,
+    /// When set, the response carries `Content-Disposition: attachment` with this
+    /// filename (or `transcript.<ext>` if the value is empty).
+    pub download: Option<String>,
+    /// Maximum characters per subtitle/caption line. `0` = unlimited.
+    #[serde(default)]
+    pub max_chars_per_line: Option<usize>,
+    /// Maximum words per subtitle/caption line. `0` = unlimited.
+    #[serde(default)]
+    pub max_words_per_line: Option<usize>,
+    /// Include per-word timestamps in Markdown output.
+    #[serde(default)]
+    pub word_timestamps: Option<bool>,
+}
+
+/// Render a transcription result into the requested export format.
+///
+/// Returns `None` when the caller explicitly requested the default JSON
+/// response, so the handler can keep serving the existing `TranscribeResponse`
+/// contract unchanged.
+#[allow(clippy::result_large_err)]
+fn render_export_response(
+    result: &gigastt_core::inference::TranscribeResult,
+    params: &ExportParams,
+) -> Result<Option<Response>, ApiError> {
+    let format_str = params.format.as_deref().unwrap_or("json");
+    if format_str.eq_ignore_ascii_case("json") {
+        return Ok(None);
+    }
+
+    let format = ExportFormat::from_str(format_str)
+        .map_err(|e| api_error(StatusCode::BAD_REQUEST, &format!("{e}"), "invalid_format"))?;
+
+    let opts = RenderOpts {
+        max_chars_per_line: params.max_chars_per_line.unwrap_or(80),
+        max_words_per_line: params.max_words_per_line.unwrap_or(14),
+        include_word_timestamps: params.word_timestamps.unwrap_or(false),
+    };
+
+    let body = format.render(result, &opts);
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, format.content_type());
+
+    if let Some(filename) = &params.download {
+        let filename = if filename.is_empty() {
+            format!("transcript.{}", format.extension())
+        } else {
+            filename.clone()
+        };
+        // The filename is user-controlled (query param), so build the header value
+        // defensively: a filename with control characters would be an invalid
+        // header value and otherwise panic when the response is built below. Fall
+        // back to the safe default name when the requested value isn't valid.
+        let disposition =
+            header::HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
+                .unwrap_or_else(|_| {
+                    header::HeaderValue::from_str(&format!(
+                        "attachment; filename=\"transcript.{}\"",
+                        format.extension()
+                    ))
+                    .expect("static content-disposition is always a valid header value")
+                });
+        builder = builder.header(header::CONTENT_DISPOSITION, disposition);
+    }
+
+    let response = builder.body(axum::body::Body::from(body)).map_err(|e| {
+        api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to build response: {e}"),
+            "internal_error",
+        )
+    })?;
+    Ok(Some(response))
 }
 
 /// Error response produced by the REST handlers. Using `Response` directly
@@ -343,8 +425,9 @@ pub async fn models(State(state): State<Arc<AppState>>) -> Json<ModelInfo> {
 /// from [`RuntimeLimits::body_limit_bytes`] (default 50 MiB).
 pub async fn transcribe(
     State(state): State<Arc<AppState>>,
+    Query(params): Query<ExportParams>,
     body: Bytes,
-) -> Result<Json<TranscribeResponse>, ApiError> {
+) -> Result<Response, ApiError> {
     if body.is_empty() {
         return Err(api_error(
             StatusCode::BAD_REQUEST,
@@ -462,11 +545,18 @@ pub async fn transcribe(
     }
 
     match result {
-        Ok(Ok(result)) => Ok(Json(TranscribeResponse {
-            text: result.text,
-            words: result.words,
-            duration: result.duration_s,
-        })),
+        Ok(Ok(result)) => {
+            if let Some(rendered) = render_export_response(&result, &params)? {
+                Ok(rendered)
+            } else {
+                Ok(Json(TranscribeResponse {
+                    text: result.text,
+                    words: result.words,
+                    duration: result.duration_s,
+                })
+                .into_response())
+            }
+        }
         Ok(Err(e)) => {
             tracing::error!("Transcription error: {e}");
             Err(api_error(
@@ -866,7 +956,7 @@ mod tests {
             tracker: tokio_util::task::TaskTracker::new(),
         });
         let body = Bytes::from(vec![0u8; 100]);
-        let result = transcribe(State(state), body).await;
+        let result = transcribe(State(state), Query(ExportParams::default()), body).await;
         match result {
             Err(resp) => assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE),
             Ok(_) => panic!("expected payload_too_large error"),
@@ -915,7 +1005,7 @@ mod tests {
             tracker: tokio_util::task::TaskTracker::new(),
         });
         let body = Bytes::from(vec![0u8; 100]);
-        let result = transcribe(State(state), body).await;
+        let result = transcribe(State(state), Query(ExportParams::default()), body).await;
         match result {
             Err(resp) => assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE),
             Ok(_) => panic!("expected pool_closed error"),
@@ -992,7 +1082,7 @@ mod tests {
             tracker: tokio_util::task::TaskTracker::new(),
         });
         let body = short_wav();
-        match transcribe(State(state), body).await {
+        match transcribe(State(state), Query(ExportParams::default()), body).await {
             Ok(_) => {}
             Err(_) => panic!("transcribe with metrics failed"),
         }
@@ -1013,6 +1103,100 @@ mod tests {
             Ok(_) => {}
             Err(_) => panic!("transcribe_stream with metrics failed"),
         }
+    }
+
+    fn sample_export_result() -> gigastt_core::inference::TranscribeResult {
+        use gigastt_core::inference::WordInfo;
+        gigastt_core::inference::TranscribeResult {
+            text: "привет мир".into(),
+            words: vec![
+                WordInfo::new("привет", 0.0, 0.5, 0.98, Some(0)),
+                WordInfo::new("мир", 0.6, 1.0, 0.97, Some(0)),
+            ],
+            duration_s: 1.0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_render_export_default_returns_none() {
+        let result = sample_export_result();
+        let params = ExportParams::default();
+        assert!(render_export_response(&result, &params).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_render_export_txt() {
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("txt".into()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(body, "привет мир");
+    }
+
+    #[tokio::test]
+    async fn test_render_export_srt_content_type() {
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("srt".into()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/x-subrip; charset=utf-8"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("[SPEAKER_0] привет мир"));
+    }
+
+    #[tokio::test]
+    async fn test_render_export_vtt_download_header() {
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("vtt".into()),
+            download: Some("recording.vtt".into()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(
+            resp.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            "attachment; filename=\"recording.vtt\""
+        );
+    }
+
+    #[tokio::test]
+    async fn test_render_export_download_filename_with_control_char_does_not_panic() {
+        // The download filename is user-controlled; a control character must not
+        // produce an invalid header value / panic — it falls back to the default.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("srt".into()),
+            download: Some("evil\r\nInjected: x".into()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            "attachment; filename=\"transcript.srt\""
+        );
+    }
+
+    #[tokio::test]
+    async fn test_render_export_invalid_format() {
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("docx".into()),
+            ..ExportParams::default()
+        };
+        let err = render_export_response(&result, &params).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 
     fn test_engine() -> Arc<Engine> {

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,7 +30,7 @@ are additive only.
 | `/health` | GET | Health check (`{"status":"ok"}`) |
 | `/ready` | GET | Readiness probe (200 when the engine pool is ready) |
 | `/v1/models` | GET | Model info (encoder type, pool size, capabilities) |
-| `/v1/transcribe` | POST | File transcription, full JSON response |
+| `/v1/transcribe` | POST | File transcription, full JSON response or export format |
 | `/v1/transcribe/stream` | POST | File transcription with SSE streaming |
 | `/v1/ws` | GET | WebSocket upgrade for real-time streaming |
 | `/metrics` | GET | Prometheus metrics (enabled with `--metrics`). Served on the separate `--metrics-listen` port (default `127.0.0.1:9090`), not the main API port. |
@@ -48,11 +48,45 @@ curl -X POST http://127.0.0.1:9876/v1/transcribe/stream \
 # data: {"type":"final","text":"Привет, как дела?"}
 ```
 
+### Export formats
+
+`/v1/transcribe` supports alternative output formats via the `format` query
+parameter:
+
+| Format | Query value | Content-Type | Notes |
+|---|---|---|---|
+| JSON (default) | `json` | `application/json` | Same response as before |
+| Plain text | `txt` | `text/plain` | Transcript text only |
+| SubRip | `srt` | `application/x-subrip` | Speaker-aware cues |
+| WebVTT | `vtt` | `text/vtt` | Speaker-aware cues |
+| Markdown | `md` | `text/markdown` | YAML frontmatter + transcript |
+
+```sh
+# SubRip subtitles
+curl -X POST "http://127.0.0.1:9876/v1/transcribe?format=srt" \
+  -H "Content-Type: application/octet-stream" --data-binary @recording.wav
+
+# Markdown with word timings
+curl -X POST "http://127.0.0.1:9876/v1/transcribe?format=md&word_timestamps=true" \
+  -H "Content-Type: application/octet-stream" --data-binary @recording.wav
+
+# Force download as attachment
+curl -X POST "http://127.0.0.1:9876/v1/transcribe?format=vtt&download=recording.vtt" \
+  -H "Content-Type: application/octet-stream" --data-binary @recording.wav
+```
+
+Optional formatter controls:
+
+- `max_chars_per_line` — subtitle line length limit (default 80, 0 = unlimited)
+- `max_words_per_line` — subtitle word count limit (default 14, 0 = unlimited)
+- `word_timestamps` — include per-word table in Markdown (default false)
+
 ### Error responses
 
 | HTTP | Code | When |
 |---|---|---|
 | 400 | `empty_body` | Request body is empty |
+| 400 | `invalid_format` | Unsupported `format` query value |
 | 413 | `payload_too_large` | Body exceeds `--body-limit-bytes` (default 50 MiB) |
 | 422 | `invalid_audio` | Audio could not be decoded (unsupported/corrupt format) |
 | 422 | `transcription_error` | Audio decoded but inference failed |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,8 +66,18 @@ gigastt download [OPTIONS]
   --skip-quantize        Skip auto-quantization after download (FP32 only)
 
 gigastt transcribe [OPTIONS] <FILE>
-  --model-dir <DIR>      Model directory [default: ~/.gigastt/models]
+  --model-dir <DIR>           Model directory [default: ~/.gigastt/models]
+  -f, --format <FORMAT>       Export format: json, txt, srt, vtt, md [default: txt]
+  -o, --output <FILE>         Write rendered output to file instead of stdout
+  --max-chars-per-line <N>    Max chars per subtitle line (SRT/VTT) [default: 80]
+  --max-words-per-line <N>    Max words per subtitle line (SRT/VTT) [default: 14]
+  --word-timestamps           Include per-word timestamps in Markdown output
   Supports: WAV, M4A, MP3, OGG, FLAC (mono or auto-mixed)
+
+  Examples:
+    gigastt transcribe recording.wav
+    gigastt transcribe recording.wav -f srt -o recording.srt
+    gigastt transcribe recording.wav -f md --word-timestamps -o notes.md
 
 gigastt quantize [OPTIONS]          # always available since v0.9.0
   --model-dir <DIR>      Model directory [default: ~/.gigastt/models]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -164,9 +164,51 @@ paths:
         Upload an audio file and receive a complete transcription.
         Supports WAV, MP3, M4A/AAC, OGG/Vorbis, and FLAC.
 
+        The default response is JSON. Alternative export formats are available
+        via the `format` query parameter: `txt`, `srt`, `vtt`, `md`. Use
+        `download` to send `Content-Disposition: attachment`.
+
         The entire file is processed in a single inference session.
         Max audio duration: 10 minutes.
       operationId: transcribeFile
+      parameters:
+        - name: format
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [json, txt, srt, vtt, md]
+            default: json
+          description: Export format for the transcription result.
+        - name: download
+          in: query
+          required: false
+          schema:
+            type: string
+          description: |
+            Filename for the `Content-Disposition: attachment` header. If the
+            value is empty, the server uses `transcript.<ext>`.
+        - name: max_chars_per_line
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 80
+          description: Maximum characters per subtitle line (SRT/VTT). 0 = unlimited.
+        - name: max_words_per_line
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 14
+          description: Maximum words per subtitle line (SRT/VTT). 0 = unlimited.
+        - name: word_timestamps
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: Include per-word timestamps in Markdown output.
       requestBody:
         required: true
         content:
@@ -215,6 +257,38 @@ paths:
                     start: 1.1
                     end: 1.4
                 duration: 2.5
+            text/plain:
+              schema:
+                type: string
+              example: "привет как дела"
+            application/x-subrip:
+              schema:
+                type: string
+              example: |
+                1
+                00:00:00,000 --> 00:00:02,500
+                привет как дела
+            text/vtt:
+              schema:
+                type: string
+              example: |
+                WEBVTT
+
+                00:00:00.000 --> 00:00:02.500
+                привет как дела
+            text/markdown:
+              schema:
+                type: string
+              example: |
+                ---
+                duration: 2.5
+                language: ru
+                speakers: 0
+                ---
+
+                # Transcript
+
+                привет как дела
         "400":
           $ref: "#/components/responses/BadRequest"
         "413":


### PR DESCRIPTION
Implements roadmap task **32 — export-formats**.

## What
- New `gigastt-core::export` module with pure formatters: `to_txt`, `to_json`, `to_srt`, `to_vtt`, `to_md` + `ExportFormat` (FromStr/Display/content_type/extension) and `RenderOpts`.
- **REST** `/v1/transcribe?format=txt|json|srt|vtt|md` (JSON remains the default → existing `TranscribeResponse` contract unchanged). Optional `max_chars_per_line`, `max_words_per_line`, `word_timestamps`, `download`.
- **CLI** `gigastt transcribe`: `--format`/`-f`, `--output`/`-o`, `--max-chars-per-line`, `--max-words-per-line`, `--word-timestamps` (+ env vars).
- SRT/VTT are speaker-aware (`[SPEAKER_N]`); Markdown carries YAML frontmatter (`duration`, `language: ru`, `speakers`).
- Docs updated: `docs/api.md`, `docs/cli.md`, `docs/openapi.yaml`, `AGENTS.md`, `CHANGELOG.md`.

## Review hardening
- The `download` filename is user-controlled and flows into `Content-Disposition`. Building the header value is now defensive: a filename with control characters reverts to the safe default name instead of unwrapping the response builder (which would panic per-request). Added a regression test.

## Verification
- `cargo fmt --check`, `cargo clippy --lib --bins` clean.
- `cargo test --lib --bins` — gigastt lib 71, bins 25, gigastt-core 188, ffi 14, all pass (model-gated tests ignored as usual).
- Unit tests per formatter + REST export paths + CLI parsing.

## Notes
- Known minor follow-up (not in this PR): `max_chars_per_line` counts bytes, so Cyrillic lines break at ~half the nominal character count.