### PR TITLE
feat(post): Russian ITN + punctuation-model auto-download

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,7 @@ All CLI flags have corresponding env vars:
 | `GIGASTT_MODEL_VARIANT` | `--model-variant` | rnnt (fresh installs) |
 | `GIGASTT_PUNCTUATION` | `--punctuation` | auto |
 | `GIGASTT_PUNCT_MODEL_DIR` | `--punct-model-dir` | `~/.gigastt/models/punct/` |
+| `GIGASTT_ITN` | `--itn` | auto |
 | `GIGASTT_FORMAT` | `transcribe --format` | `txt` |
 | `GIGASTT_OUTPUT` | `transcribe --output` | — |
 | `GIGASTT_MAX_CHARS_PER_LINE` | `transcribe --max-chars-per-line` | — |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Inverse text normalization for the `rnnt` head (`--itn`).** An optional
+  post-processing pass converts spelled-out Russian numbers into digits
+  (e.g. `шестьдесят тысяч` → `60000`, `две тысячи двадцать` → `2020`). It runs
+  **before** the punctuation pass, so the combined pipeline turns
+  `шестьдесят тысяч тенге сколько будет стоить` into
+  `60 000 тенге, сколько будет стоить?`. `--itn <auto|on|off>`
+  (env `GIGASTT_ITN`, default `auto` = on for `rnnt`, off for `e2e_rnnt` which
+  already digitizes numbers). The number-word table and the words→digits state
+  machine are a verbatim port of the WER benchmark normalizer, so online and
+  offline number handling stay symmetric.
+- **Punctuation model auto-download.** The RUPunct ONNX artifact is now published
+  at `ekhodzitsky/rupunct-small-onnx` (public, MIT) and downloads automatically
+  into `--punct-model-dir` (with SHA-256 verification + atomic rename) the first
+  time the punctuation pass is enabled, so `--punctuation on` works out of the
+  box. A download failure is logged and swallowed — transcription is never
+  blocked.
 - **Punctuation + capitalization restoration for the `rnnt` head
   (`--punctuation`).** An optional post-processing pass turns the plain `rnnt`
   head's bare lowercase output into properly cased, punctuated Russian
@@ -50,9 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for `e2e_rnnt` which already punctuates) and `--punct-model-dir`
   (env `GIGASTT_PUNCT_MODEL_DIR`, default `~/.gigastt/models/punct/`). The pass is
   fully optional: if the model is absent it logs once and returns the text
