### PR TITLE
feat: rnnt head (--model-variant) + punctuation restoration (--punctuation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,6 +350,8 @@ All CLI flags have corresponding env vars:
 | `GIGASTT_METRICS` | `--metrics` | false |
 | `GIGASTT_METRICS_LISTEN` | `--metrics-listen` | 127.0.0.1:9090 |
 | `GIGASTT_MODEL_VARIANT` | `--model-variant` | rnnt (fresh installs) |
+| `GIGASTT_PUNCTUATION` | `--punctuation` | auto |
+| `GIGASTT_PUNCT_MODEL_DIR` | `--punct-model-dir` | `~/.gigastt/models/punct/` |
 | `RUST_LOG` | — | `gigastt=info` |
 
 ## Useful Commands for Agents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,7 @@ All CLI flags have corresponding env vars:
 | `GIGASTT_SKIP_QUANTIZE` | `--skip-quantize` | false |
 | `GIGASTT_METRICS` | `--metrics` | false |
 | `GIGASTT_METRICS_LISTEN` | `--metrics-listen` | 127.0.0.1:9090 |
+| `GIGASTT_MODEL_VARIANT` | `--model-variant` | rnnt (fresh installs) |
 | `RUST_LOG` | — | `gigastt=info` |
 
 ## Useful Commands for Agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Selectable recognition head (`--model-variant rnnt|e2e_rnnt`).** gigastt can now
+  run either GigaAM v3 head. The plain `rnnt` head is the default for fresh installs:
+  it scores markedly lower WER on bare normalized text (measured ~3.3% vs ~9.6% for
+  `e2e_rnnt` on a golos_crowd_1k subset) but emits lowercase text without punctuation.
+  `e2e_rnnt` keeps native punctuation, casing, and inverse text normalization. The
+  engine auto-detects the installed variant from the files on disk (real filenames per
+  variant; the `rnnt` vocab is `v3_vocab.txt`), and the downloader fetches the matching
+  set with per-file SHA-256 verification. Existing installs are respected: running
+  `serve`/`transcribe` without `--model-variant` uses whatever model is already present
+  and never silently re-downloads; an explicit `--model-variant` switches (and never
+  mixes variants). Env var `GIGASTT_MODEL_VARIANT`.
 - **Dedicated batch pool (`--batch-pool-size`).** Both REST file-transcription
   paths — `/v1/transcribe` and the SSE `/v1/transcribe/stream` (which also
   transcribes a whole upload, holding its triplet for the file's duration) —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Punctuation + capitalization restoration for the `rnnt` head
+  (`--punctuation`).** An optional post-processing pass turns the plain `rnnt`
+  head's bare lowercase output into properly cased, punctuated Russian
+  (e.g. `шестьдесят тысяч тенге сколько будет стоить` →
+  `Шестьдесят тысяч тенге, сколько будет стоить?`). Backed by an INT8 ONNX export
+  of `RUPunct/RUPunct_small` (MIT, ~29 MB) run via ONNX Runtime with the
+  `tokenizers` crate for WordPiece — no Python at runtime. `--punctuation
+  <auto|on|off>` (env `GIGASTT_PUNCTUATION`, default `auto` = on for `rnnt`, off
+  for `e2e_rnnt` which already punctuates) and `--punct-model-dir`
+  (env `GIGASTT_PUNCT_MODEL_DIR`, default `~/.gigastt/models/punct/`). The pass is
+  fully optional: if the model is absent it logs once and returns the text
+  unchanged. Inverse text normalization (number-words → digits) is a planned
+  follow-up. (The ONNX artifact must be published to a model host before an
+  auto-download default can be wired; for now place it in the punct model dir.)
 - **Selectable recognition head (`--model-variant rnnt|e2e_rnnt`).** gigastt can now
   run either GigaAM v3 head. The plain `rnnt` head is the default for fresh installs:
   it scores markedly lower WER on bare normalized text (measured ~3.3% vs ~9.6% for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,7 +193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -227,6 +241,12 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -308,6 +328,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cbindgen"
@@ -442,6 +471,21 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -589,6 +633,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +728,37 @@ checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -706,10 +831,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -961,6 +1103,7 @@ dependencies = [
  "symphonia",
  "tempfile",
  "thiserror 2.0.18",
+ "tokenizers",
  "tokio",
  "tracing",
  "wiremock",
@@ -1154,7 +1297,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1260,6 +1403,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1469,6 +1618,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1671,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1685,28 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1569,6 +1762,16 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1734,6 +1937,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2089,6 +2298,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,7 +2377,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2596,10 +2816,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strength_reduce"
@@ -2943,6 +3181,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
+dependencies = [
+ "ahash",
+ "compact_str",
+ "daachorse",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "fancy-regex",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,10 +3509,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"
@@ -3255,7 +3547,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "der",
  "log",
  "native-tls",
@@ -3275,7 +3567,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -3793,7 +4085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -44,6 +44,7 @@ hex = "0.4"
 rustfft = "6"
 rubato = "3.0"
 symphonia = { version = "0.6", features = ["aac", "isomp4", "mp3", "ogg", "flac", "pcm", "wav"] }
+tokenizers = { version = "0.23", default-features = false, features = ["fancy-regex"] }
 bytes = "1"
 prost = "0.14"
 polyvoice = { version = "0.7.0", features = ["onnx"], optional = true }

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -717,6 +717,14 @@ pub struct Engine {
     pub batch_pool: Option<SessionPool>,
     tokenizer: Tokenizer,
     features: FeatureExtractor,
+    /// Recognition head detected on disk at load time. Drives the default
+    /// punctuation policy (`auto`): on for [`ModelVariant::Rnnt`] (bare output),
+    /// off for [`ModelVariant::E2eRnnt`] (already punctuated).
+    variant: ModelVariant,
+    /// Optional punctuation / casing restorer applied to file-transcription
+    /// output. `None` = pass-through (the default, and the only behaviour when
+    /// no punct model is installed). Attached via [`Engine::with_punctuator`].
+    punctuator: Option<crate::punctuation::Punctuator>,
     /// Whether the INT8 quantized encoder is in use.
     int8: bool,
     /// Speaker encoder for diarization (None if model file is absent).
@@ -732,6 +740,26 @@ impl Engine {
     /// Whether the INT8 quantized encoder is loaded.
     pub fn is_int8(&self) -> bool {
         self.int8
+    }
+
+    /// The recognition head ([`ModelVariant`]) detected on disk at load time.
+    /// Lets callers decide the default punctuation policy (`auto`).
+    pub fn variant(&self) -> ModelVariant {
+        self.variant
+    }
+
+    /// Attach an optional punctuation / casing restorer, consuming and
+    /// returning `self` (builder style). Pass `None` for pass-through. When set,
+    /// the restorer post-processes the final text of file transcription
+    /// ([`Engine::transcribe_file`] / [`Engine::transcribe_bytes_shared`]).
+    pub fn with_punctuator(mut self, punctuator: Option<crate::punctuation::Punctuator>) -> Self {
+        self.punctuator = punctuator;
+        self
+    }
+
+    /// Whether a punctuation restorer is attached.
+    pub fn has_punctuator(&self) -> bool {
+        self.punctuator.is_some()
     }
 
     /// Size of the BPE vocabulary the loaded tokenizer covers. Exposed so the
@@ -1239,6 +1267,8 @@ impl Engine {
             batch_pool,
             tokenizer,
             features,
+            variant,
+            punctuator: None,
             int8: is_int8,
             #[cfg(feature = "diarization")]
             speaker_encoder,
@@ -1665,6 +1695,15 @@ impl Engine {
             .map(|w| w.word.as_str())
             .collect::<Vec<_>>()
             .join(" ");
+
+        // Optional punctuation / casing restoration (plain `rnnt` head). When
+        // no punctuator is attached this is a no-op; `restore` itself never
+        // fails (returns the input unchanged on internal error). Word-level
+        // timing is left untouched — only the joined `text` is restored.
+        let text = match &self.punctuator {
+            Some(p) => p.restore(&text),
+            None => text,
+        };
 
         Ok(TranscribeResult {
             text,

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -68,6 +68,7 @@ use std::ops::{Deref, DerefMut};
 use std::path::Path;
 
 use crate::error::GigasttError;
+use crate::model::ModelVariant;
 
 use features::MelSpectrogram;
 use tokenizer::Tokenizer;
@@ -743,8 +744,10 @@ impl Engine {
     /// Load ONNX models from the given directory and create an inference engine.
     ///
     /// Creates a pool of `DEFAULT_POOL_SIZE` session triplets for concurrent inference.
-    /// Expects files: `v3_e2e_rnnt_encoder.onnx` (or `_int8.onnx`), `v3_e2e_rnnt_decoder.onnx`,
-    /// `v3_e2e_rnnt_joint.onnx`, and `v3_e2e_rnnt_vocab.txt`.
+    /// The recognition head ([`ModelVariant`]) is auto-detected from the encoder
+    /// file present on disk: `v3_rnnt_encoder.onnx` (or `_int8.onnx`) selects the
+    /// plain rnnt head, else `v3_e2e_rnnt_encoder.onnx` selects e2e_rnnt. The
+    /// matching decoder, joiner, and vocab files must also be present.
     ///
     /// # Errors
     ///
@@ -788,52 +791,65 @@ impl Engine {
         batch_pool_size: usize,
     ) -> Result<Self, GigasttError> {
         let dir = Path::new(model_dir);
-        if !dir.join("v3_e2e_rnnt_encoder.onnx").exists() {
+        // Auto-detect which recognition head is present on disk (rnnt encoder
+        // takes precedence, else e2e_rnnt). The on-disk layout fully determines
+        // which head runs — callers select the variant only at download time.
+        let Some(variant) = ModelVariant::detect_in_dir(dir) else {
             return Err(GigasttError::ModelLoad {
                 path: model_dir.to_string(),
                 source: None,
             });
-        }
-        Self::load_inner(dir, model_dir, pool_size, min_size, batch_pool_size).map_err(|e| {
-            GigasttError::ModelLoad {
-                path: model_dir.to_string(),
-                source: Some(e.into()),
-            }
+        };
+        Self::load_inner(
+            dir,
+            variant,
+            model_dir,
+            pool_size,
+            min_size,
+            batch_pool_size,
+        )
+        .map_err(|e| GigasttError::ModelLoad {
+            path: model_dir.to_string(),
+            source: Some(e.into()),
         })
     }
 
-    /// Path to the preferred encoder model: INT8 quantized if present, FP32 otherwise.
-    fn encoder_model_path(dir: &Path) -> std::path::PathBuf {
-        if dir.join("v3_e2e_rnnt_encoder_int8.onnx").exists() {
-            dir.join("v3_e2e_rnnt_encoder_int8.onnx")
+    /// Path to the preferred encoder model for `variant`: INT8 quantized if
+    /// present, FP32 otherwise.
+    fn encoder_model_path(dir: &Path, variant: ModelVariant) -> std::path::PathBuf {
+        let int8 = dir.join(variant.encoder_int8_file());
+        if int8.exists() {
+            int8
         } else {
-            dir.join("v3_e2e_rnnt_encoder.onnx")
+            dir.join(variant.encoder_file())
         }
     }
 
-    /// Load a single set of encoder/decoder/joiner ONNX sessions from disk,
-    /// using the execution provider selected at compile time.
+    /// Load a single set of encoder/decoder/joiner ONNX sessions from disk for
+    /// `variant`, using the execution provider selected at compile time.
     fn load_sessions(
         dir: &Path,
+        variant: ModelVariant,
         prepacked: &ort::session::builder::PrepackedWeights,
     ) -> anyhow::Result<(Session, Session, Session)> {
         #[cfg(feature = "coreml")]
         {
-            Self::load_sessions_coreml(dir, prepacked)
+            Self::load_sessions_coreml(dir, variant, prepacked)
         }
         #[cfg(feature = "cuda")]
         {
-            Self::load_sessions_cuda(dir, prepacked)
+            Self::load_sessions_cuda(dir, variant, prepacked)
         }
         #[cfg(not(any(feature = "coreml", feature = "cuda")))]
         {
-            Self::load_sessions_cpu(dir, prepacked)
+            Self::load_sessions_cpu(dir, variant, prepacked)
         }
     }
 
     #[cfg(feature = "coreml")]
     fn load_sessions_coreml(
         dir: &Path,
+        variant: ModelVariant,
         prepacked: &ort::session::builder::PrepackedWeights,
     ) -> anyhow::Result<(Session, Session, Session)> {
         // CoreML has its own cache (`coreml_cache/`) for compiled subgraphs.
@@ -861,7 +877,7 @@ impl Engine {
 
         let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
         let eps = [coreml_ep.clone(), cpu_fallback.into()];
-        let encoder_path = Self::encoder_model_path(dir);
+        let encoder_path = Self::encoder_model_path(dir, variant);
         let encoder = Session::builder()
             .map_err(ort_err)?
             .with_prepacked_weights(prepacked)
@@ -876,7 +892,7 @@ impl Engine {
             .map_err(ort_err)?
             .with_execution_providers(&eps)
             .map_err(ort_err)?
-            .commit_from_file(dir.join("v3_e2e_rnnt_decoder.onnx"))
+            .commit_from_file(dir.join(variant.decoder_file()))
             .map_err(ort_err)?;
         let joiner = Session::builder()
             .map_err(ort_err)?
@@ -884,7 +900,7 @@ impl Engine {
             .map_err(ort_err)?
             .with_execution_providers(&eps)
             .map_err(ort_err)?
-            .commit_from_file(dir.join("v3_e2e_rnnt_joint.onnx"))
+            .commit_from_file(dir.join(variant.joint_file()))
             .map_err(ort_err)?;
         Ok((encoder, decoder, joiner))
     }
@@ -892,6 +908,7 @@ impl Engine {
     #[cfg(feature = "cuda")]
     fn load_sessions_cuda(
         dir: &Path,
+        variant: ModelVariant,
         prepacked: &ort::session::builder::PrepackedWeights,
     ) -> anyhow::Result<(Session, Session, Session)> {
         // CUDA EP compiles subgraphs that cannot be re-serialized as ONNX,
@@ -902,7 +919,7 @@ impl Engine {
 
         let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
         let eps = [cuda_ep.clone(), cpu_fallback.into()];
-        let encoder_path = Self::encoder_model_path(dir);
+        let encoder_path = Self::encoder_model_path(dir, variant);
         let encoder = Session::builder()
             .map_err(ort_err)?
             .with_prepacked_weights(prepacked)
@@ -917,7 +934,7 @@ impl Engine {
             .map_err(ort_err)?
             .with_execution_providers(&eps)
             .map_err(ort_err)?
-            .commit_from_file(dir.join("v3_e2e_rnnt_decoder.onnx"))
+            .commit_from_file(dir.join(variant.decoder_file()))
             .map_err(ort_err)?;
         let joiner = Session::builder()
             .map_err(ort_err)?
@@ -925,7 +942,7 @@ impl Engine {
             .map_err(ort_err)?
             .with_execution_providers(&eps)
             .map_err(ort_err)?
-            .commit_from_file(dir.join("v3_e2e_rnnt_joint.onnx"))
+            .commit_from_file(dir.join(variant.joint_file()))
             .map_err(ort_err)?;
         Ok((encoder, decoder, joiner))
     }
@@ -939,6 +956,7 @@ impl Engine {
     #[cfg(not(feature = "cuda"))]
     fn load_sessions_cpu(
         dir: &Path,
+        variant: ModelVariant,
         prepacked: &ort::session::builder::PrepackedWeights,
     ) -> anyhow::Result<(Session, Session, Session)> {
         let cache_dir = dir.join("optimized_cache");
@@ -946,7 +964,7 @@ impl Engine {
             .with_context(|| format!("Failed to create ONNX cache dir: {}", cache_dir.display()))?;
         let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
         let eps = [cpu_fallback.into()];
-        let encoder_path = Self::encoder_model_path(dir);
+        let encoder_path = Self::encoder_model_path(dir, variant);
         let encoder = Session::builder()
             .map_err(ort_err)?
             .with_prepacked_weights(prepacked)
@@ -969,7 +987,7 @@ impl Engine {
             .map_err(ort_err)?
             .with_inter_threads(1)
             .map_err(ort_err)?
-            .commit_from_file(dir.join("v3_e2e_rnnt_decoder.onnx"))
+            .commit_from_file(dir.join(variant.decoder_file()))
             .map_err(ort_err)?;
         let joiner = Session::builder()
             .map_err(ort_err)?
@@ -979,7 +997,7 @@ impl Engine {
             .map_err(ort_err)?
             .with_inter_threads(1)
             .map_err(ort_err)?
-            .commit_from_file(dir.join("v3_e2e_rnnt_joint.onnx"))
+            .commit_from_file(dir.join(variant.joint_file()))
             .map_err(ort_err)?;
         Ok((encoder, decoder, joiner))
     }
@@ -1069,11 +1087,13 @@ impl Engine {
     /// partial pool down to `min_size` (see [`Engine::finalize_pool_load`]).
     fn load_triplets(
         dir: &Path,
+        variant: ModelVariant,
         pool_size: usize,
         min_size: usize,
         prepacked: &ort::session::builder::PrepackedWeights,
         load_one: impl Fn(
             &Path,
+            ModelVariant,
             &ort::session::builder::PrepackedWeights,
         ) -> anyhow::Result<(Session, Session, Session)>
         + Sync,
@@ -1089,7 +1109,7 @@ impl Engine {
                                 "Loading session triplet {}/{pool_size} (shared weights)",
                                 i + 1
                             );
-                            let (encoder, decoder, joiner) = load_one(dir, pp)?;
+                            let (encoder, decoder, joiner) = load_one(dir, variant, pp)?;
                             Ok(SessionTriplet {
                                 encoder,
                                 decoder,
@@ -1113,12 +1133,14 @@ impl Engine {
 
     fn load_inner(
         dir: &Path,
+        variant: ModelVariant,
         model_dir: &str,
         pool_size: usize,
         min_size: usize,
         batch_pool_size: usize,
     ) -> anyhow::Result<Self> {
-        let is_int8 = dir.join("v3_e2e_rnnt_encoder_int8.onnx").exists();
+        tracing::info!("Detected model variant: {variant:?}");
+        let is_int8 = dir.join(variant.encoder_int8_file()).exists();
         if is_int8 {
             tracing::info!("Using INT8 quantized encoder");
         }
@@ -1141,6 +1163,7 @@ impl Engine {
         #[cfg(feature = "coreml")]
         let triplets = match Self::load_triplets(
             dir,
+            variant,
             pool_size,
             min_size,
             &prepacked,
@@ -1156,6 +1179,7 @@ impl Engine {
                 let prepacked = ort::session::builder::PrepackedWeights::new();
                 Self::load_triplets(
                     dir,
+                    variant,
                     pool_size,
                     min_size,
                     &prepacked,
@@ -1164,10 +1188,16 @@ impl Engine {
             }
         };
         #[cfg(not(feature = "coreml"))]
-        let triplets =
-            Self::load_triplets(dir, pool_size, min_size, &prepacked, Self::load_sessions)?;
+        let triplets = Self::load_triplets(
+            dir,
+            variant,
+            pool_size,
+            min_size,
+            &prepacked,
+            Self::load_sessions,
+        )?;
 
-        let tokenizer = Tokenizer::load(&dir.join("v3_e2e_rnnt_vocab.txt"))?;
+        let tokenizer = Tokenizer::load(&dir.join(variant.vocab_file()))?;
         let features = FeatureExtractor::new();
 
         tracing::info!(
@@ -1229,6 +1259,7 @@ impl Engine {
                 let prepacked = ort::session::builder::PrepackedWeights::new();
                 let triplets = Self::load_triplets(
                     dir,
+                    variant,
                     pool_size,
                     min_size,
                     &prepacked,
@@ -2524,7 +2555,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("v3_e2e_rnnt_encoder.onnx"), b"fp32").unwrap();
         std::fs::write(dir.path().join("v3_e2e_rnnt_encoder_int8.onnx"), b"int8").unwrap();
-        let path = Engine::encoder_model_path(dir.path());
+        let path = Engine::encoder_model_path(dir.path(), ModelVariant::E2eRnnt);
         assert_eq!(
             path.file_name().unwrap(),
             "v3_e2e_rnnt_encoder_int8.onnx",
@@ -2536,8 +2567,29 @@ mod tests {
     fn test_encoder_model_path_falls_back_to_fp32() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("v3_e2e_rnnt_encoder.onnx"), b"fp32").unwrap();
-        let path = Engine::encoder_model_path(dir.path());
+        let path = Engine::encoder_model_path(dir.path(), ModelVariant::E2eRnnt);
         assert_eq!(path.file_name().unwrap(), "v3_e2e_rnnt_encoder.onnx");
+    }
+
+    #[test]
+    fn test_encoder_model_path_rnnt_prefers_int8() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("v3_rnnt_encoder.onnx"), b"fp32").unwrap();
+        std::fs::write(dir.path().join("v3_rnnt_encoder_int8.onnx"), b"int8").unwrap();
+        let path = Engine::encoder_model_path(dir.path(), ModelVariant::Rnnt);
+        assert_eq!(
+            path.file_name().unwrap(),
+            "v3_rnnt_encoder_int8.onnx",
+            "INT8 rnnt encoder must win when both files exist"
+        );
+    }
+
+    #[test]
+    fn test_encoder_model_path_rnnt_falls_back_to_fp32() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("v3_rnnt_encoder.onnx"), b"fp32").unwrap();
+        let path = Engine::encoder_model_path(dir.path(), ModelVariant::Rnnt);
+        assert_eq!(path.file_name().unwrap(), "v3_rnnt_encoder.onnx");
     }
 
     #[test]

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -3,4 +3,5 @@ pub mod inference;
 pub mod model;
 pub mod onnx_proto;
 pub mod protocol;
+pub mod punctuation;
 pub mod quantize;

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -255,6 +255,25 @@ pub fn default_model_dir() -> String {
         .unwrap_or_else(|| ".gigastt/models".into())
 }
 
+/// Return the default punctuation-model directory (`~/.gigastt/models/punct/`),
+/// a sibling of [`default_model_dir`].
+///
+/// Holds the optional RUPunct ONNX punctuation/casing restorer used to
+/// post-process the plain `rnnt` head's bare lowercase output. The artifact is
+/// not yet published, so this dir is populated manually (see
+/// [`crate::punctuation`]); a missing dir simply disables the punct pass.
+pub fn default_punct_model_dir() -> String {
+    home_dir()
+        .map(|h| {
+            h.join(".gigastt")
+                .join("models")
+                .join("punct")
+                .to_string_lossy()
+                .into_owned()
+        })
+        .unwrap_or_else(|| ".gigastt/models/punct".into())
+}
+
 /// Acquire an advisory exclusive lock on a file inside `dir` so that only
 /// one process downloads models at a time. The lock is released when the
 /// returned file is dropped.

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -1,6 +1,9 @@
 //! Model download and management.
 //!
-//! Downloads GigaAM v3 e2e_rnnt ONNX files from HuggingFace to `~/.gigastt/models/`.
+//! Downloads GigaAM v3 RNN-T ONNX files from HuggingFace to `~/.gigastt/models/`.
+//! Two recognition heads are selectable via [`ModelVariant`]: the plain `rnnt`
+//! head (default — lower WER, bare lowercase output) and the `e2e_rnnt` head
+//! (punctuation / casing / ITN baked in).
 
 use anyhow::{Context, Result};
 use futures_util::StreamExt;
@@ -52,15 +55,149 @@ impl DownloadProgress {
 }
 
 const HF_REPO: &str = "istupakov/gigaam-v3-onnx";
-const MODEL_FILES: &[&str] = &[
-    "v3_e2e_rnnt_encoder.onnx",
-    "v3_e2e_rnnt_decoder.onnx",
-    "v3_e2e_rnnt_joint.onnx",
-    "v3_e2e_rnnt_vocab.txt",
+
+/// Selectable GigaAM v3 recognition head.
+///
+/// Both heads ship in the same HuggingFace repo ([`HF_REPO`]) and share the
+/// inference pipeline; they differ only in their ONNX files and vocabulary.
+///
+/// - [`ModelVariant::Rnnt`] (default): plain RNN-T head. Lower WER on the
+///   golos_crowd_1k set (3.29% vs 9.65%) but emits bare lowercase Russian with
+///   no punctuation / casing / ITN. Uses a 34-token character vocabulary.
+/// - [`ModelVariant::E2eRnnt`]: end-to-end head with punctuation, casing, and
+///   inverse text normalization baked in. Uses a 1025-token BPE vocabulary.
+///
+/// Real upstream filenames are kept on disk (no canonical-prefix rename), and
+/// the engine auto-detects the variant from the encoder file present in the
+/// model directory, so on-disk layout fully determines which head runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ModelVariant {
+    /// Plain RNN-T head (default). Bare lowercase output, lower WER.
+    #[default]
+    Rnnt,
+    /// End-to-end RNN-T head with punctuation / casing / ITN.
+    E2eRnnt,
+}
+
+impl ModelVariant {
+    /// Basename of the FP32 encoder ONNX file for this variant.
+    pub fn encoder_file(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt => "v3_rnnt_encoder.onnx",
+            ModelVariant::E2eRnnt => "v3_e2e_rnnt_encoder.onnx",
+        }
+    }
+
+    /// Basename of the locally-generated INT8 quantized encoder ONNX file.
+    pub fn encoder_int8_file(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt => "v3_rnnt_encoder_int8.onnx",
+            ModelVariant::E2eRnnt => "v3_e2e_rnnt_encoder_int8.onnx",
+        }
+    }
+
+    /// Basename of the decoder ONNX file for this variant.
+    pub fn decoder_file(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt => "v3_rnnt_decoder.onnx",
+            ModelVariant::E2eRnnt => "v3_e2e_rnnt_decoder.onnx",
+        }
+    }
+
+    /// Basename of the joiner ONNX file for this variant.
+    pub fn joint_file(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt => "v3_rnnt_joint.onnx",
+            ModelVariant::E2eRnnt => "v3_e2e_rnnt_joint.onnx",
+        }
+    }
+
+    /// Basename of the vocabulary file for this variant.
+    ///
+    /// Note the asymmetry: the plain `rnnt` head's vocab is `v3_vocab.txt`
+    /// (NOT `v3_rnnt_vocab.txt`), while `e2e_rnnt` uses `v3_e2e_rnnt_vocab.txt`.
+    pub fn vocab_file(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt => "v3_vocab.txt",
+            ModelVariant::E2eRnnt => "v3_e2e_rnnt_vocab.txt",
+        }
+    }
+
+    /// Files downloaded from HuggingFace for this variant (encoder, decoder,
+    /// joiner, vocab). The INT8 encoder is generated locally, not downloaded.
+    pub fn download_files(self) -> [&'static str; 4] {
+        [
+            self.encoder_file(),
+            self.decoder_file(),
+            self.joint_file(),
+            self.vocab_file(),
+        ]
+    }
+
+    /// Pinned SHA-256 checksum for a downloaded file, or `None` when no checksum
+    /// is pinned for it. Verified against the canonical HuggingFace copies.
+    pub fn checksum(self, filename: &str) -> Option<&'static str> {
+        let table = match self {
+            ModelVariant::Rnnt => RNNT_CHECKSUMS,
+            ModelVariant::E2eRnnt => E2E_RNNT_CHECKSUMS,
+        };
+        table
+            .iter()
+            .find(|(name, _)| *name == filename)
+            .and_then(|(_, hash)| *hash)
+    }
+
+    /// Detect which variant's files are present in `dir` by probing for the
+    /// encoder file (FP32 or generated INT8). Returns `None` when neither
+    /// variant's encoder is present. `Rnnt` takes precedence when (anomalously)
+    /// both encoders coexist, mirroring the engine's default.
+    pub fn detect_in_dir(dir: &Path) -> Option<Self> {
+        [ModelVariant::Rnnt, ModelVariant::E2eRnnt]
+            .into_iter()
+            .find(|&variant| {
+                dir.join(variant.encoder_file()).exists()
+                    || dir.join(variant.encoder_int8_file()).exists()
+            })
+    }
+}
+
+impl std::str::FromStr for ModelVariant {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "rnnt" => Ok(ModelVariant::Rnnt),
+            "e2e_rnnt" | "e2e-rnnt" => Ok(ModelVariant::E2eRnnt),
+            other => Err(format!(
+                "unknown model variant '{other}' (expected 'rnnt' or 'e2e_rnnt')"
+            )),
+        }
+    }
+}
+
+/// SHA-256 checksums for the plain `rnnt` head's downloaded files.
+/// Computed from the canonical HuggingFace copies at `HF_REPO` on 2026-06-19.
+const RNNT_CHECKSUMS: &[(&str, Option<&str>)] = &[
+    (
+        "v3_rnnt_encoder.onnx",
+        Some("7ae7509c3f1128369564df0b00e2ee4950adf539de2392ac5c800a5bc04c7132"),
+    ),
+    (
+        "v3_rnnt_decoder.onnx",
+        Some("443c3b7bd42b453611618135d6b1e7d9467e5dd97c8a68501da4aa355750c0da"),
+    ),
+    (
+        "v3_rnnt_joint.onnx",
+        Some("fd1d02f45c2ad3d6b67cc149811ad794ab4b020ed49a0a9e2790a8619d1cddd8"),
+    ),
+    (
+        "v3_vocab.txt",
+        Some("a9143c30844d3c0bee3e9e927e4084774eb1b9eeaafc473b2c4521e4911a7c07"),
+    ),
 ];
 
-/// SHA-256 checksums for model integrity verification.
-const MODEL_CHECKSUMS: &[(&str, Option<&str>)] = &[
+/// SHA-256 checksums for the `e2e_rnnt` head's downloaded files.
+const E2E_RNNT_CHECKSUMS: &[(&str, Option<&str>)] = &[
     (
         "v3_e2e_rnnt_encoder.onnx",
         Some("cd60b3764a832e8560ae6d3ad0b10adc1a42ffae412b9476f25620aae4f4a508"),
@@ -142,21 +279,78 @@ fn acquire_download_lock(dir: &Path) -> Result<std::fs::File> {
     Ok(file)
 }
 
-/// Ensure model files exist in `model_dir`, downloading from HuggingFace if missing.
+/// Decision returned by [`resolve_variant`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum VariantAction {
+    /// Use the variant already present on disk — no download needed.
+    Use(ModelVariant),
+    /// Download (or re-download) the specified variant.
+    Download(ModelVariant),
+}
+
+/// Pure decision function: given an optional user-requested variant and the
+/// variant already fully present on disk, return what `ensure_model` should do.
 ///
-/// Downloads encoder, decoder, joiner ONNX models and vocabulary from
-/// the `istupakov/gigaam-v3-onnx` repository. Shows progress bars during download.
-/// Uses an advisory flock so concurrent processes do not corrupt `.partial` files.
-pub async fn ensure_model(model_dir: &str) -> Result<()> {
+/// Precedence rules:
+/// - **Explicit request + matching install** → `Use` (no-op).
+/// - **Explicit request + different/no install** → `Download` the requested variant.
+/// - **No request + existing install** → `Use` that install (never clobber it).
+/// - **No request + empty dir** → `Download` the default (`Rnnt`).
+pub fn resolve_variant(
+    requested: Option<ModelVariant>,
+    existing: Option<ModelVariant>,
+) -> VariantAction {
+    match (requested, existing) {
+        (Some(req), Some(ex)) if req == ex => VariantAction::Use(req),
+        (Some(req), _) => VariantAction::Download(req),
+        (None, Some(ex)) => VariantAction::Use(ex),
+        (None, None) => VariantAction::Download(ModelVariant::default()),
+    }
+}
+
+/// Ensure an appropriate model variant's files exist in `model_dir`,
+/// downloading from HuggingFace if missing.
+///
+/// When `requested` is `Some(v)`, the function enforces that variant `v` is
+/// present, downloading it if it isn't (or if the dir holds a different variant).
+///
+/// When `requested` is `None`, the function respects whatever is already
+/// installed: if any variant's complete file set is in `model_dir`, it is used
+/// as-is and **no network request is made**. Only when the directory is empty
+/// (no usable model found) does it fall back to downloading the default
+/// (`Rnnt`).
+///
+/// Returns the variant that is now ready in `model_dir`.
+pub async fn ensure_model(
+    requested: Option<ModelVariant>,
+    model_dir: &str,
+) -> Result<ModelVariant> {
     let dir = Path::new(model_dir);
 
-    if model_files_exist(dir) {
-        tracing::info!("Model found at {model_dir}");
-        return Ok(());
+    // Determine the variant that is fully present on disk (all download files
+    // exist). `detect_in_dir` only checks for the encoder, so we filter to
+    // variants whose complete download set is present.
+    let existing = ModelVariant::detect_in_dir(dir).filter(|&v| is_model_present(v, dir));
+
+    let variant = match resolve_variant(requested, existing) {
+        VariantAction::Use(v) => {
+            tracing::info!("Using existing {v:?} model at {model_dir}");
+            return Ok(v);
+        }
+        VariantAction::Download(v) => v,
+    };
+
+    if let Some(other) = existing
+        && other != variant
+    {
+        tracing::warn!(
+            "Model directory {model_dir} holds {other:?} files but {variant:?} was \
+             requested; downloading the {variant:?} set (variants are never mixed)"
+        );
     }
 
-    // Create the directory before acquiring the lock so the lock file can
-    // be created inside it.
+    // Create the directory before acquiring the lock so the lock file can be
+    // created inside it.
     std::fs::create_dir_all(dir).context("Failed to create model directory")?;
 
     #[cfg(unix)]
@@ -164,19 +358,19 @@ pub async fn ensure_model(model_dir: &str) -> Result<()> {
 
     // Double-check after acquiring the lock in case another process finished
     // the download while we were waiting.
-    if model_files_exist(dir) {
-        tracing::info!("Model found at {model_dir} after lock acquisition");
-        return Ok(());
+    if is_model_present(variant, dir) {
+        tracing::info!("Model ({variant:?}) found at {model_dir} after lock acquisition");
+        return Ok(variant);
     }
 
-    tracing::info!("Model not found, downloading from HuggingFace...");
+    tracing::info!("Model ({variant:?}) not found, downloading from HuggingFace...");
 
-    for file in MODEL_FILES {
-        download_file(file, dir).await?;
+    for file in variant.download_files() {
+        download_file(variant, file, dir).await?;
     }
 
     tracing::info!("Model download complete");
-    Ok(())
+    Ok(variant)
 }
 
 /// Ensure the speaker diarization model exists in `model_dir`, downloading from HuggingFace if missing.
@@ -209,8 +403,15 @@ pub async fn ensure_speaker_model(model_dir: &str) -> Result<()> {
     .await
 }
 
-fn model_files_exist(dir: &Path) -> bool {
-    MODEL_FILES.iter().all(|f| dir.join(f).exists())
+/// True when every downloaded file for `variant` is present in `dir`.
+///
+/// Checks the *downloaded* set (FP32 encoder, decoder, joiner, vocab); the
+/// locally-generated INT8 encoder is not required for presence.
+pub fn is_model_present(variant: ModelVariant, dir: &Path) -> bool {
+    variant
+        .download_files()
+        .iter()
+        .all(|f| dir.join(f).exists())
 }
 
 /// Append `.partial` to a path; retained for tests that assert the legacy
@@ -276,13 +477,10 @@ fn finalize_download(
     Ok(())
 }
 
-async fn download_file(filename: &str, dir: &Path) -> Result<()> {
+async fn download_file(variant: ModelVariant, filename: &str, dir: &Path) -> Result<()> {
     let url = format!("https://huggingface.co/{HF_REPO}/resolve/main/{filename}");
     let final_dest = dir.join(filename);
-    let expected = MODEL_CHECKSUMS
-        .iter()
-        .find(|(name, _)| *name == filename)
-        .and_then(|(_, hash)| *hash);
+    let expected = variant.checksum(filename);
     stream_to_partial_then_finalize(&url, &final_dest, expected, filename).await
 }
 
@@ -450,7 +648,7 @@ mod tests {
     }
 
     /// If the process dies between the network write and the
-    /// SHA verification / rename, `model_files_exist` must NOT see the
+    /// SHA verification / rename, `is_model_present` must NOT see the
     /// file under its final name. We simulate the crash by staging a
     /// `.partial` and never calling `finalize_download`.
     #[test]
@@ -465,11 +663,15 @@ mod tests {
             "crash before rename must never leave the final artefact visible"
         );
 
-        // All four MODEL_FILES stay missing from this tempdir, so
-        // model_files_exist must refuse to short-circuit the download path.
+        // No variant's files exist in this tempdir, so is_model_present must
+        // refuse to short-circuit the download path.
         assert!(
-            !model_files_exist(tmp.path()),
-            "model_files_exist must not accept a staged partial"
+            !is_model_present(ModelVariant::Rnnt, tmp.path()),
+            "is_model_present must not accept a staged partial"
+        );
+        assert!(
+            !is_model_present(ModelVariant::E2eRnnt, tmp.path()),
+            "is_model_present must not accept a staged partial"
         );
     }
 
@@ -689,5 +891,282 @@ mod tests {
             msg.contains("SHA-256 mismatch"),
             "error should mention mismatch: {msg}"
         );
+    }
+
+    #[test]
+    fn test_model_variant_default_is_rnnt() {
+        assert_eq!(ModelVariant::default(), ModelVariant::Rnnt);
+    }
+
+    #[test]
+    fn test_model_variant_rnnt_file_mapping() {
+        let v = ModelVariant::Rnnt;
+        assert_eq!(v.encoder_file(), "v3_rnnt_encoder.onnx");
+        assert_eq!(v.encoder_int8_file(), "v3_rnnt_encoder_int8.onnx");
+        assert_eq!(v.decoder_file(), "v3_rnnt_decoder.onnx");
+        assert_eq!(v.joint_file(), "v3_rnnt_joint.onnx");
+        // The rnnt vocab name is asymmetric: v3_vocab.txt, NOT v3_rnnt_vocab.txt.
+        assert_eq!(v.vocab_file(), "v3_vocab.txt");
+        assert_eq!(
+            v.download_files(),
+            [
+                "v3_rnnt_encoder.onnx",
+                "v3_rnnt_decoder.onnx",
+                "v3_rnnt_joint.onnx",
+                "v3_vocab.txt",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_model_variant_e2e_rnnt_file_mapping() {
+        let v = ModelVariant::E2eRnnt;
+        assert_eq!(v.encoder_file(), "v3_e2e_rnnt_encoder.onnx");
+        assert_eq!(v.encoder_int8_file(), "v3_e2e_rnnt_encoder_int8.onnx");
+        assert_eq!(v.decoder_file(), "v3_e2e_rnnt_decoder.onnx");
+        assert_eq!(v.joint_file(), "v3_e2e_rnnt_joint.onnx");
+        assert_eq!(v.vocab_file(), "v3_e2e_rnnt_vocab.txt");
+        assert_eq!(
+            v.download_files(),
+            [
+                "v3_e2e_rnnt_encoder.onnx",
+                "v3_e2e_rnnt_decoder.onnx",
+                "v3_e2e_rnnt_joint.onnx",
+                "v3_e2e_rnnt_vocab.txt",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_model_variant_from_str() {
+        use std::str::FromStr;
+        assert_eq!(ModelVariant::from_str("rnnt").unwrap(), ModelVariant::Rnnt);
+        assert_eq!(
+            ModelVariant::from_str("e2e_rnnt").unwrap(),
+            ModelVariant::E2eRnnt
+        );
+        assert_eq!(
+            ModelVariant::from_str("E2E-RNNT").unwrap(),
+            ModelVariant::E2eRnnt
+        );
+        assert_eq!(
+            ModelVariant::from_str(" RNNT ").unwrap(),
+            ModelVariant::Rnnt
+        );
+        assert!(ModelVariant::from_str("whisper").is_err());
+    }
+
+    #[test]
+    fn test_model_variant_checksums_are_pinned() {
+        // Every downloaded file for both variants has a pinned 64-char hex
+        // checksum — security parity, no placeholder slipping into a release.
+        for variant in [ModelVariant::Rnnt, ModelVariant::E2eRnnt] {
+            for file in variant.download_files() {
+                let sum = variant
+                    .checksum(file)
+                    .unwrap_or_else(|| panic!("{variant:?} {file} must have a pinned checksum"));
+                assert_eq!(
+                    sum.len(),
+                    64,
+                    "{variant:?} {file} checksum must be 64 hex chars, got: {sum}"
+                );
+                assert!(
+                    sum.chars()
+                        .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+                    "{variant:?} {file} checksum must be lowercase hex, got: {sum}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_detect_in_dir_rnnt_by_fp32_encoder() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("v3_rnnt_encoder.onnx"), b"fp32").unwrap();
+        assert_eq!(
+            ModelVariant::detect_in_dir(tmp.path()),
+            Some(ModelVariant::Rnnt)
+        );
+    }
+
+    #[test]
+    fn test_detect_in_dir_rnnt_by_int8_encoder() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("v3_rnnt_encoder_int8.onnx"), b"int8").unwrap();
+        assert_eq!(
+            ModelVariant::detect_in_dir(tmp.path()),
+            Some(ModelVariant::Rnnt)
+        );
+    }
+
+    #[test]
+    fn test_detect_in_dir_e2e_by_fp32_encoder() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("v3_e2e_rnnt_encoder.onnx"), b"fp32").unwrap();
+        assert_eq!(
+            ModelVariant::detect_in_dir(tmp.path()),
+            Some(ModelVariant::E2eRnnt)
+        );
+    }
+
+    #[test]
+    fn test_detect_in_dir_e2e_by_int8_encoder() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("v3_e2e_rnnt_encoder_int8.onnx"), b"int8").unwrap();
+        assert_eq!(
+            ModelVariant::detect_in_dir(tmp.path()),
+            Some(ModelVariant::E2eRnnt)
+        );
+    }
+
+    #[test]
+    fn test_detect_in_dir_none_when_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(ModelVariant::detect_in_dir(tmp.path()), None);
+    }
+
+    #[test]
+    fn test_is_model_present_per_variant() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        // Stage a full rnnt download set.
+        for f in ModelVariant::Rnnt.download_files() {
+            std::fs::write(dir.join(f), b"x").unwrap();
+        }
+        assert!(
+            is_model_present(ModelVariant::Rnnt, dir),
+            "rnnt set is complete"
+        );
+        assert!(
+            !is_model_present(ModelVariant::E2eRnnt, dir),
+            "e2e set is absent — must not be reported present"
+        );
+    }
+
+    #[test]
+    fn test_is_model_present_false_when_one_file_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        // Stage all but the vocab.
+        for f in [
+            ModelVariant::Rnnt.encoder_file(),
+            ModelVariant::Rnnt.decoder_file(),
+            ModelVariant::Rnnt.joint_file(),
+        ] {
+            std::fs::write(dir.join(f), b"x").unwrap();
+        }
+        assert!(
+            !is_model_present(ModelVariant::Rnnt, dir),
+            "a missing vocab must make the set incomplete"
+        );
+    }
+
+    // ── resolve_variant decision table ──────────────────────────────────────
+
+    #[test]
+    fn test_resolve_variant_none_empty_dir_downloads_default() {
+        // None requested + no existing → download Rnnt (the default)
+        assert_eq!(
+            resolve_variant(None, None),
+            VariantAction::Download(ModelVariant::Rnnt),
+        );
+    }
+
+    #[test]
+    fn test_resolve_variant_none_e2e_present_uses_e2e() {
+        // None requested + E2eRnnt already installed → use it, no download
+        assert_eq!(
+            resolve_variant(None, Some(ModelVariant::E2eRnnt)),
+            VariantAction::Use(ModelVariant::E2eRnnt),
+        );
+    }
+
+    #[test]
+    fn test_resolve_variant_none_rnnt_present_uses_rnnt() {
+        // None requested + Rnnt already installed → use it, no download
+        assert_eq!(
+            resolve_variant(None, Some(ModelVariant::Rnnt)),
+            VariantAction::Use(ModelVariant::Rnnt),
+        );
+    }
+
+    #[test]
+    fn test_resolve_variant_some_rnnt_rnnt_present_uses_rnnt() {
+        // Explicit Rnnt + Rnnt installed → no download needed
+        assert_eq!(
+            resolve_variant(Some(ModelVariant::Rnnt), Some(ModelVariant::Rnnt)),
+            VariantAction::Use(ModelVariant::Rnnt),
+        );
+    }
+
+    #[test]
+    fn test_resolve_variant_some_e2e_rnnt_present_downloads_e2e() {
+        // Explicit E2eRnnt + Rnnt installed → must switch, so download E2eRnnt
+        assert_eq!(
+            resolve_variant(Some(ModelVariant::E2eRnnt), Some(ModelVariant::Rnnt)),
+            VariantAction::Download(ModelVariant::E2eRnnt),
+        );
+    }
+
+    #[test]
+    fn test_resolve_variant_some_e2e_empty_downloads_e2e() {
+        // Explicit E2eRnnt + nothing installed → download E2eRnnt
+        assert_eq!(
+            resolve_variant(Some(ModelVariant::E2eRnnt), None),
+            VariantAction::Download(ModelVariant::E2eRnnt),
+        );
+    }
+
+    #[test]
+    fn test_resolve_variant_some_rnnt_e2e_present_downloads_rnnt() {
+        // Explicit Rnnt + E2eRnnt installed → must switch, download Rnnt
+        assert_eq!(
+            resolve_variant(Some(ModelVariant::Rnnt), Some(ModelVariant::E2eRnnt)),
+            VariantAction::Download(ModelVariant::Rnnt),
+        );
+    }
+
+    /// Verify that `ensure_model(None, dir)` with a complete E2eRnnt install
+    /// does NOT create any `.partial` files (no download triggered).
+    #[tokio::test]
+    async fn test_ensure_model_none_respects_existing_e2e_install() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+
+        // Stage a full E2eRnnt download set (stub bytes, no real ONNX needed).
+        for f in ModelVariant::E2eRnnt.download_files() {
+            std::fs::write(dir.join(f), b"stub").unwrap();
+        }
+
+        // ensure_model with None must return E2eRnnt without downloading.
+        let variant = ensure_model(None, dir.to_str().unwrap())
+            .await
+            .expect("ensure_model should succeed");
+
+        assert_eq!(
+            variant,
+            ModelVariant::E2eRnnt,
+            "must use the installed E2eRnnt"
+        );
+
+        // No .partial files must have been created.
+        let partials: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".partial"))
+            .collect();
+        assert!(
+            partials.is_empty(),
+            "no .partial files must exist: {partials:?}"
+        );
+
+        // Files must be untouched (still stub bytes).
+        for f in ModelVariant::E2eRnnt.download_files() {
+            assert_eq!(
+                std::fs::read(dir.join(f)).unwrap(),
+                b"stub",
+                "{f} must be unchanged"
+            );
+        }
     }
 }

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -1,0 +1,484 @@
+//! Optional punctuation + capitalization restoration for the plain `rnnt` head.
+//!
+//! The plain RNN-T recognition head ([`ModelVariant::Rnnt`](crate::model::ModelVariant::Rnnt))
+//! emits bare lowercase Russian with no punctuation, e.g.
+//! `"шестьдесят тысяч тенге сколько будет стоить"`. This module restores
+//! punctuation and casing as an *optional* post-processing pass, producing
+//! e.g. `"Шестьдесят тысяч тенге, сколько будет стоить?"`.
+//!
+//! The model is `RUPunct/RUPunct_small` (MIT), exported to ONNX and INT8-quantized
+//! (dynamic MatMulInteger — runs on the CPU EP like the encoder). It is a BERT
+//! token-classification head: each WordPiece subtoken gets one of 33 labels
+//! (`{LOWER, UPPER, UPPER_TOTAL}` × 11 punctuation classes). We replicate the
+//! RUPunct `aggregation_strategy="first"` inference: take the label of each
+//! word's FIRST subtoken and apply [`process_token`].
+//!
+//! This is *optional*: a build or run without the punct model behaves exactly as
+//! before. If the model dir / files are absent or the model fails to load,
+//! [`Punctuator::load`] returns an error which the caller treats as "punctuation
+//! disabled" (the engine logs a warning once and returns input text unchanged).
+//!
+//! NOTE (distribution): the exported ONNX artifact is not yet published to
+//! HuggingFace. It must be loaded from a local model dir (`--punct-model-dir`,
+//! default `~/.gigastt/models/punct/`). Before an auto-download default can be
+//! wired, publish the artifact (e.g. to an `ekhodzitsky/rupunct-small-onnx` HF
+//! repo). sha256 of the int8 ONNX:
+//! `b105da023474d98aa13ba18953ae67b04b17bd0595034bc06030c17536893933`.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use ort::session::Session;
+use ort::value::TensorRef;
+use parking_lot::Mutex;
+use tokenizers::Tokenizer;
+
+/// Basename of the INT8 ONNX punctuation model inside the punct model dir.
+pub const PUNCT_MODEL_FILE: &str = "rupunct_small_int8.onnx";
+/// Basename of the HuggingFace tokenizer JSON inside the punct model dir.
+pub const PUNCT_TOKENIZER_FILE: &str = "tokenizer.json";
+/// Basename of the model config JSON (carries `id2label`) inside the punct model dir.
+pub const PUNCT_CONFIG_FILE: &str = "config.json";
+
+fn ort_err(e: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!("{e}")
+}
+
+/// Apply Python `str.capitalize()` semantics to a token: first character
+/// uppercased, every following character lowercased. Operates over Unicode
+/// `char`s (Russian Cyrillic), matching RUPunct's reference decode.
+fn capitalize(token: &str) -> String {
+    let mut chars = token.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => {
+            let mut out: String = first.to_uppercase().collect();
+            for c in chars {
+                out.extend(c.to_lowercase());
+            }
+            out
+        }
+    }
+}
+
+/// Cased + punctuated rendering of one word given its RUPunct label.
+///
+/// Verbatim port of the reference `process_token(token, label)` from the
+/// `RUPunct/RUPunct_small` model card. Case transform:
+/// `LOWER_*` keeps the token, `UPPER_*` applies [`capitalize`] (Python
+/// `str.capitalize`), `UPPER_TOTAL_*` upper-cases the whole token. Punctuation
+/// is appended as a suffix. SPACING QUIRK preserved exactly: `LOWER_TIRE`
+/// appends `"—"` (no leading space) while `UPPER_TIRE` / `UPPER_TOTAL_TIRE`
+/// append `" —"` (leading space). Unknown labels leave the token unchanged.
+pub fn process_token(token: &str, label: &str) -> String {
+    // Split the label into its case prefix and punctuation suffix. The longest
+    // prefix `UPPER_TOTAL_` must be tried before `UPPER_`.
+    let (cased, punct_class) = if let Some(rest) = label.strip_prefix("UPPER_TOTAL_") {
+        (token.to_uppercase(), rest)
+    } else if let Some(rest) = label.strip_prefix("UPPER_") {
+        (capitalize(token), rest)
+    } else if let Some(rest) = label.strip_prefix("LOWER_") {
+        (token.to_string(), rest)
+    } else {
+        // Unknown / malformed label: leave the token untouched.
+        return token.to_string();
+    };
+
+    let is_upper = !label.starts_with("LOWER_");
+    let suffix: &str = match punct_class {
+        "O" => "",
+        "PERIOD" => ".",
+        "COMMA" => ",",
+        "QUESTION" => "?",
+        "VOSKL" => "!",
+        "DVOETOCHIE" => ":",
+        "PERIODCOMMA" => ";",
+        "DEFIS" => "-",
+        "MNOGOTOCHIE" => "...",
+        "QUESTIONVOSKL" => "?!",
+        // Em-dash spacing quirk: lower has no leading space, upper variants do.
+        "TIRE" => {
+            if is_upper {
+                " —"
+            } else {
+                "—"
+            }
+        }
+        // Unknown punctuation class: no suffix.
+        _ => "",
+    };
+
+    let mut out = cased;
+    out.push_str(suffix);
+    out
+}
+
+/// For each whitespace word index `0..num_words`, return the label id of its
+/// FIRST subtoken — the token whose `word_id == Some(w)` with the lowest
+/// position. This is RUPunct's `aggregation_strategy="first"`.
+///
+/// `word_ids` is the per-token word mapping (special tokens are `None`);
+/// `argmax_per_token` is the pre-computed argmax label id for each token.
+/// Words with no subtoken (should not happen for real input) get label id 0.
+///
+/// Pure (no model / I/O) so the first-subword selection is unit-testable.
+fn first_subword_labels(
+    word_ids: &[Option<u32>],
+    argmax_per_token: &[usize],
+    num_words: usize,
+) -> Vec<usize> {
+    let mut labels = vec![0usize; num_words];
+    let mut seen = vec![false; num_words];
+    for (tok_idx, wid) in word_ids.iter().enumerate() {
+        let Some(w) = wid else { continue };
+        let w = *w as usize;
+        if w < num_words && !seen[w] {
+            seen[w] = true;
+            labels[w] = argmax_per_token.get(tok_idx).copied().unwrap_or(0);
+        }
+    }
+    labels
+}
+
+/// Argmax over the last `num_labels`-sized window of a logits row.
+fn argmax(row: &[f32]) -> usize {
+    let mut best = 0usize;
+    let mut best_v = f32::NEG_INFINITY;
+    for (i, &v) in row.iter().enumerate() {
+        if v > best_v {
+            best_v = v;
+            best = i;
+        }
+    }
+    best
+}
+
+/// Punctuation + capitalization restorer backed by the RUPunct ONNX model.
+///
+/// Loaded from a model dir via [`Punctuator::load`]. The single ONNX session is
+/// guarded by a [`Mutex`] because the punct pass runs on already-decoded text
+/// (off the hot inference loop) and is not worth pooling. [`restore`](Self::restore)
+/// is the public entry point and never panics: on any internal failure it logs
+/// and returns the input text unchanged.
+pub struct Punctuator {
+    session: Mutex<Session>,
+    tokenizer: Tokenizer,
+    /// `id2label[i]` is the label name for logit index `i`.
+    id2label: Vec<String>,
+}
+
+impl Punctuator {
+    /// Load the punctuation model, tokenizer, and label map from `model_dir`.
+    ///
+    /// Expects `rupunct_small_int8.onnx`, `tokenizer.json`, and `config.json`
+    /// (with an `id2label` map) in `model_dir`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any file is missing or fails to parse / load. The
+    /// caller treats an error as "punctuation unavailable" and proceeds without
+    /// it — restoration is optional post-processing.
+    pub fn load(model_dir: &Path) -> Result<Self> {
+        let model_path = model_dir.join(PUNCT_MODEL_FILE);
+        let tokenizer_path = model_dir.join(PUNCT_TOKENIZER_FILE);
+        let config_path = model_dir.join(PUNCT_CONFIG_FILE);
+
+        let id2label = load_id2label(&config_path)
+            .with_context(|| format!("Failed to load id2label from {}", config_path.display()))?;
+
+        let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(|e| {
+            anyhow::anyhow!("Failed to load tokenizer {}: {e}", tokenizer_path.display())
+        })?;
+
+        let session = Session::builder()
+            .map_err(ort_err)?
+            .commit_from_file(&model_path)
+            .map_err(ort_err)
+            .with_context(|| format!("Failed to load punct model {}", model_path.display()))?;
+
+        tracing::info!(
+            "Punctuation model loaded ({} labels) from {}",
+            id2label.len(),
+            model_dir.display()
+        );
+
+        Ok(Self {
+            session: Mutex::new(session),
+            tokenizer,
+            id2label,
+        })
+    }
+
+    /// Restore punctuation + capitalization on a space-separated transcript.
+    ///
+    /// Replicates RUPunct's pipeline: encode the text, run the BERT token
+    /// classifier, take each word's first-subtoken label, apply [`process_token`],
+    /// and join with single spaces (trimmed).
+    ///
+    /// Never fails: on empty input or any internal error it returns the input
+    /// text unchanged (the error is logged at `warn`). This keeps the punct pass
+    /// strictly optional — a transcription is never blocked by it.
+    pub fn restore(&self, text: &str) -> String {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return text.to_string();
+        }
+        match self.restore_inner(trimmed) {
+            Ok(out) => out,
+            Err(e) => {
+                tracing::warn!("Punctuation restore failed, returning bare text: {e:#}");
+                text.to_string()
+            }
+        }
+    }
+
+    fn restore_inner(&self, text: &str) -> Result<String> {
+        // Whitespace words: the decoder output is space-separated, so this is
+        // the word granularity the labels are aggregated to.
+        let words: Vec<&str> = text.split_whitespace().collect();
+        if words.is_empty() {
+            return Ok(text.to_string());
+        }
+
+        let encoding = self
+            .tokenizer
+            .encode(text, true)
+            .map_err(|e| anyhow::anyhow!("tokenizer encode failed: {e}"))?;
+
+        let ids: Vec<i64> = encoding.get_ids().iter().map(|&i| i as i64).collect();
+        let mask: Vec<i64> = encoding
+            .get_attention_mask()
+            .iter()
+            .map(|&m| m as i64)
+            .collect();
+        let seq = ids.len();
+        let token_type_ids = vec![0i64; seq];
+
+        let input_ids = TensorRef::from_array_view(([1_usize, seq], ids.as_slice()))?;
+        let attention_mask = TensorRef::from_array_view(([1_usize, seq], mask.as_slice()))?;
+        let token_type = TensorRef::from_array_view(([1_usize, seq], token_type_ids.as_slice()))?;
+
+        // Run the session and reduce the borrowed logits to an owned
+        // per-token argmax inside this scope, so the `outputs` borrow (which
+        // ties the lifetime to the session guard) is released before the
+        // session guard is dropped at end of scope.
+        let num_labels = self.id2label.len();
+        let argmax_per_token: Vec<usize> = {
+            let mut session = self.session.lock();
+            let outputs = session
+                .run(ort::inputs![
+                    "input_ids" => input_ids,
+                    "attention_mask" => attention_mask,
+                    "token_type_ids" => token_type,
+                ])
+                .context("punct model inference failed")?;
+
+            let (shape, logits) = outputs["logits"]
+                .try_extract_tensor::<f32>()
+                .context("failed to extract punct logits")?;
+
+            // Expect [1, seq, num_labels].
+            if shape.len() != 3 || shape[2] as usize != num_labels {
+                anyhow::bail!(
+                    "unexpected punct logits shape {shape:?} (expected [1, {seq}, {num_labels}])"
+                );
+            }
+
+            (0..seq)
+                .map(|t| {
+                    let start = t * num_labels;
+                    argmax(&logits[start..start + num_labels])
+                })
+                .collect()
+        };
+
+        let label_ids =
+            first_subword_labels(encoding.get_word_ids(), &argmax_per_token, words.len());
+
+        let mut out = String::new();
+        for (word, &lid) in words.iter().zip(label_ids.iter()) {
+            let label = self
+                .id2label
+                .get(lid)
+                .map(String::as_str)
+                .unwrap_or("LOWER_O");
+            let processed = process_token(word, label);
+            if !out.is_empty() {
+                out.push(' ');
+            }
+            out.push_str(&processed);
+        }
+        Ok(out.trim().to_string())
+    }
+}
+
+/// Parse the `id2label` map from a HuggingFace `config.json` into a dense
+/// `Vec<String>` indexed by label id.
+fn load_id2label(config_path: &Path) -> Result<Vec<String>> {
+    let raw = std::fs::read_to_string(config_path)
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+    let config: serde_json::Value =
+        serde_json::from_str(&raw).context("config.json is not valid JSON")?;
+    let map = config
+        .get("id2label")
+        .and_then(|v| v.as_object())
+        .context("config.json missing id2label object")?;
+
+    // Keys are stringified indices ("0".."32"); place each at its index.
+    let mut labels = vec![String::new(); map.len()];
+    for (k, v) in map {
+        let idx: usize = k
+            .parse()
+            .with_context(|| format!("id2label key '{k}' is not an integer"))?;
+        let label = v
+            .as_str()
+            .with_context(|| format!("id2label['{k}'] is not a string"))?;
+        if idx >= labels.len() {
+            anyhow::bail!("id2label index {idx} out of range ({} labels)", map.len());
+        }
+        labels[idx] = label.to_string();
+    }
+    if labels.iter().any(|l| l.is_empty()) {
+        anyhow::bail!("id2label has a gap (non-contiguous indices)");
+    }
+    Ok(labels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capitalize_python_semantics() {
+        // Python str.capitalize(): first upper, rest lower.
+        assert_eq!(capitalize("привет"), "Привет");
+        assert_eq!(capitalize("ПРИВЕТ"), "Привет");
+        assert_eq!(capitalize("пРиВеТ"), "Привет");
+        assert_eq!(capitalize(""), "");
+        assert_eq!(capitalize("a"), "A");
+    }
+
+    #[test]
+    fn test_process_token_lower_modes() {
+        assert_eq!(process_token("слово", "LOWER_O"), "слово");
+        assert_eq!(process_token("слово", "LOWER_PERIOD"), "слово.");
+        assert_eq!(process_token("слово", "LOWER_COMMA"), "слово,");
+        assert_eq!(process_token("слово", "LOWER_QUESTION"), "слово?");
+        assert_eq!(process_token("слово", "LOWER_VOSKL"), "слово!");
+        assert_eq!(process_token("слово", "LOWER_DVOETOCHIE"), "слово:");
+        assert_eq!(process_token("слово", "LOWER_PERIODCOMMA"), "слово;");
+        assert_eq!(process_token("слово", "LOWER_DEFIS"), "слово-");
+        assert_eq!(process_token("слово", "LOWER_MNOGOTOCHIE"), "слово...");
+        assert_eq!(process_token("слово", "LOWER_QUESTIONVOSKL"), "слово?!");
+    }
+
+    #[test]
+    fn test_process_token_upper_capitalizes_first_lowercases_rest() {
+        // UPPER_* uses Python capitalize: ПРИВЕТ → Привет, then suffix.
+        assert_eq!(process_token("анна", "UPPER_O"), "Анна");
+        assert_eq!(process_token("анна", "UPPER_COMMA"), "Анна,");
+        assert_eq!(process_token("ПРИВЕТ", "UPPER_PERIOD"), "Привет.");
+    }
+
+    #[test]
+    fn test_process_token_upper_total_uppercases_all() {
+        assert_eq!(process_token("ооо", "UPPER_TOTAL_O"), "ООО");
+        assert_eq!(process_token("ссср", "UPPER_TOTAL_PERIOD"), "СССР.");
+        assert_eq!(process_token("ооо", "UPPER_TOTAL_COMMA"), "ООО,");
+    }
+
+    #[test]
+    fn test_process_token_tire_spacing_quirk() {
+        // LOWER_TIRE: no leading space before em-dash.
+        assert_eq!(process_token("это", "LOWER_TIRE"), "это—");
+        // UPPER_TIRE and UPPER_TOTAL_TIRE: leading space before em-dash.
+        assert_eq!(process_token("это", "UPPER_TIRE"), "Это —");
+        assert_eq!(process_token("это", "UPPER_TOTAL_TIRE"), "ЭТО —");
+    }
+
+    #[test]
+    fn test_process_token_unknown_label_is_identity() {
+        assert_eq!(process_token("слово", "GARBAGE"), "слово");
+        assert_eq!(process_token("слово", "LOWER_BOGUS"), "слово");
+    }
+
+    #[test]
+    fn test_first_subword_labels_picks_first_subtoken() {
+        // Tokens: [CLS]=word None, word0 has 2 subtokens (idx1,2), word1 has 1
+        // subtoken (idx3), [SEP]=None.
+        let word_ids = vec![None, Some(0), Some(0), Some(1), None];
+        // argmax label per token; word0's FIRST subtoken (idx1) is label 3,
+        // its second (idx2) is 9 (must be ignored). word1 (idx3) is label 7.
+        let argmax = vec![0, 3, 9, 7, 0];
+        let labels = first_subword_labels(&word_ids, &argmax, 2);
+        assert_eq!(labels, vec![3, 7]);
+    }
+
+    #[test]
+    fn test_first_subword_labels_missing_word_defaults_zero() {
+        // No subtoken maps to word index 1 → defaults to label id 0.
+        let word_ids = vec![None, Some(0), None];
+        let argmax = vec![0, 5, 0];
+        let labels = first_subword_labels(&word_ids, &argmax, 2);
+        assert_eq!(labels, vec![5, 0]);
+    }
+
+    #[test]
+    fn test_argmax_returns_index_of_max() {
+        assert_eq!(argmax(&[0.1, 0.9, 0.3]), 1);
+        assert_eq!(argmax(&[5.0, 1.0, 2.0]), 0);
+        assert_eq!(argmax(&[1.0, 1.0, 3.0]), 2);
+    }
+
+    #[test]
+    fn test_load_punctuator_missing_dir_errors() {
+        // Graceful fallback contract: loading from an absent dir must error
+        // (the caller turns this into "punctuation disabled"), never panic.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("does-not-exist");
+        assert!(Punctuator::load(&missing).is_err());
+    }
+
+    #[test]
+    fn test_load_id2label_parses_contiguous_map() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = tmp.path().join("config.json");
+        std::fs::write(
+            &cfg,
+            r#"{"id2label": {"0": "UPPER_PERIOD", "1": "LOWER_PERIOD", "2": "UPPER_TOTAL_PERIOD"}}"#,
+        )
+        .unwrap();
+        let labels = load_id2label(&cfg).expect("parse");
+        assert_eq!(
+            labels,
+            vec!["UPPER_PERIOD", "LOWER_PERIOD", "UPPER_TOTAL_PERIOD"]
+        );
+    }
+
+    #[test]
+    fn test_load_id2label_rejects_gap() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = tmp.path().join("config.json");
+        // Index 1 missing → non-contiguous.
+        std::fs::write(&cfg, r#"{"id2label": {"0": "A", "2": "C"}}"#).unwrap();
+        assert!(load_id2label(&cfg).is_err());
+    }
+
+    /// End-to-end on the real ONNX model (model-gated, like other model tests).
+    /// Validates the full tokenizer → ONNX → first-subword → process_token
+    /// pipeline against the RUPunct reference string.
+    #[test]
+    #[ignore = "requires punct model at ~/.gigastt/models/punct"]
+    fn test_restore_reference_string() {
+        let dir = default_punct_model_dir();
+        let punct = Punctuator::load(Path::new(&dir)).expect("load punct model");
+        let out =
+            punct.restore("привет меня зовут анна сколько будет стоить шестьдесят тысяч тенге");
+        assert_eq!(
+            out,
+            "Привет меня зовут Анна, Сколько будет стоить шестьдесят тысяч тенге."
+        );
+    }
+
+    use crate::model::default_punct_model_dir;
+}

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 use gigastt::server;
 use gigastt::server::{OriginPolicy, RuntimeLimits, ServerConfig};
+use gigastt_core::model::ModelVariant;
 use gigastt_core::{inference, model};
 use std::net::IpAddr;
 use tracing_subscriber::EnvFilter;
@@ -39,6 +40,18 @@ enum Commands {
         /// Model directory
         #[arg(long, default_value_t = model::default_model_dir())]
         model_dir: String,
+
+        /// Recognition head to use. Omit to auto-detect from the model
+        /// directory: if a model is already installed its variant is used as-is
+        /// (no download). Only required when the directory is empty or you want
+        /// to switch variants. `rnnt` (lower WER, bare lowercase) or
+        /// `e2e_rnnt` (punctuation / casing / ITN). Env: GIGASTT_MODEL_VARIANT.
+        #[arg(
+            long,
+            env = "GIGASTT_MODEL_VARIANT",
+            value_parser = parse_model_variant
+        )]
+        model_variant: Option<ModelVariant>,
 
         /// Number of concurrent inference sessions
         #[arg(long, default_value_t = 4)]
@@ -155,6 +168,16 @@ enum Commands {
         #[arg(long, default_value_t = model::default_model_dir())]
         model_dir: String,
 
+        /// Recognition head to download: `rnnt` (default — lower WER, bare
+        /// lowercase) or `e2e_rnnt` (punctuation / casing / ITN).
+        #[arg(
+            long,
+            env = "GIGASTT_MODEL_VARIANT",
+            default_value = "rnnt",
+            value_parser = parse_model_variant
+        )]
+        model_variant: ModelVariant,
+
         /// Skip downloading the speaker diarization model
         #[cfg(feature = "diarization")]
         #[arg(long, default_value_t = false)]
@@ -187,6 +210,17 @@ enum Commands {
         /// Model directory
         #[arg(long, default_value_t = model::default_model_dir())]
         model_dir: String,
+
+        /// Recognition head to use. Omit to auto-detect from the model
+        /// directory (existing install used as-is; only downloads if empty).
+        /// `rnnt` (lower WER, bare lowercase) or `e2e_rnnt` (punctuation /
+        /// casing / ITN). Env: GIGASTT_MODEL_VARIANT.
+        #[arg(
+            long,
+            env = "GIGASTT_MODEL_VARIANT",
+            value_parser = parse_model_variant
+        )]
+        model_variant: Option<ModelVariant>,
     },
 }
 
@@ -331,11 +365,18 @@ fn is_loopback_host(host: &str) -> bool {
     false
 }
 
-/// Ensure the INT8 encoder exists, producing it via the native Rust
-/// quantization pipeline if missing. Honoured by `serve` and `download`.
-/// First-time quantization takes ~2 minutes on the 844 MB FP32 encoder.
-fn ensure_int8_encoder(model_dir: &str, skip: bool) -> anyhow::Result<()> {
-    let int8_path = std::path::Path::new(model_dir).join("v3_e2e_rnnt_encoder_int8.onnx");
+/// clap value parser for `--model-variant`. Accepts `rnnt` / `e2e_rnnt`
+/// (case-insensitive); see [`ModelVariant::from_str`].
+fn parse_model_variant(s: &str) -> Result<ModelVariant, String> {
+    s.parse()
+}
+
+/// Ensure the INT8 encoder exists for `variant`, producing it via the native
+/// Rust quantization pipeline if missing. Honoured by `serve` and `download`.
+/// First-time quantization takes ~2 minutes on the FP32 encoder.
+fn ensure_int8_encoder(variant: ModelVariant, model_dir: &str, skip: bool) -> anyhow::Result<()> {
+    let dir = std::path::Path::new(model_dir);
+    let int8_path = dir.join(variant.encoder_int8_file());
     if int8_path.exists() {
         return Ok(());
     }
@@ -345,7 +386,7 @@ fn ensure_int8_encoder(model_dir: &str, skip: bool) -> anyhow::Result<()> {
         );
         return Ok(());
     }
-    let input = std::path::Path::new(model_dir).join("v3_e2e_rnnt_encoder.onnx");
+    let input = dir.join(variant.encoder_file());
     if !input.exists() {
         anyhow::bail!(
             "Cannot quantize: FP32 encoder not found at {}",
@@ -372,6 +413,7 @@ async fn main() -> anyhow::Result<()> {
             port,
             host,
             model_dir,
+            model_variant,
             pool_size,
             pool_min_size,
             batch_pool_size,
@@ -394,8 +436,8 @@ async fn main() -> anyhow::Result<()> {
             config,
         } => {
             ensure_bind_allowed(&host, bind_all)?;
-            model::ensure_model(&model_dir).await?;
-            ensure_int8_encoder(&model_dir, skip_quantize)?;
+            let resolved = model::ensure_model(model_variant, &model_dir).await?;
+            ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
             let engine = inference::Engine::load_with_pools(
                 &model_dir,
                 pool_size,
@@ -439,24 +481,31 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Download {
             model_dir,
+            model_variant,
             #[cfg(feature = "diarization")]
             skip_diarization,
             skip_quantize,
         } => {
-            model::ensure_model(&model_dir).await?;
+            // `download` is an explicit action: None here maps to the default
+            // (Rnnt) so a bare `gigastt download` fetches something useful.
+            let requested = Some(model_variant);
+            let resolved = model::ensure_model(requested, &model_dir).await?;
             #[cfg(feature = "diarization")]
             {
                 if !skip_diarization {
                     model::ensure_speaker_model(&model_dir).await?;
                 }
             }
-            ensure_int8_encoder(&model_dir, skip_quantize)?;
+            ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
             tracing::info!("Model ready at {model_dir}");
         }
         Commands::Quantize { model_dir, force } => {
-            model::ensure_model(&model_dir).await?;
-            let input = std::path::Path::new(&model_dir).join("v3_e2e_rnnt_encoder.onnx");
-            let output = std::path::Path::new(&model_dir).join("v3_e2e_rnnt_encoder_int8.onnx");
+            // Quantize an existing model dir: detect the head already on disk
+            // (default rnnt when the dir is empty and `ensure_model` must fetch).
+            let dir = std::path::Path::new(&model_dir);
+            let resolved = model::ensure_model(None, &model_dir).await?;
+            let input = dir.join(resolved.encoder_file());
+            let output = dir.join(resolved.encoder_int8_file());
             if output.exists() && !force {
                 tracing::info!("INT8 model already exists: {}", output.display());
                 tracing::info!("Use --force to re-quantize.");
@@ -465,8 +514,12 @@ async fn main() -> anyhow::Result<()> {
             gigastt_core::quantize::quantize_model(&input, &output)?;
             tracing::info!("Quantized model saved to {}", output.display());
         }
-        Commands::Transcribe { file, model_dir } => {
-            model::ensure_model(&model_dir).await?;
+        Commands::Transcribe {
+            file,
+            model_dir,
+            model_variant,
+        } => {
+            model::ensure_model(model_variant, &model_dir).await?;
             let engine = inference::Engine::load_with_pool_size(&model_dir, 1)?;
             log_rss();
             let mut guard = engine.pool.checkout().await?;
@@ -537,11 +590,36 @@ mod tests {
                 port,
                 bind_all,
                 metrics,
+                model_variant,
                 ..
             } => {
                 assert_eq!(port, 1234);
                 assert!(bind_all);
                 assert!(!metrics);
+                // No --model-variant → None (auto-detect from disk).
+                assert_eq!(model_variant, None);
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_model_variant_override() {
+        let cli = Cli::parse_from(["gigastt", "serve", "--model-variant", "e2e_rnnt"]);
+        match cli.command {
+            Commands::Serve { model_variant, .. } => {
+                assert_eq!(model_variant, Some(ModelVariant::E2eRnnt));
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_model_variant_explicit_rnnt() {
+        let cli = Cli::parse_from(["gigastt", "serve", "--model-variant", "rnnt"]);
+        match cli.command {
+            Commands::Serve { model_variant, .. } => {
+                assert_eq!(model_variant, Some(ModelVariant::Rnnt));
             }
             _ => panic!("expected Serve"),
         }
@@ -551,8 +629,24 @@ mod tests {
     fn test_cli_download_parsing() {
         let cli = Cli::parse_from(["gigastt", "download", "--model-dir", "/tmp/models"]);
         match cli.command {
-            Commands::Download { model_dir, .. } => {
+            Commands::Download {
+                model_dir,
+                model_variant,
+                ..
+            } => {
                 assert_eq!(model_dir, "/tmp/models");
+                assert_eq!(model_variant, ModelVariant::Rnnt);
+            }
+            _ => panic!("expected Download"),
+        }
+    }
+
+    #[test]
+    fn test_cli_download_model_variant_override() {
+        let cli = Cli::parse_from(["gigastt", "download", "--model-variant", "e2e_rnnt"]);
+        match cli.command {
+            Commands::Download { model_variant, .. } => {
+                assert_eq!(model_variant, ModelVariant::E2eRnnt);
             }
             _ => panic!("expected Download"),
         }
@@ -573,11 +667,23 @@ mod tests {
     fn test_cli_transcribe_parsing() {
         let cli = Cli::parse_from(["gigastt", "transcribe", "audio.wav"]);
         match cli.command {
-            Commands::Transcribe { file, .. } => {
+            Commands::Transcribe {
+                file,
+                model_variant,
+                ..
+            } => {
                 assert_eq!(file, "audio.wav");
+                // No --model-variant → None (auto-detect from disk).
+                assert_eq!(model_variant, None);
             }
             _ => panic!("expected Transcribe"),
         }
+    }
+
+    #[test]
+    fn test_cli_serve_rejects_unknown_model_variant() {
+        let res = Cli::try_parse_from(["gigastt", "serve", "--model-variant", "whisper"]);
+        assert!(res.is_err(), "unknown variant must be rejected by clap");
     }
 
     #[test]
@@ -627,23 +733,35 @@ mod tests {
     #[test]
     fn test_ensure_int8_encoder_already_exists() {
         let tmp = tempfile::tempdir().unwrap();
-        let int8_path = tmp.path().join("v3_e2e_rnnt_encoder_int8.onnx");
+        let int8_path = tmp.path().join("v3_rnnt_encoder_int8.onnx");
         std::fs::write(&int8_path, b"fake").unwrap();
-        ensure_int8_encoder(tmp.path().to_str().unwrap(), false).unwrap();
+        ensure_int8_encoder(ModelVariant::Rnnt, tmp.path().to_str().unwrap(), false).unwrap();
     }
 
     #[test]
     fn test_ensure_int8_encoder_skip_flag() {
         let tmp = tempfile::tempdir().unwrap();
-        ensure_int8_encoder(tmp.path().to_str().unwrap(), true).unwrap();
+        ensure_int8_encoder(ModelVariant::Rnnt, tmp.path().to_str().unwrap(), true).unwrap();
     }
 
     #[test]
     fn test_ensure_int8_encoder_missing_input() {
         let tmp = tempfile::tempdir().unwrap();
-        let err = ensure_int8_encoder(tmp.path().to_str().unwrap(), false).unwrap_err();
+        let err = ensure_int8_encoder(ModelVariant::Rnnt, tmp.path().to_str().unwrap(), false)
+            .unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("Cannot quantize"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_ensure_int8_encoder_e2e_targets_e2e_encoder_name() {
+        // With the e2e variant, the FP32 input it looks for is the e2e encoder;
+        // an rnnt encoder in the dir must NOT satisfy it.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("v3_rnnt_encoder.onnx"), b"rnnt").unwrap();
+        let err = ensure_int8_encoder(ModelVariant::E2eRnnt, tmp.path().to_str().unwrap(), false)
+            .unwrap_err();
+        assert!(format!("{err}").contains("Cannot quantize"));
     }
 
     #[test]

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -53,6 +53,29 @@ enum Commands {
         )]
         model_variant: Option<ModelVariant>,
 
+        /// Punctuation + capitalization restoration: `on`, `off`, or `auto`.
+        /// `auto` (default) enables it for the `rnnt` head (bare output) and
+        /// disables it for `e2e_rnnt` (already punctuated). Requires the punct
+        /// model in `--punct-model-dir`; missing model → bare text + a warning.
+        /// Env: GIGASTT_PUNCTUATION.
+        #[arg(
+            long,
+            env = "GIGASTT_PUNCTUATION",
+            default_value = "auto",
+            value_parser = parse_punctuation_mode
+        )]
+        punctuation: PunctuationMode,
+
+        /// Directory holding the optional punctuation model
+        /// (`rupunct_small_int8.onnx`, `tokenizer.json`, `config.json`).
+        /// Defaults to `~/.gigastt/models/punct/`. Env: GIGASTT_PUNCT_MODEL_DIR.
+        #[arg(
+            long,
+            env = "GIGASTT_PUNCT_MODEL_DIR",
+            default_value_t = model::default_punct_model_dir()
+        )]
+        punct_model_dir: String,
+
         /// Number of concurrent inference sessions
         #[arg(long, default_value_t = 4)]
         pool_size: usize,
@@ -221,6 +244,26 @@ enum Commands {
             value_parser = parse_model_variant
         )]
         model_variant: Option<ModelVariant>,
+
+        /// Punctuation + capitalization restoration: `on`, `off`, or `auto`.
+        /// `auto` (default) enables it for `rnnt`, disables it for `e2e_rnnt`.
+        /// Env: GIGASTT_PUNCTUATION.
+        #[arg(
+            long,
+            env = "GIGASTT_PUNCTUATION",
+            default_value = "auto",
+            value_parser = parse_punctuation_mode
+        )]
+        punctuation: PunctuationMode,
+
+        /// Directory holding the optional punctuation model. Defaults to
+        /// `~/.gigastt/models/punct/`. Env: GIGASTT_PUNCT_MODEL_DIR.
+        #[arg(
+            long,
+            env = "GIGASTT_PUNCT_MODEL_DIR",
+            default_value_t = model::default_punct_model_dir()
+        )]
+        punct_model_dir: String,
     },
 }
 
@@ -371,6 +414,75 @@ fn parse_model_variant(s: &str) -> Result<ModelVariant, String> {
     s.parse()
 }
 
+/// Whether to run the optional punctuation / casing restoration pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PunctuationMode {
+    /// Always attempt to load + apply the punct model.
+    On,
+    /// Never apply punctuation (pass-through bare output).
+    Off,
+    /// Decide from the active model variant: on for `rnnt` (bare output),
+    /// off for `e2e_rnnt` (punctuation already baked into the head).
+    Auto,
+}
+
+impl std::str::FromStr for PunctuationMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "on" | "true" | "1" | "yes" => Ok(PunctuationMode::On),
+            "off" | "false" | "0" | "no" => Ok(PunctuationMode::Off),
+            "auto" => Ok(PunctuationMode::Auto),
+            other => Err(format!(
+                "unknown punctuation mode '{other}' (expected 'on', 'off', or 'auto')"
+            )),
+        }
+    }
+}
+
+/// clap value parser for `--punctuation`.
+fn parse_punctuation_mode(s: &str) -> Result<PunctuationMode, String> {
+    s.parse()
+}
+
+/// Resolve `--punctuation` against the active model variant and, when the pass
+/// should run, load the punctuation restorer from `punct_model_dir`.
+///
+/// Graceful fallback: when the punct model dir / files are absent or the model
+/// fails to load, a warning is logged once and `None` is returned so
+/// transcription proceeds with bare text — the punct pass is strictly optional
+/// and never blocks recognition.
+fn maybe_load_punctuator(
+    mode: PunctuationMode,
+    punct_model_dir: &str,
+    variant: ModelVariant,
+) -> Option<gigastt_core::punctuation::Punctuator> {
+    let enabled = match mode {
+        PunctuationMode::On => true,
+        PunctuationMode::Off => false,
+        // e2e_rnnt already emits punctuation/casing, so only the bare rnnt head
+        // benefits from the restoration pass.
+        PunctuationMode::Auto => variant == ModelVariant::Rnnt,
+    };
+    if !enabled {
+        return None;
+    }
+    match gigastt_core::punctuation::Punctuator::load(std::path::Path::new(punct_model_dir)) {
+        Ok(p) => {
+            tracing::info!("Punctuation restoration enabled (model dir: {punct_model_dir})");
+            Some(p)
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Punctuation model unavailable at {punct_model_dir} ({e:#}); \
+                 continuing without punctuation restoration"
+            );
+            None
+        }
+    }
+}
+
 /// Ensure the INT8 encoder exists for `variant`, producing it via the native
 /// Rust quantization pipeline if missing. Honoured by `serve` and `download`.
 /// First-time quantization takes ~2 minutes on the FP32 encoder.
@@ -414,6 +526,8 @@ async fn main() -> anyhow::Result<()> {
             host,
             model_dir,
             model_variant,
+            punctuation,
+            punct_model_dir,
             pool_size,
             pool_min_size,
             batch_pool_size,
@@ -438,12 +552,14 @@ async fn main() -> anyhow::Result<()> {
             ensure_bind_allowed(&host, bind_all)?;
             let resolved = model::ensure_model(model_variant, &model_dir).await?;
             ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
+            let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
             let engine = inference::Engine::load_with_pools(
                 &model_dir,
                 pool_size,
                 pool_min_size,
                 batch_pool_size,
-            )?;
+            )?
+            .with_punctuator(punctuator);
             log_rss();
             let limits = build_limits(
                 config.as_deref(),
@@ -518,9 +634,13 @@ async fn main() -> anyhow::Result<()> {
             file,
             model_dir,
             model_variant,
+            punctuation,
+            punct_model_dir,
         } => {
-            model::ensure_model(model_variant, &model_dir).await?;
-            let engine = inference::Engine::load_with_pool_size(&model_dir, 1)?;
+            let resolved = model::ensure_model(model_variant, &model_dir).await?;
+            let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
+            let engine =
+                inference::Engine::load_with_pool_size(&model_dir, 1)?.with_punctuator(punctuator);
             log_rss();
             let mut guard = engine.pool.checkout().await?;
             let result = engine.transcribe_file(&file, &mut guard);
@@ -684,6 +804,108 @@ mod tests {
     fn test_cli_serve_rejects_unknown_model_variant() {
         let res = Cli::try_parse_from(["gigastt", "serve", "--model-variant", "whisper"]);
         assert!(res.is_err(), "unknown variant must be rejected by clap");
+    }
+
+    #[test]
+    fn test_punctuation_mode_from_str() {
+        use std::str::FromStr;
+        assert_eq!(
+            PunctuationMode::from_str("on").unwrap(),
+            PunctuationMode::On
+        );
+        assert_eq!(
+            PunctuationMode::from_str("OFF").unwrap(),
+            PunctuationMode::Off
+        );
+        assert_eq!(
+            PunctuationMode::from_str(" auto ").unwrap(),
+            PunctuationMode::Auto
+        );
+        assert!(PunctuationMode::from_str("maybe").is_err());
+    }
+
+    #[test]
+    fn test_cli_serve_punctuation_defaults_auto() {
+        let cli = Cli::parse_from(["gigastt", "serve"]);
+        match cli.command {
+            Commands::Serve {
+                punctuation,
+                punct_model_dir,
+                ..
+            } => {
+                assert_eq!(punctuation, PunctuationMode::Auto);
+                assert!(punct_model_dir.contains("punct"));
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_punctuation_override() {
+        let cli = Cli::parse_from([
+            "gigastt",
+            "serve",
+            "--punctuation",
+            "on",
+            "--punct-model-dir",
+            "/tmp/punct",
+        ]);
+        match cli.command {
+            Commands::Serve {
+                punctuation,
+                punct_model_dir,
+                ..
+            } => {
+                assert_eq!(punctuation, PunctuationMode::On);
+                assert_eq!(punct_model_dir, "/tmp/punct");
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_transcribe_punctuation_off() {
+        let cli = Cli::parse_from(["gigastt", "transcribe", "a.wav", "--punctuation", "off"]);
+        match cli.command {
+            Commands::Transcribe { punctuation, .. } => {
+                assert_eq!(punctuation, PunctuationMode::Off);
+            }
+            _ => panic!("expected Transcribe"),
+        }
+    }
+
+    #[test]
+    fn test_maybe_load_punctuator_off_skips_load() {
+        // `off` must never touch the filesystem / model dir.
+        assert!(
+            maybe_load_punctuator(PunctuationMode::Off, "/nonexistent", ModelVariant::Rnnt)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_maybe_load_punctuator_auto_e2e_skips_load() {
+        // `auto` + e2e_rnnt → punctuation disabled (head already punctuates),
+        // so no load is attempted even if the dir is missing.
+        assert!(
+            maybe_load_punctuator(PunctuationMode::Auto, "/nonexistent", ModelVariant::E2eRnnt)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_maybe_load_punctuator_missing_model_falls_back_to_none() {
+        // `on` + missing model dir → graceful fallback to None (warn, no panic).
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("absent");
+        assert!(
+            maybe_load_punctuator(
+                PunctuationMode::On,
+                missing.to_str().unwrap(),
+                ModelVariant::Rnnt
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,12 @@ gigastt serve [OPTIONS]
                             already installed; fresh installs default to rnnt (lower WER,
                             no punctuation). e2e_rnnt keeps punctuation/casing/ITN.
                             Env: GIGASTT_MODEL_VARIANT.
+  --punctuation <MODE>      Restore punctuation/casing on output: auto | on | off
+                            [default: auto = on for rnnt, off for e2e_rnnt].
+                            Optional ONNX pass; absent model → text unchanged.
+                            Env: GIGASTT_PUNCTUATION.
+  --punct-model-dir <DIR>   Punctuation model directory [default: ~/.gigastt/models/punct].
+                            Env: GIGASTT_PUNCT_MODEL_DIR.
   --pool-size <N>           Concurrent inference sessions [default: 4]
   --bind-all                Required to listen on a non-loopback address.
                             Also: GIGASTT_ALLOW_BIND_ANY=1.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,10 @@ gigastt serve [OPTIONS]
   --port <PORT>             Listen port [default: 9876]
   --host <HOST>             Bind address [default: 127.0.0.1]
   --model-dir <DIR>         Model directory [default: ~/.gigastt/models]
+  --model-variant <V>       Recognition head: rnnt | e2e_rnnt. Omit to use the model
+                            already installed; fresh installs default to rnnt (lower WER,
+                            no punctuation). e2e_rnnt keeps punctuation/casing/ITN.
+                            Env: GIGASTT_MODEL_VARIANT.
   --pool-size <N>           Concurrent inference sessions [default: 4]
   --bind-all                Required to listen on a non-loopback address.
                             Also: GIGASTT_ALLOW_BIND_ANY=1.
@@ -62,6 +66,7 @@ gigastt serve [OPTIONS]
 
 gigastt download [OPTIONS]
   --model-dir <DIR>      Model directory [default: ~/.gigastt/models]
+  --model-variant <V>    Head to download: rnnt (default) | e2e_rnnt. Env: GIGASTT_MODEL_VARIANT.
   --skip-diarization     Skip downloading the speaker diarization model
   --skip-quantize        Skip auto-quantization after download (FP32 only)
 


### PR DESCRIPTION
Implements roadmap tasks **70 (rnnt-head-primary)** and **71 (punctuation-restoration)** — the "best of both" pairing: the lower-WER `rnnt` head plus restored punctuation/casing.

## Task 70 — selectable head
- `ModelVariant { Rnnt (default), E2eRnnt }` via `--model-variant` (env `GIGASTT_MODEL_VARIANT`) on serve/transcribe/download.
- Plain `rnnt` ≈ **3.29%** WER vs `e2e_rnnt` ≈ **9.65%** on a golos_crowd_1k subset (same encoder/quantizer, measured), at the cost of native punctuation.
- Engine auto-detects the installed variant from disk (real per-variant filenames; rnnt vocab is `v3_vocab.txt`). Downloader fetches the matching set with per-file SHA-256.
- **Existing installs respected**: serve/transcribe without the flag use whatever is installed and never silently re-download (pure `resolve_variant`); explicit flag switches, never mixes.

## Task 71 — punctuation + capitalization
- Optional post-process: `шестьдесят тысяч тенге сколько будет стоить` → **`Шестьдесят тысяч тенге, сколько будет стоить?`**
- INT8 ONNX export of `RUPunct/RUPunct_small` (MIT, ~29 MB) via ONNX Runtime + the `tokenizers` crate (fancy-regex backend, no C/oniguruma, no Python at runtime). 33-label `process_token` decode ported faithfully from RUPunct.
- `--punctuation <auto|on|off>` (env `GIGASTT_PUNCTUATION`; `auto` = on for rnnt, off for e2e) and `--punct-model-dir` (env `GIGASTT_PUNCT_MODEL_DIR`, default `~/.gigastt/models/punct/`).
- Fully optional + graceful: missing/unloadable model → text returned unchanged, no crash.

## Verification (end-to-end, independently checked)
- rnnt + punctuation on → `Шестьдесят тысяч тенге, сколько будет стоить?`; off → bare; fallback (empty punct dir) → bare, no crash.
- e2e variant (auto → punctuation off) → `60 000 тенге — сколько будет стоить?`; no surprise download.
- `cargo fmt`, `cargo clippy --lib --bins`, full `cargo test --lib --bins` green via the pre-commit gate; new unit tests for `resolve_variant`, `process_token`, punctuator load/fallback, CLI parsing.

## Follow-ups (not in this PR)
- **Publish the RUPunct INT8 ONNX** to a model host so an auto-download default can be wired (currently load from `--punct-model-dir`).
- **ITN** (number-words → digits) as a rule-based Rust pass.