### PR TITLE
fix(ci): VAD model-gated tests skip when Silero model absent

### DIFF
--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -570,6 +570,13 @@ mod tests {
     fn test_silero_silence_low_prob_and_runs() {
         let home = std::env::var("HOME").expect("HOME");
         let path = std::path::PathBuf::from(home).join(".gigastt/models/vad/silero_vad.onnx");
+        // The Silero VAD model is a separate, optional download (not part of the
+        // GigaAM model cache). Skip gracefully when it is absent so the
+        // `--ignored` coverage run doesn't fail where only GigaAM is present.
+        if !path.exists() {
+            eprintln!("skipping {}: Silero VAD model not present", path.display());
+            return;
+        }
         let vad = SileroVad::load(&path).expect("load silero");
 
         // 1 s of pure silence → several frames, all low probability.

--- a/crates/gigastt-core/tests/vad_file.rs
+++ b/crates/gigastt-core/tests/vad_file.rs
@@ -47,7 +47,16 @@ fn vad_file_skips_silence_keeps_transcript() {
     drop(t);
 
     // VAD: decode only detected speech regions, remapping timestamps back.
+    // The Silero VAD model is an optional separate download; skip gracefully if
+    // it is absent (only the GigaAM model is required to reach this point).
     let vad_path = Path::new(&default_vad_model_dir()).join(VAD_MODEL_FILE);
+    if !vad_path.exists() {
+        eprintln!(
+            "skipping vad_file: Silero VAD model not present at {}",
+            vad_path.display()
+        );
+        return;
+    }
     let vad = SileroVad::load(&vad_path).expect("load silero vad");
     let vad_engine = Engine::load(&model_dir)
         .expect("load vad engine")


### PR DESCRIPTION
The Coverage (E2E) job (the last red main-push job) ran lib tests with `--ignored`, executing the model-gated VAD test. The Silero VAD model is a separate optional download (not in the cached GigaAM model), so it panicked with `Failed to load VAD model`.

Both the `vad.rs` session smoke test and the `vad_file` integration test now early-return when the model file is absent — proper model-gated-test hygiene. With the model present (locally) they still run fully. E2E Tests and Security Audit already went green via #85; this clears the last failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)