### PR TITLE
feat(ffi): emit staticlib for iOS / static linking

### DIFF
--- a/crates/gigastt-ffi/Cargo.toml
+++ b/crates/gigastt-ffi/Cargo.toml
@@ -10,7 +10,9 @@ keywords = ["stt", "speech-recognition", "ffi", "gigaam", "russian"]
 categories = ["multimedia::audio", "api-bindings"]
 
 [lib]
-crate-type = ["cdylib"]
+# cdylib for JNI / dynamic loading (Android, dlopen); staticlib (.a) for iOS /
+# static linking into a host binary (consumed by the SwiftPM xcframework).
+crate-type = ["staticlib", "cdylib"]
 
 [features]
 default = []


### PR DESCRIPTION
Roadmap wave 80 (embedded easy-integration), task 82. Unblocks iOS packaging for the UniFFI bindings (task 81).

## Change
`gigastt-ffi` was `crate-type = ["cdylib"]` only (Android JNI / `dlopen`). Add a `staticlib` (`.a`) output so the C-ABI can be statically linked into a host binary — the path iOS / SwiftPM xcframework integration needs. `cdylib` is kept for Android.

```toml
crate-type = ["staticlib", "cdylib"]
```

## Verification
- Host build emits both `libgigastt_ffi.a` (~367 MB, static onnxruntime) and `libgigastt_ffi.dylib` (~51 MB).
- `cargo build -p gigastt-ffi --target aarch64-apple-ios` builds cleanly (ort/onnxruntime compiles for iOS) → `target/aarch64-apple-ios/debug/libgigastt_ffi.a`.
- `cargo test -p gigastt-ffi` green; pre-commit (fmt/clippy/typos) passed.

One-line manifest change; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)