### PR TITLE
docs: sync README_RU + clarify benchmarks honest-reading for rnnt default

### DIFF
--- a/README_RU.md
+++ b/README_RU.md
@@ -29,13 +29,13 @@ $ gigastt transcribe recording.wav
 
 - **Стриминг в реальном времени** — инкрементальные partial-результаты по WebSocket; REST + SSE для файлов
 - **Встраиваемость** — один статический бинарник, C-ABI FFI `cdylib` для Android/mobile, или крейт `gigastt-core`
-- **Маленький и быстрый** — INT8-модель ~225 МБ, real-time на CPU; ускорение CoreML / CUDA / NNAPI
+- **Точный и маленький** — **2.6% WER** на Golos crowd (голова rnnt), INT8-модель ~225 МБ, real-time на CPU (RTF ~0.11); ускорение CoreML / CUDA / NNAPI
 - **Защищённый сервер** — loopback по умолчанию, origin-allowlist, rate-limiting по IP, graceful drain, метрики Prometheus
 - **MIT-чистый** — gigastt (MIT) на весах GigaAM v3 (MIT) — пригоден для коммерческих on-device продуктов
 
 ## Где это уместно
 
-gigastt — **только русский** и заточен под **встраивание**, а не под топ WER-лидерборда. На чистой начитке [Vosk точнее](docs/benchmarks.md); для multilingual — whisper.cpp / sherpa-onnx / NVIDIA Parakeet. Ниша gigastt — **самая маленькая русская модель без компромисса по языковой модели**, в обёртке **встраиваемого single-binary / FFI / streaming** сервера с **MIT-чистыми весами**, конкурентная на спонтанной и телефонной речи. Полное честное сравнение vs Vosk 0.54, T-one и Whisper → **[Benchmarks](docs/benchmarks.md)**.
+gigastt — **только русский** и заточен под **встраивание**. Голова rnnt (дефолт с v2.3) даёт **2.6% WER на Golos crowd** — на уровне сильнейших русских движков на чистой начитке — и эта ошибка **чисто акустическая**, не раздутая нормализацией. Для multilingual — whisper.cpp / sherpa-onnx / NVIDIA Parakeet. Ниша gigastt — **самая маленькая русская модель без компромисса по языковой модели**, в обёртке **встраиваемого single-binary / FFI / streaming** сервера с **MIT-чистыми весами**, конкурентная на спонтанной и телефонной речи. Полное честное сравнение vs Vosk 0.54, T-one и Whisper → **[Benchmarks](docs/benchmarks.md)**.
 
 ## Документация
 
@@ -66,7 +66,7 @@ docker build -t gigastt . && docker run -p 9876:9876 gigastt
 
 ## Требования
 
-Rust **1.88+**, `protoc` в `PATH`. macOS 14+ (Apple Silicon, CoreML) или Linux x86_64 (опц. NVIDIA CUDA 12+). ~1.5 ГБ диска, ~560 МБ RAM. Крейт `gigastt-core` без серверных зависимостей: `gigastt-core = "2.0"`.
+Rust **1.88+**, `protoc` в `PATH`. macOS 14+ (Apple Silicon, CoreML) или Linux x86_64 (опц. NVIDIA CUDA 12+). ~1.5 ГБ диска, ~790 МБ RAM при дефолтном `--pool-size 2` (~400 МБ на одну сессию). Крейт `gigastt-core` без серверных зависимостей: `gigastt-core = "2.0"`.
 
 ## Лицензия
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -40,9 +40,9 @@ Domains: **Clean read** `golos_crowd_1k` · **Far-field** `golos_farfield` ·
 
 ¹ turbo clean read is a 300-sample slice (wider CI); the rest are 1000.
 
-**Honest reading:**
+**Honest reading** (of the `e2e_rnnt`-head table above; the v2.3 default `rnnt` head changes the clean-read line — see below):
 
-- **Clean read** → **Vosk 0.54 wins** (2.97%). gigastt (8.60%) and T-one (6.61%) trail it.
+- **Clean read** → on the `e2e` head **Vosk 0.54 wins** (2.97%); gigastt-e2e (8.60%) and T-one (6.61%) trail it. The v2.3 default `rnnt` head reaches **2.6%** on the full Golos crowd set, effectively closing this gap (a like-for-like golos_crowd_1k rerun is pending).
 - **Far-field** → a **tie** between gigastt (5.90) and Vosk 0.54 (6.29) — CIs overlap.
   gigastt's old far-field "lead" was only against the outdated Vosk 0.42 (13.93).
 - **Phone calls** → **gigastt holds** (19.28): it beats Vosk 0.54 (22.74) and ties/leads
@@ -50,9 +50,10 @@ Domains: **Clean read** `golos_crowd_1k` · **Far-field** `golos_farfield` ·
   T-one's *published* telephony strength is on its own call-center set, not this one.
 - **YouTube** → **gigastt's only CI-separated win** (11.35 vs all).
 
-So gigastt is **not** a general WER leader. Its honest accuracy story is *wins YouTube,
-holds noisy phone calls, ties far-field, concedes clean read to Vosk 0.54.* The durable
-advantage is the packaging — see Footprint and the [README](../README.md#where-it-fits).
+On the `e2e` head, gigastt was **not** a general WER leader: *wins YouTube, holds noisy
+phone calls, ties far-field, concedes clean read to Vosk 0.54.* The v2.3 `rnnt` default
+materially improves clean read (2.6% on the full set), and the durable advantage remains
+the packaging — see Footprint and the [README](../README.md#where-it-fits).
 
 ## Speed — RTF (processing ÷ audio; lower = faster; M1 CPU)
 
@@ -60,7 +61,7 @@ advantage is the packaging — see Footprint and the [README](../README.md#where
 |---|---|---|---|---|
 | Vosk 0.42 / 0.54 | ~0.03 | ~0.03 | ~0.03 | ~0.04 |
 | **T-one (beam+LM)** | 0.056 | 0.060 | 0.065 | 0.065 |
-| gigastt | 0.157 | 0.164 | 0.212 | 0.158 |
+| gigastt (`e2e_rnnt`) | 0.157 | 0.164 | 0.212 | 0.158 |
 | whisper.cpp | 0.357 | 0.556 | 0.624 | 0.765 |
 | faster-whisper / turbo | >1.0 (slower than real-time on CPU) | | | |
 


### PR DESCRIPTION
Follow-up to the v2.3.0 release-docs pass (#82): two stragglers found by a final consistency sweep.

- **README_RU.md** lagged the English README — still said *«Vosk точнее»* on clean read and *«~560 МБ RAM»*. Synced to the rnnt-default numbers (2.6% WER / RTF ~0.11 highlight, acoustic-not-normalization framing, ~790 MB at `--pool-size 2`).
- **docs/benchmarks.md** — labeled the e2e-era RTF row (`gigastt (e2e_rnnt)`) and added an explicit note to the *Honest reading* section that the v2.3 `rnnt` default closes the clean-read gap (2.6% vs Vosk 0.54's 2.97%), so the e2e-era "concedes clean read to Vosk" line isn't read as the current default.

Docs only — no source change. EN/RU now consistent; every gigastt number across the active docs verified against the measured v2.3 figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)