### PR TITLE
test: raise coverage to 94% line / 95.6% function (+142 tests, 4 rounds)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,21 +533,6 @@ jobs:
         if: steps.cache-model.outputs.cache-hit != 'true'
         run: cargo run -p gigastt -- download
 
-      - name: Generate test WAV
-        run: |
-          # Create a minimal 1-second silent WAV for CLI transcribe coverage
-          python3 -c "
-          import struct, wave, io
-          data = io.BytesIO()
-          with wave.open(data, 'wb') as w:
-            w.setnchannels(1)
-            w.setsampwidth(2)
-            w.setframerate(16000)
-            w.writeframes(b'\x00' * 32000)
-          with open('/tmp/test_silence.wav', 'wb') as f:
-            f.write(data.getvalue())
-          "
-
       - name: Run e2e coverage
         # Run each integration test target sequentially with `--no-report` so
         # coverage data accumulates in target/llvm-cov-target, then generate a
@@ -558,16 +543,22 @@ jobs:
         # exercise CLI commands to push coverage toward 90 %.
         run: |
           cargo llvm-cov --no-report --workspace --lib --bins -- --ignored --test-threads=1
-          cargo llvm-cov --no-report -p gigastt --test e2e_rest     -- --ignored --test-threads=1
-          cargo llvm-cov --no-report -p gigastt --test e2e_ws       -- --ignored --test-threads=1
-          cargo llvm-cov --no-report -p gigastt --test e2e_errors   -- --ignored --test-threads=1
-          cargo llvm-cov --no-report -p gigastt --test e2e_shutdown -- --ignored --test-threads=1
+          # gigastt-ffi is a `cdylib`; the `--workspace --lib` pass above does not
+          # run its model-gated (#[ignore]) lib tests, so run them explicitly or
+          # the FFI streaming/transcribe paths read as uncovered.
+          cargo llvm-cov --no-report -p gigastt-ffi --lib -- --ignored --test-threads=1
+          cargo llvm-cov --no-report -p gigastt --test e2e_rest      -- --ignored --test-threads=1
+          cargo llvm-cov --no-report -p gigastt --test e2e_ws        -- --ignored --test-threads=1
+          cargo llvm-cov --no-report -p gigastt --test e2e_errors    -- --ignored --test-threads=1
+          cargo llvm-cov --no-report -p gigastt --test e2e_shutdown  -- --ignored --test-threads=1
           cargo llvm-cov --no-report -p gigastt --test e2e_rate_limit -- --ignored --test-threads=1
-          cargo llvm-cov --no-report run -p gigastt -- --help || true
-          cargo llvm-cov --no-report run -p gigastt -- serve --help || true
+          # CLI subprocess + REST/SSE handler coverage. e2e_cli has non-ignored
+          # tests too, so use --include-ignored to run the whole target.
+          cargo llvm-cov --no-report -p gigastt --test e2e_cli       -- --include-ignored --test-threads=1
+          cargo llvm-cov --no-report -p gigastt --test e2e_http_cov  -- --ignored --test-threads=1
+          # Exercise the download command arm (network path) that the subprocess
+          # tests can't reach offline.
           cargo llvm-cov --no-report run -p gigastt -- download || true
-          cargo llvm-cov --no-report run -p gigastt -- quantize --force || true
-          cargo llvm-cov --no-report run -p gigastt -- transcribe /tmp/test_silence.wav || true
           cargo llvm-cov report --cobertura --output-path cobertura-e2e.xml
 
       - uses: codecov/codecov-action@v7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,49 @@
+# Codecov configuration.
+#
+# Coverage is uploaded from two CI jobs and merged by flag:
+#   * unit — `cargo llvm-cov --workspace --lib --bins` (every PR/push)
+#   * e2e  — model-gated lib/bin + integration + CLI subprocess coverage
+#            (main-push only; needs the ~850 MB model)
+#
+# Measured line coverage of the merged report is ~94% and function coverage
+# ~95.5%. The remaining uncovered lines are dominated by fault-injection-only
+# paths (ONNX-runtime internal failures, network model-download errors, forced
+# panics / inference timeouts, OS-signal handlers) and defensive guards that are
+# unreachable in normal operation — deliberately left untested rather than
+# covered with brittle mocks.
+
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        # No-regression gate: the merged coverage must not fall more than
+        # `threshold` below the base commit. This locks in the achieved level
+        # without pinning a brittle absolute number we then have to chase.
+        target: auto
+        threshold: 0.5%
+        informational: false
+    patch:
+      default:
+        # New / changed lines should be well covered.
+        target: 80%
+        threshold: 0%
+        informational: false
+
+flags:
+  unit:
+    carryforward: true
+  e2e:
+    carryforward: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false
+
+ignore:
+  - "**/tests/**"
+  - "crates/gigastt-core/src/onnx_proto.rs" # prost-generated ONNX protobuf types

--- a/crates/gigastt-core/src/export.rs
+++ b/crates/gigastt-core/src/export.rs
@@ -428,6 +428,160 @@ mod tests {
     }
 
     #[test]