-  unchanged. Inverse text normalization (number-words → digits) is a planned
-  follow-up. (The ONNX artifact must be published to a model host before an
-  auto-download default can be wired; for now place it in the punct model dir.)
+  unchanged.
 - **Selectable recognition head (`--model-variant rnnt|e2e_rnnt`).** gigastt can now
   run either GigaAM v3 head. The plain `rnnt` head is the default for fresh installs:
   it scores markedly lower WER on bare normalized text (measured ~3.3% vs ~9.6% for

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -744,6 +744,10 @@ pub struct Engine {
     /// output. `None` = pass-through (the default, and the only behaviour when
     /// no punct model is installed). Attached via [`Engine::with_punctuator`].
     punctuator: Option<crate::punctuation::Punctuator>,
+    /// Whether to run inverse text normalization (Russian number-words →
+    /// digits) on file-transcription output, *before* the punctuation pass.
+    /// Off by default; toggled via [`Engine::with_itn`].
+    itn: bool,
     /// Whether the INT8 quantized encoder is in use.
     int8: bool,
     /// Speaker encoder for diarization (None if model file is absent).
@@ -779,6 +783,20 @@ impl Engine {
     /// Whether a punctuation restorer is attached.
     pub fn has_punctuator(&self) -> bool {
         self.punctuator.is_some()
+    }
+
+    /// Enable or disable inverse text normalization (Russian number-words →
+    /// digits) on file-transcription output, consuming and returning `self`
+    /// (builder style). When enabled, ITN runs *before* the punctuation pass so
+    /// the restorer cases the already-digitized text.
+    pub fn with_itn(mut self, enabled: bool) -> Self {
+        self.itn = enabled;
+        self
+    }
+
+    /// Whether inverse text normalization is enabled.
+    pub fn has_itn(&self) -> bool {
+        self.itn
     }
 
     /// Size of the BPE vocabulary the loaded tokenizer covers. Exposed so the
@@ -1288,6 +1306,7 @@ impl Engine {
             features,
             variant,
             punctuator: None,
+            itn: false,
             int8: is_int8,
             #[cfg(feature = "diarization")]
             speaker_encoder,
@@ -1714,6 +1733,16 @@ impl Engine {
             .map(|w| w.word.as_str())
             .collect::<Vec<_>>()
             .join(" ");
+
+        // Optional inverse text normalization (number-words → digits) for the
+        // plain `rnnt` head. Runs BEFORE punctuation so the restorer cases the
+        // already-digitized text. No-op when disabled; word-level timing is
+        // left untouched — only the joined `text` is rewritten.
+        let text = if self.itn {
+            crate::itn::apply_itn(&text)
+        } else {
+            text
+        };
 
         // Optional punctuation / casing restoration (plain `rnnt` head). When
         // no punctuator is attached this is a no-op; `restore` itself never

--- a/crates/gigastt-core/src/itn.rs
+++ b/crates/gigastt-core/src/itn.rs
@@ -1,0 +1,351 @@
+//! Inverse text normalization (ITN): Russian number-words → Arabic digits.
+//!
+//! The plain RNN-T recognition head ([`ModelVariant::Rnnt`](crate::model::ModelVariant::Rnnt))
+//! spells numbers out as words (e.g. `"шестьдесят тысяч"`). This module turns
+//! those number-word runs into digit tokens (`"60000"`) as an *optional*
+//! post-processing pass. It runs **before** punctuation restoration so the
+//! punctuator sees and cases the already-digitized text.
+//!
+//! [`apply_itn`] is the public entry point: whitespace-tokenize the input, run
+//! the words→numbers state machine, merge adjacent short digit groups, then
+//! rejoin with single spaces. Non-number tokens (and any punctuation attached
+//! to them) pass through unchanged.
+//!
+//! This is a verbatim Rust port of the reference implementation in
+//! `benchmark/common.py` (`_NUMBER_WORDS` / `_words_to_numbers` /
+//! `_merge_digit_groups`), kept symmetric with the WER benchmark so the same
+//! number normalization applies online and offline.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+const UNIT: i64 = 1;
+const TEEN: i64 = 10;
+const TEN: i64 = 10;
+const HUNDRED: i64 = 100;
+const THOUSAND: i64 = 1000;
+const MILLION: i64 = 1_000_000;
+
+/// Lazily-built `word -> (value, scale)` lookup, mirroring `_NUMBER_WORDS` in
+/// the Python reference. Keys are lowercase so the lookup is case-insensitive
+/// (it works on already-capitalized text too).
+fn number_words() -> &'static HashMap<&'static str, (i64, i64)> {
+    static TABLE: OnceLock<HashMap<&'static str, (i64, i64)>> = OnceLock::new();
+    TABLE.get_or_init(|| {
+        let mut m: HashMap<&'static str, (i64, i64)> = HashMap::new();
+        let mut add = |value: i64, scale: i64, forms: &[&'static str]| {
+            for &form in forms {
+                m.insert(form, (value, scale));
+            }
+        };
+
+        // Cardinals 0-9 with common case/gender forms.
+        add(0, UNIT, &["ноль", "ноля", "нолю", "нолем", "нолём", "ноле"]);
+        add(
+            1,
+            UNIT,
+            &[
+                "один",
+                "одна",
+                "одно",
+                "одного",
+                "одной",
+                "одному",
+                "одном",
+                "одним",
+            ],
+        );
+        add(2, UNIT, &["два", "две", "двух", "двум", "двумя"]);
+        add(3, UNIT, &["три", "трех", "трёх", "трем", "трём", "тремя"]);
+        add(
+            4,
+            UNIT,
+            &[
+                "четыре",
+                "четырёх",
+                "четырех",
+                "четырём",
+                "четырем",
+                "четырьмя",
+            ],
+        );
+        add(5, UNIT, &["пять", "пяти", "пятью"]);
+        add(6, UNIT, &["шесть", "шести", "шестью"]);
+        add(7, UNIT, &["семь", "семи", "семью"]);
+        add(8, UNIT, &["восемь", "восьми", "восьмью"]);
+        add(9, UNIT, &["девять", "девяти", "девятью"]);
+
+        // Teens 10-19.
+        add(10, TEEN, &["десять", "десяти", "десятью"]);
+        add(11, TEEN, &["одиннадцать", "одиннадцати"]);
+        add(12, TEEN, &["двенадцать", "двенадцати"]);
+        add(13, TEEN, &["тринадцать", "тринадцати"]);
+        add(14, TEEN, &["четырнадцать", "четырнадцати"]);
+        add(15, TEEN, &["пятнадцать", "пятнадцати"]);
+        add(16, TEEN, &["шестнадцать", "шестнадцати"]);
+        add(17, TEEN, &["семнадцать", "семнадцати"]);
+        add(18, TEEN, &["восемнадцать", "восемнадцати"]);
+        add(19, TEEN, &["девятнадцать", "девятнадцати"]);
+
+        // Tens 20-90.
+        add(20, TEN, &["двадцать", "двадцати"]);
+        add(30, TEN, &["тридцать", "тридцати"]);
+        add(40, TEN, &["сорок", "сорока"]);
+        add(50, TEN, &["пятьдесят", "пятидесяти"]);
+        add(60, TEN, &["шестьдесят", "шестидесяти"]);
+        add(70, TEN, &["семьдесят", "семидесяти"]);
+        add(80, TEN, &["восемьдесят", "восьмидесяти"]);
+        add(90, TEN, &["девяносто", "девяноста"]);
+
+        // Hundreds 100-900.
+        add(100, HUNDRED, &["сто", "ста"]);
+        add(200, HUNDRED, &["двести", "двухсот"]);
+        add(300, HUNDRED, &["триста", "трехсот", "трёхсот"]);
+        add(400, HUNDRED, &["четыреста", "четырёхсот"]);
+        add(500, HUNDRED, &["пятьсот", "пятисот"]);
+        add(600, HUNDRED, &["шестьсот", "шестисот"]);
+        add(700, HUNDRED, &["семьсот", "семисот"]);
+        add(800, HUNDRED, &["восемьсот", "восьмисот"]);
+        add(900, HUNDRED, &["девятьсот", "девятисот"]);
+
+        // Scale words (all common case forms).
+        add(
+            1000,
+            THOUSAND,
+            &[
+                "тысяча",
+                "тысячи",
+                "тысяч",
+                "тысяче",
+                "тысячу",
+                "тысячей",
+                "тысячам",
+                "тысячами",
+                "тысячах",
+            ],
+        );
+        add(
+            1_000_000,
+            MILLION,
+            &[
+                "миллион",
+                "миллиона",
+                "миллионов",
+                "миллиону",
+                "миллионе",
+                "миллионам",
+                "миллионами",
+                "миллионах",
+            ],
+        );
+
+        m
+    })
+}
+
+/// Convert Russian number-word sequences into Arabic digit tokens.
+///
+/// Compound numbers such as `"две тысячи двадцать"` become a single token
+/// `"2020"`, while independent digit groups (e.g. phone-number chunks) are
+/// emitted separately based on scale-order jumps. Verbatim port of the
+/// reference `_words_to_numbers`.
+fn words_to_numbers(tokens: &[String]) -> Vec<String> {
+    let table = number_words();
+    let mut result: Vec<String> = Vec::with_capacity(tokens.len());
+
+    let mut current: i64 = 0;
+    let mut running_total: i64 = 0;
+    let mut prev_scale: i64 = 0;
+    let mut in_number = false;
+
+    // Local flush closure cannot borrow the mutable state we mutate in the
+    // loop, so it is inlined as a macro-free helper via explicit blocks below.
+    for token in tokens {
+        // Case-insensitive lookup: the rnnt head can be lowercase, but ITN may
+        // also run on already-capitalized text.
+        let key = token.to_lowercase();
+        match table.get(key.as_str()) {
+            Some(&(value, scale)) => {
+                in_number = true;
+                if scale == THOUSAND || scale == MILLION {
+                    if current == 0 {
+                        current = 1;
+                    }
+                    running_total += current * scale;
+                    current = 0;
+                    prev_scale = scale;
+                } else if current > 0 && scale >= prev_scale {
+                    // Python: flush() then `current = value; in_number = True`.
+                    // The flush emits `running_total + current` and resets the
+                    // running total; `current`, `in_number`, and `prev_scale`
+                    // are immediately re-set below, so only their final values
+                    // matter here.
+                    result.push((running_total + current).to_string());
+                    running_total = 0;
+                    current = value;
+                    in_number = true;
+                    prev_scale = scale;
+                } else {
+                    current += value;
+                    prev_scale = scale;
+                }
+            }
+            None => {
+                // flush()
+                let total = running_total + current;
+                if in_number {
+                    result.push(total.to_string());
+                }
+                current = 0;
+                running_total = 0;
+                prev_scale = 0;
+                in_number = false;
+
+                result.push(token.clone());
+            }
+        }
+    }
+
+    // Final flush().
+    let total = running_total + current;
+    if in_number {
+        result.push(total.to_string());
+    }
+
+    result
+}
+
+/// True when `s` is non-empty and every char is an ASCII digit, mirroring
+/// Python `str.isdigit()` for the digit tokens this pipeline produces.
+fn is_digit_token(s: &str) -> bool {
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Merge adjacent digit tokens when every token in the run has length ≤ 3.
+/// Verbatim port of the reference `_merge_digit_groups`.
+fn merge_digit_groups(tokens: &[String]) -> Vec<String> {
+    let mut result: Vec<String> = Vec::with_capacity(tokens.len());
+    let n = tokens.len();
+    let mut i = 0;
+    while i < n {
+        if is_digit_token(&tokens[i]) {
+            let mut j = i;
+            let mut group: Vec<&String> = Vec::new();
+            while j < n && is_digit_token(&tokens[j]) {
+                group.push(&tokens[j]);
+                j += 1;
+            }
+            if !group.is_empty() && group.iter().all(|t| t.chars().count() <= 3) {
+                result.push(group.iter().map(|t| t.as_str()).collect::<String>());
+            } else {
+                result.extend(group.iter().map(|t| (*t).clone()));
+            }
+            i = j;
+        } else {
+            result.push(tokens[i].clone());
+            i += 1;
+        }
+    }
+    result
+}
+
+/// Apply inverse text normalization: convert Russian number-words to digits.
+///
+/// Whitespace-tokenizes the input, runs the words→numbers state machine, merges
+/// adjacent short digit groups, and rejoins with single spaces. Non-number
+/// tokens (and any punctuation attached to them) pass through unchanged.
+///
+/// Examples: `"двадцать один"` → `"21"`, `"две тысячи двадцать"` → `"2020"`,
+/// `"шестьдесят тысяч"` → `"60000"`, `"позвони на шестьдесят"` →
+/// `"позвони на 60"`.
+pub fn apply_itn(text: &str) -> String {
+    let tokens: Vec<String> = text.split_whitespace().map(str::to_string).collect();
+    let tokens = words_to_numbers(&tokens);
+    let tokens = merge_digit_groups(&tokens);
+    tokens.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_itn_tens_plus_unit() {
+        assert_eq!(apply_itn("двадцать один"), "21");
+    }
+
+    #[test]
+    fn test_apply_itn_compound_thousand() {
+        assert_eq!(apply_itn("две тысячи двадцать"), "2020");
+    }
+
+    #[test]
+    fn test_apply_itn_sixty_thousand() {
+        assert_eq!(apply_itn("шестьдесят тысяч"), "60000");
+    }
+
+    #[test]
+    fn test_apply_itn_hundred() {
+        assert_eq!(apply_itn("сто"), "100");
+    }
+
+    #[test]
+    fn test_apply_itn_plain_words_unchanged() {
+        assert_eq!(apply_itn("привет как дела"), "привет как дела");
+    }
+
+    #[test]
+    fn test_apply_itn_mixed_words_and_number() {
+        assert_eq!(apply_itn("позвони на шестьдесят"), "позвони на 60");
+    }
+
+    #[test]
+    fn test_apply_itn_case_insensitive() {
+        // Capitalized number-words still convert (lowercased for lookup).
+        assert_eq!(apply_itn("Двадцать один"), "21");
+    }
+
+    #[test]
+    fn test_apply_itn_digit_group_merge() {
+        // Adjacent short (<=3 char) digit groups merge: "сто двадцать три" is a
+        // single compound (123), but two independent ≤3-digit runs join too.
+        // "восемь девять пять" → 8 9 5 → all length 1 → merged "895".
+        assert_eq!(apply_itn("восемь девять пять"), "895");
+    }
+
+    #[test]
+    fn test_apply_itn_trailing_unit_folds_into_running_total() {
+        // The state machine folds a trailing unit into the running total, so
+        // "шестьдесят тысяч пять" → 60000 + 5 = "60005" as ONE token (verified
+        // against the Python reference _words_to_numbers).
+        assert_eq!(apply_itn("шестьдесят тысяч пять"), "60005");
+    }
+
+    #[test]
+    fn test_apply_itn_long_digit_run_not_merged() {
+        // A scale jump flushes into two digit tokens; the 4-char "1100" blocks
+        // the run from merging, so they stay space-separated (verified against
+        // the Python reference: ["1100", "200"]).
+        assert_eq!(apply_itn("тысяча сто двести"), "1100 200");
+    }
+
+    #[test]
+    fn test_apply_itn_phrase_with_trailing_words() {
+        // The end-to-end pipeline example: number run digitizes, words pass through.
+        assert_eq!(
+            apply_itn("шестьдесят тысяч тенге сколько будет стоить"),
+            "60000 тенге сколько будет стоить"
+        );
+    }
+
+    #[test]
+    fn test_apply_itn_empty_string() {
+        assert_eq!(apply_itn(""), "");
+    }
+
+    #[test]
+    fn test_apply_itn_punctuation_passes_through() {
+        // Non-number token with attached punctuation is unchanged.
+        assert_eq!(apply_itn("привет, мир"), "привет, мир");
+    }
+}

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod export;
 pub mod inference;
+pub mod itn;
 pub mod model;
 pub mod onnx_proto;
 pub mod protocol;

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -56,6 +56,27 @@ impl DownloadProgress {
 
 const HF_REPO: &str = "istupakov/gigaam-v3-onnx";
 
+/// HuggingFace repo hosting the optional RUPunct punctuation model (MIT).
+const PUNCT_HF_REPO: &str = "ekhodzitsky/rupunct-small-onnx";
+
+/// The three files the punctuation pass needs, with their pinned SHA-256
+/// checksums. Filenames mirror the `PUNCT_*` constants in [`crate::punctuation`].
+/// Verified against the canonical HuggingFace copies on 2026-06-19.
+const PUNCT_FILES: &[(&str, &str)] = &[
+    (
+        crate::punctuation::PUNCT_MODEL_FILE,
+        "b105da023474d98aa13ba18953ae67b04b17bd0595034bc06030c17536893933",
+    ),
+    (
+        crate::punctuation::PUNCT_TOKENIZER_FILE,
+        "7ca617388c2092a3a84272025c52bbf3c6db0aee225c0351186295c0b5d3ddc6",
+    ),
+    (
+        crate::punctuation::PUNCT_CONFIG_FILE,
+        "6924a8cf41ec2bd3a3aa73a387ae0ccd0aed253ec7cac4d2f53c7d27440891eb",
+    ),
+];
+
 /// Selectable GigaAM v3 recognition head.
 ///
 /// Both heads ship in the same HuggingFace repo (`HF_REPO`) and share the
@@ -259,9 +280,10 @@ pub fn default_model_dir() -> String {
 /// a sibling of [`default_model_dir`].
 ///
 /// Holds the optional RUPunct ONNX punctuation/casing restorer used to
-/// post-process the plain `rnnt` head's bare lowercase output. The artifact is
-/// not yet published, so this dir is populated manually (see
-/// [`crate::punctuation`]); a missing dir simply disables the punct pass.
+/// post-process the plain `rnnt` head's bare lowercase output. The artifact
+/// auto-downloads from `ekhodzitsky/rupunct-small-onnx` via
+/// [`ensure_punct_model`] when the punct pass is enabled (see
+/// [`crate::punctuation`]); a download failure simply disables the punct pass.
 pub fn default_punct_model_dir() -> String {
     home_dir()
         .map(|h| {
@@ -429,6 +451,45 @@ pub async fn ensure_speaker_model(model_dir: &str) -> Result<()> {
         SPEAKER_MODEL_FILE,
     )
     .await
+}
+
+/// Ensure the optional punctuation model exists in `punct_model_dir`,
+/// downloading any missing files from the `ekhodzitsky/rupunct-small-onnx`
+/// HuggingFace repo (public, MIT).
+///
+/// Downloads the three files the punctuation pass needs
+/// (`rupunct_small_int8.onnx`, `tokenizer.json`, `config.json`) — only those
+/// not already present — using the same streaming-download + atomic-rename +
+/// SHA-256 infra as the main model download. Files already on disk are left
+/// untouched, so a second call is a no-op (no re-download).
+///
+/// The pass is strictly optional: callers treat a download error as
+/// "punctuation unavailable" and proceed with bare text.
+pub async fn ensure_punct_model(punct_model_dir: &str) -> Result<()> {
+    let dir = Path::new(punct_model_dir);
+
+    if PUNCT_FILES.iter().all(|(file, _)| dir.join(file).exists()) {
+        tracing::info!("Punctuation model found at {punct_model_dir}");
+        return Ok(());
+    }
+
+    tracing::info!("Punctuation model not found, downloading from HuggingFace...");
+    std::fs::create_dir_all(dir).context("Failed to create punctuation model directory")?;
+
+    #[cfg(unix)]
+    let _lock = acquire_download_lock(dir)?;
+
+    for (file, sha256) in PUNCT_FILES {
+        let final_dest = dir.join(file);
+        if final_dest.exists() {
+            continue;
+        }
+        let url = format!("https://huggingface.co/{PUNCT_HF_REPO}/resolve/main/{file}");
+        stream_to_partial_then_finalize(&url, &final_dest, Some(sha256), file).await?;
+    }
+
+    tracing::info!("Punctuation model download complete");
+    Ok(())
 }
 
 /// True when every downloaded file for `variant` is present in `dir`.
@@ -919,6 +980,50 @@ mod tests {
             msg.contains("SHA-256 mismatch"),
             "error should mention mismatch: {msg}"
         );
+    }
+
+    #[test]
+    fn test_punct_files_checksums_are_pinned() {
+        // Three files, each with a 64-char lowercase hex digest — no truncation
+        // or placeholder slipping into a release.
+        assert_eq!(PUNCT_FILES.len(), 3);
+        for (file, sum) in PUNCT_FILES {
+            assert_eq!(
+                sum.len(),
+                64,
+                "{file} punct checksum must be 64 hex chars, got: {sum}"
+            );
+            assert!(
+                sum.chars()
+                    .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+                "{file} punct checksum must be lowercase hex, got: {sum}"
+            );
+        }
+    }
+
+    /// `ensure_punct_model` short-circuits (no network, no `.partial`) when all
+    /// three files are already present.
+    #[tokio::test]
+    async fn test_ensure_punct_model_present_no_download() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        for (file, _) in PUNCT_FILES {
+            std::fs::write(dir.join(file), b"stub").unwrap();
+        }
+
+        ensure_punct_model(dir.to_str().unwrap())
+            .await
+            .expect("present model must short-circuit");
+
+        let partials: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".partial"))
+            .collect();
+        assert!(partials.is_empty(), "no .partial files: {partials:?}");
+        for (file, _) in PUNCT_FILES {
+            assert_eq!(std::fs::read(dir.join(file)).unwrap(), b"stub");
+        }
     }
 
     #[test]

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -18,11 +18,12 @@
 //! [`Punctuator::load`] returns an error which the caller treats as "punctuation
 //! disabled" (the engine logs a warning once and returns input text unchanged).
 //!
-//! NOTE (distribution): the exported ONNX artifact is not yet published to
-//! HuggingFace. It must be loaded from a local model dir (`--punct-model-dir`,
-//! default `~/.gigastt/models/punct/`). Before an auto-download default can be
-//! wired, publish the artifact (e.g. to an `ekhodzitsky/rupunct-small-onnx` HF
-//! repo). sha256 of the int8 ONNX:
+//! NOTE (distribution): the exported ONNX artifact is published at the
+//! `ekhodzitsky/rupunct-small-onnx` HuggingFace repo (public, MIT) and
+//! auto-downloads into the punct model dir (`--punct-model-dir`, default
+//! `~/.gigastt/models/punct/`) on first use via
+//! [`crate::model::ensure_punct_model`]. A local dir is still honoured if
+//! pre-populated. sha256 of the int8 ONNX:
 //! `b105da023474d98aa13ba18953ae67b04b17bd0595034bc06030c17536893933`.
 
 use std::path::Path;

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -71,13 +71,27 @@ enum Commands {
 
         /// Directory holding the optional punctuation model
         /// (`rupunct_small_int8.onnx`, `tokenizer.json`, `config.json`).
-        /// Defaults to `~/.gigastt/models/punct/`. Env: GIGASTT_PUNCT_MODEL_DIR.
+        /// Defaults to `~/.gigastt/models/punct/`. Auto-downloaded from
+        /// `ekhodzitsky/rupunct-small-onnx` when enabled and absent.
+        /// Env: GIGASTT_PUNCT_MODEL_DIR.
         #[arg(
             long,
             env = "GIGASTT_PUNCT_MODEL_DIR",
             default_value_t = model::default_punct_model_dir()
         )]
         punct_model_dir: String,
+
+        /// Inverse text normalization (Russian number-words → digits):
+        /// `on`, `off`, or `auto`. `auto` (default) enables it for the `rnnt`
+        /// head (spells numbers as words) and disables it for `e2e_rnnt`
+        /// (ITN already baked in). Runs before punctuation. Env: GIGASTT_ITN.
+        #[arg(
+            long,
+            env = "GIGASTT_ITN",
+            default_value = "auto",
+            value_parser = parse_itn_mode
+        )]
+        itn: ItnMode,
 
         /// Number of concurrent inference sessions
         #[arg(long, default_value_t = 4)]
@@ -260,13 +274,26 @@ enum Commands {
         punctuation: PunctuationMode,
 
         /// Directory holding the optional punctuation model. Defaults to
-        /// `~/.gigastt/models/punct/`. Env: GIGASTT_PUNCT_MODEL_DIR.
+        /// `~/.gigastt/models/punct/`. Auto-downloaded from
+        /// `ekhodzitsky/rupunct-small-onnx` when enabled and absent.
+        /// Env: GIGASTT_PUNCT_MODEL_DIR.
         #[arg(
             long,
             env = "GIGASTT_PUNCT_MODEL_DIR",
             default_value_t = model::default_punct_model_dir()
         )]
         punct_model_dir: String,
+
+        /// Inverse text normalization (Russian number-words → digits):
+        /// `on`, `off`, or `auto`. `auto` (default) enables it for `rnnt`,
+        /// disables it for `e2e_rnnt`. Runs before punctuation. Env: GIGASTT_ITN.
+        #[arg(
+            long,
+            env = "GIGASTT_ITN",
+            default_value = "auto",
+            value_parser = parse_itn_mode
+        )]
+        itn: ItnMode,
 
         /// Export format: json, txt, srt, vtt, md [default: txt]
         #[arg(short, long, env = "GIGASTT_FORMAT", default_value = "txt")]
