### PR TITLE
feat(bench): report verbatim (naive) WER alongside normalized WER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Verbatim ("naive") WER reported alongside normalized WER in the benchmark.**
+  Both the Python (`benchmark.py`) and Rust (`crates/gigastt/tests/benchmark.rs`)
+  harnesses now compute a second WER per sample with verbatim rules only
+  (lowercase + `ё`→`е` + strip non-word characters, but no words-to-digits ITN,
+  digit-group merging, or anglicism mapping) and surface `naive_wer`, its 95% CI,
+  and `naive_delta = wer - naive_wer`. A negative delta means writing convention
+  (number style, punctuation, transliteration) — not acoustics — produced the WER
+  gap, which separates genuine recognition error from formatting. The Python
+  results table gains `naive %` / `Δ pp` columns. The Rust regression gate still
+  decides pass/fail on the normalized WER only; the verbatim numbers are
+  reported, never gated.
 - **Configurable encoder threads (`--encoder-intra-threads`).** The CPU encoder runs
   single-threaded by default; on weak CPUs or long single-file jobs it can now take more
   intra-op threads (env `GIGASTT_ENCODER_INTRA_THREADS`, default 1 — unchanged), clamped so

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -43,6 +43,8 @@ WER is computed after symmetric text normalization so that Russian number words 
 
 Normalization is therefore the single largest lever on the reported WER gap, and it rewards gigastt's output style: much of gigastt's lead over Vosk on clean read speech in the ITN-digit numbers is produced by the normalization itself, not by acoustics. (*naive* = lowercase + `ё`→`е` + strip everything outside `[a-zа-я0-9\s]` + split; *ITN* = the pipeline below.)
 
+**This split is now reported on every run, not just the offline table above.** `benchmark.py` computes both passes per sample and emits, for each engine, the verbatim WER (`naive_wer`, `naive_ci_low`, `naive_ci_high`) alongside the normalized `wer`, plus `naive_delta = wer - naive_wer` (a negative delta means normalization — number style, punctuation, transliteration — closed the gap, not acoustics). The results table prints `naive %` and `Δ pp` columns next to the WER column. Because the verbatim pass applies no words-to-digits ITN or anglicism mapping and strips to the exact same `[a-zа-я0-9\s]` character class in both harnesses, the `naive_wer` numbers are directly comparable across the Python and Rust harnesses even though their ITN passes differ.
+
 The normalization steps are:
 
 1. Lowercase and replace `ё` with `е`.
@@ -76,7 +78,7 @@ WER is reported with a bootstrap 95% confidence interval computed by resampling 
 
 ### CI / Rust harness divergence note
 
