### PR TITLE
test(e2e): make /v1/models id/name assertion variant-aware

### DIFF
--- a/crates/gigastt-ffi/Cargo.toml
+++ b/crates/gigastt-ffi/Cargo.toml
@@ -10,7 +10,9 @@ keywords = ["stt", "speech-recognition", "ffi", "gigaam", "russian"]
 categories = ["multimedia::audio", "api-bindings"]
 
 [lib]
-crate-type = ["cdylib"]
+# cdylib for JNI / dynamic loading (Android, dlopen); staticlib (.a) for iOS /
+# static linking into a host binary (consumed by the SwiftPM xcframework).
+crate-type = ["staticlib", "cdylib"]
 
 [features]
 default = []

--- a/crates/gigastt/tests/e2e_rest.rs
+++ b/crates/gigastt/tests/e2e_rest.rs
@@ -468,12 +468,30 @@ async fn test_server_list_models() {
     assert_eq!(resp.status(), 200);
     let text = resp.text().await.unwrap();
     let body: serde_json::Value = serde_json::from_str(&text).unwrap();
-    assert_eq!(body["id"], "gigaam-v3-e2e-rnnt");
-    assert_eq!(body["name"], "GigaAM v3 RNN-T");
+    // id/name/variant reflect the head actually loaded on disk (rnnt or
+    // e2e_rnnt), not a fixed literal — assert the consistent pair instead.
+    let id = body["id"].as_str().unwrap();
+    let variant = body["variant"].as_str().unwrap();
+    assert!(
+        (id == "gigaam-v3-rnnt" && variant == "rnnt")
+            || (id == "gigaam-v3-e2e-rnnt" && variant == "e2e_rnnt"),
+        "unexpected id/variant pair: {id} / {variant}"
+    );
+    assert_eq!(
+        body["name"],
+        if variant == "e2e_rnnt" {
+            "GigaAM v3 E2E RNN-T"
+        } else {
+            "GigaAM v3 RNN-T"
+        }
+    );
     assert_eq!(body["sample_rate"], 16000);
     let enc = body["encoder"].as_str().unwrap();
     assert!(enc == "int8" || enc == "fp32");
     assert!(body["vocab_size"].as_u64().unwrap() > 0);
+    // New capability fields are present and boolean.
+    assert!(body["punctuation"].is_boolean());
+    assert!(body["itn"].is_boolean());
     let _ = shutdown.send(());
 }
 


### PR DESCRIPTION
Fixes the `main`-push E2E failure from #89: `test_server_list_models` hardcoded `id == "gigaam-v3-e2e-rnnt"`, but `/v1/models` now reports the head actually loaded (`gigaam-v3-rnnt` on the default/CI install). The assertion is now variant-aware (checks the consistent id/variant/name pair for either head) and also validates the new `punctuation`/`itn` fields. This e2e file runs on main-push only, so it bypassed the PR gate on #89.

Verified locally with the model present: `cargo test -p gigastt --test e2e_rest test_server_list_models -- --ignored` passes (loads the rnnt head).