@@ -469,6 +496,49 @@ fn parse_punctuation_mode(s: &str) -> Result<PunctuationMode, String> {
     s.parse()
 }
 
+/// Whether to run the optional inverse text normalization pass
+/// (Russian number-words → digits). Mirrors [`PunctuationMode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ItnMode {
+    /// Always apply ITN.
+    On,
+    /// Never apply ITN (pass-through number-words).
+    Off,
+    /// Decide from the active model variant: on for `rnnt` (spells numbers as
+    /// words), off for `e2e_rnnt` (ITN already baked into the head).
+    Auto,
+}
+
+impl std::str::FromStr for ItnMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "on" | "true" | "1" | "yes" => Ok(ItnMode::On),
+            "off" | "false" | "0" | "no" => Ok(ItnMode::Off),
+            "auto" => Ok(ItnMode::Auto),
+            other => Err(format!(
+                "unknown ITN mode '{other}' (expected 'on', 'off', or 'auto')"
+            )),
+        }
+    }
+}
+
+/// clap value parser for `--itn`.
+fn parse_itn_mode(s: &str) -> Result<ItnMode, String> {
+    s.parse()
+}
+
+/// Resolve `--itn` against the active model variant: `auto` enables ITN only
+/// for the bare `rnnt` head (the `e2e_rnnt` head already digitizes numbers).
+fn resolve_itn(mode: ItnMode, variant: ModelVariant) -> bool {
+    match mode {
+        ItnMode::On => true,
+        ItnMode::Off => false,
+        ItnMode::Auto => variant == ModelVariant::Rnnt,
+    }
+}
+
 /// Resolve `--punctuation` against the active model variant and, when the pass
 /// should run, load the punctuation restorer from `punct_model_dir`.
 ///