-The Rust CI harness in `crates/gigastt/tests/benchmark.rs` uses a simpler digit-to-words normalization. Its WER numbers may therefore diverge from the Python benchmark on samples with digits, dates, or currency; this is tracked separately and is not part of this fix.
+The Rust CI harness in `crates/gigastt/tests/benchmark.rs` uses a simpler digit-to-words normalization. Its normalized WER numbers may therefore diverge from the Python benchmark on samples with digits, dates, or currency; this is tracked separately and is not part of this fix. The Rust harness also emits the verbatim (`naive_wer`, `naive_delta`) split in its JSON output and stderr summary; since the verbatim pass strips to the identical `[a-zа-я0-9\s]` character class in both harnesses, those naive numbers do line up.
 
 ### Dataset contamination
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -23,6 +23,7 @@ from common import (
     collect_repro_metadata,
     compute_histograms,
     compute_wer,
+    compute_wer_naive,
     load_manifest,
 )
 from runners import (
@@ -62,12 +63,15 @@ def run_benchmark(
 
     total_ref_words = 0
     total_errors = 0
+    total_naive_errors = 0
+    total_naive_ref_words = 0
     total_audio_sec = 0.0
     total_proc_sec = 0.0
     failures = 0
     cached_hits = 0
     details = []
     per_sample = []
+    naive_per_sample = []
 
     print(f"\n=== {runner.name} ===")
     for idx, sample in enumerate(manifest):
@@ -101,10 +105,14 @@ def run_benchmark(
                 source = "error"
 
         wer, errors, ref_count = compute_wer(ref, hyp)
+        naive_wer, naive_errors, naive_ref_count = compute_wer_naive(ref, hyp)
 
         total_ref_words += ref_count
         total_errors += errors
         per_sample.append((ref_count, errors))
+        total_naive_ref_words += naive_ref_count
+        total_naive_errors += naive_errors
+        naive_per_sample.append((naive_ref_count, naive_errors))
 
         if success:
             total_audio_sec += dur
@@ -117,6 +125,9 @@ def run_benchmark(
             "wer": round(wer, 2),
             "errors": errors,
             "ref_words": ref_count,
+            "naive_wer": round(naive_wer, 2),
+            "naive_errors": naive_errors,
+            "naive_ref_words": naive_ref_count,
             "audio_sec": round(dur, 2),
             "proc_sec": round(proc_time, 2),
             "failed": not success,
@@ -132,8 +143,14 @@ def run_benchmark(
             )
 
     overall_wer = (total_errors / total_ref_words * 100.0) if total_ref_words > 0 else 0.0
+    overall_naive_wer = (
+        (total_naive_errors / total_naive_ref_words * 100.0)
+        if total_naive_ref_words > 0
+        else 0.0
+    )
     overall_rtf = total_proc_sec / total_audio_sec if total_audio_sec > 0 else 0.0
     ci_low, ci_high = bootstrap_ci(per_sample, iterations=1000)
+    naive_ci_low, naive_ci_high = bootstrap_ci(naive_per_sample, iterations=1000)
 
     return {
         "name": runner.name,
@@ -145,6 +162,16 @@ def run_benchmark(
         "ci_high": round(ci_high, 2),
         "total_errors": total_errors,
         "total_ref_words": total_ref_words,
+        # Verbatim ("naive") WER reported alongside the normalized WER. The gap
+        # (naive_delta = wer - naive_wer, usually negative) is the share of the
+        # apparent error that is writing convention — number style, punctuation,
+        # transliteration — rather than acoustic recognition error.
+        "naive_wer": round(overall_naive_wer, 2),
+        "naive_ci_low": round(naive_ci_low, 2),
+        "naive_ci_high": round(naive_ci_high, 2),
+        "naive_total_errors": total_naive_errors,
+        "naive_total_ref_words": total_naive_ref_words,
+        "naive_delta": round(overall_wer - overall_naive_wer, 2),
         "total_audio_sec": round(total_audio_sec, 2),
         "total_proc_sec": round(total_proc_sec, 2),
         "rtf": round(overall_rtf, 3),
@@ -154,12 +181,12 @@ def run_benchmark(
 
 
 def print_results_table(results: list[dict]):
-    print("\n" + "=" * 90)
+    print("\n" + "=" * 104)
     print(
         f"{'Engine':<20} {'Samples':>8} {'Failures':>9} {'WER %':>8} "
-        f"{'95% CI':>16} {'RTF':>8} {'Errors':>10} {'Words':>10}"
+        f"{'95% CI':>16} {'naive %':>8} {'Δ pp':>7} {'RTF':>8} {'Errors':>10}"
     )
-    print("-" * 90)
+    print("-" * 104)
     for r in results:
         ci = f"[{r['ci_low']:.1f}, {r['ci_high']:.1f}]"
         print(
@@ -168,11 +195,16 @@ def print_results_table(results: list[dict]):
             f"{r['failures']:>9} "
             f"{r['wer']:>8.2f} "
             f"{ci:>16} "
+            f"{r.get('naive_wer', 0.0):>8.2f} "
+            f"{r.get('naive_delta', 0.0):>+7.2f} "
             f"{r['rtf']:>8.3f} "
-            f"{r['total_errors']:>10} "
-            f"{r['total_ref_words']:>10}"
+            f"{r['total_errors']:>10}"
         )
-    print("=" * 90)
+    print("=" * 104)
+    print(
+        "  WER % = normalized (ITN) · naive % = verbatim · "
+        "Δ pp = WER − naive (negative ⇒ normalization, not acoustics, closed the gap)"
+    )
 
 
 def print_histograms(results: list[dict]):

--- a/benchmark/common.py
+++ b/benchmark/common.py
@@ -413,6 +413,29 @@ def normalize_for_wer(text: str) -> list[str]:
     return tokens
 
 
+# Verbatim normalization keeps only word characters: letters (Latin or
+# Cyrillic), digits, and whitespace. Everything else (punctuation, currency,
+# percent, dashes) is removed without acting as a separator, matching the
+# "naive" baseline described in benchmark/README.md.
+_NAIVE_STRIP_RE = re.compile(r"[^a-zа-я0-9\s]", re.UNICODE)
+
+
+def normalize_for_wer_naive(text: str) -> list[str]:
+    """Normalize text to a word list with verbatim ("naive") rules only.
+
+    Applies lowercasing, ``ё``→``е`` folding, removal of every non-word
+    character, and whitespace splitting — but NONE of the words-to-digits ITN,
+    digit-group merging, ordinal resolution, or anglicism mapping that
+    :func:`normalize_for_wer` performs. The difference between the WER computed
+    over this pass and the ITN pass isolates how much of the apparent error is a
+    writing-convention mismatch (number style, punctuation, transliteration)
+    rather than an acoustic recognition error.
+    """
+    text = text.lower().replace("ё", "е")
+    text = _NAIVE_STRIP_RE.sub("", text)
+    return text.split()
+
+
 def word_edit_distance(reference: list[str], hypothesis: list[str]) -> int:
     """Levenshtein distance at word level."""
     m, n = len(reference), len(hypothesis)
@@ -433,6 +456,21 @@ def compute_wer(reference: str, hypothesis: str) -> tuple[float, int, int]:
     """Returns (wer_percent, errors, ref_word_count)."""
     ref_words = normalize_for_wer(reference)
     hyp_words = normalize_for_wer(hypothesis)
+    errors = word_edit_distance(ref_words, hyp_words)
+    ref_count = len(ref_words)
+    wer = (errors / ref_count * 100.0) if ref_count > 0 else 0.0
+    return wer, errors, ref_count
+
+
+def compute_wer_naive(reference: str, hypothesis: str) -> tuple[float, int, int]:
+    """Returns (wer_percent, errors, ref_word_count) under verbatim rules.
+
+    Mirrors :func:`compute_wer` but uses :func:`normalize_for_wer_naive`, so no
+    words-to-digits ITN or anglicism mapping is applied. Reported alongside the
+    normalized WER to expose the writing-convention share of the error.
+    """
+    ref_words = normalize_for_wer_naive(reference)
+    hyp_words = normalize_for_wer_naive(hypothesis)
     errors = word_edit_distance(ref_words, hyp_words)
     ref_count = len(ref_words)
     wer = (errors / ref_count * 100.0) if ref_count > 0 else 0.0

--- a/benchmark/recompute_wer.py
+++ b/benchmark/recompute_wer.py
@@ -38,33 +38,55 @@ def recompute_file(input_path: Path, output_path: Path) -> list[dict]:
         total_errors = 0
         total_ref_words = 0
         per_sample: list[tuple[int, int]] = []
+        total_naive_errors = 0
+        total_naive_ref_words = 0
+        naive_per_sample: list[tuple[int, int]] = []
 
         for detail in runner.get("details", []):
             ref = detail.get("reference", "")
             hyp = detail.get("hypothesis", "")
 
             wer, errors, ref_count = common.compute_wer(ref, hyp)
+            naive_wer, naive_errors, naive_ref_count = common.compute_wer_naive(ref, hyp)
 
             detail["wer"] = wer
             detail["errors"] = errors
             detail["ref_words"] = ref_count
+            detail["naive_wer"] = naive_wer
+            detail["naive_errors"] = naive_errors
+            detail["naive_ref_words"] = naive_ref_count
 
             total_errors += errors
             total_ref_words += ref_count
             per_sample.append((ref_count, errors))
+            total_naive_errors += naive_errors
+            total_naive_ref_words += naive_ref_count
+            naive_per_sample.append((naive_ref_count, naive_errors))
 
         overall_wer = (
             (total_errors / total_ref_words * 100.0)
             if total_ref_words > 0
             else 0.0
         )
+        overall_naive_wer = (
+            (total_naive_errors / total_naive_ref_words * 100.0)
+            if total_naive_ref_words > 0
+            else 0.0
+        )
         ci_low, ci_high = common.bootstrap_ci(per_sample, iterations=1000)
+        naive_ci_low, naive_ci_high = common.bootstrap_ci(naive_per_sample, iterations=1000)
 
         runner["wer"] = overall_wer
         runner["ci_low"] = ci_low
         runner["ci_high"] = ci_high
         runner["total_errors"] = total_errors
         runner["total_ref_words"] = total_ref_words
+        runner["naive_wer"] = overall_naive_wer
+        runner["naive_ci_low"] = naive_ci_low
+        runner["naive_ci_high"] = naive_ci_high
+        runner["naive_total_errors"] = total_naive_errors
+        runner["naive_total_ref_words"] = total_naive_ref_words
+        runner["naive_delta"] = overall_wer - overall_naive_wer
 
         rows.append(
             {

--- a/benchmark/tests/test_benchmark.py
+++ b/benchmark/tests/test_benchmark.py
@@ -42,6 +42,12 @@ def _fake_result(name: str = "fake") -> dict:
         "ci_high": 0.0,
         "total_errors": 0,
         "total_ref_words": 0,
+        "naive_wer": 0.0,
+        "naive_ci_low": 0.0,
+        "naive_ci_high": 0.0,
+        "naive_total_errors": 0,
+        "naive_total_ref_words": 0,
+        "naive_delta": 0.0,
         "total_audio_sec": 0.0,
         "total_proc_sec": 0.0,
         "rtf": 0.0,
@@ -111,6 +117,30 @@ def test_run_benchmark_uses_cache():
     assert result["cached_hits"] == 1
     assert result["details"][0]["cached"] is True
     assert result["details"][0]["hypothesis"] == "hello"
+
+
+def test_run_benchmark_reports_naive_wer():
+    # gigastt-style hypothesis (digits) vs spoken-number reference: the ITN pass
+    # forgives the digit/word convention difference, the verbatim pass does not.
+    # run_benchmark must surface both, with naive_delta = wer - naive_wer.
+    class _FakeCache:
+        def get(self, runner, wav_path):
+            return {"hypothesis": "5%", "proc_time": 0.1}
+
+        def set(self, *args, **kwargs):
+            pass
+
+    runner = MagicMock()
+    runner.name = "fake"
+    manifest = [{"filename": "a.wav", "reference": "пять процентов"}]
+    result = benchmark.run_benchmark(runner, manifest, cache=_FakeCache())
+
+    assert result["wer"] == 0.0
+    assert result["naive_wer"] > 0.0
+    assert result["naive_delta"] == round(result["wer"] - result["naive_wer"], 2)
+    assert result["naive_total_errors"] >= 1
+    assert result["details"][0]["naive_wer"] > 0.0
+    assert result["details"][0]["naive_errors"] >= 1
 
 
 def test_no_cache_flag_disables_cache(tmp_path):

--- a/benchmark/tests/test_common.py
+++ b/benchmark/tests/test_common.py
@@ -1,6 +1,13 @@
 """Unit tests for benchmark/common.py WER normalization and manifest loading."""
 
-from common import compute_wer, load_manifest, normalize_for_wer, word_edit_distance
+from common import (
+    compute_wer,
+    compute_wer_naive,
+    load_manifest,
+    normalize_for_wer,
+    normalize_for_wer_naive,
+    word_edit_distance,
+)
 
 
 def _wer_info(reference: str, hypothesis: str) -> tuple[float, int, int, list[str], list[str]]:
@@ -171,3 +178,75 @@ def test_percent_keeps_adjacent_numbers_separate():
 
 def test_chunked_thousands_merge():
     assert normalize_for_wer("3 000 ₽") == ["3000"]
+
+
+# --- Verbatim ("naive") normalization: lowercase + ё→е + strip non-word
+# characters + split, with NO words-to-digits ITN, digit merging, ordinal
+# resolution, or anglicism mapping. The gap between naive and ITN WER isolates
+# how much of the apparent error is writing convention vs acoustics. ---
+
+
+def test_naive_lowercases_and_strips_punctuation():
+    assert normalize_for_wer_naive("Привет, Мир!") == ["привет", "мир"]
+
+
+def test_naive_folds_yo_to_ye():
+    assert normalize_for_wer_naive("счёт") == ["счет"]
+
+
+def test_naive_keeps_digits_and_words_apart_no_itn():
+    # Naive does NOT convert number words to digits or strip currency/percent
+    # words, so the digit and word forms stay incomparable.
+    assert normalize_for_wer_naive("пять процентов") == ["пять", "процентов"]
+    assert normalize_for_wer_naive("5%") == ["5"]
+
+
+def test_naive_does_not_merge_digit_groups():
+    # ITN merges short groups ("79193358931"); naive leaves them split.
+    assert normalize_for_wer_naive("7 919 335") == ["7", "919", "335"]
+
+
+def test_naive_does_not_map_anglicisms():
+    assert normalize_for_wer_naive("youtube") == ["youtube"]
+
+
+def test_naive_drops_chars_outside_ascii_cyrillic_class():
+    # The strip class is exactly [a-zа-я0-9\s]; accented Latin and non-ASCII
+    # digits are dropped (here "ï" is removed, leaving "nave"). This pins
+    # cross-harness parity with the Rust benchmark's normalize_for_wer_naive,
+    # which uses the same character class.
+    assert normalize_for_wer_naive("naïve") == ["nave"]
+
+
+def test_naive_wer_penalizes_convention_where_itn_forgives():
+    # The ITN pipeline collapses "пять процентов" to the single token ["5"]
+    # (пять→5, "процентов" dropped as an empty token) and "5%" to ["5"], so it
+    # scores them as a perfect match. The verbatim pass keeps both words and the
+    # digit apart, counting the convention difference as error. That gap is
+    # exactly the "writing convention" share of the WER.
+    ref = "пять процентов"
+    hyp = "5%"
+    itn_wer, itn_err, _ = compute_wer(ref, hyp)
+    naive_wer, naive_err, naive_count = compute_wer_naive(ref, hyp)
+
+    assert itn_err == 0
+    assert itn_wer == 0.0
+    assert naive_err > 0
+    assert naive_wer > 0.0
+    assert naive_count == 2
+
+
+def test_naive_wer_equals_itn_on_plain_words():
+    # With no digits, Latin tokens, or punctuation, the two passes agree.
+    ref = hyp = "привет дорогой мир"
+    itn_wer, itn_err, itn_count = compute_wer(ref, hyp)
+    naive_wer, naive_err, naive_count = compute_wer_naive(ref, hyp)
+
+    assert (itn_wer, itn_err, itn_count) == (0.0, 0, 3)
+    assert (naive_wer, naive_err, naive_count) == (0.0, 0, 3)
+
+
+def test_naive_wer_empty_reference_is_zero():
+    wer, errors, ref_count = compute_wer_naive("", "что-то")
+    assert wer == 0.0
+    assert ref_count == 0

--- a/crates/gigastt/tests/benchmark.rs
+++ b/crates/gigastt/tests/benchmark.rs
@@ -299,6 +299,33 @@ fn normalize_for_wer(text: &str) -> Vec<String> {
     translit_anglicisms(&words)
 }
 
+/// Verbatim ("naive") normalization: lowercase, `ё`→`е`, keep only
+/// alphanumeric/whitespace characters, split. Unlike `normalize_for_wer` it does
+/// NOT convert dashes to spaces, merge digit groups, resolve ordinals, convert
+/// cardinals to words, or transliterate anglicisms. Reporting WER over this pass
+/// alongside the normalized WER isolates the writing-convention share of the
+/// error (number style, punctuation, transliteration) from the acoustic share.
+/// The definition mirrors the Python benchmark's `normalize_for_wer_naive`.
+fn normalize_for_wer_naive(text: &str) -> Vec<String> {
+    let text = text.to_lowercase();
+    let text = text.replace('ё', "е");
+    // Keep only the `[a-zа-я0-9]` + whitespace class — character-for-character
+    // identical to the Python benchmark's `_NAIVE_STRIP_RE`. A broader
+    // `is_alphanumeric` filter would keep accented Latin (`café`) and non-ASCII
+    // digits that the Python ASCII-class pass drops, so the two harnesses'
+    // verbatim WER would diverge on such transcripts; this keeps them equal.
+    let text: String = text
+        .chars()
+        .filter(|c| {
+            c.is_ascii_lowercase()
+                || ('а'..='я').contains(c)
+                || c.is_ascii_digit()
+                || c.is_whitespace()
+        })
+        .collect();
+    text.split_whitespace().map(String::from).collect()
+}
+
 /// Word-level edit distance (Levenshtein) between reference and hypothesis.
 fn word_edit_distance(reference: &[String], hypothesis: &[String]) -> usize {
     let m = reference.len();
@@ -425,6 +452,56 @@ fn run_gate_self_test() {
     let missing = read_baseline(Path::new("/nonexistent/benchmark_baseline.json"));
     assert_eq!(missing["tolerance_pp"].as_f64(), Some(0.5));
     assert!(missing["sets"]["bundled"]["wer"].as_f64().is_none());
+
+    // normalize_for_wer_naive: verbatim rules only — lowercase, ё→е, strip
+    // punctuation, NO words-to-digits ITN, digit merging, or anglicism mapping.
+    assert_eq!(
+        normalize_for_wer_naive("Привет, Мир!"),
+        vec!["привет".to_string(), "мир".to_string()],
+        "naive lowercases and strips punctuation"
+    );
+    assert_eq!(
+        normalize_for_wer_naive("счёт"),
+        vec!["счет".to_string()],
+        "naive folds ё→е"
+    );
+    assert_eq!(
+        normalize_for_wer_naive("пять процентов"),
+        vec!["пять".to_string(), "процентов".to_string()],
+        "naive does not strip percent/currency words"
+    );
+    assert_eq!(
+        normalize_for_wer_naive("5%"),
+        vec!["5".to_string()],
+        "naive strips the percent sign but keeps the digit, with no ITN"
+    );
+    assert_eq!(
+        normalize_for_wer_naive("7 919 335"),
+        vec!["7".to_string(), "919".to_string(), "335".to_string()],
+        "naive does not merge digit groups"
+    );
+    assert_eq!(
+        normalize_for_wer_naive("naïve"),
+        vec!["nave".to_string()],
+        "naive drops accented Latin (outside [a-zа-я0-9]), matching the Python pass"
+    );
+    // The verbatim pass counts the digit↔word number convention as an error
+    // where the normalized pass forgives it — that gap is the whole point.
+    // (The Rust harness normalizes digits→words; the Python harness goes the
+    // other way. Both forgive this pair, so the naive numbers stay comparable.)
+    let ref_n = normalize_for_wer_naive("пять");
+    let hyp_n = normalize_for_wer_naive("5");
+    assert!(
+        word_edit_distance(&ref_n, &hyp_n) > 0,
+        "naive must penalize the digit/word difference the ITN pass forgives"
+    );
+    let ref_i = normalize_for_wer("пять");
+    let hyp_i = normalize_for_wer("5");
+    assert_eq!(
+        word_edit_distance(&ref_i, &hyp_i),
+        0,
+        "the normalized (ITN) pass forgives the digit/word number convention"
+    );
 }
 
 fn main() {
@@ -495,8 +572,11 @@ fn main() {
 
     let mut total_ref_words = 0usize;
     let mut total_errors = 0usize;
+    let mut total_naive_ref_words = 0usize;
+    let mut total_naive_errors = 0usize;
     let mut details = Vec::new();
     let mut per_sample: Vec<(usize, usize)> = Vec::with_capacity(manifest.len());
+    let mut naive_per_sample: Vec<(usize, usize)> = Vec::with_capacity(manifest.len());
 
     let start_time = std::time::Instant::now();
 
@@ -521,9 +601,16 @@ fn main() {
             errors as f64 / ref_words.len() as f64 * 100.0
         };
 
+        let ref_words_naive = normalize_for_wer_naive(&sample.reference);
+        let hyp_words_naive = normalize_for_wer_naive(&hypothesis.text);
+        let naive_errors = word_edit_distance(&ref_words_naive, &hyp_words_naive);
+
         total_ref_words += ref_words.len();
         total_errors += errors;
         per_sample.push((ref_words.len(), errors));
+        total_naive_ref_words += ref_words_naive.len();
+        total_naive_errors += naive_errors;
+        naive_per_sample.push((ref_words_naive.len(), naive_errors));
 
         if idx % PROGRESS_EVERY == 0 || idx + 1 == manifest.len() {
             let elapsed = start_time.elapsed().as_secs_f64();
@@ -564,6 +651,21 @@ fn main() {
     let ci_lo_r = (ci_lo * 10.0).round() / 10.0;
     let ci_hi_r = (ci_hi * 10.0).round() / 10.0;
 
+    // Verbatim ("naive") WER: the same metric without words-to-digits ITN or
+    // anglicism mapping. The gap (naive_delta = wer - naive_wer) is the
+    // writing-convention share of the error. Reported for transparency only —
+    // the regression gate below stays on the normalized WER.
+    let naive_wer = if total_naive_ref_words > 0 {
+        total_naive_errors as f64 / total_naive_ref_words as f64 * 100.0
+    } else {
+        0.0
+    };
+    let naive_wer_rounded = (naive_wer * 10.0).round() / 10.0;
+    let (naive_ci_lo, naive_ci_hi) = bootstrap_ci(&naive_per_sample, 1000);
+    let naive_ci_lo_r = (naive_ci_lo * 10.0).round() / 10.0;
+    let naive_ci_hi_r = (naive_ci_hi * 10.0).round() / 10.0;
+    let naive_delta_r = ((wer - naive_wer) * 10.0).round() / 10.0;
+
     eprintln!(
         "\n  WER: {:.1}% ({} errors / {} words)  Score: {:.1}  Samples: {}",
         wer,
@@ -573,6 +675,10 @@ fn main() {
         manifest.len()
     );
     eprintln!("  95% CI: [{:.1}%, {:.1}%]", ci_lo_r, ci_hi_r);
+    eprintln!(
+        "  Verbatim (naive) WER: {:.1}% ({} errors / {} words)  Δ {:+.1}pp vs normalized",
+        naive_wer_rounded, total_naive_errors, total_naive_ref_words, naive_delta_r
+    );
 
     // ---- Regression gate ---------------------------------------------------
     // Two hard checks (non-zero exit so CI actually fails on regression):
@@ -638,6 +744,12 @@ fn main() {
         "wer": wer_rounded,
         "ci_low": ci_lo_r,
         "ci_high": ci_hi_r,
+        "naive_wer": naive_wer_rounded,
+        "naive_ci_low": naive_ci_lo_r,
+        "naive_ci_high": naive_ci_hi_r,
+        "naive_total_errors": total_naive_errors,
+        "naive_total_words": total_naive_ref_words,
+        "naive_delta": naive_delta_r,
         "total_words": total_ref_words,
         "total_errors": total_errors,
         "samples": manifest.len(),


### PR DESCRIPTION
## What

Both benchmark harnesses (Python `benchmark.py` and the Rust CI harness `crates/gigastt/tests/benchmark.rs`) now compute a **second WER per sample** under verbatim rules — lowercase + `ё`→`е` + strip to the `[a-zа-я0-9\s]` character class, with **no** words-to-digits ITN, digit-group merging, or anglicism mapping — and surface it alongside the existing normalized WER:

- `naive_wer` + 95% CI (`naive_ci_low`/`naive_ci_high`)
- `naive_delta = wer - naive_wer`

The Python results table gains `naive %` and `Δ pp` columns; the Rust harness emits the same fields in its JSON output and stderr summary.

## Why

It answers a methodological question the project couldn't quantify per-run: **how much of the reported WER is acoustic recognition error vs. a writing-convention mismatch** (number style, punctuation, transliteration)? A negative `naive_delta` means normalization — not acoustics — closed the gap. This makes the offline naive-vs-ITN table in `benchmark/README.md` a live, every-run output, and lets us see whether there is genuine acoustic headroom left in gigastt's WER or whether the residual is mostly convention.

## Safety / scope

- **Purely additive.** No existing JSON keys renamed or removed.
- **CI gate unchanged.** The Rust regression gate still decides pass/fail on the normalized WER only; the verbatim numbers are reported, never gated.
- Both harnesses strip to the **identical** character class, so the `naive_wer` numbers are directly comparable across them even though their ITN passes differ (pinned by a `naïve`→`nave` test on each side).
- `recompute_wer.py` recomputes the naive fields too, so re-normalized artifacts stay self-consistent.

## Tests

- Python: 9 new `*_naive` unit tests in `test_common.py` + a wiring test in `test_benchmark.py` (naive fields present, `naive_delta` math, per-detail fields). 64 pass.
- Rust: verbatim-normalization assertions added to the model-free `--self-test` (runs in PR CI). Build + clippy clean.

This change was reviewed by an independent multi-lens adversarial pass (definitional correctness, regression safety, test adequacy); the one substantive finding — an overstated cross-harness comparability claim — was fixed by making the Rust character class byte-identical to Python's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)