### PR TITLE
fix(ci): green E2E + Security Audit under the rnnt default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,12 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     name: Security Audit
+    # audit-check posts results as a check run; without `checks: write` it fails
+    # with "Resource not accessible by integration" under the default read-only
+    # token. `contents: read` is needed for checkout.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       # `rustsec/audit-check` ships a prebuilt cargo-audit, saving the ~90 s
@@ -284,6 +290,9 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # `paste` is unmaintained (RUSTSEC-2024-0436) and pulled in transitively
+          # via `tokenizers`; no fix available. Mirrors the deny.toml ignore.
+          ignore: RUSTSEC-2024-0436
 
   deny:
     runs-on: ubuntu-latest

--- a/benchmark/benchmark_footprint.py
+++ b/benchmark/benchmark_footprint.py
@@ -47,9 +47,12 @@ def _model_size_mb(runner) -> float | None:
     name = runner.name
     home = Path.home()
     if name.startswith("gigastt"):
-        enc = home / ".gigastt" / "models" / "v3_e2e_rnnt_encoder_int8.onnx"
-        if enc.exists():
-            return round(enc.stat().st_size / (1024 * 1024), 1)
+        # rnnt is the default head since v2.3; fall back to e2e_rnnt.
+        models = home / ".gigastt" / "models"
+        for fn in ("v3_rnnt_encoder_int8.onnx", "v3_e2e_rnnt_encoder_int8.onnx"):
+            enc = models / fn
+            if enc.exists():
+                return round(enc.stat().st_size / (1024 * 1024), 1)
     if name.startswith("vosk"):
         model_dir = getattr(runner, "download_dir", None)
         model_name = getattr(runner, "model_name", None)

