### PR TITLE
perf(cpu): configurable encoder intra-op threads (default 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Configurable encoder threads (`--encoder-intra-threads`).** The CPU encoder runs
+  single-threaded by default; on weak CPUs or long single-file jobs it can now take more
+  intra-op threads (env `GIGASTT_ENCODER_INTRA_THREADS`, default 1 — unchanged), clamped so
+  `pool_size × threads` stays within the logical CPU count. Decoder/joiner and the
+  CoreML/CUDA paths are untouched.
 - **Chunked long-form file decoding (bounded peak memory).** File transcription now
   splits long audio into overlapping ~24 s windows, decodes each independently, and
   stitches the words (overlap de-dup, monotonic timestamps) — peak encoder activation

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -972,6 +972,24 @@ impl Engine {
         min_size: usize,
         batch_pool_size: usize,
     ) -> Result<Self, GigasttError> {
+        Self::load_with_pools_threads(model_dir, pool_size, min_size, batch_pool_size, 1)
+    }
+
+    /// Like [`Engine::load_with_pools`], but with a configurable encoder
+    /// intra-op thread count for the CPU EP. `encoder_intra_threads == 1` (the
+    /// default everywhere else) builds sessions identical to the prior
+    /// behaviour. Values `> 1` give the dominant encoder more intra-op
+    /// parallelism on weak CPUs / long single-file jobs; the count is clamped
+    /// against the logical CPU count so `pool_size * threads` can't oversubscribe
+    /// the machine (see [`Engine::clamp_encoder_intra_threads`]). Ignored by the
+    /// CoreML / CUDA builds (the accelerator owns scheduling there).
+    pub fn load_with_pools_threads(
+        model_dir: &str,
+        pool_size: usize,
+        min_size: usize,
+        batch_pool_size: usize,
+        encoder_intra_threads: usize,
+    ) -> Result<Self, GigasttError> {
         let dir = Path::new(model_dir);
         // Auto-detect which recognition head is present on disk (rnnt encoder
         // takes precedence, else e2e_rnnt). The on-disk layout fully determines
@@ -990,6 +1008,13 @@ impl Engine {
             .map(|m| m.len())
             .unwrap_or(0);
         let pool_size = Self::cap_pool_size_for_ram(pool_size, encoder_bytes, total_ram_bytes());
+        // Don't let `pool_size * encoder_intra_threads` oversubscribe the CPU
+        // (no-op when the default `1` is requested).
+        let logical_cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        let encoder_intra_threads =
+            Self::clamp_encoder_intra_threads(pool_size, encoder_intra_threads, logical_cpus);
         Self::load_inner(
             dir,
             variant,
@@ -997,6 +1022,7 @@ impl Engine {
             pool_size,
             min_size,
             batch_pool_size,
+            encoder_intra_threads,
         )
         .map_err(|e| GigasttError::ModelLoad {
             path: model_dir.to_string(),
@@ -1017,22 +1043,29 @@ impl Engine {
 
     /// Load a single set of encoder/decoder/joiner ONNX sessions from disk for
     /// `variant`, using the execution provider selected at compile time.
+    ///
+    /// `encoder_intra_threads` configures the encoder session's intra-op thread
+    /// count on the CPU EP only; the CoreML / CUDA loaders ignore it (the
+    /// accelerator owns scheduling there).
     fn load_sessions(
         dir: &Path,
         variant: ModelVariant,
         prepacked: &ort::session::builder::PrepackedWeights,
+        encoder_intra_threads: usize,
     ) -> anyhow::Result<(Session, Session, Session)> {
         #[cfg(feature = "coreml")]
         {
+            let _ = encoder_intra_threads;
             Self::load_sessions_coreml(dir, variant, prepacked)
         }
         #[cfg(feature = "cuda")]
         {
+            let _ = encoder_intra_threads;
             Self::load_sessions_cuda(dir, variant, prepacked)
         }
         #[cfg(not(any(feature = "coreml", feature = "cuda")))]
         {
-            Self::load_sessions_cpu(dir, variant, prepacked)
+            Self::load_sessions_cpu(dir, variant, prepacked, encoder_intra_threads)
         }
     }
 
@@ -1148,6 +1181,7 @@ impl Engine {
         dir: &Path,
         variant: ModelVariant,
         prepacked: &ort::session::builder::PrepackedWeights,
+        encoder_intra_threads: usize,
     ) -> anyhow::Result<(Session, Session, Session)> {
         let cache_dir = dir.join("optimized_cache");
         std::fs::create_dir_all(&cache_dir)
@@ -1155,11 +1189,15 @@ impl Engine {
         let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
         let eps = [cpu_fallback.into()];
         let encoder_path = Self::encoder_model_path(dir, variant);
+        // Only the encoder's intra-op count is configurable (it dominates the
+        // single-utterance cost); inter-op stays 1 because the Conformer is a
+        // near-linear chain, and the decoder/joiner stay intra=1 (tiny ops).
+        // Default `encoder_intra_threads == 1` ⇒ identical to the prior build.
         let encoder = Session::builder()
             .map_err(ort_err)?
             .with_prepacked_weights(prepacked)
             .map_err(ort_err)?
-            .with_intra_threads(1)
+            .with_intra_threads(encoder_intra_threads.max(1))
             .map_err(ort_err)?
             .with_inter_threads(1)
             .map_err(ort_err)?
@@ -1264,6 +1302,41 @@ impl Engine {
         }
     }
 
+    /// Clamp the requested encoder intra-op thread count so the pooled encoder
+    /// sessions can't oversubscribe the CPU. Each of `pool_size` triplets can
+    /// run concurrently, so the total intra-op parallelism is
+    /// `pool_size * threads`; capping that at `logical_cpus` keeps the machine
+    /// from thrashing on context switches. The effective per-encoder count is
+    /// therefore `clamp(requested, 1, logical_cpus / pool_size)`, never below 1.
+    /// Logs a warning when it lowers the request. The default `requested == 1`
+    /// always returns `1`, so the built sessions are unchanged.
+    ///
+    /// Pure and total so the budgeting math is unit-tested without spawning ORT
+    /// sessions or probing the real CPU count.
+    fn clamp_encoder_intra_threads(
+        pool_size: usize,
+        requested: usize,
+        logical_cpus: usize,
+    ) -> usize {
+        let requested = requested.max(1);
+        let pool_size = pool_size.max(1);
+        let logical_cpus = logical_cpus.max(1);
+        // Leave at least one thread per encoder even on a machine with fewer
+        // logical CPUs than pooled triplets.
+        let max_per_encoder = (logical_cpus / pool_size).max(1);
+        if requested > max_per_encoder {
+            tracing::warn!(
+                "Capping encoder intra-op threads {requested} -> {max_per_encoder}: \
+                 {pool_size} pooled encoder(s) x {requested} threads would exceed \
+                 the {logical_cpus} logical CPU(s) available. Lower --pool-size or \
+                 --encoder-intra-threads to silence this."
+            );
+            max_per_encoder
+        } else {
+            requested
+        }
+    }
+
     /// Decide the final pool from per-triplet load results: returns the
     /// successfully loaded triplets when at least `min_size` loaded (warning
     /// when the pool is degraded below `pool_size`), or an error describing the
@@ -1363,6 +1436,7 @@ impl Engine {
         pool_size: usize,
         min_size: usize,
         batch_pool_size: usize,
+        encoder_intra_threads: usize,
     ) -> anyhow::Result<Self> {
         tracing::info!("Detected model variant: {variant:?}");
         let is_int8 = dir.join(variant.encoder_int8_file()).exists();
@@ -1392,7 +1466,7 @@ impl Engine {
             pool_size,
             min_size,
             &prepacked,
-            Self::load_sessions,
+            |d, v, pp| Self::load_sessions(d, v, pp, encoder_intra_threads),
         ) {
             Ok(triplets) => triplets,
             Err(load_err) => {
@@ -1402,25 +1476,16 @@ impl Engine {
                 // Fresh container: the failed attempt may have pre-packed
                 // weights with CoreML-specific kernel layouts.
                 let prepacked = ort::session::builder::PrepackedWeights::new();
-                Self::load_triplets(
-                    dir,
-                    variant,
-                    pool_size,
-                    min_size,
-                    &prepacked,
-                    Self::load_sessions_cpu,
-                )?
+                Self::load_triplets(dir, variant, pool_size, min_size, &prepacked, |d, v, pp| {
+                    Self::load_sessions_cpu(d, v, pp, encoder_intra_threads)
+                })?
             }
         };
         #[cfg(not(feature = "coreml"))]
-        let triplets = Self::load_triplets(
-            dir,
-            variant,
-            pool_size,
-            min_size,
-            &prepacked,
-            Self::load_sessions,
-        )?;
+        let triplets =
+            Self::load_triplets(dir, variant, pool_size, min_size, &prepacked, |d, v, pp| {
+                Self::load_sessions(d, v, pp, encoder_intra_threads)
+            })?;
 
         let tokenizer = Tokenizer::load(&dir.join(variant.vocab_file()))?;
         let features = FeatureExtractor::new();
@@ -1492,7 +1557,7 @@ impl Engine {
                     pool_size,
                     min_size,
                     &prepacked,
-                    Self::load_sessions_cpu,
+                    |d, v, pp| Self::load_sessions_cpu(d, v, pp, encoder_intra_threads),
                 )?;
                 let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
                 e.pool = pool;
@@ -2251,6 +2316,27 @@ mod tests {
         // pool_size <= 1 is returned as-is (min 1).
         assert_eq!(Engine::cap_pool_size_for_ram(1, 200 << 20, 1 << 30), 1);
         assert_eq!(Engine::cap_pool_size_for_ram(0, 200 << 20, 1 << 30), 1);
+    }
+
+    #[test]
+    fn test_clamp_encoder_intra_threads() {
+        // Default request of 1 is always returned unchanged (no behavior change).
+        assert_eq!(Engine::clamp_encoder_intra_threads(2, 1, 10), 1);
+        assert_eq!(Engine::clamp_encoder_intra_threads(4, 1, 4), 1);
+
+        // Fits within budget: pool 2 x 4 threads = 8 <= 16 CPUs -> 4.
+        assert_eq!(Engine::clamp_encoder_intra_threads(2, 4, 16), 4);
+
+        // Over budget: pool 4 x 4 = 16 > 10 CPUs -> floor(10/4) = 2 per encoder.
+        assert_eq!(Engine::clamp_encoder_intra_threads(4, 4, 10), 2);
+
+        // More pooled encoders than CPUs still leaves at least 1 thread each.
+        assert_eq!(Engine::clamp_encoder_intra_threads(8, 4, 4), 1);
+
+        // Zero inputs are floored to 1 (total function, never panics/divides-by-0).
+        assert_eq!(Engine::clamp_encoder_intra_threads(0, 4, 8), 4);
+        assert_eq!(Engine::clamp_encoder_intra_threads(2, 0, 8), 1);
+        assert_eq!(Engine::clamp_encoder_intra_threads(2, 4, 0), 1);
     }
 
     #[test]

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -133,6 +133,14 @@ enum Commands {
         #[arg(long, env = "GIGASTT_BATCH_POOL_SIZE", default_value_t = 0)]
         batch_pool_size: usize,
 
+        /// Intra-op thread count for the encoder session on the CPU build. The
+        /// encoder dominates the single-utterance cost, so more threads help on
+        /// weak CPUs / long single-file jobs. Default 1 (no change vs prior
+        /// builds). Auto-clamped so `pool_size * encoder_intra_threads` can't
+        /// exceed the logical CPU count. No effect on CoreML / CUDA builds.
+        #[arg(long, env = "GIGASTT_ENCODER_INTRA_THREADS", default_value_t = 1)]
+        encoder_intra_threads: usize,
+
         /// Explicitly acknowledge binding to a non-loopback address.
         /// Can also be enabled via `GIGASTT_ALLOW_BIND_ANY=1`.
         /// Without this flag the server refuses to listen on anything other than
@@ -334,6 +342,13 @@ enum Commands {
         /// unless hotwords are configured. Env: GIGASTT_HOTWORDS_BOOST.
         #[arg(long, env = "GIGASTT_HOTWORDS_BOOST")]
         hotwords_boost: Option<f32>,
+
+        /// Intra-op thread count for the encoder session on the CPU build. The
+        /// encoder dominates the single-utterance cost, so more threads speed up
+        /// long single-file jobs on weak CPUs. Default 1 (no change vs prior
+        /// builds). No effect on CoreML / CUDA builds.
+        #[arg(long, env = "GIGASTT_ENCODER_INTRA_THREADS", default_value_t = 1)]
+        encoder_intra_threads: usize,
 
         /// Export format: json, txt, srt, vtt, md [default: txt]
         #[arg(short, long, env = "GIGASTT_FORMAT", default_value = "txt")]
@@ -747,6 +762,7 @@ async fn main() -> anyhow::Result<()> {
             pool_size,
             pool_min_size,
             batch_pool_size,
+            encoder_intra_threads,
             bind_all,
             allow_origin,
             cors_allow_any,
@@ -771,11 +787,12 @@ async fn main() -> anyhow::Result<()> {
             maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
             let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
             let hotwords = resolve_hotwords(hotwords_file.as_deref(), hotwords_default);
-            let mut engine = inference::Engine::load_with_pools(
+            let mut engine = inference::Engine::load_with_pools_threads(
                 &model_dir,
                 pool_size,
                 pool_min_size,
                 batch_pool_size,
+                encoder_intra_threads,
             )?
             .with_punctuator(punctuator)
             .with_itn(resolve_itn(itn, resolved));
@@ -863,6 +880,7 @@ async fn main() -> anyhow::Result<()> {
             hotwords_file,
             hotwords_default,
             hotwords_boost,
+            encoder_intra_threads,
             format,
             output,
             max_chars_per_line,
@@ -873,9 +891,17 @@ async fn main() -> anyhow::Result<()> {
             maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
             let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
             let hotwords = resolve_hotwords(hotwords_file.as_deref(), hotwords_default);
-            let mut engine = inference::Engine::load_with_pool_size(&model_dir, 1)?
-                .with_punctuator(punctuator)
-                .with_itn(resolve_itn(itn, resolved));
+            // Single-triplet pool for offline file transcription; thread count
+            // is opt-in (default 1 ⇒ identical sessions to the prior build).
+            let mut engine = inference::Engine::load_with_pools_threads(
+                &model_dir,
+                1,
+                1,
+                0,
+                encoder_intra_threads,
+            )?
+            .with_punctuator(punctuator)
+            .with_itn(resolve_itn(itn, resolved));
             if let Some(pairs) = hotwords {
                 engine =
                     engine.with_hotwords(&pairs, hotwords_boost.unwrap_or(DEFAULT_HOTWORDS_BOOST));
@@ -976,6 +1002,109 @@ mod tests {
                 assert_eq!(model_variant, None);
             }
             _ => panic!("expected Serve"),
+        }
+    }
+
+    // Restore a captured env value when dropped, so an env-mutating test never
+    // leaks `GIGASTT_ENCODER_INTRA_THREADS` to a sibling test (clap reads the
+    // process environment). Paired with `ENV_LOCK` to serialize these tests.
+    struct EnvRestore(&'static str, Option<String>);
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match &self.1 {
+                Some(v) => unsafe { std::env::set_var(self.0, v) },
+                None => unsafe { std::env::remove_var(self.0) },
+            }
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_encoder_intra_threads_default() {
+        // Unset → default 1 (no behavior change vs prior builds).
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(
+            "GIGASTT_ENCODER_INTRA_THREADS",
+            std::env::var("GIGASTT_ENCODER_INTRA_THREADS").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_ENCODER_INTRA_THREADS");
+        }
+        let cli = Cli::parse_from(["gigastt", "serve"]);
+        match cli.command {
+            Commands::Serve {
+                encoder_intra_threads,
+                ..
+            } => assert_eq!(encoder_intra_threads, 1),
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_encoder_intra_threads_flag() {
+        // The explicit flag wins over any inherited env value.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(
+            "GIGASTT_ENCODER_INTRA_THREADS",
+            std::env::var("GIGASTT_ENCODER_INTRA_THREADS").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_ENCODER_INTRA_THREADS");
+        }
+        let cli = Cli::parse_from(["gigastt", "serve", "--encoder-intra-threads", "4"]);
+        match cli.command {
+            Commands::Serve {
+                encoder_intra_threads,
+                ..
+            } => assert_eq!(encoder_intra_threads, 4),
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_encoder_intra_threads_env() {
+        // The flag is wired to GIGASTT_ENCODER_INTRA_THREADS; clap reads the
+        // process environment, so serialize against other env-mutating tests.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(
+            "GIGASTT_ENCODER_INTRA_THREADS",
+            std::env::var("GIGASTT_ENCODER_INTRA_THREADS").ok(),
+        );
+        unsafe {
+            std::env::set_var("GIGASTT_ENCODER_INTRA_THREADS", "6");
+        }
+        let cli = Cli::parse_from(["gigastt", "serve"]);
+        match cli.command {
+            Commands::Serve {
+                encoder_intra_threads,
+                ..
+            } => assert_eq!(encoder_intra_threads, 6),
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_transcribe_encoder_intra_threads_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(
+            "GIGASTT_ENCODER_INTRA_THREADS",
+            std::env::var("GIGASTT_ENCODER_INTRA_THREADS").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_ENCODER_INTRA_THREADS");
+        }
+        let cli = Cli::parse_from([
+            "gigastt",
+            "transcribe",
+            "audio.wav",
+            "--encoder-intra-threads",
+            "3",
+        ]);
+        match cli.command {
+            Commands::Transcribe {
+                encoder_intra_threads,
+                ..
+            } => assert_eq!(encoder_intra_threads, 3),
+            _ => panic!("expected Transcribe"),
         }
     }
 


### PR DESCRIPTION
Opt-in encoder threading for weak CPUs / long single-file jobs. `--encoder-intra-threads <N>` (env `GIGASTT_ENCODER_INTRA_THREADS`, **default 1 — no behavior change**), clamped so `pool_size × threads` stays within the logical CPU count. `inter_threads`=1, decoder/joiner stay single-threaded, CoreML/CUDA loaders untouched. Verified: default + `--encoder-intra-threads 4` produce an identical transcript (threads change perf, not output); clamp + CLI parse unit-tested; `fmt`/`clippy`/`test --lib --bins` green; `cargo check --features coreml|cuda` clean.