@@ -476,19 +546,24 @@ fn parse_punctuation_mode(s: &str) -> Result<PunctuationMode, String> {
 /// fails to load, a warning is logged once and `None` is returned so
 /// transcription proceeds with bare text — the punct pass is strictly optional
 /// and never blocks recognition.
-fn maybe_load_punctuator(
-    mode: PunctuationMode,
-    punct_model_dir: &str,
-    variant: ModelVariant,
-) -> Option<gigastt_core::punctuation::Punctuator> {
-    let enabled = match mode {
+/// Resolve `--punctuation` against the active model variant: `auto` enables the
+/// pass only for the bare `rnnt` head (`e2e_rnnt` already punctuates).
+fn resolve_punctuation(mode: PunctuationMode, variant: ModelVariant) -> bool {
+    match mode {
         PunctuationMode::On => true,
         PunctuationMode::Off => false,
         // e2e_rnnt already emits punctuation/casing, so only the bare rnnt head
         // benefits from the restoration pass.
         PunctuationMode::Auto => variant == ModelVariant::Rnnt,
-    };
-    if !enabled {
+    }
+}
+
+fn maybe_load_punctuator(
+    mode: PunctuationMode,
+    punct_model_dir: &str,
+    variant: ModelVariant,
+) -> Option<gigastt_core::punctuation::Punctuator> {
+    if !resolve_punctuation(mode, variant) {
         return None;
     }
     match gigastt_core::punctuation::Punctuator::load(std::path::Path::new(punct_model_dir)) {
@@ -503,6 +578,30 @@ fn maybe_load_punctuator(
             );
             None
         }
+    }
+}
+
+/// When the punctuation pass resolves to ENABLED and the punct model files are
+/// absent in `punct_model_dir`, auto-download them from the
+/// `ekhodzitsky/rupunct-small-onnx` HuggingFace repo so the pass works out of
+/// the box.
+///
+/// Graceful: a download failure is logged as a warning and swallowed — the
+/// subsequent [`maybe_load_punctuator`] call then falls back to bare text. The
+/// punct pass never blocks transcription.
+async fn maybe_download_punct_model(
+    mode: PunctuationMode,
+    punct_model_dir: &str,
+    variant: ModelVariant,
+) {
+    if !resolve_punctuation(mode, variant) {
+        return;
+    }
+    if let Err(e) = model::ensure_punct_model(punct_model_dir).await {
+        tracing::warn!(
+            "Punctuation model download failed for {punct_model_dir} ({e:#}); \
+             continuing without punctuation restoration"
+        );
     }
 }
 
@@ -551,6 +650,7 @@ async fn main() -> anyhow::Result<()> {
             model_variant,
             punctuation,
             punct_model_dir,
+            itn,
             pool_size,
             pool_min_size,
             batch_pool_size,
@@ -575,6 +675,7 @@ async fn main() -> anyhow::Result<()> {
             ensure_bind_allowed(&host, bind_all)?;
             let resolved = model::ensure_model_variant(model_variant, &model_dir).await?;
             ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
+            maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
             let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
             let engine = inference::Engine::load_with_pools(
                 &model_dir,
@@ -582,7 +683,8 @@ async fn main() -> anyhow::Result<()> {
                 pool_min_size,
                 batch_pool_size,
             )?
-            .with_punctuator(punctuator);
+            .with_punctuator(punctuator)
+            .with_itn(resolve_itn(itn, resolved));
             log_rss();
             let limits = build_limits(
                 config.as_deref(),
@@ -659,6 +761,7 @@ async fn main() -> anyhow::Result<()> {
             model_variant,
             punctuation,
             punct_model_dir,
+            itn,
             format,
             output,
             max_chars_per_line,
@@ -666,9 +769,11 @@ async fn main() -> anyhow::Result<()> {
             word_timestamps,
         } => {
             let resolved = model::ensure_model_variant(model_variant, &model_dir).await?;
+            maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
             let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
-            let engine =
-                inference::Engine::load_with_pool_size(&model_dir, 1)?.with_punctuator(punctuator);
+            let engine = inference::Engine::load_with_pool_size(&model_dir, 1)?
+                .with_punctuator(punctuator)
+                .with_itn(resolve_itn(itn, resolved));
             log_rss();
             let mut guard = engine.pool.checkout().await?;
             let result = engine.transcribe_file(&file, &mut guard);
@@ -976,6 +1081,43 @@ mod tests {
             Commands::Transcribe { punctuation, .. } => {
                 assert_eq!(punctuation, PunctuationMode::Off);
             }
+            _ => panic!("expected Transcribe"),
+        }
+    }
+
+    #[test]
+    fn test_itn_mode_from_str() {
+        use std::str::FromStr;
+        assert_eq!(ItnMode::from_str("on").unwrap(), ItnMode::On);
+        assert_eq!(ItnMode::from_str("OFF").unwrap(), ItnMode::Off);
+        assert_eq!(ItnMode::from_str(" auto ").unwrap(), ItnMode::Auto);
+        assert!(ItnMode::from_str("maybe").is_err());
+    }
+
+    #[test]
+    fn test_resolve_itn_auto_per_variant() {
+        // auto → on for the bare rnnt head, off for the already-ITN e2e head.
+        assert!(resolve_itn(ItnMode::Auto, ModelVariant::Rnnt));
+        assert!(!resolve_itn(ItnMode::Auto, ModelVariant::E2eRnnt));
+        // on/off override the variant.
+        assert!(resolve_itn(ItnMode::On, ModelVariant::E2eRnnt));
+        assert!(!resolve_itn(ItnMode::Off, ModelVariant::Rnnt));
+    }
+
+    #[test]
+    fn test_cli_serve_itn_defaults_auto() {
+        let cli = Cli::parse_from(["gigastt", "serve"]);
+        match cli.command {
+            Commands::Serve { itn, .. } => assert_eq!(itn, ItnMode::Auto),
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_transcribe_itn_override() {
+        let cli = Cli::parse_from(["gigastt", "transcribe", "a.wav", "--itn", "on"]);
+        match cli.command {
+            Commands::Transcribe { itn, .. } => assert_eq!(itn, ItnMode::On),
             _ => panic!("expected Transcribe"),
         }
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,7 +29,12 @@ gigastt serve [OPTIONS]
                             Optional ONNX pass; absent model → text unchanged.
                             Env: GIGASTT_PUNCTUATION.
   --punct-model-dir <DIR>   Punctuation model directory [default: ~/.gigastt/models/punct].
+                            Auto-downloaded from ekhodzitsky/rupunct-small-onnx when
+                            the pass is enabled and the files are absent.
                             Env: GIGASTT_PUNCT_MODEL_DIR.
+  --itn <MODE>              Inverse text normalization (number-words → digits):
+                            auto | on | off [default: auto = on for rnnt, off for
+                            e2e_rnnt]. Runs before punctuation. Env: GIGASTT_ITN.
   --pool-size <N>           Concurrent inference sessions [default: 4]
   --bind-all                Required to listen on a non-loopback address.
                             Also: GIGASTT_ALLOW_BIND_ANY=1.
@@ -78,6 +83,17 @@ gigastt download [OPTIONS]
 
 gigastt transcribe [OPTIONS] <FILE>
   --model-dir <DIR>           Model directory [default: ~/.gigastt/models]
+  --model-variant <V>         Recognition head: rnnt | e2e_rnnt. Omit to auto-detect.
+                              Env: GIGASTT_MODEL_VARIANT.
+  --punctuation <MODE>        Restore punctuation/casing: auto | on | off
+                              [default: auto = on for rnnt, off for e2e_rnnt].
+                              Env: GIGASTT_PUNCTUATION.
+  --punct-model-dir <DIR>     Punctuation model directory [default: ~/.gigastt/models/punct].
+                              Auto-downloaded from ekhodzitsky/rupunct-small-onnx when
+                              enabled and absent. Env: GIGASTT_PUNCT_MODEL_DIR.
+  --itn <MODE>                Inverse text normalization (number-words → digits):
+                              auto | on | off [default: auto = on for rnnt, off for
+                              e2e_rnnt]. Runs before punctuation. Env: GIGASTT_ITN.
   -f, --format <FORMAT>       Export format: json, txt, srt, vtt, md [default: txt]
   -o, --output <FILE>         Write rendered output to file instead of stdout
   --max-chars-per-line <N>    Max chars per subtitle line (SRT/VTT) [default: 80]


### PR DESCRIPTION
Completes the deferred follow-ups of roadmap tasks **70/71** (rnnt head + punctuation): inverse text normalization and out-of-the-box punctuation-model download.

## ITN (number-words → digits)
- New `gigastt-core::itn::apply_itn` — a verbatim Rust port of the benchmark's Russian words→digits (`_words_to_numbers` + `_merge_digit_groups` + the number-word table). `шестьдесят тысяч` → `60000`, `две тысячи двадцать` → `2020`.
- `--itn <auto|on|off>` (env `GIGASTT_ITN`; `auto` = on for `rnnt`, off for `e2e_rnnt`). Applied BEFORE the punctuation pass: rnnt text → ITN → punctuation.

## Punctuation-model auto-download
- `model::ensure_punct_model` fetches the punctuation ONNX + tokenizer + config from the published **[ekhodzitsky/rupunct-small-onnx](https://huggingface.co/ekhodzitsky/rupunct-small-onnx)** (MIT) with per-file SHA-256, auto-invoked when punctuation is enabled and the model is absent. Graceful: a download failure logs a warning and falls back to bare text. Replaces the prior "load from a local dir only" limitation.

## Verification (end-to-end, independently checked)
- rnnt `--itn on --punctuation on` → `60000 тенге, сколько будет стоить?`; `--itn off --punctuation on` → `Шестьдесят тысяч тенге, сколько будет стоить?`.
- Fresh empty `--punct-model-dir` → downloads the 3 sha-checked files from HF and punctuates.
- e2e variant (auto → itn/punct off) → `60 000 тенге — сколько будет стоить?`; no model download.
- `cargo fmt`/`clippy --lib --bins`/`test --lib --bins` green across default + coreml + cuda + diarization feature checks; new ITN unit tests + CLI tests.