### PR TITLE
chore: fix clippy + rustdoc lints surfaced by newer stable toolchain

### DIFF
--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -890,7 +890,7 @@ impl Engine {
 
     /// Attach a contextual hotword biaser built from `(phrase, weight)` pairs
     /// and an additive `boost`, consuming and returning `self` (builder style).
-    /// Each phrase is tokenized with the engine's own [`Tokenizer`], so biasing
+    /// Each phrase is tokenized with the engine's own `Tokenizer`, so biasing
     /// adapts to whichever recognition head is loaded.
     ///
     /// When `phrases` is empty, `boost <= 0`, or no phrase is representable in
@@ -981,7 +981,7 @@ impl Engine {
     /// behaviour. Values `> 1` give the dominant encoder more intra-op
     /// parallelism on weak CPUs / long single-file jobs; the count is clamped
     /// against the logical CPU count so `pool_size * threads` can't oversubscribe
-    /// the machine (see [`Engine::clamp_encoder_intra_threads`]). Ignored by the
+    /// the machine (see `Engine::clamp_encoder_intra_threads`). Ignored by the
     /// CoreML / CUDA builds (the accelerator owns scheduling there).
     pub fn load_with_pools_threads(
         model_dir: &str,
@@ -2516,6 +2516,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // intentional compile-time sanity check on the chunk constants
     fn test_chunk_constants_sane() {
         // Window > overlap (positive stride) and threshold ≥ window so the
         // single-pass path covers everything up to one full window.


### PR DESCRIPTION
## What

Two workspace CI jobs are red against the **current stable toolchain**, independent of any feature work:

- **Clippy** (`--workspace --all-targets -- -D warnings`): `assertions_on_constants` now fires on the chunk-constant sanity test, which deliberately asserts on two `const` values.
- **Doc Build** (`cargo doc --no-deps --workspace`, `RUSTDOCFLAGS=-D warnings`): two public doc comments intra-link to private items (`Tokenizer`, `Engine::clamp_encoder_intra_threads`), tripping `rustdoc::private_intra_doc_links`.

Both landed earlier without being caught because that CI run used an older toolchain; the last green main run predates the toolchain bump. They now block **every** PR.

## Fix

- `#[allow(clippy::assertions_on_constants)]` on `test_chunk_constants_sane` — the whole point of that test is a compile-time sanity check over constants.
- Drop the two intra-doc links to plain code spans (`` `Tokenizer` ``, `` `Engine::clamp_encoder_intra_threads` ``), matching how other private references in this file are written.

No behavior change. Verified locally with the exact CI invocations: `cargo clippy --workspace --all-targets -- -D warnings -A dead_code` and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` both clean; all unit/bin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)