+    fn test_export_format_display_all_variants() {
+        assert_eq!(ExportFormat::Json.to_string(), "json");
+        assert_eq!(ExportFormat::Txt.to_string(), "txt");
+        assert_eq!(ExportFormat::Srt.to_string(), "srt");
+        assert_eq!(ExportFormat::Vtt.to_string(), "vtt");
+        assert_eq!(ExportFormat::Md.to_string(), "md");
+    }
+
+    #[test]
+    fn test_export_format_content_type_all_variants() {
+        assert_eq!(
+            ExportFormat::Json.content_type(),
+            "application/json; charset=utf-8"
+        );
+        assert_eq!(
+            ExportFormat::Txt.content_type(),
+            "text/plain; charset=utf-8"
+        );
+        assert_eq!(
+            ExportFormat::Srt.content_type(),
+            "application/x-subrip; charset=utf-8"
+        );
+        assert_eq!(ExportFormat::Vtt.content_type(), "text/vtt; charset=utf-8");
+        assert_eq!(
+            ExportFormat::Md.content_type(),
+            "text/markdown; charset=utf-8"
+        );
+    }
+
+    #[test]
+    fn test_export_format_extension_all_variants() {
+        assert_eq!(ExportFormat::Json.extension(), "json");
+        assert_eq!(ExportFormat::Txt.extension(), "txt");
+        assert_eq!(ExportFormat::Srt.extension(), "srt");
+        assert_eq!(ExportFormat::Vtt.extension(), "vtt");
+        assert_eq!(ExportFormat::Md.extension(), "md");
+    }
+
+    #[test]
+    fn test_render_dispatches_each_format() {
+        let result = sample_result();
+        let opts = RenderOpts::default();
+
+        let json = ExportFormat::Json.render(&result, &opts);
+        assert_eq!(json, to_json(&result));
+
+        let txt = ExportFormat::Txt.render(&result, &opts);
+        assert_eq!(txt, "привет как дела");
+
+        let srt = ExportFormat::Srt.render(&result, &opts);
+        assert!(srt.starts_with("1\n"));
+
+        let vtt = ExportFormat::Vtt.render(&result, &opts);
+        assert!(vtt.starts_with("WEBVTT\n\n"));
+
+        let md = ExportFormat::Md.render(&result, &opts);
+        assert!(md.starts_with("---\n"));
+        // Default opts disable word timestamps, so no table is emitted.
+        assert!(!md.contains("| Word | Start | End |"));
+    }
+
+    #[test]
+    fn test_render_md_with_word_timestamps_opt_in() {
+        let result = sample_result();
+        let opts = RenderOpts {
+            include_word_timestamps: true,
+            ..RenderOpts::default()
+        };
+        let md = ExportFormat::Md.render(&result, &opts);
+        assert!(md.contains("# Word timings"));
+        assert!(md.contains("| Word | Start | End |"));
+    }
+
+    #[test]
+    fn test_render_opts_default_values() {
+        let opts = RenderOpts::default();
+        assert_eq!(opts.max_chars_per_line, 80);
+        assert_eq!(opts.max_words_per_line, 14);
+        assert!(!opts.include_word_timestamps);
+    }
+
+    #[test]
+    fn test_from_str_all_aliases() {
+        assert_eq!(ExportFormat::from_str("json").unwrap(), ExportFormat::Json);
+        assert_eq!(ExportFormat::from_str("txt").unwrap(), ExportFormat::Txt);
+        assert_eq!(ExportFormat::from_str("text").unwrap(), ExportFormat::Txt);
+        assert_eq!(ExportFormat::from_str("vtt").unwrap(), ExportFormat::Vtt);
+        assert_eq!(ExportFormat::from_str("md").unwrap(), ExportFormat::Md);
+    }
+
+    #[test]
+    fn test_to_md_no_speakers_zero_count() {
+        let result = TranscribeResult {
+            text: "no speaker words".to_string(),
+            words: vec![WordInfo {
+                word: "no".to_string(),
+                start: 0.0,
+                end: 0.3,
+                confidence: 0.9,
+                speaker: None,
+            }],
+            duration_s: 0.3,
+        };
+        let md = to_md(&result, true);
+        assert!(md.contains("speakers: 0"));
+        // Speaker column renders "-" when no speaker is assigned.
+        assert!(md.contains("| - |"));
+    }
+
+    #[test]
+    fn test_to_md_word_timestamps_skipped_when_empty() {
+        let result = TranscribeResult {
+            text: String::new(),
+            words: Vec::new(),
+            duration_s: 0.0,
+        };
+        let md = to_md(&result, true);
+        // Empty word list means the appendix table is omitted entirely.
+        assert!(!md.contains("# Word timings"));
+        assert!(md.contains("speakers: 0"));
+    }
+
+    #[test]
+    fn test_to_md_escapes_pipe_in_word() {
+        let result = TranscribeResult {
+            text: "a|b".to_string(),
+            words: vec![WordInfo {
+                word: "a|b".to_string(),
+                start: 0.0,
+                end: 0.5,
+                confidence: 0.91,
+                speaker: Some(2),
+            }],
+            duration_s: 0.5,
+        };
+        let md = to_md(&result, true);
+        // Pipe in the word must be escaped to avoid breaking the table column.
+        assert!(md.contains("a\\|b"));
+        assert!(md.contains("SPEAKER_2"));
+        assert!(md.contains("speakers: 3"));
+    }
+
+    #[test]
+    fn test_srt_speaker_change_breaks_cue_with_label() {
+        // Two speakers force a cue break; each cue carries its speaker label.
+        let words = sample_words();
+        let cues = build_cues(&words, 80, 14);
+        assert_eq!(cues.len(), 2);
+        assert!(cues[0].text.starts_with("[SPEAKER_0]"));
+        assert!(cues[1].text.starts_with("[SPEAKER_1]"));
+        assert!(cues[1].text.contains("дела"));
+    }
+
+    #[test]
     fn test_line_breaking() {
         let words: Vec<WordInfo> = (0..20)
             .map(|i| WordInfo {

--- a/crates/gigastt-core/src/inference/audio.rs
+++ b/crates/gigastt-core/src/inference/audio.rs
@@ -1005,6 +1005,231 @@ mod tests {
         assert_eq!(max_decode_samples(192_000), max_decode_samples(48_000));
     }
 
+    // --- SampleRate tests ---
+
+    #[test]
+    fn test_sample_rate_new_zero_errors() {
+        let result = SampleRate::new(0);
+        assert!(result.is_err(), "zero sample rate must error");
+    }
+
+    #[test]
+    fn test_sample_rate_new_positive_ok() {
+        let sr = SampleRate::new(16000).unwrap();
+        assert_eq!(sr.get(), 16000);
+        assert_eq!(sr.0, 16000);
+    }
+
+    // --- stereo WAV helper + multi-channel mixing tests ---
+
+    fn make_stereo_wav_bytes(frames: &[(i16, i16)], sample_rate: u32) -> Vec<u8> {
+        let data_size = (frames.len() * 4) as u32; // 2 channels * 2 bytes
+        let file_size = 36 + data_size;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&file_size.to_le_bytes());
+        buf.extend_from_slice(b"WAVE");
+        buf.extend_from_slice(b"fmt ");
+        buf.extend_from_slice(&16u32.to_le_bytes()); // chunk size
+        buf.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        buf.extend_from_slice(&2u16.to_le_bytes()); // stereo
+        buf.extend_from_slice(&sample_rate.to_le_bytes());
+        buf.extend_from_slice(&(sample_rate * 4).to_le_bytes()); // byte rate
+        buf.extend_from_slice(&4u16.to_le_bytes()); // block align
+        buf.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+        buf.extend_from_slice(b"data");
+        buf.extend_from_slice(&data_size.to_le_bytes());
+        for &(l, r) in frames {
+            buf.extend_from_slice(&l.to_le_bytes());
+            buf.extend_from_slice(&r.to_le_bytes());
+        }
+        buf
+    }
+
+    #[test]
+    fn test_decode_stereo_mixes_to_mono() {
+        // Left = +16384 (0.5), Right = -16384 (-0.5) → mono average ≈ 0.0.
+        // Exercises the multi-channel mixing branch in decode_audio_inner.
+        let frames: Vec<(i16, i16)> = vec![(16384, -16384); 16000];
+        let wav = make_stereo_wav_bytes(&frames, 16000);
+        let samples = decode_audio_bytes(&wav).unwrap();
+        assert!(!samples.is_empty());
+        // Output is mono (one sample per frame), not interleaved.
+        assert!((samples.len() as i64 - 16000).unsigned_abs() <= 100);
+        // The L/R cancel: each mono sample is ~0.0.
+        for &s in &samples {
+            assert!(s.abs() < 0.01, "stereo mix should cancel to ~0, got {s}");
+        }
+    }
+
+    #[test]
+    fn test_decode_stereo_constant_preserves_value() {
+        // Both channels carry the same value → mono mix preserves it.
+        let frames: Vec<(i16, i16)> = vec![(8192, 8192); 8000];
+        let wav = make_stereo_wav_bytes(&frames, 16000);
+        let samples = decode_audio_bytes(&wav).unwrap();
+        assert!(!samples.is_empty());
+        for &s in &samples {
+            assert!((s - 0.25).abs() < 0.01, "expected ~0.25, got {s}");
+        }
+    }
+
+    #[test]
+    fn test_decode_wav_resamples_to_16k() {
+        // 48kHz mono WAV exercises the n_frames_hint capacity reservation and
+        // the post-decode resample-to-16kHz branch.
+        let silence: Vec<i16> = vec![0; 48000]; // 1 second at 48kHz
+        let wav = make_wav_bytes(&silence, 48000);
+        let samples = decode_audio_bytes(&wav).unwrap();
+        assert!(!samples.is_empty());
+        // Resampled to 16kHz → ~16000 samples (rubato FIR delay shortens it).
+        assert!(
+            samples.len() > 14000 && samples.len() < 17000,
+            "expected ~16000 after resample, got {}",
+            samples.len()
+        );
+    }
+
+    // --- resample_with_cache tests ---
+
+    #[test]
+    fn test_resample_with_cache_empty_clears_buffer() {
+        let mut cache: Option<rubato::Async<f32>> = None;
+        let mut out = vec![1.0, 2.0, 3.0];
+        resample_with_cache(
+            Vec::new(),
+            SampleRate(48000),
+            SampleRate(16000),
+            &mut cache,
+            &mut out,
+        )
+        .unwrap();
+        assert!(out.is_empty(), "empty input must clear the output buffer");
+        assert!(cache.is_none(), "no resampler created for empty input");
+    }
+
+    #[test]
+    fn test_resample_with_cache_zero_rate_clears_buffer() {
+        let mut cache: Option<rubato::Async<f32>> = None;
+        let mut out = vec![9.0];
+        resample_with_cache(
+            vec![1.0, 2.0],
+            SampleRate(0),
+            SampleRate(16000),
+            &mut cache,
+            &mut out,
+        )
+        .unwrap();
+        assert!(out.is_empty());
+        let mut out2 = vec![9.0];
+        resample_with_cache(
+            vec![1.0, 2.0],
+            SampleRate(16000),
+            SampleRate(0),
+            &mut cache,
+            &mut out2,
+        )
+        .unwrap();
+        assert!(out2.is_empty());
+    }
+
+    #[test]
+    fn test_resample_with_cache_same_rate_passthrough() {
+        let mut cache: Option<rubato::Async<f32>> = None;
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let mut out = Vec::new();
+        resample_with_cache(
+            input.clone(),
+            SampleRate(16000),
+            SampleRate(16000),
+            &mut cache,
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(out, input, "same rate must pass through unchanged");
+        assert!(
+            cache.is_none(),
+            "no resampler created for same-rate passthrough"
+        );
+    }
+
+    #[test]
+    fn test_resample_with_cache_sanitizes_non_finite() {
+        let mut cache: Option<rubato::Async<f32>> = None;
+        let mut input = vec![0.5_f32; 480];
+        input[10] = f32::NAN;
+        input[20] = f32::INFINITY;
+        input[30] = f32::NEG_INFINITY;
+        let mut out = Vec::new();
+        resample_with_cache(
+            input,
+            SampleRate(48000),
+            SampleRate(16000),
+            &mut cache,
+            &mut out,
+        )
+        .unwrap();
+        assert!(!out.is_empty());
+        assert!(
+            cache.is_some(),
+            "resampler should be cached after first use"
+        );
+        for &s in &out {
+            assert!(
+                s.is_finite(),
+                "non-finite values must be sanitized, got {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_resample_with_cache_reuses_then_recreates() {
+        let mut cache: Option<rubato::Async<f32>> = None;
+        let mut out = Vec::new();
+        // First call creates the resampler.
+        let input1: Vec<f32> = (0..480).map(|i| (i as f32 * 0.01).sin()).collect();
+        resample_with_cache(
+            input1,
+            SampleRate(48000),
+            SampleRate(16000),
+            &mut cache,
+            &mut out,
+        )
+        .unwrap();
+        assert!(cache.is_some());
+        let len_first = out.len();
+        assert!(len_first > 0);
+
+        // Second call with the SAME chunk size reuses the cached resampler.
+        let input2: Vec<f32> = (0..480).map(|i| (i as f32 * 0.02).cos()).collect();
+        resample_with_cache(
+            input2,
+            SampleRate(48000),
+            SampleRate(16000),
+            &mut cache,
+            &mut out,
+        )
+        .unwrap();
+        assert!(cache.is_some());
+        assert!(!out.is_empty());
+
+        // Third call with a DIFFERENT chunk size forces recreation (or resize).
+        let input3: Vec<f32> = (0..960).map(|i| (i as f32 * 0.01).sin()).collect();
+        resample_with_cache(
+            input3,
+            SampleRate(48000),
+            SampleRate(16000),
+            &mut cache,
+            &mut out,
+        )
+        .unwrap();
+        assert!(cache.is_some());
+        assert!(!out.is_empty());
+        for &s in &out {
+            assert!(s.is_finite());
+        }
+    }
+
     #[test]
     fn test_decode_rejects_adversarial_sample_rate() {
         // A crafted header with an out-of-range sample rate must be rejected

--- a/crates/gigastt-core/src/inference/bias.rs
+++ b/crates/gigastt-core/src/inference/bias.rs
@@ -253,4 +253,118 @@ mod tests {
         b.boost_logits(&state, &mut logits); // no panic
         assert!(logits.iter().all(|&l| l == 0.0));
     }
+
+    use crate::inference::tokenizer::Tokenizer;
+
+    /// A char-vocab tokenizer covering the Cyrillic letters used below plus a
+    /// `▁` word-boundary marker, so `encode_phrase` produces deterministic ids.
+    fn char_tokenizer() -> Tokenizer {
+        let tokens = vec![
+            "а".to_string(),
+            "б".to_string(),
+            "в".to_string(),
+            "г".to_string(),
+            "д".to_string(),
+            "\u{2581}".to_string(), // word-boundary marker
+            "<unk>".to_string(),
+            "<blk>".to_string(),
+        ];
+        Tokenizer::from_tokens(tokens)
+    }
+
+    #[test]
+    fn test_from_phrases_zero_boost_returns_none() {
+        let tok = char_tokenizer();
+        let phrases = vec![("аб".to_string(), 1.0)];
+        assert!(Biaser::from_phrases(&tok, &phrases, 0.0).is_none());
+    }
+
+    #[test]
+    fn test_from_phrases_negative_boost_returns_none() {
+        let tok = char_tokenizer();
+        let phrases = vec![("аб".to_string(), 1.0)];
+        assert!(Biaser::from_phrases(&tok, &phrases, -3.0).is_none());
+    }
+
+    #[test]
+    fn test_from_phrases_empty_slice_returns_none() {
+        let tok = char_tokenizer();
+        assert!(Biaser::from_phrases(&tok, &[], 5.0).is_none());
+    }
+
+    #[test]
+    fn test_from_phrases_all_zero_weight_returns_none() {
+        // Positive boost but every phrase filtered out by weight <= 0 → None.
+        let tok = char_tokenizer();
+        let phrases = vec![("аб".to_string(), 0.0), ("вг".to_string(), -1.0)];
+        assert!(Biaser::from_phrases(&tok, &phrases, 5.0).is_none());
+    }
+
+    #[test]
+    fn test_from_phrases_unrepresentable_only_returns_none() {
+        // A phrase with no codepoints in the vocab is dropped; nothing survives.
+        let tok = char_tokenizer();
+        let phrases = vec![("xyz".to_string(), 1.0)];
+        assert!(Biaser::from_phrases(&tok, &phrases, 5.0).is_none());
+    }
+
+    #[test]
+    fn test_from_phrases_single_token_phrase_boosts_first_token() {
+        // "а" encodes to a leading ▁ (id 5) then char id 0. The first emitted
+        // token of the hotword is the boundary marker, so the root boosts id 5.
+        let tok = char_tokenizer();
+        let phrases = vec![("а".to_string(), 1.0)];
+        let b = Biaser::from_phrases(&tok, &phrases, 7.0).expect("phrase compiles");
+        assert_eq!(b.phrase_count(), 1);
+
+        let ids = tok.encode_phrase("а").expect("representable");
+        let state = b.new_state();
+        let mut logits = vec![0.0; 8];
+        b.boost_logits(&state, &mut logits);
+        // First token of the encoded phrase is boostable at the root.
+        assert_eq!(logits[ids[0]], 7.0, "first token of phrase boosted at root");
+    }
+
+    #[test]
+    fn test_from_phrases_multi_token_phrase_boosts_continuation() {
+        // "аб" → [▁(5), а(0), б(1)]. After advancing through the encoded
+        // prefix, the next continuation token must be boosted.
+        let tok = char_tokenizer();
+        let phrases = vec![("аб".to_string(), 1.0)];
+        let b = Biaser::from_phrases(&tok, &phrases, 4.0).expect("phrase compiles");
+        assert_eq!(b.phrase_count(), 1);
+
+        let ids = tok.encode_phrase("аб").expect("representable");
+        assert_eq!(ids, vec![5, 0, 1]);
+
+        let mut state = b.new_state();
+        b.advance(&mut state, ids[0]); // ▁
+        b.advance(&mut state, ids[1]); // а
+        let mut logits = vec![0.0; 8];
+        b.boost_logits(&state, &mut logits);
+        assert_eq!(
+            logits[ids[2]], 4.0,
+            "third token boosted after two-token prefix"
+        );
+    }
+
+    #[test]
+    fn test_from_phrases_drops_unrepresentable_keeps_representable() {
+        // One good phrase, one with an out-of-vocab codepoint. The good one
+        // survives; the count reflects only the compiled phrase.
+        let tok = char_tokenizer();
+        let phrases = vec![("аб".to_string(), 1.0), ("аz".to_string(), 1.0)];
+        let b = Biaser::from_phrases(&tok, &phrases, 5.0).expect("one phrase compiles");
+        assert_eq!(b.phrase_count(), 1);
+    }
+
+    #[test]
+    fn test_from_phrases_weight_filters_per_phrase() {
+        // Two representable phrases; one has weight 0 and is dropped before
+        // tokenization, leaving a single compiled phrase.
+        let tok = char_tokenizer();
+        let phrases = vec![("аб".to_string(), 1.0), ("вг".to_string(), 0.0)];
+        let b = Biaser::from_phrases(&tok, &phrases, 5.0).expect("one phrase compiles");
+        assert_eq!(b.phrase_count(), 1);
+    }
 }

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -3301,4 +3301,319 @@ mod tests {
             "every triplet must be returned to the pool after warmup"
         );
     }
+
+    // ---- More pure (no-model) coverage -------------------------------------
+
+    #[test]
+    fn test_finalize_pool_load_degraded_includes_error_detail() {
+        // The degraded-pool branch logs the first error; exercise the
+        // `first_err` formatting path (the loaded triplets are still returned).
+        let r: Vec<anyhow::Result<u32>> = vec![Ok(1), Err(anyhow::anyhow!("first failure cause"))];
+        assert_eq!(Engine::finalize_pool_load(r, 2, 1).unwrap(), vec![1]);
+    }
+
+    #[test]
+    fn test_finalize_pool_load_below_min_no_errors_when_all_ok_but_short() {
+        // No Err entries, but fewer results than pool_size with min above the
+        // loaded count → still errors (loaded count is what matters).
+        let r: Vec<anyhow::Result<u32>> = vec![Ok(1)];
+        let err = Engine::finalize_pool_load(r, 3, 2).unwrap_err().to_string();
+        assert!(err.contains("loaded only 1/3"), "got: {err}");
+    }
+
+    #[test]
+    fn test_transcript_assembler_set_words_overwrites() {
+        // The sliding-window streaming path overwrites (not appends) on each
+        // re-decode via `set_words`. A second call replaces the first.
+        let mut asm = TranscriptAssembler::new();
+        asm.set_words(vec![word("alpha", 0.0, 0.4), word("beta", 0.5, 0.9)]);
+        let p = asm.partial(0.0);
+        assert_eq!(p.text, "alpha beta");
+        assert_eq!(p.words.len(), 2);
+
+        asm.set_words(vec![word("gamma", 1.0, 1.4)]);
+        let p = asm.partial(0.0);
+        assert_eq!(p.text, "gamma", "set_words must overwrite, not append");
+        assert_eq!(p.words.len(), 1);
+    }
+
+    #[test]
+    fn test_transcript_assembler_set_words_empty_resets_text() {
+        let mut asm = TranscriptAssembler::new();
+        asm.set_words(vec![word("x", 0.0, 0.4)]);
+        assert!(!asm.is_empty());
+        asm.set_words(vec![]);
+        assert!(asm.is_empty(), "empty set_words clears the accumulation");
+    }
+
+    #[test]
+    fn test_token_formatter_last_word_empty_confidences_defaults_to_one() {
+        // A word whose only token is a bare boundary marker (`▁`, no body)
+        // contributes no confidence sample; a following real word that itself
+        // has no recorded confidences must default to 1.0 on the final-emit
+        // path. We build a vocab whose tokens are pure boundary markers so the
+        // `clean` body is empty and no confidence is pushed.
+        let tok = Tokenizer::from_tokens(vec![
+            "\u{2581}real".into(), // 0: a real word
+            "\u{2581}".into(),     // 1: bare boundary, empty body
+        ]);
+        let tokens = vec![
+            decode::TokenInfo {
+                token_id: 0,
+                frame_index: 0,
+                confidence: 0.7,
+            },
+            // A bare boundary token forces emission of "real" (mid-loop emit),
+            // then contributes nothing to a new word.
+            decode::TokenInfo {
+                token_id: 1,
+                frame_index: 1,
+                confidence: 0.5,
+            },
+        ];
+        let words = TokenFormatter::tokens_to_words(&tok, &tokens, 0);
+        // Only "real" is emitted; the trailing bare boundary leaves no word.
+        assert_eq!(words.len(), 1);
+        assert_eq!(words[0].word, "real");
+        assert!((words[0].confidence - 0.7).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_feature_extractor_prepare_buffer_accumulates() {
+        // `prepare_buffer` appends to the buffer and reports the usable sample
+        // count once a full frame is available; below N_FFT it returns None.
+        let fe = FeatureExtractor::new();
+        let mut buf: Vec<f32> = Vec::new();
+        // A handful of samples — fewer than N_FFT — yields no usable frame yet.
+        let usable = fe.prepare_buffer(&[0.1; 10], &mut buf);
+        assert_eq!(usable, None, "sub-frame input is buffered, not yet usable");
+        assert_eq!(buf.len(), 10, "samples are retained in the buffer");
+
+        // Append enough to cross a frame boundary; a usable count is reported.
+        let usable = fe.prepare_buffer(&vec![0.2; N_FFT], &mut buf);
+        assert!(
+            usable.is_some(),
+            "crossing a frame boundary yields a usable count"
+        );
+    }
+
+    #[test]
+    fn test_feature_extractor_compute_mel_reuses_buffers() {
+        // `compute_mel` writes into caller-owned scratch buffers and returns the
+        // frame count. One second of 16 kHz audio → ~100 frames; the output
+        // buffer holds frames * N_MELS values.
+        let fe = FeatureExtractor::new();
+        let samples = vec![0.0f32; 16000];
+        let mut fft_buf = Vec::new();
+        let mut power_buf = Vec::new();
+        let mut out_buf = Vec::new();
+        let frames = fe.compute_mel(&samples, &mut fft_buf, &mut power_buf, &mut out_buf);
+        assert!(frames > 0, "1s of audio yields at least one mel frame");
+        assert_eq!(
+            out_buf.len(),
+            frames * N_MELS,
+            "output buffer holds frames * N_MELS values"
+        );
+    }
+
+    // ---- Model-backed coverage (process_chunk / transcribe / state) --------
+    //
+    // These need the GigaAM model on disk; CI / coverage runs them with
+    // `--include-ignored`. They exercise the real streaming + file-decode
+    // branches (empty input, sub-stride, sub-N_FFT, full decode + slide,
+    // silence/short transcription, finish_stream / flush_state).
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_create_state_initial_fields() {
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let state = engine.create_state(false);
+        assert!(state.audio_buffer.is_empty());
+        assert!(state.assembler.is_empty());
+        assert_eq!(state.window_start_samples, 0);
+        assert_eq!(state.context_samples, 0);
+        assert_eq!(state.pending_samples, 0);
+        assert!(state.resampler.is_none());
+        // No VAD attached on a default engine → no endpointer.
+        assert!(state.vad_endpointer.is_none());
+        // Decoder state seeded to blank.
+        assert_eq!(state.decoder.consecutive_blanks, 0);
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_create_state_diarization_flag_ignored_without_feature() {
+        // Without the `diarization` feature the flag is silently ignored and a
+        // perfectly usable state still comes back.
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let state = engine.create_state(true);
+        assert!(state.audio_buffer.is_empty());
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_process_chunk_empty_input_returns_no_segments() {
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut guard = engine.pool.checkout_blocking().expect("checkout");
+        let mut state = engine.create_state(false);
+        let segs = engine
+            .process_chunk(&[], &mut state, &mut guard)
+            .expect("empty chunk must not error");
+        assert!(segs.is_empty(), "empty input yields no segments");
+        assert_eq!(state.audio_buffer.len(), 0);
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_process_chunk_sub_stride_buffers_without_decoding() {
+        // A chunk smaller than the decode stride is buffered and triggers no
+        // decode (the stride gate returns early).
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut guard = engine.pool.checkout_blocking().expect("checkout");
+        let mut state = engine.create_state(false);
+        let small = vec![0.0f32; 1600]; // 0.1s ≪ 0.8s stride
+        let segs = engine
+            .process_chunk(&small, &mut state, &mut guard)
+            .expect("sub-stride chunk must not error");
+        assert!(segs.is_empty(), "sub-stride chunk yields no segments yet");
+        assert_eq!(state.audio_buffer.len(), 1600, "samples are buffered");
+        assert_eq!(state.pending_samples, 1600, "pending counter advances");
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_process_chunk_silence_over_stride_decodes_no_words() {
+        // Enough silence to cross the decode stride: the encoder runs but
+        // produces no words (silence), so the partial path returns no segments
+        // and the pending counter resets.
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut guard = engine.pool.checkout_blocking().expect("checkout");
+        let mut state = engine.create_state(false);
+        let chunk = vec![0.0f32; 16000]; // 1s of silence, > 0.8s stride
+        let segs = engine
+            .process_chunk(&chunk, &mut state, &mut guard)
+            .expect("decode of silence must not error");
+        // Silence → no words → empty assembler → no partial segment emitted.
+        assert!(segs.is_empty(), "silence decodes to no words");
+        assert_eq!(
+            state.pending_samples, 0,
+            "decode resets the pending counter"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_flush_state_empty_returns_none() {
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut state = engine.create_state(false);
+        assert!(
+            engine.flush_state(&mut state).is_none(),
+            "an empty assembler flushes to None"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_flush_state_nonempty_returns_final_segment() {
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut state = engine.create_state(false);
+        state.assembler.set_words(vec![word("hello", 0.0, 0.4)]);
+        let seg = engine
+            .flush_state(&mut state)
+            .expect("non-empty assembler flushes to a Final segment");
+        assert!(seg.is_final);
+        assert_eq!(seg.text, "hello");
+        assert!(
+            engine.flush_state(&mut state).is_none(),
+            "finalize resets the assembler"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_finish_stream_no_pending_flushes_assembler() {
+        // No buffered audio and no pending samples: finish_stream skips the
+        // forced decode and just flushes whatever the assembler holds.
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut guard = engine.pool.checkout_blocking().expect("checkout");
+        let mut state = engine.create_state(false);
+        state.assembler.set_words(vec![word("trailing", 0.0, 0.4)]);
+        let seg = engine
+            .finish_stream(&mut state, &mut guard)
+            .expect("finish_stream flushes the assembler");
+        assert_eq!(seg.text, "trailing");
+        assert!(seg.is_final);
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_finish_stream_empty_state_returns_none() {
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut guard = engine.pool.checkout_blocking().expect("checkout");
+        let mut state = engine.create_state(false);
+        assert!(
+            engine.finish_stream(&mut state, &mut guard).is_none(),
+            "an idle stream finishes to None"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_transcribe_samples_silence_yields_empty_text() {
+        // The single-pass file path on pure silence: the encoder runs, decode
+        // produces no words, and the result text is empty with a correct
+        // duration.
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut guard = engine.pool.checkout_blocking().expect("checkout");
+        let silence = vec![0.0f32; 16000 * 2]; // 2s
+        let result = engine
+            .transcribe_samples(&silence, &mut guard)
+            .expect("silence transcription must not error");
+        assert!(result.text.trim().is_empty(), "silence yields no text");
+        assert!(result.words.is_empty());
+        assert!((result.duration_s - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_transcribe_samples_short_sub_frame_audio() {
+        // Audio shorter than a single FFT frame: the mel extractor pads to one
+        // zero frame and the encoder still runs — exercising the short-input
+        // single-pass branch without panicking. The decode output is whatever
+        // the model emits on a lone padded frame; we only assert it doesn't
+        // error and the reported duration matches the (tiny) input.
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut guard = engine.pool.checkout_blocking().expect("checkout");
+        let tiny = vec![0.0f32; 100]; // < N_FFT (320)
+        let result = engine
+            .transcribe_samples(&tiny, &mut guard)
+            .expect("sub-frame audio must not error");
+        assert!((result.duration_s - 100.0 / 16000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    #[ignore = "requires model"]
+    fn test_transcribe_samples_below_chunk_threshold_single_pass() {
+        // Just under the long-form chunk threshold (30s) takes the single-pass
+        // path; pure silence still yields no words but must not error.
+        let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
+            .expect("engine should load");
+        let mut guard = engine.pool.checkout_blocking().expect("checkout");
+        let samples = vec![0.0f32; CHUNK_THRESHOLD_SAMPLES]; // exactly at threshold → single pass
+        let result = engine
+            .transcribe_samples(&samples, &mut guard)
+            .expect("at-threshold audio must not error");
+        assert!(result.words.is_empty(), "silence decodes to no words");
+    }
 }

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -1369,4 +1369,131 @@ mod tests {
             );
         }
     }
+
+    /// The legacy public `ensure_model(dir)` wrapper delegates to
+    /// `ensure_model_variant(None, dir)`: with a complete install already on
+    /// disk it must succeed without touching the network (no `.partial` files).
+    #[tokio::test]
+    async fn test_ensure_model_wrapper_uses_existing_install() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+
+        // Stage a complete default (Rnnt) download set.
+        for f in ModelVariant::Rnnt.download_files() {
+            std::fs::write(dir.join(f), b"stub").unwrap();
+        }
+
+        ensure_model(dir.to_str().unwrap())
+            .await
+            .expect("ensure_model must succeed against an existing install");
+
+        let partials: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".partial"))
+            .collect();
+        assert!(
+            partials.is_empty(),
+            "ensure_model must not download when the set is present: {partials:?}"
+        );
+    }
+
+    /// `ensure_model_variant(Some(Rnnt), dir)` against a matching install is the
+    /// `VariantAction::Use` branch: returns Rnnt with no download.
+    #[tokio::test]
+    async fn test_ensure_model_variant_explicit_match_uses_existing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+
+        for f in ModelVariant::Rnnt.download_files() {
+            std::fs::write(dir.join(f), b"stub").unwrap();
+        }
+
+        let variant = ensure_model_variant(Some(ModelVariant::Rnnt), dir.to_str().unwrap())
+            .await
+            .expect("explicit matching variant must short-circuit");
+        assert_eq!(variant, ModelVariant::Rnnt);
+
+        let has_partial = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".partial"));
+        assert!(!has_partial, "no download for an explicit matching variant");
+    }
+
+    /// `ensure_vad_model` short-circuits (no network, no `.partial`) when the
+    /// Silero ONNX file is already present in the VAD directory.
+    #[tokio::test]
+    async fn test_ensure_vad_model_present_no_download() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        std::fs::write(dir.join(crate::vad::VAD_MODEL_FILE), b"stub vad").unwrap();
+
+        ensure_vad_model(dir.to_str().unwrap())
+            .await
+            .expect("present VAD model must short-circuit");
+
+        let partials: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".partial"))
+            .collect();
+        assert!(partials.is_empty(), "no .partial files: {partials:?}");
+        assert_eq!(
+            std::fs::read(dir.join(crate::vad::VAD_MODEL_FILE)).unwrap(),
+            b"stub vad",
+            "existing VAD model must be left untouched"
+        );
+    }
+
+    /// `default_punct_model_dir` and `default_vad_model_dir` are siblings of the
+    /// main model dir under `.gigastt/models`, with the expected leaf names.
+    #[test]
+    fn test_default_punct_and_vad_dirs_are_model_siblings() {
+        let punct = default_punct_model_dir();
+        let vad = default_vad_model_dir();
+        assert!(
+            punct.contains(".gigastt") && punct.ends_with("punct"),
+            "punct dir should be under .gigastt and end with 'punct', got: {punct}"
+        );
+        assert!(
+            vad.contains(".gigastt") && vad.ends_with("vad"),
+            "vad dir should be under .gigastt and end with 'vad', got: {vad}"
+        );
+    }
+
+    /// `VAD_MODEL_SHA256` is a 64-char lowercase hex digest (no truncation or
+    /// placeholder slipping into a release).
+    #[test]
+    fn test_vad_model_sha256_shape() {
+        assert_eq!(
+            VAD_MODEL_SHA256.len(),
+            64,
+            "VAD_MODEL_SHA256 must be a 64-char hex digest"
+        );
+        assert!(
+            VAD_MODEL_SHA256
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "VAD_MODEL_SHA256 must be lowercase hex; got: {VAD_MODEL_SHA256}"
+        );
+    }
+
+    /// `ensure_model_variant` tolerates a deep, freshly-created model directory:
+    /// a complete Rnnt set pre-staged under a nested path is detected and used
+    /// as-is (early `Use(...)` return) without any network access.
+    #[tokio::test]
+    async fn test_ensure_model_variant_uses_complete_set_in_nested_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nested = tmp.path().join("a").join("b").join("models");
+        std::fs::create_dir_all(&nested).unwrap();
+        for f in ModelVariant::Rnnt.download_files() {
+            std::fs::write(nested.join(f), b"stub").unwrap();
+        }
+
+        let variant = ensure_model_variant(None, nested.to_str().unwrap())
+            .await
+            .expect("nested complete install must be used as-is");
+        assert_eq!(variant, ModelVariant::Rnnt);
+    }
 }

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -431,6 +431,76 @@ mod tests {
         assert_eq!(argmax(&[1.0, 1.0, 3.0]), 2);
     }
 
+    /// `ort_err` flattens any `Display` error into an `anyhow::Error` carrying
+    /// the same message (the Send/Sync workaround used at every `ort` boundary).
+    #[test]
+    fn test_ort_err_preserves_display_message() {
+        let err = ort_err("session build exploded");
+        assert_eq!(err.to_string(), "session build exploded");
+    }
+
+    /// A minimal but valid HuggingFace tokenizer.json (WordLevel model). Used to
+    /// drive `Punctuator::load` past the tokenizer step so the ONNX-session
+    /// failure branch is exercised without the real model.
+    const MINIMAL_TOKENIZER_JSON: &str = r#"{
+        "version": "1.0",
+        "truncation": null,
+        "padding": null,
+        "added_tokens": [],
+        "normalizer": null,
+        "pre_tokenizer": {"type": "Whitespace"},
+        "post_processor": null,
+        "decoder": null,
+        "model": {
+            "type": "WordLevel",
+            "vocab": {"[UNK]": 0, "a": 1, "b": 2},
+            "unk_token": "[UNK]"
+        }
+    }"#;
+
+    /// A valid config.json with an `id2label` map: lets `load` clear the
+    /// id2label step so later failures (tokenizer / model) are reached.
+    const MINIMAL_CONFIG_JSON: &str = r#"{"id2label": {"0": "LOWER_O"}}"#;
+
+    /// `load` must surface the id2label parse failure (missing object) before it
+    /// ever touches the tokenizer or ONNX session.
+    #[test]
+    fn test_load_missing_id2label_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join(PUNCT_CONFIG_FILE), r#"{"foo": 1}"#).unwrap();
+        assert!(Punctuator::load(tmp.path()).is_err());
+    }
+
+    /// config.json parses but tokenizer.json is malformed: `load` must fail at
+    /// the `Tokenizer::from_file` step (graceful "punct unavailable", no panic).
+    #[test]
+    fn test_load_valid_config_invalid_tokenizer_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join(PUNCT_CONFIG_FILE), MINIMAL_CONFIG_JSON).unwrap();
+        std::fs::write(tmp.path().join(PUNCT_TOKENIZER_FILE), "{ not valid json").unwrap();
+        // `Punctuator` is not `Debug`, so match instead of `expect_err`.
+        match Punctuator::load(tmp.path()) {
+            Ok(_) => panic!("malformed tokenizer must error"),
+            Err(e) => assert!(e.to_string().contains("tokenizer")),
+        }
+    }
+
+    /// config + tokenizer both load, but the ONNX model file is absent: `load`
+    /// must fail at `Session::commit_from_file` (the `ort_err` + context branch),
+    /// never panic. This is the last gate the caller turns into "punct disabled".
+    #[test]
+    fn test_load_valid_config_and_tokenizer_missing_model_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join(PUNCT_CONFIG_FILE), MINIMAL_CONFIG_JSON).unwrap();
+        std::fs::write(
+            tmp.path().join(PUNCT_TOKENIZER_FILE),
+            MINIMAL_TOKENIZER_JSON,
+        )
+        .unwrap();
+        // No rupunct_small_int8.onnx written → session build must fail.
+        assert!(Punctuator::load(tmp.path()).is_err());
+    }
+
     #[test]
     fn test_load_punctuator_missing_dir_errors() {
         // Graceful fallback contract: loading from an absent dir must error

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -609,4 +609,69 @@ mod tests {
                 .is_empty()
         );
     }
+
+    fn silero_model_path() -> std::path::PathBuf {
+        let home = std::env::var("HOME").expect("HOME");
+        std::path::PathBuf::from(home).join(".gigastt/models/vad/silero_vad.onnx")
+    }
+
+    /// Model-gated: drives [`VadEndpointer::push`] with sub-frame chunks to
+    /// exercise the leftover-buffer accumulation + drain across `push` calls
+    /// (the model is required because `push` runs every full frame through the
+    /// real Silero session). Verifies the chunk-accumulation mechanics, not
+    /// classification: chunks that individually fall short of one 512-sample
+    /// frame must not error and must not endpoint (no frame processed yet); once
+    /// a full frame's worth of samples accumulates, the frame is consumed and
+    /// the remainder retained for the next push.
+    #[test]
+    #[ignore = "requires the Silero VAD model at ~/.gigastt/models/vad/silero_vad.onnx"]
+    fn test_endpointer_buffers_subframe_chunks_across_pushes() {
+        let path = silero_model_path();
+        if !path.exists() {
+            eprintln!("skipping {}: Silero VAD model not present", path.display());
+            return;
+        }
+        let vad = SileroVad::load(&path).expect("load silero");
+        let c = VadConfig::default();
+        let mut ep = VadEndpointer::new(&c);
+
+        // Two sub-frame silence chunks that together fall short of one frame:
+        // no frame is processed, so no endpoint.
+        let part = vec![0.0f32; 200];
+        assert!(!ep.push(&vad, &part).expect("push part 1"));
+        assert!(!ep.push(&vad, &part).expect("push part 2")); // 400 < 512 buffered
+
+        // A third chunk crosses the frame boundary (600 buffered) → exactly one
+        // full frame is consumed and the remainder retained; still no endpoint
+        // on silence alone.
+        let rest = vec![0.0f32; 200];
+        assert!(!ep.push(&vad, &rest).expect("push part 3")); // 600 buffered, 1 frame
+    }
+
+    /// Model-gated: a single large silence chunk processes many frames in one
+    /// `push` (the inner accumulation loop) and must never endpoint before any
+    /// speech is seen; a following empty push processes no frames and stays
+    /// non-endpointing.
+    #[test]
+    #[ignore = "requires the Silero VAD model at ~/.gigastt/models/vad/silero_vad.onnx"]
+    fn test_endpointer_no_endpoint_on_leading_silence() {
+        let path = silero_model_path();
+        if !path.exists() {
+            eprintln!("skipping {}: Silero VAD model not present", path.display());
+            return;
+        }
+        let vad = SileroVad::load(&path).expect("load silero");
+        let c = VadConfig::default();
+        let mut ep = VadEndpointer::new(&c);
+
+        // 1 s of silence = ~31 frames in a single push; leading silence (no
+        // speech yet) must never report an endpoint.
+        let silence = vec![0.0f32; 16000];
+        assert!(
+            !ep.push(&vad, &silence).expect("push silence"),
+            "leading silence must not endpoint"
+        );
+        // A follow-up empty push processes no frames and stays non-endpointing.
+        assert!(!ep.push(&vad, &[]).expect("push empty"));
+    }
 }

--- a/crates/gigastt-ffi/include/gigastt.h
+++ b/crates/gigastt-ffi/include/gigastt.h
@@ -91,9 +91,10 @@ gigastt_ void gigastt_engine_free(struct GigasttGigasttEngine *engine);
 /**
  * Quantize the FP32 encoder model to INT8 in-place.
  *
- * Looks for `v3_e2e_rnnt_encoder.onnx` inside `model_dir` and produces
- * `v3_e2e_rnnt_encoder_int8.onnx` in the same directory.
- * If the INT8 file already exists and `force` is `false`, returns immediately.
+ * Auto-detects the recognition head present in `model_dir` (the `rnnt` default
+ * since v2.3, or `e2e_rnnt`) and quantizes that variant's FP32 encoder, writing
+ * the matching `*_int8.onnx` beside it. If the INT8 file already exists and
+ * `force` is `false`, returns immediately.
  *
  * # Safety
  * `model_dir` must be a valid, null-terminated UTF-8 string.

--- a/crates/gigastt-ffi/src/lib.rs
+++ b/crates/gigastt-ffi/src/lib.rs
@@ -787,4 +787,138 @@ mod tests {
     fn test_string_free_null() {
         unsafe { gigastt_string_free(ptr::null_mut()) };
     }
+
+    /// An empty directory holds no encoder, so `Engine::load_*` returns Err and
+    /// the FFI wrapper must surface that as a NULL handle (engine-load error
+    /// branch), without needing the real model on disk.
+    #[test]
+    fn test_engine_new_with_pool_size_missing_model_returns_null() {
+        let tmp = std::env::temp_dir().join(format!("gigastt_ffi_empty_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let dir = CString::new(tmp.to_str().unwrap()).unwrap();
+        let engine = unsafe { gigastt_engine_new_with_pool_size(dir.as_ptr(), 1) };
+        assert!(engine.is_null());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The default-pool wrapper funnels through the same load path, so a
+    /// model-less directory must likewise yield a NULL handle.
+    #[test]
+    fn test_engine_new_missing_model_returns_null() {
+        let tmp =
+            std::env::temp_dir().join(format!("gigastt_ffi_empty_default_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let dir = CString::new(tmp.to_str().unwrap()).unwrap();
+        let engine = unsafe { gigastt_engine_new(dir.as_ptr()) };
+        assert!(engine.is_null());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A directory with no recognition-head encoder makes `detect_in_dir`
+    /// return `None`; quantize must report that as an error string (not "ok"),
+    /// exercising the no-encoder-found branch.
+    #[test]
+    fn test_quantize_model_no_encoder_found() {
+        let tmp =
+            std::env::temp_dir().join(format!("gigastt_ffi_quant_empty_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let dir = CString::new(tmp.to_str().unwrap()).unwrap();
+        let r = unsafe { gigastt_quantize_model(dir.as_ptr(), false) };
+        assert!(!r.is_null());
+        let s = unsafe { CStr::from_ptr(r) }.to_str().unwrap();
+        assert!(
+            s.contains("no recognition-head encoder"),
+            "unexpected message: {s}"
+        );
+        unsafe { gigastt_string_free(r) };
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// `force = true` on a model-less directory still has nothing to quantize,
+    /// so the no-encoder-found branch fires regardless of the force flag.
+    #[test]
+    fn test_quantize_model_no_encoder_found_forced() {
+        let tmp = std::env::temp_dir().join(format!(
+            "gigastt_ffi_quant_empty_force_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let dir = CString::new(tmp.to_str().unwrap()).unwrap();
+        let r = unsafe { gigastt_quantize_model(dir.as_ptr(), true) };
+        assert!(!r.is_null());
+        let s = unsafe { CStr::from_ptr(r) }.to_str().unwrap();
+        assert!(
+            s.contains("no recognition-head encoder"),
+            "unexpected message: {s}"
+        );
+        unsafe { gigastt_string_free(r) };
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Invalid UTF-8 in `model_dir` must yield a NULL engine handle via the
+    /// pool-size wrapper's UTF-8 guard.
+    #[test]
+    fn test_engine_new_with_pool_size_invalid_utf8() {
+        let bad = [0x80u8, 0x81, 0x82, 0];
+        let engine = unsafe { gigastt_engine_new_with_pool_size(bad.as_ptr() as *const c_char, 1) };
+        assert!(engine.is_null());
+    }
+
+    /// Transcribing with a freed engine must be rejected by the early
+    /// `disposed` check, returning NULL. Loading a real engine is required to
+    /// build a disposable handle, so this is model-gated.
+    #[test]
+    #[ignore = "requires model"]
+    fn test_transcribe_file_disposed_engine_returns_null() {
+        let dir = CString::new(gigastt_core::model::default_model_dir()).unwrap();
+        let engine = unsafe { gigastt_engine_new_with_pool_size(dir.as_ptr(), 1) };
+        assert!(!engine.is_null());
+        unsafe { gigastt_engine_free(engine) };
+        let file = CString::new("audio.wav").unwrap();
+        let r = unsafe { gigastt_transcribe_file(engine, file.as_ptr()) };
+        assert!(r.is_null());
+    }
+
+    /// With a live engine, a NULL stream pointer must be rejected by the
+    /// stream-null branch of `process_chunk`. Reaching that branch requires a
+    /// non-null engine, so the test is model-gated.
+    #[test]
+    #[ignore = "requires model"]
+    fn test_stream_process_chunk_null_stream_with_engine() {
+        let engine = shared_test_engine();
+        let pcm16: Vec<u8> = vec![0u8; 16];
+        let r = unsafe {
+            gigastt_stream_process_chunk(
+                engine,
+                ptr::null_mut(),
+                pcm16.as_ptr(),
+                pcm16.len(),
+                16000,
+            )
+        };
+        assert!(r.is_null());
+    }
+
+    /// With a live engine and stream, a NULL PCM buffer must be rejected by the
+    /// pcm16-null branch of `process_chunk`.
+    #[test]
+    #[ignore = "requires model"]
+    fn test_stream_process_chunk_null_pcm_with_engine() {
+        let engine = shared_test_engine();
+        let stream = unsafe { gigastt_stream_new(engine) };
+        assert!(!stream.is_null());
+        let r = unsafe { gigastt_stream_process_chunk(engine, stream, ptr::null(), 0, 16000) };
+        assert!(r.is_null());
+        unsafe { gigastt_stream_free(stream) };
+    }
+
+    /// A flush against a NULL stream (with a live engine) hits the stream-null
+    /// branch and returns NULL.
+    #[test]
+    #[ignore = "requires model"]
+    fn test_stream_flush_null_stream_with_engine() {
+        let engine = shared_test_engine();
+        let r = unsafe { gigastt_stream_flush(engine, ptr::null_mut()) };
+        assert!(r.is_null());
+    }
 }

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -1865,4 +1865,426 @@ mod tests {
         );
         assert_eq!(cfg.limits.idle_timeout_secs, limits.idle_timeout_secs);
     }
+
+    #[test]
+    fn test_parse_model_variant_valid_and_invalid() {
+        assert_eq!(parse_model_variant("rnnt").unwrap(), ModelVariant::Rnnt);
+        assert_eq!(
+            parse_model_variant("e2e_rnnt").unwrap(),
+            ModelVariant::E2eRnnt
+        );
+        assert!(parse_model_variant("whisper").is_err());
+    }
+
+    #[test]
+    fn test_parse_punctuation_mode_value_parser() {
+        assert_eq!(parse_punctuation_mode("on").unwrap(), PunctuationMode::On);
+        assert_eq!(
+            parse_punctuation_mode("auto").unwrap(),
+            PunctuationMode::Auto
+        );
+        assert!(parse_punctuation_mode("garbage").is_err());
+    }
+
+    #[test]
+    fn test_parse_itn_mode_value_parser() {
+        assert_eq!(parse_itn_mode("off").unwrap(), ItnMode::Off);
+        assert_eq!(parse_itn_mode("auto").unwrap(), ItnMode::Auto);
+        assert!(parse_itn_mode("garbage").is_err());
+    }
+
+    #[test]
+    fn test_resolve_punctuation_per_variant() {
+        // auto → on for bare rnnt, off for the already-punctuated e2e head.
+        assert!(resolve_punctuation(
+            PunctuationMode::Auto,
+            ModelVariant::Rnnt
+        ));
+        assert!(!resolve_punctuation(
+            PunctuationMode::Auto,
+            ModelVariant::E2eRnnt
+        ));
+        // on/off override the variant.
+        assert!(resolve_punctuation(
+            PunctuationMode::On,
+            ModelVariant::E2eRnnt
+        ));
+        assert!(!resolve_punctuation(
+            PunctuationMode::Off,
+            ModelVariant::Rnnt
+        ));
+    }
+
+    #[test]
+    fn test_build_vad_config_defaults_when_unset() {
+        // Both overrides None → library defaults pass through untouched.
+        let cfg = build_vad_config(None, None);
+        let default = gigastt_core::vad::VadConfig::default();
+        assert_eq!(cfg.threshold, default.threshold);
+        assert_eq!(cfg.min_silence_ms, default.min_silence_ms);
+        assert_eq!(cfg.min_speech_ms, default.min_speech_ms);
+        assert_eq!(cfg.speech_pad_ms, default.speech_pad_ms);
+    }
+
+    #[test]
+    fn test_build_vad_config_applies_overrides() {
+        let cfg = build_vad_config(Some(0.75), Some(1200));
+        assert_eq!(cfg.threshold, 0.75);
+        assert_eq!(cfg.min_silence_ms, 1200);
+    }
+
+    #[test]
+    fn test_build_vad_config_clamps_threshold() {
+        // Out-of-range thresholds clamp into [0, 1].
+        assert_eq!(build_vad_config(Some(5.0), None).threshold, 1.0);
+        assert_eq!(build_vad_config(Some(-3.0), None).threshold, 0.0);
+    }
+
+    #[test]
+    fn test_maybe_load_vad_disabled_skips_load() {
+        // Disabled → never touches the filesystem, returns None.
+        assert!(maybe_load_vad(false, "/nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_maybe_load_vad_missing_model_falls_back_to_none() {
+        // Enabled but model absent → graceful warn + None (no panic).
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("absent");
+        assert!(maybe_load_vad(true, dir.to_str().unwrap()).is_none());
+    }
+
+    #[test]
+    fn test_cli_serve_vad_flags() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore_vad = EnvRestore("GIGASTT_VAD", std::env::var("GIGASTT_VAD").ok());
+        let _restore_threshold = EnvRestore(
+            "GIGASTT_VAD_THRESHOLD",
+            std::env::var("GIGASTT_VAD_THRESHOLD").ok(),
+        );
+        let _restore_sil = EnvRestore(
+            "GIGASTT_VAD_MIN_SILENCE_MS",
+            std::env::var("GIGASTT_VAD_MIN_SILENCE_MS").ok(),
+        );
+        let _restore_dir = EnvRestore(
+            "GIGASTT_VAD_MODEL_DIR",
+            std::env::var("GIGASTT_VAD_MODEL_DIR").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_VAD");
+            std::env::remove_var("GIGASTT_VAD_THRESHOLD");
+            std::env::remove_var("GIGASTT_VAD_MIN_SILENCE_MS");
+            std::env::remove_var("GIGASTT_VAD_MODEL_DIR");
+        }
+        let cli = Cli::parse_from([
+            "gigastt",
+            "serve",
+            "--vad",
+            "--vad-threshold",
+            "0.8",
+            "--vad-min-silence-ms",
+            "700",
+            "--vad-model-dir",
+            "/tmp/vad",
+        ]);
+        match cli.command {
+            Commands::Serve {
+                vad,
+                vad_threshold,
+                vad_min_silence_ms,
+                vad_model_dir,
+                ..
+            } => {
+                assert!(vad);
+                assert_eq!(vad_threshold, Some(0.8));
+                assert_eq!(vad_min_silence_ms, Some(700));
+                assert_eq!(vad_model_dir, "/tmp/vad");
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_vad_defaults_off() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore_vad = EnvRestore("GIGASTT_VAD", std::env::var("GIGASTT_VAD").ok());
+        let _restore_threshold = EnvRestore(
+            "GIGASTT_VAD_THRESHOLD",
+            std::env::var("GIGASTT_VAD_THRESHOLD").ok(),
+        );
+        let _restore_sil = EnvRestore(
+            "GIGASTT_VAD_MIN_SILENCE_MS",
+            std::env::var("GIGASTT_VAD_MIN_SILENCE_MS").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_VAD");
+            std::env::remove_var("GIGASTT_VAD_THRESHOLD");
+            std::env::remove_var("GIGASTT_VAD_MIN_SILENCE_MS");
+        }
+        let cli = Cli::parse_from(["gigastt", "serve"]);
+        match cli.command {
+            Commands::Serve {
+                vad,
+                vad_threshold,
+                vad_min_silence_ms,
+                ..
+            } => {
+                assert!(!vad);
+                assert_eq!(vad_threshold, None);
+                assert_eq!(vad_min_silence_ms, None);
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_pool_and_thread_flags() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore_min = EnvRestore(
+            "GIGASTT_POOL_MIN_SIZE",
+            std::env::var("GIGASTT_POOL_MIN_SIZE").ok(),
+        );
+        let _restore_batch = EnvRestore(
+            "GIGASTT_BATCH_POOL_SIZE",
+            std::env::var("GIGASTT_BATCH_POOL_SIZE").ok(),
+        );
+        let _restore_threads = EnvRestore(
+            "GIGASTT_ENCODER_INTRA_THREADS",
+            std::env::var("GIGASTT_ENCODER_INTRA_THREADS").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_POOL_MIN_SIZE");
+            std::env::remove_var("GIGASTT_BATCH_POOL_SIZE");
+            std::env::remove_var("GIGASTT_ENCODER_INTRA_THREADS");
+        }
+        let cli = Cli::parse_from([
+            "gigastt",
+            "serve",
+            "--pool-size",
+            "8",
+            "--pool-min-size",
+            "3",
+            "--batch-pool-size",
+            "2",
+        ]);
+        match cli.command {
+            Commands::Serve {
+                pool_size,
+                pool_min_size,
+                batch_pool_size,
+                ..
+            } => {
+                assert_eq!(pool_size, 8);
+                assert_eq!(pool_min_size, 3);
+                assert_eq!(batch_pool_size, 2);
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_runtime_limit_flags() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // These flags read env vars; clear them so the explicit args win.
+        let restores: Vec<EnvRestore> = [
+            "GIGASTT_IDLE_TIMEOUT_SECS",
+            "GIGASTT_WS_FRAME_MAX_BYTES",
+            "GIGASTT_BODY_LIMIT_BYTES",
+            "GIGASTT_RATE_LIMIT_PER_MINUTE",
+            "GIGASTT_RATE_LIMIT_BURST",
+            "GIGASTT_MAX_SESSION_SECS",
+            "GIGASTT_SHUTDOWN_DRAIN_SECS",
+            "GIGASTT_POOL_CHECKOUT_TIMEOUT_SECS",
+            "GIGASTT_INFERENCE_TIMEOUT_SECS",
+        ]
+        .iter()
+        .map(|k| {
+            let r = EnvRestore(k, std::env::var(k).ok());
+            unsafe {
+                std::env::remove_var(k);
+            }
+            r
+        })
+        .collect();
+        let cli = Cli::parse_from([
+            "gigastt",
+            "serve",
+            "--idle-timeout-secs",
+            "120",
+            "--ws-frame-max-bytes",
+            "4096",
+            "--body-limit-bytes",
+            "8192",
+            "--rate-limit-per-minute",
+            "90",
+            "--rate-limit-burst",
+            "15",
+            "--max-session-secs",
+            "777",
+            "--shutdown-drain-secs",
+            "7",
+            "--pool-checkout-timeout-secs",
+            "11",
+            "--inference-timeout-secs",
+            "300",
+            "--trust-proxy",
+        ]);
+        match cli.command {
+            Commands::Serve {
+                idle_timeout_secs,
+                ws_frame_max_bytes,
+                body_limit_bytes,
+                rate_limit_per_minute,
+                rate_limit_burst,
+                max_session_secs,
+                shutdown_drain_secs,
+                pool_checkout_timeout_secs,
+                inference_timeout_secs,
+                trust_proxy,
+                ..
+            } => {
+                assert_eq!(idle_timeout_secs, Some(120));
+                assert_eq!(ws_frame_max_bytes, Some(4096));
+                assert_eq!(body_limit_bytes, Some(8192));
+                assert_eq!(rate_limit_per_minute, Some(90));
+                assert_eq!(rate_limit_burst, Some(15));
+                assert_eq!(max_session_secs, Some(777));
+                assert_eq!(shutdown_drain_secs, Some(7));
+                assert_eq!(pool_checkout_timeout_secs, Some(11));
+                assert_eq!(inference_timeout_secs, Some(300));
+                assert!(trust_proxy);
+            }
+            _ => panic!("expected Serve"),
+        }
+        drop(restores);
+    }
+
+    #[test]
+    fn test_cli_serve_config_and_skip_quantize_flags() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(
+            "GIGASTT_SKIP_QUANTIZE",
+            std::env::var("GIGASTT_SKIP_QUANTIZE").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_SKIP_QUANTIZE");
+        }
+        let cli = Cli::parse_from([
+            "gigastt",
+            "serve",
+            "--config",
+            "/tmp/limits.toml",
+            "--skip-quantize",
+        ]);
+        match cli.command {
+            Commands::Serve {
+                config,
+                skip_quantize,
+                ..
+            } => {
+                assert_eq!(config, Some("/tmp/limits.toml".to_string()));
+                assert!(skip_quantize);
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_cors_and_origin_flags() {
+        let cli = Cli::parse_from([
+            "gigastt",
+            "serve",
+            "--allow-origin",
+            "https://a.example.com",
+            "--allow-origin",
+            "https://b.example.com",
+            "--cors-allow-any",
+        ]);
+        match cli.command {
+            Commands::Serve {
+                allow_origin,
+                cors_allow_any,
+                ..
+            } => {
+                assert_eq!(allow_origin.len(), 2);
+                assert_eq!(allow_origin[0], "https://a.example.com");
+                assert!(cors_allow_any);
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_download_skip_quantize_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(
+            "GIGASTT_SKIP_QUANTIZE",
+            std::env::var("GIGASTT_SKIP_QUANTIZE").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_SKIP_QUANTIZE");
+        }
+        let cli = Cli::parse_from(["gigastt", "download", "--skip-quantize"]);
+        match cli.command {
+            Commands::Download { skip_quantize, .. } => assert!(skip_quantize),
+            _ => panic!("expected Download"),
+        }
+    }
+
+    #[test]
+    fn test_cli_transcribe_vad_and_itn_flags() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let restores: Vec<EnvRestore> = ["GIGASTT_VAD", "GIGASTT_ITN", "GIGASTT_VAD_THRESHOLD"]
+            .iter()
+            .map(|k| {
+                let r = EnvRestore(k, std::env::var(k).ok());
+                unsafe {
+                    std::env::remove_var(k);
+                }
+                r
+            })
+            .collect();
+        let cli = Cli::parse_from([
+            "gigastt",
+            "transcribe",
+            "a.wav",
+            "--vad",
+            "--vad-threshold",
+            "0.6",
+            "--itn",
+            "off",
+        ]);
+        match cli.command {
+            Commands::Transcribe {
+                vad,
+                vad_threshold,
+                itn,
+                ..
+            } => {
+                assert!(vad);
+                assert_eq!(vad_threshold, Some(0.6));
+                assert_eq!(itn, ItnMode::Off);
+            }
+            _ => panic!("expected Transcribe"),
+        }
+        drop(restores);
+    }
+
+    #[test]
+    fn test_cli_rejects_unknown_subcommand() {
+        let res = Cli::try_parse_from(["gigastt", "bogus"]);
+        assert!(res.is_err(), "unknown subcommand must be rejected");
+    }
+
+    #[test]
+    fn test_cli_serve_rejects_bad_punctuation_value() {
+        let res = Cli::try_parse_from(["gigastt", "serve", "--punctuation", "sometimes"]);
+        assert!(res.is_err(), "invalid punctuation mode must be rejected");
+    }
+
+    #[test]
+    fn test_cli_serve_rejects_bad_itn_value() {
+        let res = Cli::try_parse_from(["gigastt", "serve", "--itn", "sometimes"]);
+        assert!(res.is_err(), "invalid itn mode must be rejected");
+    }
 }

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -1199,6 +1199,217 @@ mod tests {
         assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 
+    #[tokio::test]
+    async fn test_render_export_invalid_format_body_code() {
+        // The invalid-format error carries the machine-readable `invalid_format`
+        // code so clients can distinguish it from other 400s.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("xml".into()),
+            ..ExportParams::default()
+        };
+        let err = render_export_response(&result, &params).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(err.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["code"], "invalid_format");
+    }
+
+    #[tokio::test]
+    async fn test_render_export_uppercase_json_returns_none() {
+        // Format negotiation is case-insensitive: an explicit (any-case) "json"
+        // means "keep the default TranscribeResponse contract", so the helper
+        // returns None instead of building a Response.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("JSON".into()),
+            ..ExportParams::default()
+        };
+        assert!(render_export_response(&result, &params).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_render_export_uppercase_format_renders() {
+        // Non-JSON format strings are also case-insensitive (parsed via
+        // ExportFormat::from_str), so "SRT" still renders subtitles.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("SRT".into()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/x-subrip; charset=utf-8"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_render_export_empty_download_uses_default_name() {
+        // An empty `download` value still requests an attachment; the helper
+        // synthesizes the default `transcript.<ext>` filename.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("vtt".into()),
+            download: Some(String::new()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(
+            resp.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            "attachment; filename=\"transcript.vtt\""
+        );
+    }
+
+    #[tokio::test]
+    async fn test_render_export_md_includes_word_timestamps() {
+        // The Markdown path honours `word_timestamps` and renders the per-word
+        // table; the content type is text/markdown.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("md".into()),
+            word_timestamps: Some(true),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/markdown; charset=utf-8"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("# Transcript"));
+        assert!(text.contains("| Word | Start | End |"));
+    }
+
+    #[tokio::test]
+    async fn test_render_export_line_break_opts_passed_through() {
+        // Tight per-line caps must be threaded into RenderOpts so the rendered
+        // subtitles actually break — proving the params override the defaults.
+        let result = sample_export_result();
+        let loose = ExportParams {
+            format: Some("srt".into()),
+            ..ExportParams::default()
+        };
+        let tight = ExportParams {
+            format: Some("srt".into()),
+            max_words_per_line: Some(1),
+            ..ExportParams::default()
+        };
+        let loose_resp = render_export_response(&result, &loose).unwrap().unwrap();
+        let tight_resp = render_export_response(&result, &tight).unwrap().unwrap();
+        let loose_body = axum::body::to_bytes(loose_resp.into_body(), 4096)
+            .await
+            .unwrap();
+        let tight_body = axum::body::to_bytes(tight_resp.into_body(), 4096)
+            .await
+            .unwrap();
+        let loose_text = String::from_utf8(loose_body.to_vec()).unwrap();
+        let tight_text = String::from_utf8(tight_body.to_vec()).unwrap();
+        // One word per line yields one cue per word (more "-->" arrows) than the
+        // default 14-words-per-line grouping.
+        let loose_cues = loose_text.matches("-->").count();
+        let tight_cues = tight_text.matches("-->").count();
+        assert!(
+            tight_cues > loose_cues,
+            "tight={tight_cues} should exceed loose={loose_cues}"
+        );
+    }
+
+    #[test]
+    fn test_export_params_deserialize_from_query() {
+        // The query-param shape drives format negotiation; confirm axum's Query
+        // extractor maps every field so the handler sees the caller's choices.
+        let uri: axum::http::Uri = "http://x/?format=srt&download=out.srt&max_chars_per_line=20&max_words_per_line=3&word_timestamps=true"
+            .parse()
+            .unwrap();
+        let Query(params): Query<ExportParams> = Query::try_from_uri(&uri).unwrap();
+        assert_eq!(params.format.as_deref(), Some("srt"));
+        assert_eq!(params.download.as_deref(), Some("out.srt"));
+        assert_eq!(params.max_chars_per_line, Some(20));
+        assert_eq!(params.max_words_per_line, Some(3));
+        assert_eq!(params.word_timestamps, Some(true));
+    }
+
+    #[test]
+    fn test_export_params_default_empty_query() {
+        // No query params -> all None, which the handler maps to JSON defaults.
+        let uri: axum::http::Uri = "http://x/".parse().unwrap();
+        let Query(params): Query<ExportParams> = Query::try_from_uri(&uri).unwrap();
+        assert!(params.format.is_none());
+        assert!(params.download.is_none());
+        assert!(params.max_chars_per_line.is_none());
+    }
+
+    #[test]
+    fn test_model_info_serialization_shape() {
+        // ModelInfo is the /v1/models contract; assert the field names/values
+        // clients depend on are present and correctly typed.
+        let info = ModelInfo {
+            id: "gigaam-v3-e2e-rnnt".into(),
+            name: "GigaAM v3 RNN-T".into(),
+            version: "0.9.0".into(),
+            encoder: "int8".into(),
+            vocab_size: 1025,
+            sample_rate: 16000,
+            pool_size: 4,
+            pool_available: 3,
+            supported_formats: vec!["wav".into(), "mp3".into()],
+            supported_rates: vec![16000, 48000],
+            diarization: false,
+        };
+        let v = serde_json::to_value(&info).unwrap();
+        assert_eq!(v["id"], "gigaam-v3-e2e-rnnt");
+        assert_eq!(v["encoder"], "int8");
+        assert_eq!(v["vocab_size"], 1025);
+        assert_eq!(v["sample_rate"], 16000);
+        assert_eq!(v["diarization"], false);
+        assert_eq!(v["supported_rates"][1], 48000);
+    }
+
+    #[tokio::test]
+    async fn test_api_inference_timeout_error_body_message() {
+        // The 504 inference-timeout body should not leak internals, just the
+        // stable code + a sanitized message.
+        let resp = api_inference_timeout_error();
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["code"], "inference_timeout");
+        assert_eq!(v["error"], "Inference timed out.");
+    }
+
+    #[tokio::test]
+    async fn test_api_pool_closed_error_status_and_message() {
+        // pool_closed is a 503 with a sanitized "shutting down" message and no
+        // retry hint (the pool is not coming back).
+        let resp = api_pool_closed_error();
+        let (parts, body) = resp.into_parts();
+        assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE);
+        let bytes = axum::body::to_bytes(body, 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["error"], "Server is shutting down");
+        assert_eq!(v["code"], "pool_closed");
+    }
+
+    #[test]
+    fn test_sse_data_payload_includes_words_and_timestamp() {
+        // A successful segment carries text, timestamp and words through
+        // unchanged so SSE clients can render word-level UI.
+        use gigastt_core::inference::WordInfo;
+        let mut seg = gigastt_core::inference::TranscriptSegment::empty_final();
+        seg.text = "привет".into();
+        seg.timestamp = 1.25;
+        seg.words = vec![WordInfo::new("привет", 0.0, 0.5, 0.99, Some(0))];
+        let payload = sse_data_payload(&Ok(seg));
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(v["type"], "final");
+        assert_eq!(v["text"], "привет");
+        assert_eq!(v["timestamp"], 1.25);
+        assert_eq!(v["words"][0]["word"], "привет");
+    }
+
     fn test_engine() -> Arc<Engine> {
         use std::sync::OnceLock;
         static ENGINE: OnceLock<Arc<Engine>> = OnceLock::new();

--- a/crates/gigastt/tests/e2e_cli.rs
+++ b/crates/gigastt/tests/e2e_cli.rs
@@ -1,0 +1,387 @@
+//! End-to-end CLI tests: drive the actual `gigastt` binary as a subprocess.
+//!
+//! The e2e_rest / e2e_ws suites exercise the server through the *library*
+//! (`run_with_config_listener`), which bypasses `main()` and the CLI command
+//! dispatch entirely. These tests close that gap by spawning the built binary
+//! via `CARGO_BIN_EXE_gigastt` and asserting on exit status / output, so the
+//! `Serve` / `Transcribe` / `Quantize` match arms and their helper wiring are
+//! actually executed.
+//!
+//! Help / version / arg-validation tests need no model and run anywhere. The
+//! transcribe / serve / quantize tests are `#[ignore]` (require the GigaAM
+//! model ~850 MB at `~/.gigastt/models`). Run all with:
+//! `cargo test --test e2e_cli -- --include-ignored --test-threads=1`.
+
+mod common;
+
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Path to the binary cargo built for this test run (instrumented under
+/// `cargo llvm-cov`, so subprocess execution is captured in coverage).
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_gigastt")
+}
+
+/// Real speech fixture shipped with the gigastt crate.
+const FIXTURE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/golos_00.wav");
+
+/// Grab a free TCP port by binding to :0 and immediately releasing it.
+/// A small TOCTOU window, acceptable for a test that hands the port to a
+/// freshly-spawned child.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// Minimal blocking HTTP GET that returns just the status code. Avoids pulling
+/// an async runtime into these otherwise-synchronous subprocess tests.
+fn http_status(port: u16, path: &str) -> Option<u16> {
+    let mut s = std::net::TcpStream::connect(("127.0.0.1", port)).ok()?;
+    s.set_read_timeout(Some(Duration::from_millis(1500))).ok()?;
+    s.set_write_timeout(Some(Duration::from_millis(1500)))
+        .ok()?;
+    write!(
+        s,
+        "GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+    )
+    .ok()?;
+    let mut buf = Vec::new();
+    let _ = s.read_to_end(&mut buf);
+    let head = String::from_utf8_lossy(&buf);
+    head.lines().next()?.split_whitespace().nth(1)?.parse().ok()
+}
+
+// ─── no-model: help / version / argument validation ─────────────────────────
+
+#[test]
+fn cli_help_exits_zero() {
+    let out = Command::new(bin()).arg("--help").output().expect("run");
+    assert!(out.status.success(), "--help should exit 0");
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("Local STT"),
+        "--help should print the about text"
+    );
+}
+
+#[test]
+fn cli_version_exits_zero() {
+    let out = Command::new(bin()).arg("--version").output().expect("run");
+    assert!(out.status.success(), "--version should exit 0");
+}
+
+#[test]
+fn cli_no_subcommand_fails() {
+    // clap requires a subcommand; a bare invocation must error with usage.
+    let out = Command::new(bin()).output().expect("run");
+    assert!(!out.status.success(), "bare invocation must fail");
+}
+
+#[test]
+fn cli_unknown_subcommand_fails() {
+    let out = Command::new(bin()).arg("frobnicate").output().expect("run");
+    assert!(!out.status.success(), "unknown subcommand must fail");
+}
+
+#[test]
+fn cli_subcommand_help_exits_zero() {
+    for sub in ["serve", "download", "quantize", "transcribe"] {
+        let out = Command::new(bin())
+            .args([sub, "--help"])
+            .output()
+            .expect("run");
+        assert!(out.status.success(), "`{sub} --help` should exit 0");
+    }
+}
+
+#[test]
+fn cli_serve_non_loopback_without_bind_all_fails() {
+    // Enters the `Serve` arm and hits `ensure_bind_allowed` *before* any model
+    // load, so this is fast and needs no model. Without `--bind-all` (and with
+    // the env opt-out cleared) a non-loopback host must be rejected.
+    let port = free_port();
+    let out = Command::new(bin())
+        .args(["serve", "--host", "0.0.0.0", "--port", &port.to_string()])
+        .env_remove("GIGASTT_ALLOW_BIND_ANY")
+        .output()
+        .expect("run");
+    assert!(
+        !out.status.success(),
+        "0.0.0.0 without --bind-all must be refused"
+    );
+}
+
+// ─── model-gated: transcribe ────────────────────────────────────────────────
+
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[test]
+fn cli_transcribe_to_stdout_txt() {
+    let md = common::model_dir();
+    let out = Command::new(bin())
+        .args([
+            "transcribe",
+            FIXTURE,
+            "--model-dir",
+            &md,
+            "--punctuation",
+            "off",
+            "--itn",
+            "off",
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "transcribe failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.stdout.is_empty(),
+        "transcribe should print text to stdout"
+    );
+}
+
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[test]
+fn cli_transcribe_json_stdout() {
+    let md = common::model_dir();
+    let out = Command::new(bin())
+        .args([
+            "transcribe",
+            FIXTURE,
+            "--model-dir",
+            &md,
+            "--log-level",
+            "error",
+            "--punctuation",
+            "off",
+            "--itn",
+            "off",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "transcribe json failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // `--log-level error` keeps stdout clean; slice from the first `{` so any
+    // stray line can't break the parse.
+    let body = String::from_utf8_lossy(&out.stdout);
+    let json = &body[body.find('{').expect("json object on stdout")..];
+    let parsed: serde_json::Value =
+        serde_json::from_str(json.trim()).expect("json output should be valid JSON");
+    assert!(
+        parsed.get("text").is_some(),
+        "json should carry a text field"
+    );
+}
+
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[test]
+fn cli_transcribe_to_file_srt_with_hotwords() {
+    let md = common::model_dir();
+    let tmp = tempfile::tempdir().unwrap();
+    // Exercise parse_hotwords_file: a plain phrase, a weighted phrase, a comment
+    // and a blank line (the latter two must be ignored).
+    let hw = tmp.path().join("hotwords.txt");
+    std::fs::write(&hw, "гигачат\nсбербанк\t8.0\n# comment\n\n").unwrap();
+    let outp = tmp.path().join("out.srt");
+    let out = Command::new(bin())
+        .args([
+            "transcribe",
+            FIXTURE,
+            "--model-dir",
+            &md,
+            "--punctuation",
+            "off",
+            "--itn",
+            "off",
+            "--format",
+            "srt",
+            "-o",
+            outp.to_str().unwrap(),
+            "--hotwords-file",
+            hw.to_str().unwrap(),
+            "--hotwords-default",
+            "--hotwords-boost",
+            "6.0",
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "transcribe srt failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let body = std::fs::read_to_string(&outp).expect("srt output file");
+    assert!(!body.trim().is_empty(), "srt file should not be empty");
+}
+
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[test]
+fn cli_transcribe_missing_file_fails() {
+    let md = common::model_dir();
+    let out = Command::new(bin())
+        .args([
+            "transcribe",
+            "/no/such/file.wav",
+            "--model-dir",
+            &md,
+            "--punctuation",
+            "off",
+            "--itn",
+            "off",
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        !out.status.success(),
+        "transcribing a missing file must fail"
+    );
+}
+
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[test]
+fn cli_transcribe_bad_format_fails() {
+    // The format string is validated after a successful decode, so the model
+    // must load first — hence model-gated.
+    let md = common::model_dir();
+    let out = Command::new(bin())
+        .args([
+            "transcribe",
+            FIXTURE,
+            "--model-dir",
+            &md,
+            "--punctuation",
+            "off",
+            "--itn",
+            "off",
+            "--format",
+            "bogus",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "an unknown export format must fail");
+}
+
+// ─── model-gated: quantize ──────────────────────────────────────────────────
+
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[test]
+fn cli_quantize_existing_is_noop() {
+    let md = common::model_dir();
+    // Only run the fast "already exists" path; if no INT8 encoder is present a
+    // real quantize would take ~2 min, so skip rather than block the suite.
+    let has_int8 = ["v3_rnnt_encoder_int8.onnx", "v3_e2e_rnnt_encoder_int8.onnx"]
+        .iter()
+        .any(|f| std::path::Path::new(&md).join(f).exists());
+    if !has_int8 {
+        eprintln!("skipping cli_quantize_existing_is_noop: no INT8 encoder present");
+        return;
+    }
+    let out = Command::new(bin())
+        .args(["quantize", "--model-dir", &md])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "quantize (noop) failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ─── model-gated: serve boot + graceful shutdown ────────────────────────────
+
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[test]
+fn cli_serve_boots_and_graceful_shutdown() {
+    let md = common::model_dir();
+    let port = free_port();
+    let metrics_port = free_port();
+
+    // Boot the server through the real CLI: covers the bulk of the `Serve` arm
+    // (bind check, model resolve, INT8 check, engine load, default-hotword
+    // biasing, limits build, metrics listener, server run) plus the graceful
+    // SIGTERM shutdown path. `--punctuation off --itn off` and no `--vad` keep
+    // it hermetic (no auxiliary model downloads).
+    let mut child = Command::new(bin())
+        .args([
+            "serve",
+            "--port",
+            &port.to_string(),
+            "--model-dir",
+            &md,
+            "--punctuation",
+            "off",
+            "--itn",
+            "off",
+            "--pool-size",
+            "1",
+            "--hotwords-default",
+            "--metrics",
+            "--metrics-listen",
+            &format!("127.0.0.1:{metrics_port}"),
+        ])
+        .env_remove("GIGASTT_VAD")
+        .env_remove("GIGASTT_ALLOW_BIND_ANY")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn serve");
+
+    // Wait for readiness (model load can take a while on a cold cache).
+    let start = Instant::now();
+    let mut ready = false;
+    while start.elapsed() < Duration::from_secs(120) {
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!("serve exited early with {status}");
+        }
+        if http_status(port, "/health") == Some(200) {
+            ready = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    assert!(ready, "server did not become healthy within 120s");
+
+    // Metrics live on their own loopback port.
+    assert_eq!(
+        http_status(metrics_port, "/metrics"),
+        Some(200),
+        "metrics endpoint should answer on its dedicated port"
+    );
+
+    // Graceful shutdown: SIGTERM should drain and return a clean exit, which is
+    // also what flushes the subprocess's coverage profile.
+    let _ = Command::new("kill")
+        .arg("-TERM")
+        .arg(child.id().to_string())
+        .status();
+
+    let exit_start = Instant::now();
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => {
+                assert!(
+                    status.success(),
+                    "serve should exit cleanly on SIGTERM, got {status}"
+                );
+                break;
+            }
+            None => {
+                if exit_start.elapsed() > Duration::from_secs(20) {
+                    let _ = child.kill();
+                    panic!("serve did not exit within 20s of SIGTERM");
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+}

--- a/crates/gigastt/tests/e2e_http_cov.rs
+++ b/crates/gigastt/tests/e2e_http_cov.rs
@@ -1,0 +1,170 @@
+//! End-to-end coverage tests for REST/SSE handler paths that the existing
+//! e2e_rest suite does not exercise: the SSE inference loop driven by real
+//! speech, the inference-timeout-disabled branch, and the pool-timeout metrics
+//! paths for both the batch transcribe and SSE handlers.
+//!
+//! All model-gated (`#[ignore]`); run with:
+//! `cargo test --test e2e_http_cov -- --ignored --test-threads=1`.
+
+mod common;
+
+use futures_util::SinkExt;
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+
+const FIXTURE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/golos_00.wav");
+
+/// SSE streaming of a real speech clip must drive the per-chunk inference loop
+/// and emit `data:` events (covers the chunk-iterate / process_chunk / send-seg
+/// / finish_stream path in `transcribe_stream`).
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[tokio::test]
+async fn test_sse_stream_real_speech_emits_segments() {
+    let md = common::model_dir();
+    let (port, shutdown) = common::start_server(&md).await;
+
+    let wav = std::fs::read(FIXTURE).expect("read fixture");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/transcribe/stream"))
+        .body(wav)
+        .send()
+        .await
+        .expect("sse request");
+    assert!(resp.status().is_success(), "SSE status: {}", resp.status());
+
+    // The handler transcribes the whole file then ends the stream, so reading the
+    // full body collects every event.
+    let text = resp.text().await.expect("sse body");
+    assert!(
+        text.contains("data:"),
+        "expected SSE data events, got: {text:?}"
+    );
+
+    let _ = shutdown.send(());
+}
+
+/// With `inference_timeout_secs = 0` the REST transcribe path takes the
+/// timeout-disabled branch (`handle.await` directly) instead of wrapping the
+/// blocking run in a `tokio::time::timeout`.
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[tokio::test]
+async fn test_transcribe_inference_timeout_disabled() {
+    let md = common::model_dir();
+    let limits = gigastt::server::RuntimeLimits {
+        inference_timeout_secs: 0,
+        ..Default::default()
+    };
+    let (port, shutdown) = common::start_server_with_limits(&md, limits).await;
+
+    let wav = std::fs::read(FIXTURE).expect("read fixture");
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/transcribe"))
+        .body(wav)
+        .send()
+        .await
+        .expect("transcribe request");
+    assert!(
+        resp.status().is_success(),
+        "transcribe status: {}",
+        resp.status()
+    );
+
+    let _ = shutdown.send(());
+}
+
+/// Saturating the pool while metrics are enabled forces the REST transcribe
+/// checkout to time out and record the pool-timeout counter/histogram. Takes
+/// ~30 s (the default pool-checkout timeout).
+#[ignore = "requires the GigaAM model (~850MB); ~30s"]
+#[tokio::test]
+async fn test_transcribe_pool_timeout_records_metrics() {
+    let md = common::model_dir();
+    let (port, metrics_port, shutdown) = common::start_server_with_metrics(&md).await;
+
+    // Saturate the default-size pool (2) with held WebSocket sessions.
+    let mut held = Vec::new();
+    for _ in 0..2 {
+        let (sink, stream, _ready) = common::ws_connect(port).await;
+        held.push((sink, stream));
+    }
+
+    let wav = common::generate_wav(1, 16000);
+    let client = reqwest::Client::new();
+    let resp = tokio::time::timeout(
+        Duration::from_secs(40),
+        client
+            .post(format!("http://127.0.0.1:{port}/v1/transcribe"))
+            .body(wav)
+            .send(),
+    )
+    .await
+    .expect("request returned before the test timeout")
+    .expect("http request");
+    assert_eq!(resp.status().as_u16(), 503, "expected pool-timeout 503");
+
+    // The pool-timeout counter should now be exposed on the metrics port.
+    let metrics = reqwest::get(format!("http://127.0.0.1:{metrics_port}/metrics"))
+        .await
+        .expect("metrics request")
+        .text()
+        .await
+        .expect("metrics body");
+    assert!(
+        metrics.contains("gigastt_pool_timeouts_total"),
+        "metrics should expose the pool-timeout counter"
+    );
+
+    // Release the held sessions.
+    let stop = serde_json::to_string(&serde_json::json!({"type": "stop"})).unwrap();
+    for (mut sink, mut stream) in held {
+        let _ = sink.send(Message::Text(stop.clone().into())).await;
+        let _ = tokio::time::timeout(Duration::from_secs(5), {
+            use futures_util::StreamExt;
+            stream.next()
+        })
+        .await;
+    }
+    let _ = shutdown.send(());
+}
+
+/// Same pool-timeout path for the SSE handler: a saturated pool makes
+/// `transcribe_stream` time out at checkout and record the metric. ~30 s.
+#[ignore = "requires the GigaAM model (~850MB); ~30s"]
+#[tokio::test]
+async fn test_sse_pool_timeout_records_metrics() {
+    let md = common::model_dir();
+    let (port, _metrics_port, shutdown) = common::start_server_with_metrics(&md).await;
+
+    let mut held = Vec::new();
+    for _ in 0..2 {
+        let (sink, stream, _ready) = common::ws_connect(port).await;
+        held.push((sink, stream));
+    }
+
+    let wav = common::generate_wav(1, 16000);
+    let client = reqwest::Client::new();
+    let resp = tokio::time::timeout(
+        Duration::from_secs(40),
+        client
+            .post(format!("http://127.0.0.1:{port}/v1/transcribe/stream"))
+            .body(wav)
+            .send(),
+    )
+    .await
+    .expect("request returned before the test timeout")
+    .expect("http request");
+    assert_eq!(resp.status().as_u16(), 503, "expected SSE pool-timeout 503");
+
+    let stop = serde_json::to_string(&serde_json::json!({"type": "stop"})).unwrap();
+    for (mut sink, mut stream) in held {
+        let _ = sink.send(Message::Text(stop.clone().into())).await;
+        let _ = tokio::time::timeout(Duration::from_secs(5), {
+            use futures_util::StreamExt;
+            stream.next()
+        })
+        .await;
+    }
+    let _ = shutdown.send(());
+}

--- a/crates/gigastt/tests/e2e_rest.rs
+++ b/crates/gigastt/tests/e2e_rest.rs
@@ -477,6 +477,180 @@ async fn test_server_list_models() {
     let _ = shutdown.send(());
 }
 
+// ---------------------------------------------------------------------------
+// Routing: OPTIONS preflight on every protected route returns 204
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_options_protected_routes_return_204() {
+    // Exercises the `options(...)` route wiring on the protected sub-router for
+    // /v1/transcribe, /v1/transcribe/stream and /v1/ws (in addition to the
+    // already-covered /v1/models). A loopback Origin keeps the request inside
+    // the allowlist so the preflight reaches the route handler.
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let client = reqwest::Client::new();
+
+    for path in ["/v1/transcribe", "/v1/transcribe/stream", "/v1/ws"] {
+        let resp = client
+            .request(
+                reqwest::Method::OPTIONS,
+                format!("http://127.0.0.1:{port}{path}"),
+            )
+            .header("Origin", "http://localhost:3000")
+            .send()
+            .await
+            .unwrap_or_else(|_| panic!("OPTIONS {path} failed"));
+        assert_eq!(resp.status(), 204, "OPTIONS {path} should return 204");
+    }
+
+    let _ = shutdown.send(());
+}
+
+// ---------------------------------------------------------------------------
+// CORS / origin handling on the wired router
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_cross_origin_request_denied_on_v1() {
+    // The wired router attaches `origin_layer` to /v1/*. A non-loopback Origin
+    // must be denied with 403 + `origin_denied` before reaching the handler.
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let resp = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/v1/models"))
+        .header("Origin", "https://evil.example.com")
+        .send()
+        .await
+        .expect("GET /v1/models with foreign Origin failed");
+    assert_eq!(resp.status(), 403, "cross-origin /v1/* must be denied");
+    let text = resp.text().await.expect("text body");
+    let body: serde_json::Value = serde_json::from_str(&text).expect("JSON body");
+    assert_eq!(body["code"], "origin_denied");
+    let _ = shutdown.send(());
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_loopback_origin_gets_cors_echo() {
+    // A loopback Origin is allowed and the response echoes it back in
+    // Access-Control-Allow-Origin (no wildcard by default).
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let resp = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/v1/models"))
+        .header("Origin", "http://localhost:3000")
+        .send()
+        .await
+        .expect("GET /v1/models with loopback Origin failed");
+    assert_eq!(resp.status(), 200, "loopback Origin must be allowed");
+    assert_eq!(
+        resp.headers()
+            .get("access-control-allow-origin")
+            .and_then(|v| v.to_str().ok()),
+        Some("http://localhost:3000"),
+        "CORS echo must mirror the loopback Origin"
+    );
+    let _ = shutdown.send(());
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_health_skips_origin_guard_on_wired_router() {
+    // /health is exempt from the origin guard even on the full router, so a
+    // monitoring probe carrying a foreign Origin still gets 200.
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let resp = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .header("Origin", "https://evil.example.com")
+        .send()
+        .await
+        .expect("GET /health with foreign Origin failed");
+    assert_eq!(resp.status(), 200, "/health must skip the origin guard");
+    let _ = shutdown.send(());
+}
+
+// ---------------------------------------------------------------------------
+// Request-id middleware is wired on the full router
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_request_id_header_present_on_wired_router() {
+    // The request_id_layer is attached to the full app, so every response
+    // carries an X-Request-Id. With no client-supplied id the server mints a
+    // UUIDv7.
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let resp = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .send()
+        .await
+        .expect("GET /health failed");
+    assert_eq!(resp.status(), 200);
+    let rid = resp
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .expect("X-Request-Id header must be present");
+    assert!(
+        uuid::Uuid::parse_str(rid).is_ok(),
+        "X-Request-Id should be a UUID, got {rid:?}"
+    );
+    let _ = shutdown.send(());
+}
+
+// ---------------------------------------------------------------------------
+// /ready reports pool_exhausted when every triplet is checked out
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_ready_returns_503_when_pool_exhausted() {
+    // Single-triplet pool. Occupy the only slot with a long REST transcribe so
+    // `/ready` observes `available == 0` and returns 503 + `pool_exhausted`.
+    let (port, shutdown) = common::start_server_with_pool(&common::model_dir(), 1).await;
+    let long_wav = common::generate_wav(60, 16000);
+
+    let occupier_url = format!("http://127.0.0.1:{port}/v1/transcribe");
+    let occupier = tokio::spawn(async move {
+        let _ = reqwest::Client::new()
+            .post(&occupier_url)
+            .body(long_wav)
+            .send()
+            .await;
+    });
+
+    // Poll /ready until it flips to 503; the occupier needs a moment to
+    // actually check out the triplet.
+    let client = reqwest::Client::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    let mut saw_exhausted = false;
+    while tokio::time::Instant::now() < deadline {
+        let resp = client
+            .get(format!("http://127.0.0.1:{port}/ready"))
+            .send()
+            .await
+            .expect("GET /ready failed");
+        if resp.status() == 503 {
+            let text = resp.text().await.expect("text body");
+            let body: serde_json::Value = serde_json::from_str(&text).expect("JSON body");
+            assert_eq!(body["status"], "not_ready");
+            assert_eq!(body["reason"], "pool_exhausted");
+            assert_eq!(body["pool_total"], 1);
+            saw_exhausted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        saw_exhausted,
+        "/ready must report pool_exhausted while the only triplet is in use"
+    );
+
+    let _ = shutdown.send(());
+    occupier.abort();
+    let _ = occupier.await;
+}
+
 // The v0.9.0-rc.1 zero-copy REST decode path used to carry a
 // Linux-only VmRSS budget test here. It asserted that
 // `RSS_after - RSS_before < wav.len() * 3 + 40 MiB` after POSTing a 300 s

--- a/crates/gigastt/tests/e2e_shutdown.rs
+++ b/crates/gigastt/tests/e2e_shutdown.rs
@@ -383,3 +383,61 @@ async fn test_shutdown_during_pool_saturation_returns_503_not_500() {
         let _ = h.await;
     }
 }
+
+// ---------------------------------------------------------------------------
+// 7. clean shutdown releases the listener (drain path completes)
+// ---------------------------------------------------------------------------
+
+/// An idle server shut down via the oneshot must run the full graceful-drain
+/// path: cancel the token, close the pools, let `axum::serve` return, then
+/// drain the tracker and release the TCP listener. We observe completion
+/// externally by polling `/health` until it stops answering — the socket only
+/// frees once `run_with_config_listener` returns, which is the post-`serve`
+/// drain code at the end of the function.
+#[ignore]
+#[tokio::test]
+async fn test_clean_shutdown_releases_listener() {
+    let model_dir = common::model_dir();
+    // Tiny drain window so an idle server (no in-flight WS/SSE tasks) finishes
+    // the drain promptly.
+    let limits = gigastt::server::RuntimeLimits {
+        shutdown_drain_secs: 1,
+        ..Default::default()
+    };
+    let (port, shutdown) = common::start_server_with_limits(&model_dir, limits).await;
+
+    // Sanity: the server is serving before we signal shutdown.
+    let client = reqwest::Client::new();
+    let pre = client
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .send()
+        .await
+        .expect("GET /health before shutdown failed");
+    assert_eq!(pre.status(), 200);
+
+    let _ = shutdown.send(());
+
+    // Poll until /health stops answering — proves the listener was released
+    // after the drain path ran. Generous deadline to cover the drain window
+    // plus teardown jitter on slow CI.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    let mut listener_released = false;
+    while tokio::time::Instant::now() < deadline {
+        match client
+            .get(format!("http://127.0.0.1:{port}/health"))
+            .timeout(Duration::from_secs(1))
+            .send()
+            .await
+        {
+            Err(_) => {
+                listener_released = true;
+                break;
+            }
+            Ok(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+        }
+    }
+    assert!(
+        listener_released,
+        "clean shutdown must release the listener (drain path must complete)"
+    );
+}

--- a/crates/gigastt/tests/e2e_ws.rs
+++ b/crates/gigastt/tests/e2e_ws.rs
@@ -666,3 +666,429 @@ async fn test_ws_max_session_precheck() {
         "Must hit max session cap via pre-check or sleep_until"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 16. Every supported sample rate configures cleanly and yields a Final
+// ---------------------------------------------------------------------------
+
+/// Drive one full configure→audio→stop cycle at the given client sample rate
+/// and assert the session ends with a Final (never an Error). Exercises the
+/// resample-vs-passthrough split inside `handle_binary_frame` for each rate.
+async fn run_sample_rate_roundtrip(port: u16, rate: u32) {
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "configure", "sample_rate": rate}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    // ~0.3 s of silence at the configured rate.
+    let silence = common::generate_pcm16_silence(0.3, rate);
+    sink.send(Message::Binary(silence.into())).await.unwrap();
+
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "stop"}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(20), stream.next())
+            .await
+            .unwrap_or_else(|_| panic!("timeout waiting for Final at {rate}Hz"))
+            .expect("stream ended")
+            .expect("ws error");
+        let text = msg.into_text().expect("expected text message");
+        let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+        match v["type"].as_str().unwrap_or("") {
+            "partial" => continue,
+            "final" => break,
+            other => panic!("Unexpected message type {other} at {rate}Hz (expected final): {text}"),
+        }
+    }
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_configure_8khz_roundtrip() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+    run_sample_rate_roundtrip(port, 8000).await;
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_configure_24khz_roundtrip() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+    run_sample_rate_roundtrip(port, 24000).await;
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_configure_44100hz_roundtrip() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+    run_sample_rate_roundtrip(port, 44100).await;
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_configure_48khz_roundtrip() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+    run_sample_rate_roundtrip(port, 48000).await;
+}
+
+// ---------------------------------------------------------------------------
+// 17. Binary audio sent before any Configure uses the 48kHz default and works
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_audio_before_configure_uses_default_rate() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+
+    // No Configure at all — server must fall back to DEFAULT_SAMPLE_RATE (48k)
+    // and resample. 0.3 s of silence at 48kHz.
+    let silence = common::generate_pcm16_silence(0.3, 48000);
+    sink.send(Message::Binary(silence.into())).await.unwrap();
+
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "stop"}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(20), stream.next())
+            .await
+            .expect("timeout waiting for Final")
+            .expect("stream ended")
+            .expect("ws error");
+        let text = msg.into_text().expect("expected text message");
+        let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+        match v["type"].as_str().unwrap_or("") {
+            "partial" => continue,
+            "final" => break,
+            other => panic!("Unexpected message type {other} (expected final): {text}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 18. Stop, then more audio — Stop ends the session, so the socket closes
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_stop_then_more_audio_session_ends() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+
+    // Send a little audio, then Stop — Stop breaks the session loop.
+    let silence = common::generate_pcm16_silence(0.1, 48000);
+    sink.send(Message::Binary(silence.into())).await.unwrap();
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "stop"}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    // Drain Partials until the Final that Stop produced.
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(20), stream.next())
+            .await
+            .expect("timeout waiting for Final")
+            .expect("stream ended")
+            .expect("ws error");
+        let text = msg.into_text().expect("expected text message");
+        let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+        match v["type"].as_str().unwrap_or("") {
+            "partial" => continue,
+            "final" => break,
+            other => panic!("Unexpected message type {other} after stop: {text}"),
+        }
+    }
+
+    // The server breaks the loop after Stop, returning the triplet to the pool.
+    // Any further audio we push must NOT produce another Final/Partial — the
+    // stream is being torn down. Sending may itself fail once the close
+    // propagates; either way we must not observe more transcript frames.
+    let more = common::generate_pcm16_silence(0.1, 48000);
+    let _ = sink.send(Message::Binary(more.into())).await;
+
+    let next = tokio::time::timeout(Duration::from_secs(3), stream.next()).await;
+    match next {
+        Ok(None) | Ok(Some(Ok(Message::Close(_)))) | Ok(Some(Err(_))) | Err(_) => {}
+        Ok(Some(Ok(Message::Text(text)))) => {
+            let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+            panic!("Did not expect a transcript frame after Stop, got: {v}");
+        }
+        Ok(Some(Ok(_other))) => {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 19. A few empty binary frames (below the spam cap) are skipped, not fatal
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_empty_frames_below_cap_are_skipped() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+
+    // A handful of empty binary frames — well under MAX_EMPTY_FRAMES_PER_SESSION.
+    for _ in 0..5 {
+        sink.send(Message::Binary(vec![].into())).await.unwrap();
+    }
+
+    // Real audio still flows afterwards, and Stop produces a Final.
+    let silence = common::generate_pcm16_silence(0.2, 48000);
+    sink.send(Message::Binary(silence.into())).await.unwrap();
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "stop"}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(20), stream.next())
+            .await
+            .expect("timeout waiting for Final after empty frames")
+            .expect("stream ended")
+            .expect("ws error");
+        let text = msg.into_text().expect("expected text message");
+        let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+        match v["type"].as_str().unwrap_or("") {
+            "partial" => continue,
+            "final" => break,
+            other => panic!("Unexpected message type {other} after empty frames: {text}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 20. Client Ping → session stays usable (server ignores ping/pong frames)
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_client_ping_keeps_session_alive() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+
+    // tokio-tungstenite auto-replies to Pings with Pongs at the protocol layer,
+    // so we assert liveness functionally: after a Ping the session is still
+    // usable (server ignores Ping/Pong in its match arm and continues).
+    sink.send(Message::Ping(vec![1, 2, 3].into()))
+        .await
+        .unwrap();
+
+    // Drain any Pong the client surfaces, then prove the session still works.
+    let silence = common::generate_pcm16_silence(0.2, 48000);
+    sink.send(Message::Binary(silence.into())).await.unwrap();
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "stop"}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(20), stream.next())
+            .await
+            .expect("timeout waiting for Final after ping")
+            .expect("stream ended")
+            .expect("ws error");
+        // Pong frames are non-text; skip them.
+        if !msg.is_text() {
+            continue;
+        }
+        let text = msg.into_text().expect("expected text message");
+        let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+        match v["type"].as_str().unwrap_or("") {
+            "partial" => continue,
+            "final" => break,
+            other => panic!("Unexpected message type {other} after ping: {text}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 21. Multiple Configure messages before audio — last one wins, no errors
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_multiple_configure_last_wins() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+
+    // First configure 8kHz, then re-configure to 16kHz before any audio.
+    for rate in [8000u32, 16000u32] {
+        sink.send(Message::Text(
+            serde_json::to_string(&serde_json::json!({"type": "configure", "sample_rate": rate}))
+                .unwrap()
+                .into(),
+        ))
+        .await
+        .unwrap();
+    }
+
+    // Audio at 16kHz (the last-configured rate); 16kHz is the passthrough path.
+    let silence = common::generate_pcm16_silence(0.3, 16000);
+    sink.send(Message::Binary(silence.into())).await.unwrap();
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "stop"}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(20), stream.next())
+            .await
+            .expect("timeout waiting for Final after multiple configure")
+            .expect("stream ended")
+            .expect("ws error");
+        let text = msg.into_text().expect("expected text message");
+        let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+        match v["type"].as_str().unwrap_or("") {
+            "partial" => continue,
+            "final" => break,
+            other => panic!("Unexpected message type {other} after configure x2: {text}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 22. Configure with a diarization field is accepted (no-op without feature)
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_configure_with_diarization_field() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+
+    // diarization=false is a no-op in the default build but must not error and
+    // must leave the session fully usable.
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({
+            "type": "configure",
+            "sample_rate": 16000,
+            "diarization": false,
+        }))
+        .unwrap()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let silence = common::generate_pcm16_silence(0.3, 16000);
+    sink.send(Message::Binary(silence.into())).await.unwrap();
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "stop"}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(20), stream.next())
+            .await
+            .expect("timeout waiting for Final after diarization configure")
+            .expect("stream ended")
+            .expect("ws error");
+        let text = msg.into_text().expect("expected text message");
+        let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+        match v["type"].as_str().unwrap_or("") {
+            "partial" => continue,
+            "final" => break,
+            other => panic!("Unexpected message type {other} with diarization field: {text}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 23. Non-empty audio produces a Final whose text field is a string
+// ---------------------------------------------------------------------------
+
+#[ignore]
+#[tokio::test]
+async fn test_ws_tone_audio_produces_final_text() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+
+    // A real (non-silent) tone at 16kHz so the encoder genuinely runs.
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "configure", "sample_rate": 16000}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    let tone = common::generate_pcm16_tone(0.5, 16000, 220.0);
+    for chunk in tone.chunks(3200) {
+        sink.send(Message::Binary(chunk.to_vec().into()))
+            .await
+            .unwrap();
+    }
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "stop"}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(30), stream.next())
+            .await
+            .expect("timeout waiting for Final")
+            .expect("stream ended")
+            .expect("ws error");
+        let text = msg.into_text().expect("expected text message");
+        let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+        match v["type"].as_str().unwrap_or("") {
+            "partial" => continue,
+            "final" => {
+                assert!(v["text"].is_string(), "Final must carry a text field");
+                break;
+            }
+            other => panic!("Unexpected message type {other}: {text}"),
+        }
+    }
+}


### PR DESCRIPTION
Raises test coverage substantially and locks it in with a no-regression CI gate.

## Result (measured, reproducible from CI's test suite)

| metric | before | after |
|---|---|---|
| **line** | 91.35% | **94.15%** |
| **function** | ~94.5% | **95.56%** |
| **region** | — | **94.20%** |

+142 tests across 4 rounds, **tests only — no production behaviour changed**, clippy clean, full suite green.

> Note: an earlier "92.9%→95%" framing was based on a non-reproducible measurement (the binary had been run by hand under instrumentation). The numbers above come from a clean `cargo llvm-cov` run of the test suite — what CI actually measures.

## Rounds

1. **Targeted unit tests** (+77): bias, export, vad, punctuation, model, ffi, main, http — the easy contiguous gaps.
2. **Hard modules** (+46): inference/audio (SampleRate, stereo mix, resample cache), inference/mod (pure helpers + model-backed edges), server/ws (every Configure rate, stop-then-audio, empty-frame skip, ping, diarization no-op, tone→Final), server/mod (routing, origin allow/deny, /ready 503, clean drain).
3. **CLI subprocess** (+13, `e2e_cli.rs`): `main.rs` was the dominant gap (70%→95%) — e2e tests drive the server via the library, never through `main()`/command dispatch. Spawns the built binary via `CARGO_BIN_EXE_gigastt` so the `Serve`/`Transcribe`/`Quantize` arms execute under instrumentation (graceful SIGTERM flushes the subprocess profile).
4. **REST/SSE paths** (+4, `e2e_http_cov.rs`): SSE inference loop on real speech, inference-timeout-disabled branch, pool-timeout metrics for both handlers.

## CI / gate

- `coverage-e2e`: runs `gigastt-ffi`'s model-gated lib tests explicitly (a **cdylib** crate's `#[ignore]` lib tests are skipped by the `--workspace --lib` pass, so the FFI streaming/transcribe paths read as uncovered otherwise); wires the new `e2e_cli` + `e2e_http_cov` targets; drops the redundant `llvm-cov run -- …` hacks now covered by real CLI tests.
- `codecov.yml`: no-regression project gate (`auto` + 0.5% threshold) + 80% patch target; ignores test code and prost-generated `onnx_proto.rs`.

## Honest ceiling

The remaining ~6% of lines is dominated by **fault-injection-only** paths (ONNX-runtime internal failures, network model-download errors, forced panics / inference timeouts, OS-signal handlers) and **defensive guards unreachable in normal operation** (`_ => panic!()` test guards, interior-NUL checks, `current_dir` failure). Covering them honestly would require brittle mock scaffolding — deliberately left untested. **Function coverage already exceeds 95%.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)