### PR TITLE
feat(bias): contextual hotword biasing + brand lexicon (greedy, opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Contextual hotword biasing (`--hotwords-file` / `--hotwords-boost`).** Optional
+  token-level shallow-fusion biasing inside the existing greedy RNN-T loop (no beam
+  search): a trie over hotword phrases — each tokenized to the active vocabulary —
+  boosts the joiner logits of tokens that extend an active hotword prefix, so brands,
+  names, and domain terms are recognized more reliably. Works for both heads (char and
+  BPE vocabularies). A curated Russian brand/acronym lexicon ships as the default pack.
+  Default OFF: with no hotwords configured, decoding is byte-for-byte unchanged. Env
+  `GIGASTT_HOTWORDS_FILE` / `GIGASTT_HOTWORDS_BOOST`.
 - **Inverse text normalization for the `rnnt` head (`--itn`).** An optional
   post-processing pass converts spelled-out Russian numbers into digits
   (e.g. `шестьдесят тысяч` → `60000`, `две тысячи двадцать` → `2020`). It runs

--- a/crates/gigastt-core/src/inference/bias.rs
+++ b/crates/gigastt-core/src/inference/bias.rs
@@ -1,0 +1,256 @@
+//! Contextual hotword biasing for the greedy RNN-T decode loop.
+//!
+//! Shallow-fusion biasing steers the greedy transducer toward a curated set of
+//! phrases (brands, names, domain terms) without a beam search. Each hotword is
+//! tokenized to the id sequence the active head would emit (via
+//! [`Tokenizer::encode_phrase`](super::tokenizer::Tokenizer::encode_phrase), so
+//! it adapts to whichever vocab is loaded) and stored in a small prefix trie.
+//!
+//! During decode, a [`BiasState`] tracks which hotword prefixes are currently
+//! "active" given the recently emitted tokens. Before the argmax over the
+//! joiner logits, [`Biaser::boost_logits`] adds a fixed boost to the logits of
+//! the token-ids that would extend an active prefix. A token that completes /
+//! advances a prefix advances the state; anything else resets it (while still
+//! letting a fresh hotword start). Blank frames leave the prefix state
+//! unchanged — they emit no label, so a partially-matched hotword survives the
+//! gaps between its tokens.
+//!
+//! The [`Biaser`] itself is immutable after construction and shared across the
+//! session pool via `&Biaser`; the only mutable per-decode bookkeeping lives in
+//! [`BiasState`], created fresh for each decode. When no hotwords are
+//! configured the engine holds no biaser at all and the decode path is
+//! byte-for-byte unchanged.
+
+use super::tokenizer::Tokenizer;
+
+/// One node of the hotword prefix trie. The root is index 0.
+struct TrieNode {
+    /// Edges keyed by token id → child node index.
+    children: std::collections::HashMap<usize, usize>,
+}
+
+impl TrieNode {
+    fn new() -> Self {
+        Self {
+            children: std::collections::HashMap::new(),
+        }
+    }
+}
+
+/// Compiled hotword biaser: a prefix trie over hotword token-id sequences plus
+/// the additive logit boost. Immutable and shareable across inference sessions.
+pub struct Biaser {
+    nodes: Vec<TrieNode>,
+    /// Additive boost applied to a continuation token's logit.
+    boost: f32,
+    /// Number of distinct hotword phrases successfully compiled.
+    phrase_count: usize,
+}
+
+impl Biaser {
+    /// Build a biaser from hotword token-id sequences and a boost. Sequences
+    /// must be non-empty; empty ones are skipped. Returns `None` if no sequence
+    /// survives (so callers treat "no usable hotwords" as biasing-off).
+    ///
+    /// `pub(crate)` so the decode-loop unit tests can construct a biaser from
+    /// raw token-id sequences without a tokenizer.
+    pub(crate) fn from_sequences(sequences: Vec<Vec<usize>>, boost: f32) -> Option<Self> {
+        let mut nodes = vec![TrieNode::new()];
+        let mut phrase_count = 0;
+        for seq in sequences {
+            if seq.is_empty() {
+                continue;
+            }
+            phrase_count += 1;
+            let mut node = 0usize;
+            for tok in seq {
+                node = match nodes[node].children.get(&tok) {
+                    Some(&child) => child,
+                    None => {
+                        let child = nodes.len();
+                        nodes.push(TrieNode::new());
+                        nodes[node].children.insert(tok, child);
+                        child
+                    }
+                };
+            }
+        }
+        if phrase_count == 0 {
+            return None;
+        }
+        Some(Self {
+            nodes,
+            boost,
+            phrase_count,
+        })
+    }
+
+    /// Build a biaser from `(phrase, weight)` pairs, tokenizing each phrase with
+    /// the active [`Tokenizer`]. `weight` scales the base `boost` per phrase
+    /// (use `1.0` for the default). Phrases the tokenizer can't represent are
+    /// dropped. Returns `None` if no phrase compiles or `boost <= 0`.
+    pub fn from_phrases(
+        tokenizer: &Tokenizer,
+        phrases: &[(String, f32)],
+        boost: f32,
+    ) -> Option<Self> {
+        if boost <= 0.0 {
+            return None;
+        }
+        // Per-phrase weights are folded into the boost by storing the *highest*
+        // requested boost on each trie edge would complicate the immutable
+        // node layout; instead we keep a single base boost and treat the weight
+        // as a phrase-level filter (weight <= 0 drops the phrase). A future
+        // per-edge weight can extend TrieNode without touching the decode loop.
+        let mut sequences = Vec::new();
+        let mut dropped = 0usize;
+        for (phrase, weight) in phrases {
+            if *weight <= 0.0 {
+                continue;
+            }
+            match tokenizer.encode_phrase(phrase) {
+                Some(ids) => sequences.push(ids),
+                None => {
+                    dropped += 1;
+                    tracing::debug!(phrase = %phrase, "hotword dropped: not representable in active vocab");
+                }
+            }
+        }
+        if dropped > 0 {
+            tracing::warn!(
+                "{dropped} hotword phrase(s) dropped (not representable in active vocab)"
+            );
+        }
+        Self::from_sequences(sequences, boost)
+    }
+
+    /// Number of hotword phrases compiled into the trie.
+    pub fn phrase_count(&self) -> usize {
+        self.phrase_count
+    }
+
+    /// Create a fresh per-decode prefix-tracking state rooted at the trie root.
+    pub(crate) fn new_state(&self) -> BiasState {
+        BiasState {
+            // The root is always active so a new hotword can start at any token.
+            active: vec![0],
+        }
+    }
+
+    /// Add the boost to `logits` for every token id that extends a currently
+    /// active hotword prefix. No-op when no active node has children (i.e. no
+    /// hotword could continue here), so non-hotword regions are untouched.
+    pub(crate) fn boost_logits(&self, state: &BiasState, logits: &mut [f32]) {
+        for &node in &state.active {
+            for &tok in self.nodes[node].children.keys() {
+                if tok < logits.len() {
+                    logits[tok] += self.boost;
+                }
+            }
+        }
+    }
+
+    /// Advance the prefix state after a non-blank token `tok` was emitted.
+    ///
+    /// New active set = the children reached by `tok` from any previously active
+    /// node, plus the root (so a fresh hotword can begin on the next token).
+    /// Deduplicated to keep the active set small.
+    pub(crate) fn advance(&self, state: &mut BiasState, tok: usize) {
+        let mut next = Vec::new();
+        for &node in &state.active {
+            if let Some(&child) = self.nodes[node].children.get(&tok)
+                && !next.contains(&child)
+            {
+                next.push(child);
+            }
+        }
+        // The root stays active so biasing can restart at the next token.
+        if !next.contains(&0) {
+            next.push(0);
+        }
+        state.active = next;
+    }
+}
+
+/// Per-decode hotword prefix-tracking state. Holds the set of trie nodes whose
+/// prefix has been matched by the recently emitted tokens. Cheap to create;
+/// one per [`greedy_decode`](super::decode::greedy_decode) call.
+pub(crate) struct BiasState {
+    active: Vec<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn biaser(seqs: Vec<Vec<usize>>, boost: f32) -> Biaser {
+        Biaser::from_sequences(seqs, boost).expect("non-empty sequences")
+    }
+
+    #[test]
+    fn test_from_sequences_empty_returns_none() {
+        assert!(Biaser::from_sequences(vec![], 5.0).is_none());
+        assert!(Biaser::from_sequences(vec![vec![]], 5.0).is_none());
+    }
+
+    #[test]
+    fn test_boost_applies_to_first_token_of_each_hotword() {
+        // Two hotwords: [1,2] and [3]. At the root both 1 and 3 are boostable.
+        let b = biaser(vec![vec![1, 2], vec![3]], 5.0);
+        let state = b.new_state();
+        let mut logits = vec![0.0; 5];
+        b.boost_logits(&state, &mut logits);
+        assert_eq!(logits[1], 5.0);
+        assert_eq!(logits[3], 5.0);
+        assert_eq!(logits[2], 0.0, "mid-hotword token not boosted at root");
+        assert_eq!(logits[0], 0.0);
+    }
+
+    #[test]
+    fn test_advance_then_boost_continuation() {
+        // After emitting token 1, the hotword [1,2] should boost token 2.
+        let b = biaser(vec![vec![1, 2]], 5.0);
+        let mut state = b.new_state();
+        b.advance(&mut state, 1);
+        let mut logits = vec![0.0; 5];
+        b.boost_logits(&state, &mut logits);
+        assert_eq!(logits[2], 5.0, "continuation token boosted after prefix");
+        // Token 1 is also boostable again because the root stays active.
+        assert_eq!(logits[1], 5.0, "root keeps a fresh hotword start available");
+    }
+
+    #[test]
+    fn test_advance_off_prefix_resets_to_root_only() {
+        // Emit a non-matching token: only the root-level starts remain boosted.
+        let b = biaser(vec![vec![1, 2]], 5.0);
+        let mut state = b.new_state();
+        b.advance(&mut state, 1); // on prefix [1]
+        b.advance(&mut state, 9); // off prefix → reset to root
+        let mut logits = vec![0.0; 5];
+        b.boost_logits(&state, &mut logits);
+        assert_eq!(logits[2], 0.0, "continuation no longer boosted after reset");
+        assert_eq!(logits[1], 5.0, "root start still boosted");
+    }
+
+    #[test]
+    fn test_shared_prefix_keeps_both_branches_active() {
+        // Hotwords [1,2] and [1,3] share the first token.
+        let b = biaser(vec![vec![1, 2], vec![1, 3]], 4.0);
+        let mut state = b.new_state();
+        b.advance(&mut state, 1);
+        let mut logits = vec![0.0; 5];
+        b.boost_logits(&state, &mut logits);
+        assert_eq!(logits[2], 4.0);
+        assert_eq!(logits[3], 4.0);
+    }
+
+    #[test]
+    fn test_boost_ignores_out_of_range_token_id() {
+        // A hotword token id beyond the logits length must not panic.
+        let b = biaser(vec![vec![99]], 5.0);
+        let state = b.new_state();
+        let mut logits = vec![0.0; 5];
+        b.boost_logits(&state, &mut logits); // no panic
+        assert!(logits.iter().all(|&l| l == 0.0));
+    }
+}

--- a/crates/gigastt-core/src/inference/decode.rs
+++ b/crates/gigastt-core/src/inference/decode.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use ort::session::Session;
 use ort::value::TensorRef;
 
+use super::bias::Biaser;
 use super::{DecoderState, PRED_HIDDEN};
 
 const MAX_TOKENS_PER_STEP: usize = 10;
@@ -179,6 +180,10 @@ impl DecodeBackend for OrtBackend<'_> {
 /// Optimization: during blank runs (consecutive frames where joiner outputs blank),
 /// the decoder call is skipped and the cached decoder output is reused, since
 /// decoder inputs (prev_token, h, c) are unchanged during blank runs.
+/// `biaser` is optional contextual hotword biasing: when `Some`, a fixed boost
+/// is added to the joiner logits of token-ids that extend an active hotword
+/// prefix, before the argmax. `None` ⇒ the decode is byte-for-byte identical to
+/// the un-biased path (zero regression risk when no hotwords are configured).
 pub fn greedy_decode(
     decoder: &mut Session,
     joiner: &mut Session,
@@ -186,9 +191,10 @@ pub fn greedy_decode(
     encoded_len: usize,
     blank_id: usize,
     state: &mut DecoderState,
+    biaser: Option<&Biaser>,
 ) -> Result<DecodeResult> {
     let mut backend = OrtBackend { decoder, joiner };
-    greedy_decode_impl(&mut backend, encoded, encoded_len, blank_id, state)
+    greedy_decode_impl(&mut backend, encoded, encoded_len, blank_id, state, biaser)
 }
 
 /// Backend-generic greedy decode loop. Identical behaviour to the production
@@ -199,6 +205,7 @@ fn greedy_decode_impl<B: DecodeBackend>(
     encoded_len: usize,
     blank_id: usize,
     state: &mut DecoderState,
+    biaser: Option<&Biaser>,
 ) -> Result<DecodeResult> {
     let mut tokens = Vec::new();
     let mut endpoint_detected = false;
@@ -215,6 +222,10 @@ fn greedy_decode_impl<B: DecodeBackend>(
     // are unchanged, so the decoder output is deterministic and can be reused.
     let mut cached_decoder_output: Option<DecoderOutput> = None;
     let mut in_blank_run = false;
+
+    // Hotword prefix-tracking state, only when biasing is active. `None` keeps
+    // the loop on its exact pre-biasing path.
+    let mut bias_state = biaser.map(|b| b.new_state());
 
     anyhow::ensure!(
         encoded.len() >= ENC_DIM * encoded_len,
@@ -254,7 +265,15 @@ fn greedy_decode_impl<B: DecodeBackend>(
             joiner_calls += 1;
             backend.joiner_step(&enc_frame, &decoder_out.dec_data, &mut logits_buf)?;
 
-            // Greedy: argmax with confidence over logits
+            // === CONTEXTUAL HOTWORD BIASING (shallow fusion) ===
+            // Add the boost to continuation tokens of any active hotword prefix
+            // BEFORE the argmax, so a boosted token can overtake the bare model
+            // pick. No-op unless biasing is active.
+            if let (Some(b), Some(bs)) = (biaser, bias_state.as_ref()) {
+                b.boost_logits(bs, &mut logits_buf);
+            }
+
+            // Greedy: argmax with confidence over (possibly biased) logits
             let (token, confidence) = argmax_with_confidence(&logits_buf, blank_id);
 
             // === TOKEN CLASSIFICATION ===
@@ -293,6 +312,12 @@ fn greedy_decode_impl<B: DecodeBackend>(
             }
             state.h.copy_from_slice(&decoder_out.new_h);
             state.c.copy_from_slice(&decoder_out.new_c);
+            // Advance the hotword prefix automaton on the emitted label. Blank
+            // frames (handled above with `break`) emit no label, so a partial
+            // hotword survives the silence gaps between its tokens.
+            if let (Some(b), Some(bs)) = (biaser, bias_state.as_mut()) {
+                b.advance(bs, token);
+            }
             tokens.push(TokenInfo {
                 token_id: token,
                 frame_index: t,
@@ -446,7 +471,8 @@ mod tests {
         // vocab=5, blank=4. Frame 0 emits token 1 then blank; frame 1 emits token 2.
         let mut backend = FakeBackend::new(vec![1, 4, 2, 4], 5, 4);
         let mut state = DecoderState::new(4);
-        let result = greedy_decode_impl(&mut backend, &fake_enc(2), 2, 4, &mut state).unwrap();
+        let result =
+            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 4, &mut state, None).unwrap();
 
         assert_eq!(result.tokens.len(), 2);
         assert_eq!(result.tokens[0].token_id, 1);
@@ -465,7 +491,8 @@ mod tests {
         // The decoder must NOT be called again during the blank run (cache reuse).
         let mut backend = FakeBackend::new(vec![1, 4, 4, 4, 4], 5, 4);
         let mut state = DecoderState::new(4);
-        let result = greedy_decode_impl(&mut backend, &fake_enc(4), 4, 4, &mut state).unwrap();
+        let result =
+            greedy_decode_impl(&mut backend, &fake_enc(4), 4, 4, &mut state, None).unwrap();
 
         assert_eq!(result.tokens.len(), 1);
         assert_eq!(
@@ -484,7 +511,8 @@ mod tests {
         let mut backend = FakeBackend::new(script, 5, 4);
         let mut state = DecoderState::new(4);
         let result =
-            greedy_decode_impl(&mut backend, &fake_enc(frames), frames, 4, &mut state).unwrap();
+            greedy_decode_impl(&mut backend, &fake_enc(frames), frames, 4, &mut state, None)
+                .unwrap();
 
         assert!(
             result.endpoint_detected,
@@ -499,7 +527,8 @@ mod tests {
         let mut backend = FakeBackend::new(vec![4usize; frames], 5, 4);
         let mut state = DecoderState::new(4);
         let result =
-            greedy_decode_impl(&mut backend, &fake_enc(frames), frames, 4, &mut state).unwrap();
+            greedy_decode_impl(&mut backend, &fake_enc(frames), frames, 4, &mut state, None)
+                .unwrap();
 
         assert!(result.tokens.is_empty());
         assert!(
@@ -515,7 +544,8 @@ mod tests {
         // bump the blank counter or fire an endpoint.
         let mut backend = FakeBackend::new(vec![1usize; MAX_TOKENS_PER_STEP + 1], 5, 4);
         let mut state = DecoderState::new(4);
-        let result = greedy_decode_impl(&mut backend, &fake_enc(1), 1, 4, &mut state).unwrap();
+        let result =
+            greedy_decode_impl(&mut backend, &fake_enc(1), 1, 4, &mut state, None).unwrap();
 
         assert_eq!(result.tokens.len(), MAX_TOKENS_PER_STEP);
         assert_eq!(
@@ -540,5 +570,160 @@ mod tests {
         let (tok, conf) = argmax_with_confidence(&[], 1024);
         assert_eq!(tok, 1024);
         assert_eq!(conf, 0.0);
+    }
+
+    // --- contextual hotword biasing gate tests (no model) ---
+
+    /// Stub backend that returns a fixed per-call logit vector, so a test can
+    /// set a small margin between two tokens and check whether the bias boost
+    /// flips the argmax. Each `joiner_step` pops the next scripted logit vector;
+    /// once exhausted it emits all-blank so the loop terminates.
+    struct LogitBackend {
+        script: std::collections::VecDeque<Vec<f32>>,
+        vocab: usize,
+        blank_id: usize,
+    }
+
+    impl LogitBackend {
+        fn new(script: Vec<Vec<f32>>, vocab: usize, blank_id: usize) -> Self {
+            Self {
+                script: script.into(),
+                vocab,
+                blank_id,
+            }
+        }
+    }
+
+    impl DecodeBackend for LogitBackend {
+        fn decode_step(&mut self, _state: &DecoderState) -> Result<DecoderOutput> {
+            Ok(DecoderOutput {
+                dec_data: vec![0.0; PRED_HIDDEN],
+                new_h: vec![0.0; PRED_HIDDEN],
+                new_c: vec![0.0; PRED_HIDDEN],
+            })
+        }
+
+        fn joiner_step(
+            &mut self,
+            _enc_frame: &[f32],
+            _dec_data: &[f32],
+            logits_buf: &mut Vec<f32>,
+        ) -> Result<()> {
+            logits_buf.clear();
+            match self.script.pop_front() {
+                Some(v) => logits_buf.extend_from_slice(&v),
+                None => {
+                    // Exhausted → blank wins so the frame loop ends.
+                    logits_buf.resize(self.vocab, 0.0);
+                    logits_buf[self.blank_id] = 10.0;
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// vocab = 4: ids 0,1,2 are real tokens, id 3 is blank. Token A=1 leads B=2
+    /// by a small margin on the first frame; the second frame is blank.
+    fn ab_script() -> Vec<Vec<f32>> {
+        vec![
+            // frame 0: A(1)=2.0 beats B(2)=1.0 with no bias.
+            vec![0.0, 2.0, 1.0, 0.0],
+            // frame 0 continuation after a token emit: blank dominates (large so
+            // a bias boost can't overtake it) → next frame.
+            vec![0.0, 0.0, 0.0, 100.0],
+        ]
+    }
+
+    #[test]
+    fn test_bias_steers_argmax_to_boosted_token() {
+        // Without bias the model picks A=1. With a hotword [2] and a boost large
+        // enough to clear A's 1.0 lead, the loop must instead emit B=2.
+        // Baseline (no bias): emits token 1.
+        let mut backend = LogitBackend::new(ab_script(), 4, 3);
+        let mut state = DecoderState::new(3);
+        let unbiased =
+            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 3, &mut state, None).unwrap();
+        assert_eq!(unbiased.tokens.len(), 1);
+        assert_eq!(unbiased.tokens[0].token_id, 1, "no bias → model picks A");
+
+        // Biased: hotword whose first token is B=2, boost 5.0 > the 1.0 gap.
+        let biaser = Biaser::from_sequences(vec![vec![2]], 5.0).unwrap();
+        let mut backend = LogitBackend::new(ab_script(), 4, 3);
+        let mut state = DecoderState::new(3);
+        let biased =
+            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 3, &mut state, Some(&biaser))
+                .unwrap();
+        assert_eq!(biased.tokens.len(), 1);
+        assert_eq!(
+            biased.tokens[0].token_id, 2,
+            "boost must steer the argmax from A to the hotword token B"
+        );
+    }
+
+    #[test]
+    fn test_bias_prefix_advances_then_boosts_continuation() {
+        // vocab = 6: 0,1,2,4,5 real, 3 = blank. Hotword is the two-token
+        // sequence [5,2], where the prefix token 5 is distinct from the
+        // competitor A=1 so the continuation boost is unambiguous. Frame 0
+        // emits 5 (wins outright), advancing the prefix to expect 2; the boost
+        // on 2 then steers frame 1 where A=1 would otherwise win.
+        // Continuation (blank) frames use a large blank logit so the bias boost
+        // can never overtake the blank and spuriously emit another token —
+        // these frames only exist to terminate the per-frame inner loop.
+        let script = vec![
+            // frame 0: token 5 wins outright (start of the hotword).
+            vec![0.0, 0.0, 0.0, 0.0, 0.0, 3.0],
+            // frame 0 continuation: blank dominates → advance to frame 1.
+            vec![0.0, 0.0, 0.0, 100.0, 0.0, 0.0],
+            // frame 1: A(1)=2.0 vs B(2)=1.0 — without the prefix boost A wins.
+            vec![0.0, 2.0, 1.0, 0.0, 0.0, 0.0],
+            // frame 1 continuation: blank dominates → end.
+            vec![0.0, 0.0, 0.0, 100.0, 0.0, 0.0],
+        ];
+        let biaser = Biaser::from_sequences(vec![vec![5, 2]], 5.0).unwrap();
+        let mut backend = LogitBackend::new(script, 6, 3);
+        let mut state = DecoderState::new(3);
+        let result =
+            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 3, &mut state, Some(&biaser))
+                .unwrap();
+        assert_eq!(
+            result.tokens.iter().map(|t| t.token_id).collect::<Vec<_>>(),
+            vec![5, 2],
+            "prefix [5] must advance so the boost on the continuation 2 steers frame 1"
+        );
+    }
+
+    #[test]
+    fn test_bias_none_is_byte_for_byte_unchanged() {
+        // No-op safety: a hotword that can never apply (Some biaser) vs None must
+        // produce identical tokens to the un-biased decode on the same script.
+        // Here we compare None against a biaser whose only hotword token (id 0)
+        // never wins, so selection is unchanged but the bias code path runs.
+        let base_script = || {
+            vec![
+                vec![0.0, 2.0, 1.0, 0.0],
+                vec![0.0, 0.0, 0.0, 100.0],
+                vec![0.0, 1.5, 2.5, 0.0],
+                vec![0.0, 0.0, 0.0, 100.0],
+            ]
+        };
+        let mut b_none = LogitBackend::new(base_script(), 4, 3);
+        let mut s_none = DecoderState::new(3);
+        let none = greedy_decode_impl(&mut b_none, &fake_enc(2), 2, 3, &mut s_none, None).unwrap();
+
+        // A biaser for token id 0, which has a -inf-equivalent (0.0) logit and is
+        // dominated on every frame, so it can never change the argmax.
+        let biaser = Biaser::from_sequences(vec![vec![0]], 0.5).unwrap();
+        let mut b_some = LogitBackend::new(base_script(), 4, 3);
+        let mut s_some = DecoderState::new(3);
+        let some = greedy_decode_impl(&mut b_some, &fake_enc(2), 2, 3, &mut s_some, Some(&biaser))
+            .unwrap();
+
+        assert_eq!(
+            none.tokens.iter().map(|t| t.token_id).collect::<Vec<_>>(),
+            some.tokens.iter().map(|t| t.token_id).collect::<Vec<_>>(),
+            "a non-winning hotword must not change the decoded tokens"
+        );
+        assert_eq!(none.tokens.len(), 2);
     }
 }

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -3,6 +3,7 @@
 //! Loads encoder, decoder, and joiner ONNX models and runs the RNN-T streaming decode loop.
 
 pub mod audio;
+mod bias;
 mod decode;
 mod features;
 #[cfg(not(feature = "__internals"))]
@@ -816,6 +817,11 @@ pub struct Engine {
     /// digits) on file-transcription output, *before* the punctuation pass.
     /// Off by default; toggled via [`Engine::with_itn`].
     itn: bool,
+    /// Optional contextual hotword biaser applied inside the greedy RNN-T decode
+    /// loop (shallow fusion). `None` = no biasing (the default), and the decode
+    /// path is then byte-for-byte identical to the un-biased engine. Attached
+    /// via [`Engine::with_biaser`]. Shared across the session pool by reference.
+    biaser: Option<bias::Biaser>,
     /// Whether the INT8 quantized encoder is in use.
     int8: bool,
     /// Speaker encoder for diarization (None if model file is absent).
@@ -865,6 +871,34 @@ impl Engine {
     /// Whether inverse text normalization is enabled.
     pub fn has_itn(&self) -> bool {
         self.itn
+    }
+
+    /// Attach a contextual hotword biaser built from `(phrase, weight)` pairs
+    /// and an additive `boost`, consuming and returning `self` (builder style).
+    /// Each phrase is tokenized with the engine's own [`Tokenizer`], so biasing
+    /// adapts to whichever recognition head is loaded.
+    ///
+    /// When `phrases` is empty, `boost <= 0`, or no phrase is representable in
+    /// the active vocab, the biaser resolves to `None` and the decode path stays
+    /// byte-for-byte unchanged. Replaces any previously attached biaser.
+    pub fn with_hotwords(mut self, phrases: &[(String, f32)], boost: f32) -> Self {
+        self.biaser = if phrases.is_empty() {
+            None
+        } else {
+            bias::Biaser::from_phrases(&self.tokenizer, phrases, boost)
+        };
+        if let Some(b) = &self.biaser {
+            tracing::info!(
+                "Hotword biasing enabled ({} phrase(s), boost {boost})",
+                b.phrase_count()
+            );
+        }
+        self
+    }
+
+    /// Whether a hotword biaser is attached (biasing active).
+    pub fn has_hotwords(&self) -> bool {
+        self.biaser.is_some()
     }
 
     /// Size of the BPE vocabulary the loaded tokenizer covers. Exposed so the
@@ -1418,6 +1452,7 @@ impl Engine {
             variant,
             punctuator: None,
             itn: false,
+            biaser: None,
             int8: is_int8,
             #[cfg(feature = "diarization")]
             speaker_encoder,
@@ -1916,6 +1951,7 @@ impl Engine {
             enc_len,
             self.tokenizer.blank_id(),
             decoder_state,
+            self.biaser.as_ref(),
         )?;
         tracing::info!(
             elapsed_ms = dec_start.elapsed().as_millis() as u64,

--- a/crates/gigastt-core/src/inference/tokenizer.rs
+++ b/crates/gigastt-core/src/inference/tokenizer.rs
@@ -101,6 +101,71 @@ impl Tokenizer {
         self.blank_id
     }
 
+    /// Encode a hotword phrase into the token-id sequence the decoder would
+    /// emit for it, using greedy longest-match over the vocabulary.
+    ///
+    /// Spaces (and a leading position) map to the `▁` word-boundary marker the
+    /// same way [`Tokenizer::decode`] reverses it, so the encoding matches what
+    /// the RNN-T head produces token-for-token. Works for both heads: the plain
+    /// `rnnt` char vocab (single-codepoint tokens) and the `e2e_rnnt` BPE vocab
+    /// (multi-codepoint `▁`-prefixed pieces).
+    ///
+    /// Returns `None` if any codepoint of the phrase can't be matched against
+    /// the vocabulary (so an unrepresentable hotword is dropped rather than
+    /// silently biasing toward a wrong sub-sequence). Special tokens (`<blk>`,
+    /// `<unk>`) are never matched.
+    pub(crate) fn encode_phrase(&self, phrase: &str) -> Option<Vec<usize>> {
+        let phrase = phrase.trim();
+        if phrase.is_empty() {
+            return None;
+        }
+        // Build the marked form: leading word + every space become `▁`, so the
+        // first piece of each word carries the boundary marker the head emits.
+        let mut marked = String::new();
+        marked.push(WORD_BOUNDARY);
+        for ch in phrase.chars() {
+            if ch.is_whitespace() {
+                marked.push(WORD_BOUNDARY);
+            } else {
+                marked.push(ch);
+            }
+        }
+
+        let chars: Vec<char> = marked.chars().collect();
+        let mut ids = Vec::new();
+        let mut i = 0;
+        while i < chars.len() {
+            // Longest vocab token that matches starting at position `i`.
+            let mut best: Option<(usize, usize)> = None; // (token_id, char_len)
+            for (id, tok) in self.tokens.iter().enumerate() {
+                if tok == "<blk>" || tok == "<unk>" || tok.is_empty() {
+                    continue;
+                }
+                let tok_chars = tok.chars().count();
+                if tok_chars == 0 || i + tok_chars > chars.len() {
+                    continue;
+                }
+                if chars[i..i + tok_chars].iter().copied().eq(tok.chars())
+                    && best.is_none_or(|(_, len)| tok_chars > len)
+                {
+                    best = Some((id, tok_chars));
+                }
+            }
+            match best {
+                Some((id, len)) => {
+                    ids.push(id);
+                    i += len;
+                }
+                // A bare `▁` boundary with no vocab token for it: skip it and
+                // keep going (the next word still encodes). Any other unmatched
+                // codepoint makes the phrase unrepresentable.
+                None if chars[i] == WORD_BOUNDARY => i += 1,
+                None => return None,
+            }
+        }
+        if ids.is_empty() { None } else { Some(ids) }
+    }
+
     /// Get raw token text by id (returns empty string for out-of-range or special tokens).
     pub fn token_text(&self, id: usize) -> &str {
         if id >= self.tokens.len() {
@@ -223,6 +288,52 @@ mod tests {
         let tok = Tokenizer::load(f.path()).unwrap();
         assert_eq!(tok.vocab_size(), 3);
         assert_eq!(tok.token_text(0), "a");
+    }
+
+    #[test]
+    fn test_encode_phrase_char_vocab_longest_match() {
+        // Char-style vocab plus a `▁`-prefixed boundary token. "аб" → [▁а? no].
+        // Here "▁а", "б", "в" exist: "▁аб" greedily matches "▁а" then "б".
+        let f = create_test_vocab("▁а\t0\nб\t1\nв\t2\n▁\t3\n<blk>\t4\n");
+        let tok = Tokenizer::load(f.path()).unwrap();
+        let ids = tok.encode_phrase("аб").unwrap();
+        assert_eq!(ids, vec![0, 1]);
+        // Round-trips back to the phrase via decode.
+        assert_eq!(tok.decode(&ids), "аб");
+    }
+
+    #[test]
+    fn test_encode_phrase_bpe_word_boundary() {
+        // BPE-style vocab where whole words are single tokens.
+        let f = create_test_vocab("▁привет\t0\n▁мир\t1\n<blk>\t2\n");
+        let tok = Tokenizer::load(f.path()).unwrap();
+        let ids = tok.encode_phrase("привет мир").unwrap();
+        assert_eq!(ids, vec![0, 1]);
+        assert_eq!(tok.decode(&ids), "привет мир");
+    }
+
+    #[test]
+    fn test_encode_phrase_prefers_longest_token() {
+        // "▁аб" must win over "▁а" + "б" when the longer piece exists.
+        let f = create_test_vocab("▁а\t0\nб\t1\n▁аб\t2\n<blk>\t3\n");
+        let tok = Tokenizer::load(f.path()).unwrap();
+        assert_eq!(tok.encode_phrase("аб").unwrap(), vec![2]);
+    }
+
+    #[test]
+    fn test_encode_phrase_unrepresentable_returns_none() {
+        // 'я' is not in the vocab → the phrase can't be encoded.
+        let f = create_test_vocab("▁а\t0\nб\t1\n<blk>\t2\n");
+        let tok = Tokenizer::load(f.path()).unwrap();
+        assert!(tok.encode_phrase("яб").is_none());
+    }
+
+    #[test]
+    fn test_encode_phrase_empty_returns_none() {
+        let f = create_test_vocab("▁а\t0\n<blk>\t1\n");
+        let tok = Tokenizer::load(f.path()).unwrap();
+        assert!(tok.encode_phrase("   ").is_none());
+        assert!(tok.encode_phrase("").is_none());
     }
 
     #[test]

--- a/crates/gigastt-core/src/lexicon.rs
+++ b/crates/gigastt-core/src/lexicon.rs
@@ -1,0 +1,86 @@
+//! Default Russian brand / acronym hotword lexicon.
+//!
+//! A small curated list of brands, media/streaming services, and acronyms that
+//! a Russian STT model commonly mis-recognizes (rare or out-of-distribution
+//! against conversational training data). It seeds the default hotword pack:
+//! passing [`DEFAULT_HOTWORDS`] to
+//! [`Engine::with_hotwords`](crate::inference::Engine::with_hotwords) biases the
+//! greedy decode toward these spellings.
+//!
+//! Stored as a plain `&[&str]` rather than a `phf` compile-time map: the list is
+//! consumed exactly once (iterated to tokenize each phrase at biaser-build time)
+//! and never key-looked-up, so a hash map would add a build dependency for no
+//! runtime benefit. The Cyrillic forms mirror the transliteration targets used
+//! by the benchmark's anglicism normalization (`benchmark/common.py`), so this
+//! list doubles as the en→ru source for a future Transliterated-WER metric.
+
+/// Curated Russian brand / acronym hotwords, in their canonical Cyrillic
+/// spelling. Default-OFF: only applied when a caller opts into the default pack.
+pub const DEFAULT_HOTWORDS: &[&str] = &[
+    // Device / service brands.
+    "эпл",
+    "айфон",
+    "самсунг",
+    "сони",
+    "гугл",
+    "яндекс",
+    "сбер",
+    "алиса",
+    "маруся",
+    // Social / media / streaming.
+    "ютуб",
+    "фейсбук",
+    "инстаграм",
+    "телеграм",
+    "вконтакте",
+    "нетфликс",
+    "спотифай",
+    "ватсап",
+    "тикток",
+    "твич",
+    "кинопоиск",
+    "окко",
+    "иви",
+    "смотрешка",
+    // Marketplaces.
+    "алиэкспресс",
+    "озон",
+    "вайлдберриз",
+    // Acronyms / short brands.
+    "вк",
+    "тв",
+    "синергия",
+    "пинк",
+];
+
+/// Build the default hotword pack as `(phrase, weight)` pairs with unit weight,
+/// ready to pass to
+/// [`Engine::with_hotwords`](crate::inference::Engine::with_hotwords).
+pub fn default_hotword_pairs() -> Vec<(String, f32)> {
+    DEFAULT_HOTWORDS
+        .iter()
+        .map(|w| ((*w).to_string(), 1.0))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_hotwords_non_empty_and_unique() {
+        assert!(!DEFAULT_HOTWORDS.is_empty());
+        let mut seen = std::collections::HashSet::new();
+        for w in DEFAULT_HOTWORDS {
+            assert!(seen.insert(*w), "duplicate hotword in lexicon: {w}");
+            assert!(!w.trim().is_empty(), "empty hotword in lexicon");
+        }
+    }
+
+    #[test]
+    fn test_default_hotword_pairs_unit_weight() {
+        let pairs = default_hotword_pairs();
+        assert_eq!(pairs.len(), DEFAULT_HOTWORDS.len());
+        assert!(pairs.iter().all(|(_, w)| *w == 1.0));
+    }
+}

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod export;
 pub mod inference;
 pub mod itn;
+pub mod lexicon;
 pub mod model;
 pub mod onnx_proto;
 pub mod protocol;

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -93,6 +93,24 @@ enum Commands {
         )]
         itn: ItnMode,
 
+        /// Contextual hotword biasing: path to a file of phrases to boost during
+        /// recognition (one phrase per line, optional `\t<weight>` suffix; blank
+        /// lines and `#` comments ignored). Off when unset. Env:
+        /// GIGASTT_HOTWORDS_FILE.
+        #[arg(long, env = "GIGASTT_HOTWORDS_FILE")]
+        hotwords_file: Option<String>,
+
+        /// Also bias the built-in Russian brand/acronym lexicon. Combined with
+        /// any `--hotwords-file` phrases. Env: GIGASTT_HOTWORDS_DEFAULT.
+        #[arg(long, env = "GIGASTT_HOTWORDS_DEFAULT", default_value_t = false)]
+        hotwords_default: bool,
+
+        /// Additive logit boost applied to hotword continuation tokens during
+        /// greedy decode [default: 5.0]. Higher = stronger bias. No effect
+        /// unless hotwords are configured. Env: GIGASTT_HOTWORDS_BOOST.
+        #[arg(long, env = "GIGASTT_HOTWORDS_BOOST")]
+        hotwords_boost: Option<f32>,
+
         /// Number of concurrent inference sessions. Each session deserializes
         /// its own encoder copy (~0.4 GB resident for the INT8 encoder), so the
         /// default is 2 to bound the idle footprint; raise it for higher
@@ -298,6 +316,24 @@ enum Commands {
             value_parser = parse_itn_mode
         )]
         itn: ItnMode,
+
+        /// Contextual hotword biasing: path to a file of phrases to boost during
+        /// recognition (one phrase per line, optional `\t<weight>` suffix; blank
+        /// lines and `#` comments ignored). Off when unset. Env:
+        /// GIGASTT_HOTWORDS_FILE.
+        #[arg(long, env = "GIGASTT_HOTWORDS_FILE")]
+        hotwords_file: Option<String>,
+
+        /// Also bias the built-in Russian brand/acronym lexicon. Combined with
+        /// any `--hotwords-file` phrases. Env: GIGASTT_HOTWORDS_DEFAULT.
+        #[arg(long, env = "GIGASTT_HOTWORDS_DEFAULT", default_value_t = false)]
+        hotwords_default: bool,
+
+        /// Additive logit boost applied to hotword continuation tokens during
+        /// greedy decode [default: 5.0]. Higher = stronger bias. No effect
+        /// unless hotwords are configured. Env: GIGASTT_HOTWORDS_BOOST.
+        #[arg(long, env = "GIGASTT_HOTWORDS_BOOST")]
+        hotwords_boost: Option<f32>,
 
         /// Export format: json, txt, srt, vtt, md [default: txt]
         #[arg(short, long, env = "GIGASTT_FORMAT", default_value = "txt")]
@@ -609,6 +645,56 @@ async fn maybe_download_punct_model(
     }
 }
 
+/// Default additive logit boost for hotword continuation tokens when
+/// `--hotwords-boost` is unset.
+const DEFAULT_HOTWORDS_BOOST: f32 = 5.0;
+
+/// Parse a hotwords file: one phrase per line, optional `\t<weight>` suffix.
+/// Blank lines and `#`-prefixed comment lines are skipped. A malformed weight
+/// falls back to `1.0` (the phrase is still kept). Returns the `(phrase, weight)`
+/// pairs, or an error only when the file can't be read.
+fn parse_hotwords_file(path: &str) -> anyhow::Result<Vec<(String, f32)>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read hotwords file: {path}"))?;
+    let mut pairs = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (phrase, weight) = match line.split_once('\t') {
+            Some((p, w)) => (p.trim(), w.trim().parse::<f32>().unwrap_or(1.0)),
+            None => (line, 1.0),
+        };
+        if !phrase.is_empty() {
+            pairs.push((phrase.to_string(), weight));
+        }
+    }
+    Ok(pairs)
+}
+
+/// Resolve the hotword pack from CLI options: phrases from `--hotwords-file`
+/// (if any) plus the built-in lexicon when `--hotwords-default` is set. Returns
+/// `None` when neither source yields any phrase (biasing stays off). A file read
+/// error is logged and treated as "no file phrases" so biasing never blocks
+/// transcription.
+fn resolve_hotwords(
+    hotwords_file: Option<&str>,
+    hotwords_default: bool,
+) -> Option<Vec<(String, f32)>> {
+    let mut pairs = Vec::new();
+    if let Some(path) = hotwords_file {
+        match parse_hotwords_file(path) {
+            Ok(p) => pairs.extend(p),
+            Err(e) => tracing::warn!("{e:#}; continuing without file hotwords"),
+        }
+    }
+    if hotwords_default {
+        pairs.extend(gigastt_core::lexicon::default_hotword_pairs());
+    }
+    if pairs.is_empty() { None } else { Some(pairs) }
+}
+
 /// Ensure the INT8 encoder exists for `variant`, producing it via the native
 /// Rust quantization pipeline if missing. Honoured by `serve` and `download`.
 /// First-time quantization takes ~2 minutes on the FP32 encoder.
@@ -655,6 +741,9 @@ async fn main() -> anyhow::Result<()> {
             punctuation,
             punct_model_dir,
             itn,
+            hotwords_file,
+            hotwords_default,
+            hotwords_boost,
             pool_size,
             pool_min_size,
             batch_pool_size,
@@ -681,7 +770,8 @@ async fn main() -> anyhow::Result<()> {
             ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
             maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
             let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
-            let engine = inference::Engine::load_with_pools(
+            let hotwords = resolve_hotwords(hotwords_file.as_deref(), hotwords_default);
+            let mut engine = inference::Engine::load_with_pools(
                 &model_dir,
                 pool_size,
                 pool_min_size,
@@ -689,6 +779,10 @@ async fn main() -> anyhow::Result<()> {
             )?
             .with_punctuator(punctuator)
             .with_itn(resolve_itn(itn, resolved));
+            if let Some(pairs) = hotwords {
+                engine =
+                    engine.with_hotwords(&pairs, hotwords_boost.unwrap_or(DEFAULT_HOTWORDS_BOOST));
+            }
             log_rss();
             let limits = build_limits(
                 config.as_deref(),
@@ -766,6 +860,9 @@ async fn main() -> anyhow::Result<()> {
             punctuation,
             punct_model_dir,
             itn,
+            hotwords_file,
+            hotwords_default,
+            hotwords_boost,
             format,
             output,
             max_chars_per_line,
@@ -775,9 +872,14 @@ async fn main() -> anyhow::Result<()> {
             let resolved = model::ensure_model_variant(model_variant, &model_dir).await?;
             maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
             let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
-            let engine = inference::Engine::load_with_pool_size(&model_dir, 1)?
+            let hotwords = resolve_hotwords(hotwords_file.as_deref(), hotwords_default);
+            let mut engine = inference::Engine::load_with_pool_size(&model_dir, 1)?
                 .with_punctuator(punctuator)
                 .with_itn(resolve_itn(itn, resolved));
+            if let Some(pairs) = hotwords {
+                engine =
+                    engine.with_hotwords(&pairs, hotwords_boost.unwrap_or(DEFAULT_HOTWORDS_BOOST));
+            }
             log_rss();
             let mut guard = engine.pool.checkout().await?;
             let result = engine.transcribe_file(&file, &mut guard);
@@ -1158,6 +1260,121 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn test_cli_serve_hotwords_flags() {
+        let cli = Cli::parse_from([
+            "gigastt",
+            "serve",
+            "--hotwords-file",
+            "/tmp/hw.txt",
+            "--hotwords-default",
+            "--hotwords-boost",
+            "8.5",
+        ]);
+        match cli.command {
+            Commands::Serve {
+                hotwords_file,
+                hotwords_default,
+                hotwords_boost,
+                ..
+            } => {
+                assert_eq!(hotwords_file, Some("/tmp/hw.txt".to_string()));
+                assert!(hotwords_default);
+                assert_eq!(hotwords_boost, Some(8.5));
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_hotwords_default_off() {
+        let cli = Cli::parse_from(["gigastt", "serve"]);
+        match cli.command {
+            Commands::Serve {
+                hotwords_file,
+                hotwords_default,
+                hotwords_boost,
+                ..
+            } => {
+                assert_eq!(hotwords_file, None);
+                assert!(!hotwords_default);
+                assert_eq!(hotwords_boost, None);
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_transcribe_hotwords_flags() {
+        let cli = Cli::parse_from([
+            "gigastt",
+            "transcribe",
+            "a.wav",
+            "--hotwords-file",
+            "hw.txt",
+        ]);
+        match cli.command {
+            Commands::Transcribe {
+                hotwords_file,
+                hotwords_default,
+                ..
+            } => {
+                assert_eq!(hotwords_file, Some("hw.txt".to_string()));
+                assert!(!hotwords_default);
+            }
+            _ => panic!("expected Transcribe"),
+        }
+    }
+
+    #[test]
+    fn test_parse_hotwords_file_lines_and_weights() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            b"# comment\n\nsynergy\nyoutube\t2.5\n  spaced  \nbadweight\tnope\n",
+        )
+        .unwrap();
+        let pairs = parse_hotwords_file(tmp.path().to_str().unwrap()).unwrap();
+        assert_eq!(
+            pairs,
+            vec![
+                ("synergy".to_string(), 1.0),
+                ("youtube".to_string(), 2.5),
+                ("spaced".to_string(), 1.0),
+                ("badweight".to_string(), 1.0), // malformed weight → 1.0, phrase kept
+            ]
+        );
+    }
+
+    #[test]
+    fn test_resolve_hotwords_none_when_unset() {
+        assert!(resolve_hotwords(None, false).is_none());
+    }
+
+    #[test]
+    fn test_resolve_hotwords_default_pack_only() {
+        let pairs = resolve_hotwords(None, true).expect("default pack present");
+        assert_eq!(pairs.len(), gigastt_core::lexicon::DEFAULT_HOTWORDS.len());
+    }
+
+    #[test]
+    fn test_resolve_hotwords_file_plus_default() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "мойбренд\n").unwrap();
+        let pairs = resolve_hotwords(tmp.path().to_str().unwrap().into(), true).unwrap();
+        assert_eq!(
+            pairs.len(),
+            1 + gigastt_core::lexicon::DEFAULT_HOTWORDS.len()
+        );
+        assert_eq!(pairs[0].0, "мойбренд");
+    }
+
+    #[test]
+    fn test_resolve_hotwords_missing_file_is_graceful() {
+        // Missing file → warning + treated as no file phrases (None here).
+        assert!(resolve_hotwords(Some("/nonexistent/hw.txt"), false).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What
Token-level shallow-fusion biasing inside the existing **greedy** RNN-T loop (no beam search). A trie over hotword phrases — each tokenized to the active vocabulary — boosts the joiner logits of tokens that extend an active hotword prefix, so brands/names/domain terms are recognized more reliably. Works for both heads (char + BPE vocabs).

- `gigastt-core::inference::bias` — the trie/automaton + logit boost.
- `gigastt-core::lexicon` — a curated Russian brand/acronym pack (default hotwords).
- `--hotwords-file` (one phrase per line, optional `\tweight`) + `--hotwords-boost` on `serve` + `transcribe` (env `GIGASTT_HOTWORDS_FILE` / `GIGASTT_HOTWORDS_BOOST`).

## Safety
**Default OFF**: with no hotwords configured, decoding is byte-for-byte unchanged (unit-tested). No regression risk on the default path.

## Verification
- Unit tests: `test_bias_steers_argmax_to_boosted_token` (boost changes the greedy pick), prefix advance/reset, shared-prefix branches, out-of-range guard, `test_bias_none_is_byte_for_byte_unchanged` (off ⇒ identical), file parsing + graceful missing-file.
- `cargo fmt`/`clippy --lib --bins`/`test --lib --bins` green; `cargo check --features coreml|cuda` clean.
- rnnt transcribe with biasing off → unchanged (`шестьдесят тысяч тенге сколько будет стоить`).

## Follow-up
Transliterated-WER (T-WER) dual scoring in `benchmark/common.py` (count a hyp correct if it matches the reference or its transliteration) — deferred to keep this change focused.