--- a/crates/gigastt/tests/benchmark.rs
+++ b/crates/gigastt/tests/benchmark.rs
@@ -543,7 +543,17 @@ fn main() {
         .map(|h| h.join(".gigastt").join("models"))
         .expect("HOME not set");
 
-    if !model_dir.join("v3_e2e_rnnt_encoder.onnx").exists() {
+    // Accept either head's encoder (rnnt default since v2.3, or e2e_rnnt; FP32 or
+    // generated INT8). The engine auto-detects which variant to load.
+    let has_model = [
+        "v3_rnnt_encoder.onnx",
+        "v3_rnnt_encoder_int8.onnx",
+        "v3_e2e_rnnt_encoder.onnx",
+        "v3_e2e_rnnt_encoder_int8.onnx",
+    ]
+    .iter()
+    .any(|f| model_dir.join(f).exists());
+    if !has_model {
         println!(
             r#"{{"pass": true, "score": null, "skipped": true, "reason": "model not found"}}"#
         );

--- a/crates/gigastt/tests/common/mod.rs
+++ b/crates/gigastt/tests/common/mod.rs
@@ -29,9 +29,20 @@ pub fn model_dir() -> String {
         .expect("Cannot determine home directory")
         .join(".gigastt")
         .join("models");
+    // Accept either recognition head — the engine auto-detects the variant from
+    // whichever encoder is present (`rnnt` is the default download since v2.3,
+    // `e2e_rnnt` is the alternative; FP32 or generated INT8 both count).
+    let has_model = [
+        "v3_rnnt_encoder.onnx",
+        "v3_rnnt_encoder_int8.onnx",
+        "v3_e2e_rnnt_encoder.onnx",
+        "v3_e2e_rnnt_encoder_int8.onnx",
+    ]
+    .iter()
+    .any(|f| dir.join(f).exists());
     assert!(
-        dir.join("v3_e2e_rnnt_encoder.onnx").exists(),
-        "Model not found at {}. Run `cargo run -- download` first.",
+        has_model,
+        "Model not found at {} (no rnnt or e2e_rnnt encoder). Run `cargo run -- download` first.",
         dir.display()
     );
     dir.to_string_lossy().into_owned()
@@ -55,6 +66,29 @@ pub async fn start_server(model_dir: &str) -> (u16, oneshot::Sender<()>) {
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
     let engine = gigastt::inference::Engine::load(model_dir).unwrap();
+    let config = gigastt::server::ServerConfig::local(port);
+    tokio::spawn(gigastt::server::run_with_config_listener(
+        engine,
+        config,
+        Some(shutdown_rx),
+        listener,
+    ));
+
+    wait_for_ready(port, Duration::from_secs(30)).await;
+    (port, shutdown_tx)
+}
+
+/// Start the server with an explicit session-pool size. Used by the pool
+/// saturation tests so they don't depend on `DEFAULT_POOL_SIZE` (which changed
+/// to 2 in v2.3) or the RAM-aware cap — a small fixed pool is deterministic.
+pub async fn start_server_with_pool(
+    model_dir: &str,
+    pool_size: usize,
+) -> (u16, oneshot::Sender<()>) {
+    let (port, listener) = free_port().await;
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let engine = gigastt::inference::Engine::load_with_pool_size(model_dir, pool_size).unwrap();
     let config = gigastt::server::ServerConfig::local(port);
     tokio::spawn(gigastt::server::run_with_config_listener(
         engine,

--- a/crates/gigastt/tests/e2e_errors.rs
+++ b/crates/gigastt/tests/e2e_errors.rs
@@ -135,37 +135,40 @@ async fn test_ws_oversized_frame_rejected() {
 // ─── 3. Fifth WebSocket client is blocked ───────────────────────────────────
 
 /// Saturate the pool with 4 WebSocket clients, then try a 5th.
-/// The 5th client's TCP connection succeeds but pool.checkout() blocks,
-/// so the Ready message never arrives within 3 seconds.
+/// The (pool+1)th client's TCP connection succeeds but pool.checkout() blocks,
+/// so its Ready message never arrives within 3 seconds. Uses an explicit small
+/// pool so the test does not depend on `DEFAULT_POOL_SIZE` (2 since v2.3) or the
+/// RAM-aware cap.
 #[ignore]
 #[tokio::test]
-async fn test_ws_fifth_client_hangs() {
+async fn test_ws_client_hangs_when_pool_saturated() {
+    const POOL: usize = 2;
     let model_dir = common::model_dir();
-    let (port, shutdown) = common::start_server(&model_dir).await;
+    let (port, shutdown) = common::start_server_with_pool(&model_dir, POOL).await;
 
-    // Connect 4 clients and hold them open (saturating the pool).
+    // Connect POOL clients and hold them open (saturating the pool).
     let mut clients = Vec::new();
-    for _ in 0..4 {
+    for _ in 0..POOL {
         let (sink, stream, _ready) = common::ws_connect(port).await;
         clients.push((sink, stream));
     }
 
-    // Attempt to connect a 5th client using raw connect_async (we don't want
-    // ws_connect because that helper expects a Ready message).
-    let (mut fifth_ws, _) =
+    // Attempt one more client using raw connect_async (we don't want ws_connect
+    // because that helper expects a Ready message).
+    let (mut extra_ws, _) =
         tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/v1/ws"))
             .await
-            .expect("TCP connection for 5th client should succeed");
+            .expect("TCP connection for the extra client should succeed");
 
     // The pool is exhausted, so pool.checkout() blocks server-side.
     // The Ready message should NOT arrive within 3 seconds.
-    let result = tokio::time::timeout(Duration::from_secs(3), fifth_ws.next()).await;
+    let result = tokio::time::timeout(Duration::from_secs(3), extra_ws.next()).await;
     assert!(
         result.is_err(),
-        "5th client should NOT receive Ready while pool is saturated, but got: {result:?}"
+        "extra client should NOT receive Ready while pool is saturated, but got: {result:?}"
     );
 
-    // Release all 4 pool slots by sending Stop to each.
+    // Release all pool slots by sending Stop to each.
     let stop_json = serde_json::to_string(&serde_json::json!({"type": "stop"})).unwrap();
     for (mut sink, mut stream) in clients {
         sink.send(Message::Text(stop_json.clone().into()))
@@ -181,19 +184,21 @@ async fn test_ws_fifth_client_hangs() {
 
 // ─── 4. HTTP returns 503 when pool is saturated ─────────────────────────────
 
-/// Hold all 4 pool slots via WebSocket, then POST /v1/transcribe.
+/// Hold all pool slots via WebSocket, then POST /v1/transcribe.
 /// The HTTP handler has a 30-second pool.checkout() timeout and returns 503.
+/// Uses an explicit small pool so the test does not depend on `DEFAULT_POOL_SIZE`.
 ///
 /// This test takes ~30 seconds to complete (the HTTP timeout duration).
 #[ignore]
 #[tokio::test]
 async fn test_rest_saturated_pool_returns_503() {
+    const POOL: usize = 2;
     let model_dir = common::model_dir();
-    let (port, shutdown) = common::start_server(&model_dir).await;
+    let (port, shutdown) = common::start_server_with_pool(&model_dir, POOL).await;
 
     // Saturate the pool.
     let mut clients = Vec::new();
-    for _ in 0..4 {
+    for _ in 0..POOL {
         let (sink, stream, _ready) = common::ws_connect(port).await;
         clients.push((sink, stream));
     }

--- a/crates/gigastt/tests/e2e_ws.rs
+++ b/crates/gigastt/tests/e2e_ws.rs
@@ -341,7 +341,9 @@ async fn test_ws_client_disconnect_midstream() {
 #[tokio::test]
 async fn test_ws_concurrent_4_clients() {
     let model_dir = common::model_dir();
-    let (port, _shutdown) = common::start_server(&model_dir).await;
+    // Explicit pool of 4 so all 4 concurrent clients get a slot — the default
+    // pool size is 2 since v2.3, which would hang clients 3 and 4.
+    let (port, _shutdown) = common::start_server_with_pool(&model_dir, 4).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/ws");
 


### PR DESCRIPTION
Main-push CI has been **red since the rnnt head became the default**. The heavy jobs (E2E, Security Audit, WER benchmark) run only on `push` to main, so PR CI stayed green and the breakage went unnoticed across the recent merges.

## Root causes & fixes

**1. E2E tests hardcoded the e2e_rnnt model filename.** `tests/common/mod.rs::model_dir()` and `tests/benchmark.rs` asserted / skip-checked `v3_e2e_rnnt_encoder.onnx`, but `gigastt download` now fetches the **rnnt** head (`v3_rnnt_encoder.onnx`). The CI model cache masked this until the v2.3.0 version bump invalidated it → all e2e tests panicked at `model_dir()`. Both checks now accept **either** head (rnnt/e2e_rnnt, FP32/INT8); the engine already auto-detects the variant.

**2. Pool-saturation tests assumed `DEFAULT_POOL_SIZE == 4`** — it dropped to **2** in v2.3, so `test_*_pool_saturation` and `test_ws_concurrent_4_clients` hung waiting for Ready on clients 3–4. Added a `start_server_with_pool` helper and pinned explicit pools (saturation tests use 2, the concurrent test uses 4), independent of the default and the RAM-aware cap.

**3. Security Audit failed** with `Resource not accessible by integration` (rustsec/audit-check needs `checks: write`, missing under the default read-only token) and on the unmaintained-`paste` warning. Added `permissions: { contents: read, checks: write }` and `ignore: RUSTSEC-2024-0436` (mirrors deny.toml; 0 actual vulnerabilities).

## Verification
Full e2e suite locally: **39 passed / 0 failed** (e2e_rest/ws/errors/shutdown/rate_limit). `clippy --workspace --all-targets -D warnings` clean; benchmark self-test ok. Post-merge the main-push CI (which actually runs E2E + Security Audit) will confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)