### PR TITLE
feat(uniffi): Swift/Kotlin/Python bindings via UniFFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +302,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +381,38 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "camino"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "cast"
@@ -908,6 +999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1217,32 @@ dependencies = [
  "gigastt-core",
  "serde_json",
  "tracing",
+]
+
+[[package]]
+name = "gigastt-uniffi"
+version = "2.3.0"
+dependencies = [
+ "gigastt-core",
+ "thiserror 2.0.18",
+ "uniffi",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -1681,6 +1807,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2128,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2621,6 +2763,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2810,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2788,6 +2954,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,6 +2970,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
@@ -3108,6 +3286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,6 +3483,15 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3514,6 +3710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3545,6 +3747,124 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "uniffi"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "serde",
+ "textwrap",
+ "toml 0.5.11",
+ "uniffi_meta",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_checksum_derive"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "log",
+ "once_cell",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+dependencies = [
+ "bincode",
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml 0.5.11",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "siphasher",
+ "uniffi_checksum_derive",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "uniffi_testing",
+ "weedle2",
+]
 
 [[package]]
 name = "untrusted"
@@ -3844,6 +4164,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/gigastt-core", "crates/gigastt-ffi", "crates/gigastt"]
+members = ["crates/gigastt-core", "crates/gigastt-ffi", "crates/gigastt-uniffi", "crates/gigastt"]
 default-members = ["crates/gigastt"]
 resolver = "3"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,12 @@ COPY crates/gigastt-core/build.rs crates/gigastt-core/
 COPY crates/gigastt-core/proto/ crates/gigastt-core/proto/
 COPY crates/gigastt-ffi/Cargo.toml crates/gigastt-ffi/
 COPY crates/gigastt/Cargo.toml crates/gigastt/
-# Every [[bench]]/[[test]] target declared in the manifests must exist on disk
-# for cargo to parse the workspace, hence the extra stubs below.
-RUN mkdir -p crates/gigastt-core/src crates/gigastt-ffi/src crates/gigastt/src/server && \
+COPY crates/gigastt-uniffi/Cargo.toml crates/gigastt-uniffi/
+# Every [[bench]]/[[test]]/[[bin]] target declared in the manifests must exist
+# on disk for cargo to parse the workspace, hence the extra stubs below.
+# (gigastt-uniffi is a workspace member but not a dependency of `gigastt`, so it
+# is never compiled here — its stubs only satisfy manifest parsing.)
+RUN mkdir -p crates/gigastt-core/src crates/gigastt-ffi/src crates/gigastt/src/server crates/gigastt-uniffi/src/bin && \
     echo 'pub mod error; pub mod inference; pub mod model; pub mod onnx_proto; pub mod protocol; pub mod quantize;' > crates/gigastt-core/src/lib.rs && \
     mkdir -p crates/gigastt-core/src/inference crates/gigastt-core/src/model crates/gigastt-core/src/protocol && \
     touch crates/gigastt-core/src/error.rs crates/gigastt-core/src/onnx_proto.rs crates/gigastt-core/src/quantize.rs && \
@@ -42,6 +45,8 @@ RUN mkdir -p crates/gigastt-core/src crates/gigastt-ffi/src crates/gigastt/src/s
     touch crates/gigastt/src/server/mod.rs && \
     echo '' > crates/gigastt-ffi/src/lib.rs && \
     echo 'fn main() {}' > crates/gigastt-ffi/build.rs && \
+    echo '' > crates/gigastt-uniffi/src/lib.rs && \
+    echo 'fn main() {}' > crates/gigastt-uniffi/src/bin/uniffi-bindgen.rs && \
     mkdir -p crates/gigastt-core/benches crates/gigastt/tests && \
     echo 'fn main() {}' > crates/gigastt-core/benches/mel.rs && \
     echo 'fn main() {}' > crates/gigastt-core/benches/resample.rs && \

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -29,7 +29,8 @@ COPY crates/gigastt-core/build.rs crates/gigastt-core/
 COPY crates/gigastt-core/proto/ crates/gigastt-core/proto/
 COPY crates/gigastt-ffi/Cargo.toml crates/gigastt-ffi/
 COPY crates/gigastt/Cargo.toml crates/gigastt/
-RUN mkdir -p crates/gigastt-core/src crates/gigastt-ffi/src crates/gigastt/src/server && \
+COPY crates/gigastt-uniffi/Cargo.toml crates/gigastt-uniffi/
+RUN mkdir -p crates/gigastt-core/src crates/gigastt-ffi/src crates/gigastt/src/server crates/gigastt-uniffi/src/bin && \
     echo 'pub mod error; pub mod inference; pub mod model; pub mod onnx_proto; pub mod protocol; pub mod quantize;' > crates/gigastt-core/src/lib.rs && \
     mkdir -p crates/gigastt-core/src/inference crates/gigastt-core/src/model crates/gigastt-core/src/protocol && \
     touch crates/gigastt-core/src/error.rs crates/gigastt-core/src/onnx_proto.rs crates/gigastt-core/src/quantize.rs && \
@@ -39,6 +40,8 @@ RUN mkdir -p crates/gigastt-core/src crates/gigastt-ffi/src crates/gigastt/src/s
     touch crates/gigastt/src/server/mod.rs && \
     echo '' > crates/gigastt-ffi/src/lib.rs && \
     echo 'fn main() {}' > crates/gigastt-ffi/build.rs && \
+    echo '' > crates/gigastt-uniffi/src/lib.rs && \
+    echo 'fn main() {}' > crates/gigastt-uniffi/src/bin/uniffi-bindgen.rs && \
     mkdir -p crates/gigastt-core/benches crates/gigastt/tests && \
     echo 'fn main() {}' > crates/gigastt-core/benches/mel.rs && \
     echo 'fn main() {}' > crates/gigastt-core/benches/resample.rs && \

--- a/crates/gigastt-uniffi/.gitignore
+++ b/crates/gigastt-uniffi/.gitignore
@@ -1,0 +1,2 @@
+# Generated UniFFI bindings are build artifacts (regenerate via uniffi-bindgen).
+/bindings/

--- a/crates/gigastt-uniffi/Cargo.toml
+++ b/crates/gigastt-uniffi/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 description = "UniFFI bindings for gigastt — idiomatic Swift / Kotlin / Python from one source"
 keywords = ["stt", "speech-recognition", "uniffi", "gigaam", "russian"]
 categories = ["multimedia::audio", "api-bindings"]
+# Not a crates.io library: this is a cdylib binding-generator consumed as
+# prebuilt artifacts (xcframework / AAR / wheel), not as a Rust dependency.
+# `publish = false` also makes cargo-semver-checks skip it (no registry baseline).
+publish = false
 
 [lib]
 # cdylib for the foreign bindings to load; lib (rlib) for the uniffi-bindgen bin

--- a/crates/gigastt-uniffi/Cargo.toml
+++ b/crates/gigastt-uniffi/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "gigastt-uniffi"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "UniFFI bindings for gigastt — idiomatic Swift / Kotlin / Python from one source"
+keywords = ["stt", "speech-recognition", "uniffi", "gigaam", "russian"]
+categories = ["multimedia::audio", "api-bindings"]
+
+[lib]
+# cdylib for the foreign bindings to load; lib (rlib) for the uniffi-bindgen bin
+# + tests to reach the Rust API.
+crate-type = ["cdylib", "lib"]
+name = "gigastt_uniffi"
+
+[features]
+default = []
+coreml = ["gigastt-core/coreml"]
+cuda = ["gigastt-core/cuda"]
+nnapi = ["gigastt-core/nnapi"]
+
+[dependencies]
+# Lean core: file decoding only — no HTTP download, no async runtime (the
+# bindings side-load models and use the synchronous checkout_blocking path).
+gigastt-core = { version = "2.3.0", path = "../gigastt-core", default-features = false, features = ["file-decode"] }
+uniffi = { version = "0.28", features = ["cli"] }
+thiserror = "2"
+
+# Pin the bindgen generator to this crate's uniffi version.
+[[bin]]
+name = "uniffi-bindgen"
+path = "src/bin/uniffi-bindgen.rs"

--- a/crates/gigastt-uniffi/README.md
+++ b/crates/gigastt-uniffi/README.md
@@ -1,0 +1,67 @@
+# gigastt-uniffi
+
+Idiomatic **Swift**, **Kotlin**, and **Python** bindings for [gigastt](https://github.com/ekhodzitsky/gigastt) — on-device Russian speech-to-text — generated from one Rust source with [UniFFI](https://mozilla.github.io/uniffi-rs/).
+
+Wraps the synchronous `gigastt-core` engine: models are **side-loaded** (no HTTP download dependency) and inference uses the blocking pool path (**no tokio runtime**), so the bindings are lean. Errors are **typed** (`GigasttError` → Swift `throws` / Kotlin exceptions / Python exceptions) and objects are reference-counted (no manual free).
+
+## API
+
+| Type | Methods |
+|---|---|
+| `Engine` | `new(model_dir)` · `new_with_pool_size(model_dir, pool_size)` · `transcribe_file(path) -> Transcript` |
+| `Stream` | `new(engine)` · `process_chunk(pcm16, sample_rate) -> [TranscriptSegment]` · `flush() -> [TranscriptSegment]` |
+| records | `Transcript { text, words, duration_s }` · `TranscriptSegment { text, words, is_final }` · `Word { text, start_s, end_s, confidence, speaker }` |
+| errors | `GigasttError`: `ModelNotFound` · `InvalidAudio` · `PoolExhausted` · `Inference` · `InvalidArgument` |
+
+`process_chunk` takes little-endian mono PCM16 and resamples to 16 kHz internally.
+
+## Generating the bindings
+
+Build the cdylib, then run the version-pinned generator against it:
+
+```sh
+cargo build -p gigastt-uniffi
+LIB=target/debug/libgigastt_uniffi.dylib   # .so on Linux
+
+cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate --library "$LIB" --language python --out-dir bindings/python
+cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate --library "$LIB" --language swift  --out-dir bindings/swift
+cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate --library "$LIB" --language kotlin --out-dir bindings/kotlin
+```
+
+Generated bindings are build artifacts (`bindings/` is git-ignored). Packaging them into a SwiftPM `.xcframework`, an Android `.aar`, and a PyPI wheel is the next step (prebuilt-artifacts task).
+
+## Python (quickstart, verified)
+
+```python
+import sys; sys.path.insert(0, "bindings/python")   # + libgigastt_uniffi.dylib on the path
+import gigastt_uniffi as g
+
+engine = g.Engine("/path/to/gigastt/models")        # side-loaded model dir
+t = engine.transcribe_file("recording.wav")
+print(t.text)                                       # -> "шестьдесят тысяч тенге сколько будет стоить"
+for w in t.words:
+    print(w.text, w.start_s, w.end_s, w.confidence)
+
+# streaming
+s = g.Stream(engine)
+for seg in s.process_chunk(pcm16_bytes, 16000):
+    print(seg.text)
+print([seg.text for seg in s.flush()])
+```
+
+Errors surface as exceptions:
+
+```python
+try:
+    g.Engine("/no/such/dir")
+except g.GigasttError.ModelNotFound as e:
+    ...
+```
+
+## Features
+
+`coreml` / `cuda` / `nnapi` forward to `gigastt-core` for hardware acceleration. The core dependency is lean (`file-decode` only — no `net`, no `async-pool`).
+
+## License
+
+MIT.

--- a/crates/gigastt-uniffi/src/bin/uniffi-bindgen.rs
+++ b/crates/gigastt-uniffi/src/bin/uniffi-bindgen.rs
@@ -1,0 +1,8 @@
+//! Version-pinned UniFFI binding generator. Run, e.g.:
+//!
+//!   cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate \
+//!     --library target/debug/libgigastt_uniffi.dylib \
+//!     --language python --out-dir bindings/python
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/crates/gigastt-uniffi/src/lib.rs
+++ b/crates/gigastt-uniffi/src/lib.rs
@@ -1,0 +1,209 @@
+//! UniFFI bindings for gigastt — idiomatic Swift, Kotlin, and Python generated
+//! from one Rust source.
+//!
+//! Wraps the synchronous `gigastt-core` engine: models are side-loaded (no HTTP
+//! download) and inference uses the blocking pool path (no tokio runtime).
+//! Errors are typed (`GigasttError`) and map to Swift `throws` / Kotlin
+//! exceptions / Python exceptions instead of the C-ABI's NULL sentinels; objects
+//! are reference-counted, so there is no manual free.
+
+use std::sync::{Arc, Mutex};
+
+use gigastt_core::inference::{
+    Engine as CoreEngine, OwnedReservation, SessionTriplet, StreamingState, audio,
+};
+
+uniffi::setup_scaffolding!();
+
+/// Errors surfaced across the binding boundary.
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum GigasttError {
+    /// The model directory is missing files or the engine failed to load.
+    #[error("model not found or failed to load: {msg}")]
+    ModelNotFound { msg: String },
+    /// The audio could not be decoded (unsupported format / corrupt input).
+    #[error("invalid or undecodable audio: {msg}")]
+    InvalidAudio { msg: String },
+    /// No inference session triplet was available (pool closed/exhausted).
+    #[error("inference session pool exhausted")]
+    PoolExhausted,
+    /// Inference failed at runtime.
+    #[error("inference failed: {msg}")]
+    Inference { msg: String },
+    /// A caller-supplied argument was invalid.
+    #[error("invalid argument: {msg}")]
+    InvalidArgument { msg: String },
+}
+
+impl From<gigastt_core::error::GigasttError> for GigasttError {
+    fn from(e: gigastt_core::error::GigasttError) -> Self {
+        GigasttError::Inference { msg: e.to_string() }
+    }
+}
+
+/// A recognized word with timing, confidence, and optional speaker label.
+#[derive(uniffi::Record)]
+pub struct Word {
+    pub text: String,
+    pub start_s: f64,
+    pub end_s: f64,
+    pub confidence: f32,
+    pub speaker: Option<u32>,
+}
+
+/// A transcript segment (interim or final) with its words.
+#[derive(uniffi::Record)]
+pub struct TranscriptSegment {
+    pub text: String,
+    pub words: Vec<Word>,
+    pub is_final: bool,
+}
+
+/// The full result of transcribing a file.
+#[derive(uniffi::Record)]
+pub struct Transcript {
+    pub text: String,
+    pub words: Vec<Word>,
+    pub duration_s: f64,
+}
+
+fn word_from(w: gigastt_core::inference::WordInfo) -> Word {
+    Word {
+        text: w.word,
+        start_s: w.start,
+        end_s: w.end,
+        confidence: w.confidence,
+        speaker: w.speaker,
+    }
+}
+
+fn segment_from(s: gigastt_core::inference::TranscriptSegment) -> TranscriptSegment {
+    TranscriptSegment {
+        text: s.text,
+        words: s.words.into_iter().map(word_from).collect(),
+        is_final: s.is_final,
+    }
+}
+
+/// On-device speech-recognition engine. Reference-counted and thread-safe; share
+/// one instance across threads / streams.
+#[derive(uniffi::Object)]
+pub struct Engine {
+    inner: CoreEngine,
+}
+
+#[uniffi::export]
+impl Engine {
+    /// Load the GigaAM v3 model from `model_dir` with the default pool size.
+    #[uniffi::constructor]
+    pub fn new(model_dir: String) -> Result<Arc<Self>, GigasttError> {
+        let inner = CoreEngine::load(&model_dir)
+            .map_err(|e| GigasttError::ModelNotFound { msg: e.to_string() })?;
+        Ok(Arc::new(Self { inner }))
+    }
+
+    /// Load with an explicit session-pool size (concurrent inferences). On weak
+    /// devices use `1` to bound resident memory.
+    #[uniffi::constructor]
+    pub fn new_with_pool_size(
+        model_dir: String,
+        pool_size: u32,
+    ) -> Result<Arc<Self>, GigasttError> {
+        let inner = CoreEngine::load_with_pool_size(&model_dir, pool_size as usize)
+            .map_err(|e| GigasttError::ModelNotFound { msg: e.to_string() })?;
+        Ok(Arc::new(Self { inner }))
+    }
+
+    /// Transcribe an audio file (WAV / MP3 / M4A / OGG / FLAC) to text + word
+    /// timings. Blocks until inference completes.
+    pub fn transcribe_file(&self, path: String) -> Result<Transcript, GigasttError> {
+        let mut guard = self
+            .inner
+            .pool
+            .checkout_blocking()
+            .map_err(|_| GigasttError::PoolExhausted)?;
+        let r = self
+            .inner
+            .transcribe_file(&path, &mut guard)
+            .map_err(GigasttError::from)?;
+        Ok(Transcript {
+            text: r.text,
+            words: r.words.into_iter().map(word_from).collect(),
+            duration_s: r.duration_s,
+        })
+    }
+}
+
+struct StreamInner {
+    state: StreamingState,
+    reservation: OwnedReservation<SessionTriplet>,
+}
+
+/// A streaming transcription session. Holds one pool triplet for its lifetime
+/// (returned to the pool when this object is dropped).
+#[derive(uniffi::Object)]
+pub struct Stream {
+    engine: Arc<Engine>,
+    inner: Mutex<StreamInner>,
+}
+
+#[uniffi::export]
+impl Stream {
+    /// Open a streaming session against `engine`.
+    #[uniffi::constructor]
+    pub fn new(engine: Arc<Engine>) -> Result<Arc<Self>, GigasttError> {
+        let guard = engine
+            .inner
+            .pool
+            .checkout_blocking()
+            .map_err(|_| GigasttError::PoolExhausted)?;
+        let reservation = guard.into_owned();
+        let state = engine.inner.create_state(false);
+        Ok(Arc::new(Self {
+            engine,
+            inner: Mutex::new(StreamInner { state, reservation }),
+        }))
+    }
+
+    /// Feed a chunk of little-endian mono PCM16 audio. `sample_rate` is
+    /// resampled to 16 kHz internally. Returns any segments produced.
+    pub fn process_chunk(
+        &self,
+        pcm16: Vec<u8>,
+        sample_rate: u32,
+    ) -> Result<Vec<TranscriptSegment>, GigasttError> {
+        let mut guard = self.inner.lock().expect("stream mutex poisoned");
+        let StreamInner { state, reservation } = &mut *guard;
+
+        let mut samples: Vec<f32> = pcm16
+            .chunks_exact(2)
+            .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
+            .collect();
+
+        if sample_rate != 16000 {
+            audio::resample_with_cache(
+                samples,
+                audio::SampleRate(sample_rate),
+                audio::SampleRate(16000),
+                &mut state.resampler,
+                &mut state.resample_output_buf,
+            )
+            .map_err(|e| GigasttError::InvalidAudio { msg: e.to_string() })?;
+            samples = std::mem::take(&mut state.resample_output_buf);
+        }
+
+        let segs = self
+            .engine
+            .inner
+            .process_chunk(&samples, state, reservation)
+            .map_err(GigasttError::from)?;
+        Ok(segs.into_iter().map(segment_from).collect())
+    }
+
+    /// Flush remaining buffered audio and return any final segment(s).
+    pub fn flush(&self) -> Result<Vec<TranscriptSegment>, GigasttError> {
+        let mut guard = self.inner.lock().expect("stream mutex poisoned");
+        let seg = self.engine.inner.flush_state(&mut guard.state);
+        Ok(seg.into_iter().map(segment_from).collect())
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,12 @@ ignore = [
     # compile-time-only proc-macro with no runtime surface, so the unmaintained
     # advisory carries no runtime risk. Revisit if `tokenizers` drops it.
     "RUSTSEC-2024-0436",
+    # `bincode` 1.3.3 (RUSTSEC-2025-0141): the team ceased development, so the
+    # advisory is informational ("unmaintained"), not a vulnerability — they
+    # consider 1.3.3 feature-complete. Pulled in transitively by `uniffi_macros`
+    # for UniFFI's compile-time type metadata (gigastt-uniffi binding crate); no
+    # safe upgrade exists. Revisit when UniFFI migrates off bincode.
+    "RUSTSEC-2025-0141",
 ]
 
 [licenses]


### PR DESCRIPTION
Roadmap wave 80 (embedded easy-integration), task 81. Builds on the lean core (#90) and the FFI staticlib (#92).

## What
New **`gigastt-uniffi`** crate: one `#[uniffi::export]` Rust source generates idiomatic **Swift**, **Kotlin**, and **Python** bindings.

- `Engine` — `new(model_dir)` / `new_with_pool_size` / `transcribe_file(path) -> Transcript`
- `Stream` — `new(engine)` / `process_chunk(pcm16, sample_rate) -> [TranscriptSegment]` / `flush()`
- native records `Transcript` / `TranscriptSegment` / `Word` (replacing the C-ABI's JSON strings)
- typed `GigasttError` (`ModelNotFound` / `InvalidAudio` / `PoolExhausted` / `Inference` / `InvalidArgument`) → Swift `throws` / Kotlin & Python exceptions (replacing NULL sentinels)
- reference-counted objects (no manual free → closes the C-ABI's documented in-call free races)

Depends on `gigastt-core` with `default-features = false, features = ["file-decode"]` (no tokio / no reqwest); uses the synchronous `checkout_blocking` path. `uniffi-bindgen` is pinned as a crate bin.

## Verification
- `cargo build -p gigastt-uniffi` + `cargo clippy -p gigastt-uniffi` — clean.
- **Python smoke end-to-end:** generated the Python binding, loaded the model, `transcribe_file(golos_00.wav)` → `"шестьдесят тысяч тенге сколько будет стоить"` with 6 word timings (`шестьдесят` 0.52–1.04 s); a bad model dir raises `GigasttError.ModelNotFound`.
- Swift + Kotlin bindings generate from the same metadata. Full Swift/Kotlin runtime smoke needs their build systems (SwiftPM `.xcframework` / Android `.aar`) — that packaging is the prebuilt-artifacts task (83).

Generated `bindings/` are build artifacts (git-ignored); see the crate README for the generate commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)