### PR TITLE
feat(core): lean embeddable build via feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
           shared-key: ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test --workspace --lib --bins
+      - name: Lean embedded build (no tokio/reqwest/symphonia)
+        run: |
+          cargo build -p gigastt-core --no-default-features
+          cargo test -p gigastt-core --test lean_build
       # Model-free self-test of the WER regression-gate decision logic. The full
       # benchmark is model-gated (skipped in PR CI), so this exercises the
       # gate's comparison / boundary / null-baseline handling on every PR.

--- a/ANDROID.md
+++ b/ANDROID.md
@@ -237,7 +237,7 @@ Tips to reduce binary size:
 
 ## Current Limitations
 
-1. **Server code is excluded from FFI** — The FFI build only exposes `gigastt::inference::Engine`. The WebSocket server, REST handlers, rate limiting, and `tokio` runtime with `rt-multi-thread` are compiled out when used as a library. They still exist in the server binary (`cargo build --bin gigastt`).
+1. **Server code is excluded from FFI** — The FFI build only exposes `gigastt::inference::Engine`. The WebSocket server, REST handlers, and rate limiting live only in the server binary (`cargo build --bin gigastt`). The FFI depends on `gigastt-core` with `default-features = false, features = ["file-decode"]`, so the `tokio` runtime, the `reqwest`/HTTP download stack, and the async session pool are compiled out — the FFI uses synchronous `checkout_blocking` and side-loaded models.
 
 2. **Synchronous transcription only** — `gigastt_transcribe_file` blocks the calling thread while inference runs. Call it from a Kotlin coroutine (`withContext(Dispatchers.IO)`) so the UI thread stays responsive.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1897,7 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
+ "libloading",
  "ndarray",
  "ort-sys",
  "smallvec",

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -17,11 +17,17 @@ crate-type = ["rlib"]
 bench = false
 
 [features]
-default = ["diarization"]
+default = ["diarization", "net", "async-pool", "file-decode"]
 coreml = ["ort/coreml"]
 cuda = ["ort/cuda"]
 nnapi = ["ort/nnapi"]
 diarization = ["dep:polyvoice"]
+# Lean-build axes (all on by default; turn off for embedded targets that
+# side-load models and feed raw PCM).
+net = ["dep:reqwest", "dep:tokio", "dep:futures-util"]  # HTTP model download
+async-pool = ["dep:tokio"]                              # async Pool::checkout; blocking path needs neither
+file-decode = ["dep:symphonia"]                         # file transcription; raw-PCM streaming does not need it
+ort-load-dynamic = ["ort/load-dynamic"]                 # system/vendored onnxruntime instead of download-binaries
 quantize = []
 # Private/unstable: exposes internal items (tokenizer module + synthetic
 # constructors) so the out-of-workspace `fuzz/` crate and criterion benches can
@@ -31,9 +37,9 @@ __internals = []
 
 [dependencies]
 ort = "2.0.0-rc.12"
-tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }
-futures-util = "0.3"
-reqwest = { version = "0.13", features = ["stream"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"], optional = true }
+futures-util = { version = "0.3", optional = true }
+reqwest = { version = "0.13", features = ["stream"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
@@ -43,7 +49,7 @@ sha2 = "0.11"
 hex = "0.4"
 rustfft = "6"
 rubato = "3.0"
-symphonia = { version = "0.6", features = ["aac", "isomp4", "mp3", "ogg", "flac", "pcm", "wav"] }
+symphonia = { version = "0.6", features = ["aac", "isomp4", "mp3", "ogg", "flac", "pcm", "wav"], optional = true }
 tokenizers = { version = "0.23", default-features = false, features = ["fancy-regex"] }
 bytes = "1"
 prost = "0.14"

--- a/crates/gigastt-core/README.md
+++ b/crates/gigastt-core/README.md
@@ -6,7 +6,7 @@ Core inference engine for [gigastt](https://github.com/ekhodzitsky/gigastt) — 
 
 ```toml
 [dependencies]
-gigastt-core = "2.0"
+gigastt-core = "2.3"
 ```
 
 ```rust,ignore
@@ -50,14 +50,22 @@ let final_segments = engine.flush_state(&mut guard, &mut state)?;
 
 ## Features
 
-| Feature | Description |
-|---|---|
-| `diarization` | Speaker identification via polyvoice (default: enabled) |
-| `coreml` | CoreML + Neural Engine on macOS ARM64 |
-| `cuda` | CUDA 12+ on Linux x86_64 |
-| `nnapi` | Android NNAPI for NPU/DSP acceleration |
+Defaults (`diarization`, `net`, `async-pool`, `file-decode`) make the engine work out of the box. For a lean embedded build that side-loads models and feeds raw PCM, disable defaults:
 
-Features are compile-time and mutually exclusive (`coreml` / `cuda`).
+```toml
+gigastt-core = { version = "2.3", default-features = false }
+```
+
+That drops `tokio`, `reqwest`/HTTP, and `symphonia` from the dependency graph. Opt features back in as needed.
+
+| Feature | Default | Description |
+|---|---|---|
+| `net` | on | HTTP model download (`reqwest` + async fs); off → side-loaded models only |
+| `async-pool` | on | async `Pool::checkout`; off → synchronous `checkout_blocking` only (no tokio runtime) |
+| `file-decode` | on | file transcription via `symphonia` (WAV/MP3/M4A/OGG/FLAC); off → raw-PCM streaming only |
+| `diarization` | on | speaker identification via polyvoice |
+| `ort-load-dynamic` | off | link a system/vendored onnxruntime instead of the build-time download |
+| `coreml` / `cuda` / `nnapi` | off | hardware acceleration (`coreml` / `cuda` are mutually exclusive) |
 
 ## What's included
 

--- a/crates/gigastt-core/src/inference/audio.rs
+++ b/crates/gigastt-core/src/inference/audio.rs
@@ -1,12 +1,19 @@
 //! Audio decoding, resampling, and buffer management utilities.
 
-use anyhow::{Context, Result};
+#[cfg(feature = "file-decode")]
+use anyhow::Context;
+use anyhow::Result;
 use bytes::Bytes;
 use rubato::Resampler;
+#[cfg(feature = "file-decode")]
 use symphonia::core::codecs::audio::AudioDecoderOptions;
+#[cfg(feature = "file-decode")]
 use symphonia::core::formats::probe::Hint;
+#[cfg(feature = "file-decode")]
 use symphonia::core::formats::{FormatOptions, TrackType};
+#[cfg(feature = "file-decode")]
 use symphonia::core::io::{MediaSource, MediaSourceStream};
+#[cfg(feature = "file-decode")]
 use symphonia::core::meta::MetadataOptions;
 
 use super::{HOP_LENGTH, N_FFT};
@@ -17,15 +24,18 @@ const MAX_BUFFER_SAMPLES: usize = 16000 * 5; // 5 seconds at 16kHz
 /// `Engine::transcribe_samples_chunked`), so peak memory is O(chunk) regardless
 /// of file length; this cap now only fences off genuinely absurd / adversarial
 /// uploads rather than the old 10-minute encoder-memory limit. Raised to 2h.
+#[cfg(feature = "file-decode")]
 const MAX_DURATION_S: f64 = 7200.0; // 2 hours
 /// Upper bound on a header-declared sample rate. Legal rates (8k–48k) stay well
 /// below this; anything above is a malformed/adversarial header and is rejected
 /// before it can scale the duration cap or the capacity hint.
+#[cfg(feature = "file-decode")]
 const MAX_SAMPLE_RATE: u32 = 192_000;
 /// Ceiling used to size the duration cap and capacity hint. The header's
 /// `sample_rate` is clamped to this when computing the sample budget, so a
 /// crafted header cannot inflate either beyond `MAX_DURATION_S` × 48 kHz worth
 /// of samples.
+#[cfg(feature = "file-decode")]
 const MAX_DECODE_SAMPLE_RATE: u32 = 48_000;
 
 /// Maximum number of decoded samples allowed for `sample_rate`, the budget used
@@ -33,6 +43,7 @@ const MAX_DECODE_SAMPLE_RATE: u32 = 48_000;
 /// clamped to [`MAX_DECODE_SAMPLE_RATE`] so a crafted header cannot inflate the
 /// budget beyond [`MAX_DURATION_S`] × 48 kHz. Pure so the cap math is testable
 /// without decoding a file.
+#[cfg(feature = "file-decode")]
 fn max_decode_samples(sample_rate: u32) -> usize {
     MAX_DURATION_S as usize * sample_rate.min(MAX_DECODE_SAMPLE_RATE) as usize
 }
@@ -72,11 +83,13 @@ impl SampleRate {
 ///
 /// The type is deliberately small and crate-private: it only needs to satisfy
 /// `Read + Seek + Send + Sync` so symphonia's `MediaSourceStream` can drive it.
+#[allow(dead_code)] // unused when `file-decode` is off (raw-PCM-only lean build)
 pub(crate) struct BytesMediaSource {
     data: Bytes,
     pos: u64,
 }
 
+#[allow(dead_code)] // `new` is only called by the file-decode path
 impl BytesMediaSource {
     pub(crate) fn new(data: Bytes) -> Self {
         Self { data, pos: 0 }
@@ -119,6 +132,7 @@ impl std::io::Seek for BytesMediaSource {
     }
 }
 
+#[cfg(feature = "file-decode")]
 impl MediaSource for BytesMediaSource {
     fn is_seekable(&self) -> bool {
         true
@@ -144,6 +158,7 @@ impl MediaSource for BytesMediaSource {
 /// fn decode_audio_file(path: &str) -> Result<Vec<f32>>
 /// { ret.as_ref().map(|v| !v.is_empty() || path.is_empty()).unwrap_or(true) }
 /// ```
+#[cfg(feature = "file-decode")]
 pub fn decode_audio_file(path: &str) -> Result<Vec<f32>> {
     let file =
         std::fs::File::open(path).with_context(|| format!("Failed to open audio file: {path}"))?;
@@ -183,6 +198,7 @@ pub fn decode_audio_file(path: &str) -> Result<Vec<f32>> {
 /// fn decode_audio_bytes(data: &[u8]) -> Result<Vec<f32>>
 /// { ret.as_ref().map(|v| !v.is_empty()).unwrap_or(true) }
 /// ```
+#[cfg(feature = "file-decode")]
 pub fn decode_audio_bytes(data: &[u8]) -> Result<Vec<f32>> {
     decode_audio_bytes_shared(Bytes::copy_from_slice(data))
 }
@@ -206,6 +222,7 @@ pub fn decode_audio_bytes(data: &[u8]) -> Result<Vec<f32>> {
 /// fn decode_audio_bytes_shared(data: Bytes) -> Result<Vec<f32>>
 /// { ret.as_ref().map(|v| !v.is_empty()).unwrap_or(true) }
 /// ```
+#[cfg(feature = "file-decode")]
 pub fn decode_audio_bytes_shared(data: Bytes) -> Result<Vec<f32>> {
     let source = BytesMediaSource::new(data);
     let mss = MediaSourceStream::new(Box::new(source), Default::default());
@@ -214,6 +231,7 @@ pub fn decode_audio_bytes_shared(data: Bytes) -> Result<Vec<f32>> {
 }
 
 /// Shared decode logic: probe → format → decode → mono mix → duration check → resample.
+#[cfg(feature = "file-decode")]
 fn decode_audio_inner<'s>(
     mss: MediaSourceStream<'s>,
     hint: Hint,

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -264,6 +264,7 @@ struct PoolInner<T> {
 }
 
 enum Waiter<T> {
+    #[cfg(feature = "async-pool")]
     Async(tokio::sync::oneshot::Sender<T>),
     Blocking(std::sync::mpsc::Sender<T>),
 }
@@ -289,6 +290,7 @@ impl<T: Send> Pool<T> {
     ///
     /// Returns [`PoolError::Closed`] if the pool was shut down via
     /// [`close`](Self::close) before an item became available.
+    #[cfg(feature = "async-pool")]
     pub async fn checkout(&self) -> Result<PoolGuard<T>, PoolError> {
         // Fast path
         {
@@ -408,6 +410,7 @@ impl<T> PoolInner<T> {
             if let Some(waiter) = waiters.pop_front() {
                 drop(waiters);
                 match waiter {
+                    #[cfg(feature = "async-pool")]
                     Waiter::Async(tx) => {
                         if let Err(returned_item) = tx.send(item) {
                             item = returned_item;
@@ -1933,6 +1936,7 @@ impl Engine {
     ///
     /// Returns [`GigasttError::InvalidAudio`] if the file cannot be decoded, or
     /// [`GigasttError::Inference`] if the ONNX runtime fails.
+    #[cfg(feature = "file-decode")]
     pub fn transcribe_file(
         &self,
         path: &str,
@@ -1950,6 +1954,7 @@ impl Engine {
     /// Backwards-compatible shim: clones `data` into a [`bytes::Bytes`] and
     /// delegates to [`Engine::transcribe_bytes_shared`]. Prefer the shared
     /// variant on hot paths (REST/SSE) to avoid the extra copy.
+    #[cfg(feature = "file-decode")]
     pub fn transcribe_bytes(
         &self,
         data: &[u8],
@@ -1966,6 +1971,7 @@ impl Engine {
     /// This is the zero-copy entry point used by the REST upload handler so a
     /// 50 MiB `axum::body::Bytes` body stays as a single in-memory buffer
     /// instead of being cloned into a `Vec<u8>` before decode.
+    #[cfg(feature = "file-decode")]
     pub fn transcribe_bytes_shared(
         &self,
         data: bytes::Bytes,

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -5,22 +5,30 @@
 //! head (default — lower WER, bare lowercase output) and the `e2e_rnnt` head
 //! (punctuation / casing / ITN baked in).
 
-use anyhow::{Context, Result};
+#[cfg(feature = "net")]
+use anyhow::Context;
+use anyhow::Result;
+#[cfg(feature = "net")]
 use futures_util::StreamExt;
+#[cfg(feature = "net")]
 use sha2::{Digest, Sha256};
 use std::path::Path;
+#[cfg(feature = "net")]
 use tokio::io::AsyncWriteExt;
 
 #[cfg(unix)]
+#[cfg(feature = "net")]
 use std::os::fd::AsRawFd;
 
 /// Simple download progress reporter (no external deps).
+#[cfg(feature = "net")]
 struct DownloadProgress {
     total: u64,
     current: u64,
     last_percent: u8,
 }
 
+#[cfg(feature = "net")]
 impl DownloadProgress {
     fn new(total: u64) -> Self {
         Self {
@@ -54,22 +62,27 @@ impl DownloadProgress {
     }
 }
 
+#[cfg(feature = "net")]
 const HF_REPO: &str = "istupakov/gigaam-v3-onnx";
 
 /// HuggingFace repo hosting the optional RUPunct punctuation model (MIT).
+#[cfg(feature = "net")]
 const PUNCT_HF_REPO: &str = "ekhodzitsky/rupunct-small-onnx";
 
 /// Direct URL for the optional Silero v5 VAD model (MIT), pinned to a release
 /// tag. SHA-256 below guards integrity regardless of the host.
+#[cfg(feature = "net")]
 const VAD_MODEL_URL: &str =
     "https://github.com/snakers4/silero-vad/raw/v5.1.2/src/silero_vad/data/silero_vad.onnx";
 
 /// SHA-256 of the pinned Silero v5.1.2 `silero_vad.onnx` (verified 2026-06-19).
+#[cfg(feature = "net")]
 const VAD_MODEL_SHA256: &str = "2623a2953f6ff3d2c1e61740c6cdb7168133479b267dfef114a4a3cc5bdd788f";
 
 /// The three files the punctuation pass needs, with their pinned SHA-256
 /// checksums. Filenames mirror the `PUNCT_*` constants in [`crate::punctuation`].
 /// Verified against the canonical HuggingFace copies on 2026-06-19.
+#[cfg(feature = "net")]
 const PUNCT_FILES: &[(&str, &str)] = &[
     (
         crate::punctuation::PUNCT_MODEL_FILE,
@@ -354,6 +367,7 @@ pub fn default_vad_model_dir() -> String {
 /// one process downloads models at a time. The lock is released when the
 /// returned file is dropped.
 #[cfg(unix)]
+#[cfg(feature = "net")]
 fn acquire_download_lock(dir: &Path) -> Result<std::fs::File> {
     let lock_path = dir.join(".download.lock");
     let file = std::fs::OpenOptions::new()
@@ -407,6 +421,7 @@ pub fn resolve_variant(
 /// variant and downloading the default (`Rnnt`) only when the directory holds
 /// no usable model. Equivalent to `ensure_model_variant(None, model_dir)` with
 /// the resolved variant discarded. Preserves the pre-variant public signature.
+#[cfg(feature = "net")]
 pub async fn ensure_model(model_dir: &str) -> Result<()> {
     ensure_model_variant(None, model_dir).await?;
     Ok(())
@@ -425,6 +440,7 @@ pub async fn ensure_model(model_dir: &str) -> Result<()> {
 /// (`Rnnt`).
 ///
 /// Returns the variant that is now ready in `model_dir`.
+#[cfg(feature = "net")]
 pub async fn ensure_model_variant(
     requested: Option<ModelVariant>,
     model_dir: &str,
@@ -485,6 +501,7 @@ pub async fn ensure_model_variant(
 /// crash the final path is never observable, so a subsequent `ensure_speaker_model` call
 /// will re-download from scratch rather than loading a tampered model.
 #[cfg(feature = "diarization")]
+#[cfg(feature = "net")]
 pub async fn ensure_speaker_model(model_dir: &str) -> Result<()> {
     let dir = Path::new(model_dir);
     let final_dest = dir.join(SPEAKER_MODEL_FILE);
@@ -519,6 +536,7 @@ pub async fn ensure_speaker_model(model_dir: &str) -> Result<()> {
 ///
 /// The pass is strictly optional: callers treat a download error as
 /// "punctuation unavailable" and proceed with bare text.
+#[cfg(feature = "net")]
 pub async fn ensure_punct_model(punct_model_dir: &str) -> Result<()> {
     let dir = Path::new(punct_model_dir);
 
@@ -554,6 +572,7 @@ pub async fn ensure_punct_model(punct_model_dir: &str) -> Result<()> {
 ///
 /// VAD is strictly optional: callers treat a download error as "VAD
 /// unavailable" and proceed without silence skipping / VAD endpointing.
+#[cfg(feature = "net")]
 pub async fn ensure_vad_model(vad_model_dir: &str) -> Result<()> {
     let dir = Path::new(vad_model_dir);
     let final_dest = dir.join(crate::vad::VAD_MODEL_FILE);
@@ -608,6 +627,7 @@ fn partial_path(final_path: &Path) -> std::path::PathBuf {
 
 /// Generate a unique `.partial` path so concurrent processes never write
 /// to the same staging file. Uses PID and nanosecond timestamp.
+#[cfg(feature = "net")]
 fn partial_path_unique(final_path: &Path) -> std::path::PathBuf {
     let stamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -619,6 +639,7 @@ fn partial_path_unique(final_path: &Path) -> std::path::PathBuf {
 }
 
 /// Compute SHA-256 for a file synchronously, returning the lowercase hex digest.
+#[cfg(feature = "net")]
 fn sha256_file(path: &Path) -> Result<String> {
     let data = std::fs::read(path)
         .with_context(|| format!("Failed to read file for verification: {}", path.display()))?;
@@ -633,6 +654,7 @@ fn sha256_file(path: &Path) -> Result<String> {
 /// restart. On success the partial no longer exists and `final_path` is the
 /// only visible artefact. Separated from the network path so the filesystem
 /// contract can be unit-tested without a mock HTTP server.
+#[cfg(feature = "net")]
 fn finalize_download(
     partial_path: &Path,
     final_path: &Path,
@@ -660,6 +682,7 @@ fn finalize_download(
     Ok(())
 }
 
+#[cfg(feature = "net")]
 async fn download_file(variant: ModelVariant, filename: &str, dir: &Path) -> Result<()> {
     let url = format!("https://huggingface.co/{HF_REPO}/resolve/main/{filename}");
     let final_dest = dir.join(filename);
@@ -677,6 +700,7 @@ async fn download_file(variant: ModelVariant, filename: &str, dir: &Path) -> Res
 /// Shared by [`ensure_model`] (per-file download loop) and
 /// [`ensure_speaker_model`] (single-file diarization download) so the
 /// TOCTOU + progress + retry semantics match bit-for-bit.
+#[cfg(feature = "net")]
 async fn stream_to_partial_then_finalize(
     url: &str,
     final_dest: &Path,

--- a/crates/gigastt-core/tests/lean_build.rs
+++ b/crates/gigastt-core/tests/lean_build.rs
@@ -1,0 +1,36 @@
+//! Guards the embedded lean build: `gigastt-core` with no default features must
+//! not pull tokio, reqwest/hyper, or symphonia into its production dependency
+//! graph. Runs `cargo tree` over normal edges only (dev-deps like wiremock,
+//! which legitimately pull tokio/hyper, are excluded).
+
+use std::process::Command;
+
+#[test]
+fn lean_core_excludes_heavy_deps() {
+    let out = Command::new(env!("CARGO"))
+        .args([
+            "tree",
+            "-p",
+            "gigastt-core",
+            "--no-default-features",
+            "--edges",
+            "normal",
+            "--prefix",
+            "none",
+        ])
+        .output()
+        .expect("cargo tree runs");
+    assert!(
+        out.status.success(),
+        "cargo tree failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let tree = String::from_utf8_lossy(&out.stdout);
+    for forbidden in ["tokio ", "reqwest ", "hyper ", "symphonia "] {
+        assert!(
+            !tree.lines().any(|l| l.trim_start().starts_with(forbidden)),
+            "lean gigastt-core must not depend on `{}`; production tree:\n{tree}",
+            forbidden.trim()
+        );
+    }
+}

--- a/crates/gigastt-ffi/Cargo.toml
+++ b/crates/gigastt-ffi/Cargo.toml
@@ -20,7 +20,7 @@ cuda = ["gigastt-core/cuda"]
 diarization = ["gigastt-core/diarization"]
 
 [dependencies]
-gigastt-core = { version = "2.3.0", path = "../gigastt-core", default-features = false }
+gigastt-core = { version = "2.3.0", path = "../gigastt-core", default-features = false, features = ["file-decode"] }
 serde_json = "1"
 tracing = "0.1"
 

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -25,7 +25,7 @@ diarization = ["gigastt-core/diarization"]
 quantize = ["gigastt-core/quantize"]
 
 [dependencies]
-gigastt-core = { version = "2.3.0", path = "../gigastt-core", default-features = false }
+gigastt-core = { version = "2.3.0", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
 
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ gigastt is a 3-crate Cargo workspace:
 | [`gigastt-ffi`](../crates/gigastt-ffi) | lib (cdylib) | C-ABI FFI for Android / mobile embedding |
 | [`gigastt`](../crates/gigastt) | bin | Server (axum HTTP/WS/SSE) + CLI |
 
-Embed inference in any Rust project with `gigastt-core = "2.3"`.
+Embed inference in any Rust project with `gigastt-core = "2.3"`. For a lean embedded build, disable defaults (`default-features = false`) to drop `tokio` / `reqwest` / `symphonia`; opt capabilities back in via the `net`, `async-pool`, and `file-decode` features.
 
 ## Model
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,7 +23,7 @@ path = "../crates/gigastt-core"
 # so targets can exercise them without the 850 MB model on disk. Disable
 # default features (no diarization needed for fuzzing the pure-CPU paths).
 default-features = false
-features = ["__internals"]
+features = ["__internals", "file-decode"]
 
 [[bin]]
 name = "audio_decode"


### PR DESCRIPTION
First plan of the embedded easy-integration initiative: make `gigastt-core` build lean for embedded/edge targets without changing the server/CLI defaults.

## Problem
`gigastt-core` unconditionally pulled a full `tokio` runtime + `reqwest`/hyper/TLS even for synchronous inference with a side-loaded model — the single biggest unnecessary weight in an embed.

## Change
Cargo features, **all default-on** (server/CLI/FFI behaviour unchanged):

| Feature | Default | Gates |
|---|---|---|
| `net` | on | `reqwest` + async model download (`model/mod.rs`) |
| `async-pool` | on | tokio async `Pool::checkout` (blocking `checkout_blocking` needs no tokio) |
| `file-decode` | on | `symphonia` file decoding (raw-PCM streaming needs neither) |
| `ort-load-dynamic` | off | link a system/vendored onnxruntime instead of the build-time fetch |

Lean embed `gigastt-core = { version = "2.3", default-features = false }` drops `tokio`, `reqwest`/hyper/TLS, and `symphonia`.

- `gigastt-ffi` now depends on core with `features = ["file-decode"]` (drops tokio/reqwest — it already uses `checkout_blocking` + side-loaded models); the server keeps `net` + `async-pool` + `file-decode`.
- New `crates/gigastt-core/tests/lean_build.rs` asserts via `cargo tree` that the lean production graph has no tokio/reqwest/hyper/symphonia; wired into the `unit-tests` CI job.
- Docs: `gigastt-core` README (feature table + lean build), `ANDROID.md` (tokio "compiled out" claim is now accurate), `docs/architecture.md`.

## Verification
- `cargo build -p gigastt-core --no-default-features` — clean, **0 warnings**.
- `cargo test -p gigastt-core --test lean_build` — passes.
- default core / `gigastt-ffi` / `gigastt` server all build; workspace clippy clean; core 333 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)