### PR TITLE
test(e2e): fix flaky metrics-port probe in cli_serve_boots_and_graceful_shutdown

### DIFF
--- a/crates/gigastt/tests/e2e_cli.rs
+++ b/crates/gigastt/tests/e2e_cli.rs
@@ -351,11 +351,23 @@ fn cli_serve_boots_and_graceful_shutdown() {
     }
     assert!(ready, "server did not become healthy within 120s");
 
-    // Metrics live on their own loopback port.
-    assert_eq!(
-        http_status(metrics_port, "/metrics"),
-        Some(200),
-        "metrics endpoint should answer on its dedicated port"
+    // Metrics live on their own loopback port, bound by a separate listener that
+    // can come up slightly after the main server reports `/health` ready — more
+    // so under the instrumented coverage build. Poll it instead of probing once,
+    // to avoid a readiness race (the single-probe version flaked in CI's
+    // `Coverage (E2E)` job while the non-instrumented `E2E Tests` job passed).
+    let metrics_start = Instant::now();
+    let mut metrics_ok = false;
+    while metrics_start.elapsed() < Duration::from_secs(30) {
+        if http_status(metrics_port, "/metrics") == Some(200) {
+            metrics_ok = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    assert!(
+        metrics_ok,
+        "metrics endpoint should answer 200 on its dedicated port within 30s"
     );
 
     // Graceful shutdown: SIGTERM should drain and return a clean exit, which is


### PR DESCRIPTION
## Problem

The `Coverage (E2E)` job on `main` is red while every other job (including the plain `E2E Tests` job) is green. The sole failure:

```
cli_serve_boots_and_graceful_shutdown ... FAILED
assertion `left == right` failed: metrics endpoint should answer on its dedicated port
  left: None
  right: Some(200)
```

## Root cause

The test waits for the main server's `/health` to report ready, then probes the dedicated `--metrics` port **once**. That port is bound by a *separate* listener that can come up just after `/health` is ready — reliably so under the instrumented coverage build, which boots slower. `http_status` returns `None` (connection refused, listener not up yet), not a non-200 — i.e. a readiness race, not a missing endpoint. That's why only the slow `Coverage (E2E)` job flaked.

## Fix

Poll the metrics endpoint until it answers `200`, with a 30s timeout, mirroring the existing `/health` readiness loop. Test-only change; the poll can only wait longer for the endpoint, never less.

## Verification

- `cargo test -p gigastt --test e2e_cli cli_serve_boots_and_graceful_shutdown -- --include-ignored` → passes locally.
- `cargo fmt --check` clean · `cargo clippy -p gigastt --tests` clean.