### PR TITLE
feat(server): GHCR images, variant-aware health, non-blocking first-run boot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ permissions:
   # id-token for Sigstore + write access to the `attestations` API.
   id-token: write
   attestations: write
+  # GHCR push (docker-publish job) authenticates with GITHUB_TOKEN, which
+  # needs `packages: write` to push image tags to the registry.
+  packages: write
 
 jobs:
   build:
@@ -292,3 +295,87 @@ jobs:
             dist/SHA256SUMS.txt
             dist/*.cdx.json
             dist/*.minisig
+
+  # Publishes container images to GHCR so consumers can `docker pull
+  # ghcr.io/ekhodzitsky/gigastt:<version>` instead of building from source.
+  # Intentionally NOT a dependency of `publish` (and vice-versa): a registry
+  # hiccup must never block the binary GitHub release, and a binary failure
+  # must never block the image push — the two release channels stand alone.
+  docker-publish:
+    name: Publish container images (GHCR)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      # QEMU registers binfmt handlers so the linux/arm64 CPU image can be
+      # cross-built on the x86_64 runner. Not needed for the amd64-only CUDA
+      # image below, but harmless to set up once here.
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # CPU image: multi-arch (amd64 + arm64) so it runs on both x86_64 servers
+      # and arm64 hosts (Apple Silicon, Graviton). `ekhodzitsky/gigastt` is
+      # already lowercase, which GHCR requires. Layer cache shares the same
+      # ghcr.io buildcache ref the CI docker-build job warms on every main push.
+      # Baking the model into the image is available via
+      # `--build-arg GIGASTT_BAKE_MODEL=1` for users who want zero cold-start;
+      # we don't publish a baked tag here because it would balloon the image by
+      # ~850 MB.
+      - name: Build + push CPU image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/ekhodzitsky/gigastt:${{ steps.version.outputs.version }}
+            ghcr.io/ekhodzitsky/gigastt:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/ekhodzitsky/gigastt
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:cpu
+          cache-to: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:cpu,mode=max
+
+      # CUDA image: amd64 only — the nvidia/cuda base images and the CUDA EP
+      # are x86_64-only, so an arm64 variant cannot be built.
+      - name: Build + push CUDA image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.cuda
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/ekhodzitsky/gigastt:${{ steps.version.outputs.version }}-cuda
+            ghcr.io/ekhodzitsky/gigastt:cuda
+          labels: |
+            org.opencontainers.image.source=https://github.com/ekhodzitsky/gigastt
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:cuda
+          cache-to: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:cuda,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Prebuilt Docker images on GitHub Container Registry.** Each tagged release
+  now publishes `ghcr.io/ekhodzitsky/gigastt:{X.Y.Z,latest}` (CPU, multi-arch
+  linux/amd64 + linux/arm64) and `:{X.Y.Z-cuda,cuda}` (CUDA, linux/amd64), so
+  consumers can `docker pull` a versioned image instead of building from
+  `cargo install` in their own Dockerfile. The publish job is independent of the
+  binary GitHub release (a registry hiccup never blocks the tarballs and vice
+  versa). See [`docs/deployment.md`](docs/deployment.md).
+- **Non-blocking first-run boot.** The TCP listener now binds *before* the
+  first-run model download + INT8 quantization (which can take minutes). During
+  that window a minimal bootstrap responder answers `GET /health` with `200`
+  (`model: "loading"`) and `GET /ready` with `503 {"reason":"initializing"}`,
+  then the *same* bound socket is handed to the full server with no rebind — so
+  `curl --fail /health` and Docker `HEALTHCHECK` no longer see connection-refused
+  (indistinguishable from a crash) while the model loads. A shutdown signal
+  during loading exits cleanly without serving. The heavy load work runs on a
+  blocking thread so the bootstrap responder stays responsive.
+
+### Changed
+
+- **`/health`, `/v1/models`, and the WebSocket `Ready` frame now report the head
+  actually loaded.** They previously hardcoded `model: "gigaam-v3-e2e-rnnt"`
+  regardless of which head was running, so a default `rnnt` server misreported
+  itself as `e2e_rnnt`. `model`/`id` are now derived from the loaded variant
+  (`gigaam-v3-rnnt` vs `gigaam-v3-e2e-rnnt`), and `/health` + `/v1/models` gain
+  additive `variant` (`rnnt`/`e2e_rnnt`), `punctuation`, and `itn` fields so a
+  client can confirm the effective output style from a single probe. New fields
+  are additive (existing clients unaffected); OpenAPI updated to match.
+
 ## [2.3.0] - 2026-06-20
 
 This release makes the lower-WER `rnnt` head the default and lands the INT8

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -188,6 +188,33 @@ impl ModelVariant {
                     || dir.join(variant.encoder_int8_file()).exists()
             })
     }
+
+    /// Stable model identifier surfaced by the REST API (`/health`,
+    /// `/v1/models`). Distinguishes the two heads so a client can tell which
+    /// one is actually loaded instead of always seeing the e2e id.
+    pub fn model_id(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt => "gigaam-v3-rnnt",
+            ModelVariant::E2eRnnt => "gigaam-v3-e2e-rnnt",
+        }
+    }
+
+    /// Short variant token (`rnnt` / `e2e_rnnt`) — the value accepted by
+    /// `--model-variant` and echoed in the REST `variant` field.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt => "rnnt",
+            ModelVariant::E2eRnnt => "e2e_rnnt",
+        }
+    }
+
+    /// Human-readable model name for `/v1/models`.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt => "GigaAM v3 RNN-T",
+            ModelVariant::E2eRnnt => "GigaAM v3 E2E RNN-T",
+        }
+    }
 }
 
 impl std::str::FromStr for ModelVariant {

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -884,30 +884,6 @@ async fn main() -> anyhow::Result<()> {
             config,
         } => {
             ensure_bind_allowed(&host, bind_all)?;
-            let resolved = model::ensure_model_variant(model_variant, &model_dir).await?;
-            ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
-            maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
-            maybe_download_vad_model(vad, &vad_model_dir).await;
-            let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
-            let hotwords = resolve_hotwords(hotwords_file.as_deref(), hotwords_default);
-            let mut engine = inference::Engine::load_with_pools_threads(
-                &model_dir,
-                pool_size,
-                pool_min_size,
-                batch_pool_size,
-                encoder_intra_threads,
-            )?
-            .with_punctuator(punctuator)
-            .with_itn(resolve_itn(itn, resolved))
-            .with_vad(
-                maybe_load_vad(vad, &vad_model_dir),
-                build_vad_config(vad_threshold, vad_min_silence_ms),
-            );
-            if let Some(pairs) = hotwords {
-                engine =
-                    engine.with_hotwords(&pairs, hotwords_boost.unwrap_or(DEFAULT_HOTWORDS_BOOST));
-            }
-            log_rss();
             let limits = build_limits(
                 config.as_deref(),
                 idle_timeout_secs,
@@ -929,7 +905,7 @@ async fn main() -> anyhow::Result<()> {
             if metrics {
                 ensure_bind_allowed(&metrics_listen.ip().to_string(), bind_all)?;
             }
-            let config = build_server_config(
+            let server_config = build_server_config(
                 port,
                 host,
                 allow_origin,
@@ -940,7 +916,47 @@ async fn main() -> anyhow::Result<()> {
                 trust_proxy,
                 config,
             );
-            server::run_with_config(engine, config, None).await?;
+
+            // Build the engine in the background while a minimal bootstrap
+            // responder serves /health (200) and /ready (503 initializing) on the
+            // port, so probes / Docker HEALTHCHECK don't see connection-refused
+            // during the first-run model download + INT8 quantization. The heavy
+            // synchronous work (quantize, ONNX session load, post-processor loads)
+            // runs on a blocking thread so the bootstrap responder stays snappy.
+            let load = async move {
+                let resolved = model::ensure_model_variant(model_variant, &model_dir).await?;
+                maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
+                maybe_download_vad_model(vad, &vad_model_dir).await;
+                tokio::task::spawn_blocking(move || -> anyhow::Result<inference::Engine> {
+                    ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
+                    let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
+                    let hotwords = resolve_hotwords(hotwords_file.as_deref(), hotwords_default);
+                    let mut engine = inference::Engine::load_with_pools_threads(
+                        &model_dir,
+                        pool_size,
+                        pool_min_size,
+                        batch_pool_size,
+                        encoder_intra_threads,
+                    )?
+                    .with_punctuator(punctuator)
+                    .with_itn(resolve_itn(itn, resolved))
+                    .with_vad(
+                        maybe_load_vad(vad, &vad_model_dir),
+                        build_vad_config(vad_threshold, vad_min_silence_ms),
+                    );
+                    if let Some(pairs) = hotwords {
+                        engine = engine.with_hotwords(
+                            &pairs,
+                            hotwords_boost.unwrap_or(DEFAULT_HOTWORDS_BOOST),
+                        );
+                    }
+                    log_rss();
+                    Ok(engine)
+                })
+                .await
+                .context("engine load task panicked")?
+            };
+            server::run_with_config_loading(server_config, None, load).await?;
         }
         Commands::Download {
             model_dir,

--- a/crates/gigastt/src/server/bootstrap.rs
+++ b/crates/gigastt/src/server/bootstrap.rs
@@ -1,0 +1,181 @@
+//! Minimal HTTP bootstrap responder used while the engine is still loading.
+//!
+//! On first run gigastt downloads ~850 MB of model files and generates the INT8
+//! encoder before it can serve real requests. Without this, the TCP port is
+//! unbound during that window, so `curl --fail /health` and Docker `HEALTHCHECK`
+//! probes see connection-refused — indistinguishable from a crashed container.
+//!
+//! [`super::run_with_config_loading`] binds the listener up front and answers
+//! probes with this responder until the engine is ready, then hands the *same*
+//! socket to the full server (no rebind, no gap). The responder is deliberately
+//! tiny — a hand-written HTTP/1.1 reply per connection — so it has zero engine
+//! state and cannot itself fail to start:
+//!
+//! - `GET /health` → `200 {"status":"ok","model":"loading","version":"…"}`
+//! - `GET /ready`  → `503 {"status":"not_ready","reason":"initializing"}`
+//! - anything else → `503 {"error":"server is starting up","code":"initializing"}`
+
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Read budget for the request line. Probes send a tiny request; we only need
+/// the first line, so a slow or oversized client is dropped rather than served.
+const READ_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Serve a single bootstrap response on `stream`, then let the connection close.
+///
+/// Generic over the stream type so it can be unit-tested over an in-memory
+/// duplex pipe without a real socket.
+pub(crate) async fn handle_bootstrap_conn<S>(mut stream: S, version: &str)
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut buf = [0u8; 1024];
+    let n = match tokio::time::timeout(READ_TIMEOUT, stream.read(&mut buf)).await {
+        Ok(Ok(n)) if n > 0 => n,
+        // Timeout, EOF, or read error: nothing actionable, just drop the conn.
+        _ => return,
+    };
+
+    let path = request_path(&buf[..n]);
+    let (status_line, body) = bootstrap_response(path, version);
+
+    let response = format!(
+        "HTTP/1.1 {status_line}\r\n\
+         content-type: application/json\r\n\
+         content-length: {len}\r\n\
+         connection: close\r\n\
+         \r\n\
+         {body}",
+        len = body.len(),
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.flush().await;
+}
+
+/// Extract the request-target path from a raw HTTP/1.1 request, stripping any
+/// query string. Returns `/` when the request can't be parsed.
+fn request_path(req: &[u8]) -> &str {
+    let line_end = req
+        .iter()
+        .position(|&b| b == b'\r' || b == b'\n')
+        .unwrap_or(req.len());
+    let line = std::str::from_utf8(&req[..line_end]).unwrap_or("");
+    // Request line: "<METHOD> <PATH> HTTP/1.1" — take the second whitespace token.
+    let raw_path = line.split_whitespace().nth(1).unwrap_or("/");
+    raw_path.split('?').next().unwrap_or("/")
+}
+
+/// Map a request path to a `(status-line, json-body)` bootstrap response.
+fn bootstrap_response(path: &str, version: &str) -> (&'static str, String) {
+    match path {
+        "/health" => (
+            "200 OK",
+            format!(r#"{{"status":"ok","model":"loading","version":"{version}"}}"#),
+        ),
+        "/ready" => (
+            "503 Service Unavailable",
+            r#"{"status":"not_ready","reason":"initializing"}"#.to_string(),
+        ),
+        _ => (
+            "503 Service Unavailable",
+            r#"{"error":"server is starting up","code":"initializing"}"#.to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path_of(req: &str) -> &str {
+        request_path(req.as_bytes())
+    }
+
+    #[test]
+    fn test_request_path_parsing() {
+        assert_eq!(
+            path_of("GET /health HTTP/1.1\r\nHost: x\r\n\r\n"),
+            "/health"
+        );
+        assert_eq!(path_of("GET /ready?x=1 HTTP/1.1\r\n\r\n"), "/ready");
+        assert_eq!(
+            path_of("POST /v1/transcribe HTTP/1.1\r\n"),
+            "/v1/transcribe"
+        );
+        assert_eq!(path_of("garbage"), "/");
+        assert_eq!(path_of(""), "/");
+    }
+
+    #[test]
+    fn test_bootstrap_response_codes() {
+        assert_eq!(bootstrap_response("/health", "9.9.9").0, "200 OK");
+        assert!(
+            bootstrap_response("/health", "9.9.9")
+                .1
+                .contains("\"model\":\"loading\"")
+        );
+        assert!(
+            bootstrap_response("/health", "9.9.9")
+                .1
+                .contains("\"version\":\"9.9.9\"")
+        );
+        assert_eq!(
+            bootstrap_response("/ready", "9.9.9").0,
+            "503 Service Unavailable"
+        );
+        assert!(
+            bootstrap_response("/ready", "9.9.9")
+                .1
+                .contains("\"reason\":\"initializing\"")
+        );
+        assert_eq!(
+            bootstrap_response("/v1/transcribe", "9.9.9").0,
+            "503 Service Unavailable"
+        );
+        assert!(
+            bootstrap_response("/v1/transcribe", "9.9.9")
+                .1
+                .contains("\"code\":\"initializing\"")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_bootstrap_conn_health_over_duplex() {
+        let (mut client, server) = tokio::io::duplex(2048);
+        let task = tokio::spawn(async move {
+            handle_bootstrap_conn(server, "1.2.3").await;
+        });
+        client
+            .write_all(b"GET /health HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let mut out = Vec::new();
+        client.read_to_end(&mut out).await.unwrap();
+        task.await.unwrap();
+        let resp = String::from_utf8(out).unwrap();
+        assert!(resp.starts_with("HTTP/1.1 200 OK"), "got: {resp}");
+        assert!(resp.contains("content-length:"));
+        assert!(resp.contains("\"status\":\"ok\""));
+        assert!(resp.contains("\"model\":\"loading\""));
+    }
+
+    #[tokio::test]
+    async fn test_handle_bootstrap_conn_ready_is_503() {
+        let (mut client, server) = tokio::io::duplex(2048);
+        let task = tokio::spawn(async move {
+            handle_bootstrap_conn(server, "1.2.3").await;
+        });
+        client
+            .write_all(b"GET /ready HTTP/1.1\r\n\r\n")
+            .await
+            .unwrap();
+        let mut out = Vec::new();
+        client.read_to_end(&mut out).await.unwrap();
+        task.await.unwrap();
+        let resp = String::from_utf8(out).unwrap();
+        assert!(resp.starts_with("HTTP/1.1 503"), "got: {resp}");
+        assert!(resp.contains("\"status\":\"not_ready\""));
+        assert!(resp.contains("\"reason\":\"initializing\""));
+    }
+}

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -66,19 +66,33 @@ pub async fn metrics(State(state): State<Arc<AppState>>) -> Response {
 pub struct HealthResponse {
     /// Always `"ok"` when the server is running.
     pub status: String,
-    /// Model identifier string (e.g. `"gigaam-v3-e2e-rnnt"`).
+    /// Stable model identifier for the head actually loaded
+    /// (`"gigaam-v3-rnnt"` or `"gigaam-v3-e2e-rnnt"`).
     pub model: String,
+    /// Recognition head in use: `"rnnt"` or `"e2e_rnnt"`. Added so a client can
+    /// tell from a single `/health` call which head (and therefore which output
+    /// style) is producing transcripts.
+    pub variant: String,
     /// Server version from `CARGO_PKG_VERSION`.
     pub version: String,
+    /// Whether the punctuation / casing restoration pass is active for this
+    /// server (the effective `--punctuation` policy).
+    pub punctuation: bool,
+    /// Whether inverse text normalization (numbers → digits) is active for this
+    /// server (the effective `--itn` policy).
+    pub itn: bool,
 }
 
 /// Model info response.
 #[derive(Serialize)]
 pub struct ModelInfo {
-    /// Stable model identifier (e.g. `"gigaam-v3-e2e-rnnt"`).
+    /// Stable model identifier for the head actually loaded
+    /// (`"gigaam-v3-rnnt"` or `"gigaam-v3-e2e-rnnt"`).
     pub id: String,
     /// Human-readable model name.
     pub name: String,
+    /// Recognition head in use: `"rnnt"` or `"e2e_rnnt"`.
+    pub variant: String,
     /// Server version from `CARGO_PKG_VERSION`.
     pub version: String,
     /// Encoder precision in use: `"int8"` or `"fp32"`.
@@ -95,6 +109,12 @@ pub struct ModelInfo {
     pub supported_formats: Vec<String>,
     /// PCM sample rates accepted by the WebSocket endpoint.
     pub supported_rates: Vec<u32>,
+    /// Whether the punctuation / casing restoration pass is active (effective
+    /// `--punctuation` policy for the loaded head).
+    pub punctuation: bool,
+    /// Whether inverse text normalization (numbers → digits) is active
+    /// (effective `--itn` policy for the loaded head).
+    pub itn: bool,
     /// Whether speaker diarization is available (feature-gated build + model loaded).
     /// Added in v0.7.0 so clients can probe capabilities via REST instead of
     /// opening a WebSocket just to read the `Ready` frame.
@@ -305,14 +325,25 @@ pub struct ReadinessResponse {
 
 /// GET /health — liveness check for monitoring and Docker HEALTHCHECK.
 ///
-/// Liveness only: stays 200 while the process is alive. Pool / shutdown
-/// readiness is the separate `/ready` probe (see [`readiness`]), so this
-/// handler intentionally does not touch engine state.
-pub async fn health() -> Json<HealthResponse> {
+/// Liveness: stays 200 while the process is alive. It reads only the engine's
+/// static identity (loaded head + effective punctuation/ITN policy) — a cheap,
+/// infallible field read, no pool checkout or I/O — so a client can confirm
+/// *which* model is serving from the same probe it already makes. Pool /
+/// shutdown readiness remains the separate `/ready` probe (see [`readiness`]).
+///
+/// During first-run model download / quantization the listener is served by a
+/// minimal bootstrap responder (see [`super::run_with_config_loading`]) that
+/// reports `model: "loading"`; this handler only runs once the engine is ready.
+pub async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
+    let engine = &state.engine;
+    let variant = engine.variant();
     Json(HealthResponse {
         status: "ok".into(),
-        model: "gigaam-v3-e2e-rnnt".into(),
+        model: variant.model_id().into(),
+        variant: variant.as_str().into(),
         version: env!("CARGO_PKG_VERSION").into(),
+        punctuation: engine.has_punctuator(),
+        itn: engine.has_itn(),
     })
 }
 
@@ -393,9 +424,11 @@ pub async fn models(State(state): State<Arc<AppState>>) -> Json<ModelInfo> {
         reg.gauge_set("gigastt_pool_waiters", &[], engine.pool.waiters() as i64);
         sample_batch_pool_gauges(reg, engine);
     }
+    let variant = engine.variant();
     Json(ModelInfo {
-        id: "gigaam-v3-e2e-rnnt".into(),
-        name: "GigaAM v3 RNN-T".into(),
+        id: variant.model_id().into(),
+        name: variant.display_name().into(),
+        variant: variant.as_str().into(),
         version: env!("CARGO_PKG_VERSION").into(),
         encoder: if engine.is_int8() {
             "int8".into()
@@ -414,6 +447,8 @@ pub async fn models(State(state): State<Arc<AppState>>) -> Json<ModelInfo> {
             "flac".into(),
         ],
         supported_rates: super::config::SUPPORTED_RATES.to_vec(),
+        punctuation: engine.has_punctuator(),
+        itn: engine.has_itn(),
         diarization,
     })
 }
@@ -758,13 +793,19 @@ mod tests {
     fn test_health_response_serialization() {
         let resp = HealthResponse {
             status: "ok".into(),
-            model: "test".into(),
+            model: "gigaam-v3-rnnt".into(),
+            variant: "rnnt".into(),
             version: "0.3.0".into(),
+            punctuation: true,
+            itn: true,
         };
         let json = serde_json::to_string(&resp).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["status"], "ok");
-        assert_eq!(v["model"], "test");
+        assert_eq!(v["model"], "gigaam-v3-rnnt");
+        assert_eq!(v["variant"], "rnnt");
+        assert_eq!(v["punctuation"], true);
+        assert_eq!(v["itn"], true);
     }
 
     #[test]
@@ -975,7 +1016,21 @@ mod tests {
         });
         let resp = models(State(state)).await;
         let json = serde_json::to_value(&*resp).unwrap();
-        assert_eq!(json["id"], "gigaam-v3-e2e-rnnt");
+        // The id reflects the head actually loaded on disk (rnnt or e2e_rnnt),
+        // not a hardcoded literal, so assert the stable shape instead.
+        let id = json["id"].as_str().unwrap();
+        assert!(
+            id == "gigaam-v3-rnnt" || id == "gigaam-v3-e2e-rnnt",
+            "unexpected model id: {id}"
+        );
+        assert_eq!(
+            json["variant"],
+            if id.contains("e2e") {
+                "e2e_rnnt"
+            } else {
+                "rnnt"
+            }
+        );
     }
 
     #[tokio::test]
@@ -1348,23 +1403,29 @@ mod tests {
         // ModelInfo is the /v1/models contract; assert the field names/values
         // clients depend on are present and correctly typed.
         let info = ModelInfo {
-            id: "gigaam-v3-e2e-rnnt".into(),
+            id: "gigaam-v3-rnnt".into(),
             name: "GigaAM v3 RNN-T".into(),
+            variant: "rnnt".into(),
             version: "0.9.0".into(),
             encoder: "int8".into(),
-            vocab_size: 1025,
+            vocab_size: 34,
             sample_rate: 16000,
             pool_size: 4,
             pool_available: 3,
             supported_formats: vec!["wav".into(), "mp3".into()],
             supported_rates: vec![16000, 48000],
+            punctuation: true,
+            itn: true,
             diarization: false,
         };
         let v = serde_json::to_value(&info).unwrap();
-        assert_eq!(v["id"], "gigaam-v3-e2e-rnnt");
+        assert_eq!(v["id"], "gigaam-v3-rnnt");
+        assert_eq!(v["variant"], "rnnt");
         assert_eq!(v["encoder"], "int8");
-        assert_eq!(v["vocab_size"], 1025);
+        assert_eq!(v["vocab_size"], 34);
         assert_eq!(v["sample_rate"], 16000);
+        assert_eq!(v["punctuation"], true);
+        assert_eq!(v["itn"], true);
         assert_eq!(v["diarization"], false);
         assert_eq!(v["supported_rates"][1], 48000);
     }

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Single port serves both REST API (health, transcribe, SSE) and WebSocket.
 
+mod bootstrap;
 pub mod config;
 pub mod http;
 pub mod metrics;
@@ -77,6 +78,146 @@ pub async fn run_with_config(
         .context("Invalid host:port")?;
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     run_with_config_listener(engine, config, shutdown, listener).await
+}
+
+/// Await the external shutdown source during the loading phase: the caller's
+/// oneshot when present, otherwise Ctrl-C / SIGTERM. Mirrors the signal handling
+/// in [`run_with_config_listener`] so a stuck first-run model download can still
+/// be interrupted before the engine is ready.
+async fn wait_for_shutdown(shutdown: Option<tokio::sync::oneshot::Receiver<()>>) {
+    match shutdown {
+        Some(rx) => {
+            let _ = rx.await;
+        }
+        None => {
+            #[cfg(unix)]
+            {
+                use tokio::signal::unix::{SignalKind, signal};
+                match signal(SignalKind::terminate()) {
+                    Ok(mut sigterm) => {
+                        tokio::select! {
+                            _ = tokio::signal::ctrl_c() => {}
+                            _ = sigterm.recv() => {}
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to register SIGTERM handler during boot: {e}");
+                        let _ = tokio::signal::ctrl_c().await;
+                    }
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = tokio::signal::ctrl_c().await;
+            }
+        }
+    }
+}
+
+/// Start the server with non-blocking first-run boot.
+///
+/// Binds the listener immediately and serves a minimal bootstrap responder
+/// (`/health` → 200 with `model: "loading"`, `/ready` → 503 `initializing`)
+/// while `load` builds the engine in the background — so health probes and
+/// Docker `HEALTHCHECK` never see connection-refused during the first-run model
+/// download + INT8 quantization (which can take minutes). Once the engine is
+/// ready the *same* bound socket is handed to [`run_with_config_listener`] with
+/// no rebind / no gap. A shutdown signal that arrives before the engine finishes
+/// loading aborts cleanly without ever serving real traffic.
+///
+/// The `load` future is expected to wrap its heavy synchronous work (quantize,
+/// ONNX session load) in `spawn_blocking` so the bootstrap responder stays
+/// responsive while it runs.
+pub async fn run_with_config_loading<Fut>(
+    config: ServerConfig,
+    shutdown: Option<tokio::sync::oneshot::Receiver<()>>,
+    load: Fut,
+) -> Result<()>
+where
+    Fut: std::future::Future<Output = Result<gigastt_core::inference::Engine>> + Send + 'static,
+{
+    let addr: SocketAddr = format!("{}:{}", config.host, config.port)
+        .parse()
+        .context("Invalid host:port")?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!("gigastt bootstrapping on http://{addr} — loading model, /health is up");
+
+    // Normalize the external shutdown source into a cancellation token (observed
+    // during boot) plus a fresh oneshot forwarded to the real server, so a
+    // signal works in both phases without registering the OS handler twice.
+    let shutdown_token = tokio_util::sync::CancellationToken::new();
+    let (real_tx, real_rx) = tokio::sync::oneshot::channel();
+    {
+        let token = shutdown_token.clone();
+        tokio::spawn(async move {
+            wait_for_shutdown(shutdown).await;
+            token.cancel();
+            let _ = real_tx.send(());
+        });
+    }
+
+    // Load the engine concurrently with the bootstrap responder.
+    let mut load_task = tokio::spawn(load);
+
+    // The bootstrap accept loop owns the listener and returns it on cancellation,
+    // so the real server can reuse the same bound socket without a rebind window.
+    let boot_cancel = tokio_util::sync::CancellationToken::new();
+    let boot_task = {
+        let boot_cancel = boot_cancel.clone();
+        tokio::spawn(async move {
+            let version = env!("CARGO_PKG_VERSION");
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = boot_cancel.cancelled() => break,
+                    accepted = listener.accept() => match accepted {
+                        Ok((stream, _peer)) => {
+                            tokio::spawn(bootstrap::handle_bootstrap_conn(stream, version));
+                        }
+                        Err(e) => tracing::warn!("bootstrap accept error: {e}"),
+                    },
+                }
+            }
+            listener
+        })
+    };
+
+    enum Outcome {
+        Shutdown,
+        // Boxed: the `Engine` payload is large, so keeping it inline would make
+        // the `Shutdown` variant pay for it too (clippy::large_enum_variant).
+        Loaded(
+            Box<
+                std::result::Result<
+                    Result<gigastt_core::inference::Engine>,
+                    tokio::task::JoinError,
+                >,
+            >,
+        ),
+    }
+
+    let outcome = tokio::select! {
+        biased;
+        _ = shutdown_token.cancelled() => Outcome::Shutdown,
+        res = &mut load_task => Outcome::Loaded(Box::new(res)),
+    };
+
+    // Stop accepting bootstrap connections and reclaim the bound listener.
+    boot_cancel.cancel();
+    let listener = boot_task.await.context("bootstrap task panicked")?;
+
+    match outcome {
+        Outcome::Shutdown => {
+            load_task.abort();
+            tracing::info!("Shutdown requested during model load — exiting before serving");
+            Ok(())
+        }
+        Outcome::Loaded(res) => {
+            let engine = (*res).context("engine load task panicked")??;
+            tracing::info!("Model ready — starting full server");
+            run_with_config_listener(engine, config, Some(real_rx), listener).await
+        }
+    }
 }
 
 /// Start server with a full [`ServerConfig`], an optional shutdown signal,
@@ -645,5 +786,56 @@ mod tests {
         let _ = shutdown_tx.send(());
         let result = handle.await.expect("join");
         assert!(result.is_ok(), "server should stop gracefully");
+    }
+
+    /// Exercises the non-blocking-boot orchestration end-to-end *without* a
+    /// model: a `load` future that never resolves keeps the server in the
+    /// bootstrap phase, so we can assert (a) `/health` answers `200` with
+    /// `model:"loading"` over a real socket while "loading", and (b) a shutdown
+    /// during loading returns `Ok` without ever standing up the full server.
+    #[tokio::test]
+    async fn test_run_with_config_loading_bootstrap_then_shutdown() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        // Reserve an ephemeral port, then release it for the server to rebind.
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let config = ServerConfig::local(port);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let load = std::future::pending::<Result<gigastt_core::inference::Engine>>();
+        let handle =
+            tokio::spawn(
+                async move { run_with_config_loading(config, Some(shutdown_rx), load).await },
+            );
+
+        // Give it a beat to bind and start the bootstrap accept loop.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // /health is up during loading and reports the bootstrap placeholder.
+        let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("bootstrap listener should accept connections during load");
+        stream
+            .write_all(b"GET /health HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let resp = String::from_utf8_lossy(&buf);
+        assert!(resp.starts_with("HTTP/1.1 200 OK"), "got: {resp}");
+        assert!(resp.contains("\"model\":\"loading\""), "got: {resp}");
+
+        // A shutdown signal during loading must unwind cleanly.
+        let _ = shutdown_tx.send(());
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .expect("loading server did not stop within the timeout")
+            .expect("join");
+        assert!(
+            result.is_ok(),
+            "loading server should stop gracefully: {result:?}"
+        );
     }
 }

--- a/crates/gigastt/src/server/ws.rs
+++ b/crates/gigastt/src/server/ws.rs
@@ -533,7 +533,7 @@ async fn handle_ws_inner(
     let diarization_available = false;
 
     let ready = ServerMessage::Ready {
-        model: "gigaam-v3-e2e-rnnt".into(),
+        model: engine.variant().model_id().into(),
         sample_rate: DEFAULT_SAMPLE_RATE,
         version: gigastt_core::protocol::PROTOCOL_VERSION.into(),
         supported_rates: SUPPORTED_RATES.to_vec(),

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,8 +27,8 @@ are additive only.
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/health` | GET | Health check (`{"status":"ok"}`) |
-| `/ready` | GET | Readiness probe (200 when the engine pool is ready) |
+| `/health` | GET | Liveness check. Reports the loaded head + effective punctuation/ITN policy (`{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","punctuation":true,"itn":true,...}`). During first-run model download it stays up with `model:"loading"`. |
+| `/ready` | GET | Readiness probe (200 when the engine pool is ready; 503 `initializing` while the model loads, `pool_exhausted` when saturated) |
 | `/v1/models` | GET | Model info (encoder type, pool size, capabilities) |
 | `/v1/transcribe` | POST | File transcription, full JSON response or export format |
 | `/v1/transcribe/stream` | POST | File transcription with SSE streaming |
@@ -84,6 +84,29 @@ Optional formatter controls:
 - `max_chars_per_line` — subtitle line length limit (default 80, 0 = unlimited)
 - `max_words_per_line` — subtitle word count limit (default 14, 0 = unlimited)
 - `word_timestamps` — include per-word table in Markdown (default false)
+
+### Long recordings — send the whole file
+
+gigastt chunks long audio **internally** (overlapping windows, de-duplicated and
+stitched with monotonic timestamps), so you do **not** need to pre-segment with
+ffmpeg. POST the whole recording and let the server return real, media-relative
+timestamps — every `word` in the JSON response carries `start`/`end` in seconds,
+and the `srt`/`vtt`/`md` exports key off those, so there's no need to fabricate
+per-chunk offsets client-side.
+
+```sh
+# One long recording → Markdown transcript with real per-word timings
+curl -X POST "http://127.0.0.1:9876/v1/transcribe?format=md&word_timestamps=true" \
+  --data-binary @meeting.m4a -o meeting.md
+```
+
+Content-Type is ignored — the container format (WAV/MP3/M4A/OGG/FLAC) is sniffed
+from the bytes, so `--data-binary @file` is enough; multipart form uploads are
+not accepted. The practical ceiling is the body limit (`--body-limit-bytes`,
+default 50 MiB ≈ 26 min of 16 kHz mono WAV) and the per-request inference cap
+(`--inference-timeout-secs`, default 600 s); raise **both** together for longer
+single files. A batch worker should gate on `GET /ready` (not just `/health`) so
+it backs off on `503` pool saturation instead of failing mid-job.
 
 ### Error responses
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -171,6 +171,24 @@ gigastt serve \
 
 ## Docker
 
+### Prebuilt images (GHCR)
+
+Each tagged release publishes multi-arch images to GitHub Container Registry, so
+you can `docker pull` instead of building from source (`cargo install`):
+
+```sh
+docker pull ghcr.io/ekhodzitsky/gigastt:2.3.0        # CPU, linux/amd64 + linux/arm64
+docker pull ghcr.io/ekhodzitsky/gigastt:2.3.0-cuda   # CUDA, linux/amd64
+docker run -p 127.0.0.1:9876:9876 ghcr.io/ekhodzitsky/gigastt:2.3.0
+```
+
+Pin a concrete version (`:2.3.0`) for reproducible deploys; `:latest` / `:cuda`
+track the newest release. Want zero cold-start? Build a model-baked image
+locally with `docker build --build-arg GIGASTT_BAKE_MODEL=1 -t gigastt:baked .`
+(adds ~850 MB).
+
+### Build from source
+
 The Dockerfile defaults to `--host 0.0.0.0 --bind-all` (allows the Docker bridge). Keep the server port on loopback when binding to the host:
 
 ```sh
@@ -216,8 +234,15 @@ Both proxies can target `http://127.0.0.1:9876/health` for health checks. The `/
 
 ```sh
 curl http://127.0.0.1:9876/health
-# {"status":"ok"}
+# {"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.3.0","punctuation":true,"itn":true}
 ```
+
+**Non-blocking first run.** The port binds immediately, before the ~850 MB model
+download and INT8 quantization. During that window `/health` returns `200` with
+`model:"loading"` and `/ready` returns `503 {"reason":"initializing"}` — so a
+Docker `HEALTHCHECK` / load-balancer probe on `/health` does not flap, and an
+orchestrator can gate traffic on `/ready`. The `model`/`variant` fields report
+the head actually loaded, so a client can confirm an upgrade switched heads.
 
 ## Metrics scraping
 
@@ -278,6 +303,42 @@ services:
 ```
 
 If you observe clients hanging past the cap or not receiving `Final` on deploy, see `docs/runbook.md` for the rollback escape hatches.
+
+## Upgrading from 2.0.x / 2.1.x
+
+**The default recognition head changed.** Fresh installs from 2.2.0+ default to
+the lower-WER `rnnt` head (bare lowercase from the acoustic model, then casing +
+punctuation restored by a **separate** RUPunct model, and digits by an ITN pass —
+both `auto`-on for `rnnt`). Older releases shipped only the `e2e_rnnt` head,
+which bakes punctuation/casing/ITN into the acoustic model.
+
+What this means when you bump the image / `cargo install` version:
+
+- **Existing model volume** (e.g. a mounted `~/.gigastt`/`./data/gigastt` that
+  already holds `e2e_rnnt` files): the engine auto-detects the on-disk head and
+  keeps using `e2e_rnnt` — **no silent re-download, no transcript-style change.**
+- **Fresh install / empty volume:** you get the `rnnt` head. Output is still
+  cased and punctuated, but via the auto-downloaded RUPunct model (~29 MB) as a
+  post-processing pass that **fails open** — if that model can't be fetched you
+  get bare lowercase plus a warning, not an error.
+
+To pin behavior explicitly regardless of what's on disk:
+
+```sh
+# Keep the old end-to-end head:
+GIGASTT_MODEL_VARIANT=e2e_rnnt
+# …or take the rnnt head but force the restoration passes on:
+GIGASTT_PUNCTUATION=on
+GIGASTT_ITN=on
+```
+
+Confirm which head is live without opening a WebSocket — `GET /health` (and
+`/v1/models`) now report `model` / `variant` / `punctuation` / `itn`.
+
+**Metrics moved off the main port.** Since 2.3.0 `/metrics` is served on a
+separate listener (default `127.0.0.1:9090`), not the API port. If you pass
+`--metrics`, publish/scrape `:9090` (or set `--metrics-listen`); a scraper still
+pointed at `:9876/metrics` will get a 404.
 
 ## Hardening checklist
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -75,8 +75,13 @@ paths:
     get:
       summary: Health check
       description: |
-        Returns service health status. Suitable for load balancer health checks
-        and Docker `HEALTHCHECK`.
+        Liveness check: returns 200 while the process is alive, along with the
+        head actually loaded and the effective punctuation / ITN policy.
+        Suitable for load balancer health checks and Docker `HEALTHCHECK`.
+
+        During the first-run model download + INT8 quantization the listener is
+        already bound and answers here with `model: "loading"` (so probes never
+        see connection-refused); gate *readiness* on `GET /ready` instead.
       operationId: healthCheck
       responses:
         "200":
@@ -87,8 +92,11 @@ paths:
                 $ref: "#/components/schemas/HealthResponse"
               example:
                 status: ok
-                model: gigaam-v3-e2e-rnnt
+                model: gigaam-v3-rnnt
+                variant: rnnt
                 version: "2.3.0"
+                punctuation: true
+                itn: true
 
   /ready:
     get:
@@ -135,14 +143,17 @@ paths:
               schema:
                 $ref: "#/components/schemas/ModelInfo"
               example:
-                id: gigaam-v3-e2e-rnnt
+                id: gigaam-v3-rnnt
                 name: GigaAM v3 RNN-T
+                variant: rnnt
                 version: "2.3.0"
                 encoder: int8
                 vocab_size: 34
                 sample_rate: 16000
                 pool_size: 2
                 pool_available: 2
+                punctuation: true
+                itn: true
                 supported_formats:
                   - wav
                   - mp3
@@ -369,7 +380,10 @@ components:
       required:
         - status
         - model
+        - variant
         - version
+        - punctuation
+        - itn
       properties:
         status:
           type: string
@@ -377,12 +391,28 @@ components:
           description: Service status
         model:
           type: string
-          example: gigaam-v3-e2e-rnnt
-          description: Loaded model identifier
+          example: gigaam-v3-rnnt
+          description: >-
+            Stable identifier of the head actually loaded
+            (`gigaam-v3-rnnt` or `gigaam-v3-e2e-rnnt`). During first-run model
+            download / quantization the bootstrap responder reports `loading`.
+        variant:
+          type: string
+          enum: [rnnt, e2e_rnnt]
+          example: rnnt
+          description: Recognition head in use
         version:
           type: string
           example: "2.3.0"
           description: Server version (semver)
+        punctuation:
+          type: boolean
+          example: true
+          description: Whether the punctuation / casing restoration pass is active
+        itn:
+          type: boolean
+          example: true
+          description: Whether inverse text normalization (numbers → digits) is active
 
     ReadinessResponse:
       type: object
@@ -417,6 +447,7 @@ components:
       required:
         - id
         - name
+        - variant
         - version
         - encoder
         - vocab_size
@@ -425,14 +456,24 @@ components:
         - pool_available
         - supported_formats
         - supported_rates
+        - punctuation
+        - itn
         - diarization
       properties:
         id:
           type: string
-          example: gigaam-v3-e2e-rnnt
+          example: gigaam-v3-rnnt
+          description: >-
+            Stable identifier of the head actually loaded
+            (`gigaam-v3-rnnt` or `gigaam-v3-e2e-rnnt`).
         name:
           type: string
           example: GigaAM v3 RNN-T
+        variant:
+          type: string
+          enum: [rnnt, e2e_rnnt]
+          example: rnnt
+          description: Recognition head in use
         version:
           type: string
           example: "2.3.0"
@@ -467,6 +508,14 @@ components:
             type: integer
           example: [8000, 16000, 24000, 44100, 48000]
           description: Supported input sample rates for WebSocket streaming
+        punctuation:
+          type: boolean
+          example: true
+          description: Whether the punctuation / casing restoration pass is active
+        itn:
+          type: boolean
+          example: true
+          description: Whether inverse text normalization (numbers → digits) is active
         diarization:
           type: boolean
           example: false


### PR DESCRIPTION
## Summary

Four self-contained improvements driven by a real downstream consumer (a self-hosted Docker integrator) that pins an old version, builds from `cargo install`, and gates on `/health`:

1. **Publish prebuilt Docker images to GHCR on release.** New `docker-publish` job in `release.yml` pushes `ghcr.io/ekhodzitsky/gigastt:{X.Y.Z,latest}` (CPU, multi-arch `linux/amd64` + `linux/arm64`) and `:{X.Y.Z-cuda,cuda}` (CUDA, `linux/amd64`) on a tag, with OCI labels and the same buildcache the CI `docker-build` job warms. Adds `packages: write`. The job is **independent** of the binary GitHub release (a registry hiccup never blocks the tarballs and vice versa). Consumers can `docker pull` a versioned image instead of compiling from source.

2. **`/health`, `/v1/models`, and the WebSocket `Ready` frame report the head actually loaded.** They previously hardcoded `model: "gigaam-v3-e2e-rnnt"` regardless of the running head, so a default `rnnt` server misreported itself as `e2e_rnnt`. `model`/`id`/`name` are now derived from `engine.variant()`, and `/health` + `/v1/models` gain **additive** `variant`, `punctuation`, and `itn` fields so a client can confirm the effective output style from a single probe. OpenAPI updated to match.

3. **Non-blocking first-run boot.** The TCP listener now binds *before* the first-run model download + INT8 quantization (minutes). During that window a minimal bootstrap responder answers `GET /health` → `200 {"model":"loading"}` and `GET /ready` → `503 {"reason":"initializing"}`, then the **same bound socket** is handed to the full server with no rebind / no gap. `curl --fail /health` and Docker `HEALTHCHECK` no longer see connection-refused (indistinguishable from a crash) while the model loads. A shutdown signal during loading exits cleanly without serving. Heavy load work runs on a blocking thread so the responder stays responsive.

4. **Docs.** Long-file transcription recipe (server chunks internally — don't pre-segment; real timestamps; `Content-Type` ignored; gate batch workers on `/ready`), GHCR `docker pull` instructions, and an **"Upgrading from 2.0.x / 2.1.x"** migration note (default head `e2e_rnnt` → `rnnt`, punctuation now via a separate RUPunct model that fails open, how to pin behavior via `GIGASTT_MODEL_VARIANT` / `GIGASTT_PUNCTUATION` / `GIGASTT_ITN`, and the `/metrics` move to `:9090`).

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --tests` — clean (0 warnings)
- `cargo test --workspace --lib --bins` — all green (0 failed)
- New unit tests cover the bootstrap responder (path parsing, status codes, duplex round-trip) and the loading orchestration end-to-end **without a model**: bind → `/health` `200 model:"loading"` over a real socket → shutdown-during-load → clean return (run 3× for flakiness).

**Coverage caveat:** the happy-path handoff to the full server (engine ready) is exercised by the existing e2e/CI suite with a model; it isn't covered by a no-model unit test because an `Engine` can't be built without the ~850 MB model.

## Notes

- New REST/WS fields are additive only (existing clients unaffected).
- No behavior change for existing model volumes: an installed `e2e_rnnt` is still auto-detected and used as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
