### PR TITLE
chore: make LICENSE pristine MIT so GitHub detects it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,11 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-The MIT license above applies to the gigastt source code. Benchmark datasets
-under `benchmark/` (manifest reference transcripts and the `reference` /
-`hypothesis` fields in `benchmark/results_full/`) are NOT covered by this license
-and retain their upstream non-commercial licenses — see `NOTICE` and
-`benchmark/DATA_LICENSE`.

--- a/NOTICE
+++ b/NOTICE
@@ -3,8 +3,10 @@ gigastt
 
 The gigastt source code is licensed under the MIT License (see `LICENSE`).
 
-Benchmark datasets under `benchmark/` are NOT MIT-licensed and retain their
-upstream non-commercial licenses (see `benchmark/DATA_LICENSE`):
+Benchmark data under `benchmark/` — the manifest reference transcripts and the
+`reference` / `hypothesis` fields in `benchmark/results_full/` — is NOT
+MIT-licensed and retains its upstream non-commercial licenses (see
+`benchmark/DATA_LICENSE`):
 
 - Open STT — by snakers4 — CC BY-NC 4.0
   https://github.com/snakers4/open_stt


### PR DESCRIPTION
GitHub's Licensee classifier reports the repo license as **Other** (`NOASSERTION`) because `LICENSE` carried an MIT-plus-carve-out paragraph after the standard MIT text. That contradicts the README's "MIT-clean weights" / "commercial-ready" pitch right in the sidebar — the first thing a commercial evaluator checks.

This PR keeps `LICENSE` as unmodified, canonical MIT and moves the benchmark-data caveat entirely into `NOTICE` (which already documented it). GitHub will then render **MIT** in the sidebar.

**No rights change:** the non-commercial licensing of `benchmark/` data stays covered by `NOTICE` and `benchmark/DATA_LICENSE`; the specific scope (manifest reference transcripts + `reference`/`hypothesis` fields in `benchmark/results_full/`) is preserved verbatim in `NOTICE`.