### PR TITLE
docs(readme): clarify CoreML EP does not run encoder compute on ANE

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ gigastt serve
 | Heads | `rnnt` (34-token char, default — lowest WER) · `e2e_rnnt` (1025-token BPE, punctuation / casing / ITN baked in) |
 | Post-processing | optional punctuation, casing &amp; Russian ITN — native on `e2e_rnnt`, or a bundled RuPunct + ITN pass on `rnnt` (auto-downloaded; `--punctuation` / `--itn`) |
 | Delivery | static binary · C-ABI FFI `cdylib` (Android / mobile) · `gigastt-core` crate (no server deps) |
-| Execution providers | CPU (any platform) · CoreML / Neural Engine (macOS ARM64) · CUDA 12+ (Linux x86_64) · NNAPI (Android) |
+| Execution providers | CPU (any platform) · CoreML EP (macOS ARM64) · CUDA 12+ (Linux x86_64) · NNAPI (Android) |
 | Streaming | incremental WebSocket partials · REST + SSE for files · single port 9876 |
 | Audio in | WAV · M4A/AAC · MP3 · OGG/Vorbis · FLAC (auto mono mix for multi-channel) |
 | Export | JSON · TXT · SRT · VTT · Markdown (per-word timings + confidence) |

--- a/crates/gigastt-ffi/Cargo.toml
+++ b/crates/gigastt-ffi/Cargo.toml
@@ -10,7 +10,9 @@ keywords = ["stt", "speech-recognition", "ffi", "gigaam", "russian"]
 categories = ["multimedia::audio", "api-bindings"]
 
 [lib]
-crate-type = ["cdylib"]
+# cdylib for JNI / dynamic loading (Android, dlopen); staticlib (.a) for iOS /
+# static linking into a host binary (consumed by the SwiftPM xcframework).
+crate-type = ["staticlib", "cdylib"]
 
 [features]
 default = []


### PR DESCRIPTION
The capability table listed "CoreML / Neural Engine", which over-implies Apple Neural Engine acceleration.

Measured reality (see #42): with the INT8 ONNX encoder through the ORT CoreML EP, the encoder's compute (MatMul / Conv / LayerNorm / attention) runs on the **CPU** — the EP only offloads shape ops. Root causes: INT8 `DequantizeLinear` is unsupported by the CoreML EP, the ANE is FP16-only, and the CoreML EP requires `MatMul`'s second input to be constant (Conformer self-attention is activation×activation). The ~3× the `coreml` build gives over pure-CPU is INT8-vs-FP32 on CPU, not ANE.

This one-line change relabels the cell `CoreML / Neural Engine` → `CoreML EP` so the table no longer claims Neural Engine inference. No behaviour change.

Closes the documentation loop on #42.