### PR TITLE
feat(model): pre-quantized INT8 bundle download path + release workflow

### DIFF
--- a/.github/workflows/release-model.yml
+++ b/.github/workflows/release-model.yml
@@ -1,0 +1,120 @@
+# Publish the pre-quantized INT8 model bundle to a GitHub Release.
+#
+# Manual (`workflow_dispatch`) — run once per blessed model revision. Produces,
+# for both recognition heads, the lean bundle integrators download instead of
+# the FP32 set: INT8 encoder + decoder + joiner + vocab. Consumers fetch these
+# via `gigastt download --prequantized` (or `ensure_prequantized_model_variant`)
+# and so skip the ~844 MB FP32 download, the ~2-minute on-device quantization,
+# and the `protoc` build dependency.
+#
+# The download path verifies each file against the SHA-256 pinned in
+# `crates/gigastt-core/src/model/mod.rs` (`encoder_int8_checksum` +
+# `RNNT_CHECKSUMS`/`E2E_RNNT_CHECKSUMS`). The quantizer is deterministic, so a CI
+# re-quantization reproduces the pinned encoder bytes; if it ever diverges, the
+# pinned constants AND the release `tag` must be bumped together (the printed
+# checksums below are the reconciliation point).
+name: Release Model
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Model release tag (must match PREQUANT_RELEASE_BASE in model/mod.rs)'
+        required: true
+        default: 'models-v3-2026-06-22'
+
+permissions:
+  contents: write
+
+jobs:
+  publish-model:
+    runs-on: ubuntu-latest
+    env:
+      # GitHub Actions forbids referencing `secrets.*` directly in `if:`, so
+      # hoist the presence check into an env var (mirrors release.yml).
+      HAS_MINISIGN_KEY: ${{ secrets.MINISIGN_SECRET_KEY != '' && 'true' || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # `build.rs` invokes `prost-build`, which shells out to `protoc`.
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
+
+      # Download the FP32 set and quantize the encoder for each head. Both heads'
+      # files coexist in MODEL_DIR (variants are never mixed at runtime).
+      - name: Build + quantize both heads
+        env:
+          MODEL_DIR: ${{ runner.temp }}/models
+        run: |
+          set -euo pipefail
+          cargo build --release -p gigastt --locked
+          BIN=target/release/gigastt
+          "$BIN" download --model-dir "$MODEL_DIR" --model-variant rnnt
+          "$BIN" download --model-dir "$MODEL_DIR" --model-variant e2e_rnnt
+
+      # Assemble the lean per-variant bundle (INT8 encoder + decoder + joiner +
+      # vocab). FP32 encoders are intentionally excluded.
+      - name: Assemble bundle
+        env:
+          MODEL_DIR: ${{ runner.temp }}/models
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          for f in \
+            v3_rnnt_encoder_int8.onnx v3_rnnt_decoder.onnx v3_rnnt_joint.onnx v3_vocab.txt \
+            v3_e2e_rnnt_encoder_int8.onnx v3_e2e_rnnt_decoder.onnx v3_e2e_rnnt_joint.onnx v3_e2e_rnnt_vocab.txt; do
+            cp "$MODEL_DIR/$f" "dist/$f"
+          done
+          ls -la dist
+
+      - name: Aggregate SHA256SUMS.txt
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          : > SHA256SUMS.txt
+          for f in *; do
+            [ "$f" = "SHA256SUMS.txt" ] && continue
+            (sha256sum "$f" 2>/dev/null || shasum -a 256 "$f") >> SHA256SUMS.txt
+          done
+          echo "::notice ::Reconcile the INT8 encoder hashes below with the pinned constants in model/mod.rs:"
+          cat SHA256SUMS.txt
+
+      # minisign signatures over every asset + the checksum file. The signing
+      # secret is injected via repo secrets; when absent the step is skipped so
+      # the pipeline still publishes (mirrors release.yml).
+      - name: Sign bundle with minisign
+        if: env.HAS_MINISIGN_KEY == 'true'
+        working-directory: dist
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y --no-install-recommends minisign
+          printf '%s\n' "$MINISIGN_SECRET_KEY" > minisign.key
+          chmod 600 minisign.key
+          for f in *.onnx *.txt SHA256SUMS.txt; do
+            [ -f "$f" ] || continue
+            printf '%s\n' "$MINISIGN_PASSWORD" | minisign -Sm "$f" -s minisign.key
+          done
+          shred -u minisign.key 2>/dev/null || rm -f minisign.key
+
+      - name: Warn on missing minisign secret
+        if: env.HAS_MINISIGN_KEY != 'true'
+        run: echo "::warning ::MINISIGN_SECRET_KEY not configured — model artefacts will not carry minisign signatures."
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          name: GigaAM v3 pre-quantized INT8 model (${{ github.event.inputs.tag }})
+          body: |
+            Pre-quantized INT8 model bundle for `gigastt download --prequantized`.
+            Per head: INT8 encoder + decoder + joiner + vocab (no FP32, no on-device quantization).
+            Verify with `SHA256SUMS.txt` (and the pinned checksums in `gigastt-core`).
+          files: |
+            dist/*.onnx
+            dist/*.txt
+            dist/*.minisig

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Model download (required for E2E testing and file transcription, ~850MB):
 ```sh
 cargo run -- download                    # Downloads to ~/.gigastt/models/ and auto-generates INT8 encoder
 cargo run -- download --skip-quantize    # Skip auto-quantization (FP32 only)
+cargo run -- download --prequantized     # Lean path: fetch pre-quantized INT8 bundle from Releases (no FP32 download, no protoc, no on-device quantize)
 cargo run -- quantize                    # Regenerate INT8 encoder manually (~215MB)
 ```
 

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -65,6 +65,15 @@ impl DownloadProgress {
 #[cfg(feature = "net")]
 const HF_REPO: &str = "istupakov/gigaam-v3-onnx";
 
+/// Base URL of the pinned GitHub Release hosting the **pre-quantized** INT8
+/// model bundle (INT8 encoder + decoder + joiner + vocab, per variant). Lets
+/// integrators skip the ~844 MB FP32 encoder download AND the ~2-minute
+/// on-device quantization (and need no `protoc`). The release tag pins the
+/// revision; bump it together with the INT8 checksums when re-quantizing.
+#[cfg(feature = "net")]
+const PREQUANT_RELEASE_BASE: &str =
+    "https://github.com/ekhodzitsky/gigastt/releases/download/models-v3-2026-06-22";
+
 /// HuggingFace repo hosting the optional RUPunct punctuation model (MIT).
 #[cfg(feature = "net")]
 const PUNCT_HF_REPO: &str = "ekhodzitsky/rupunct-small-onnx";
@@ -187,6 +196,46 @@ impl ModelVariant {
             .iter()
             .find(|(name, _)| *name == filename)
             .and_then(|(_, hash)| *hash)
+    }
+
+    /// SHA-256 of the pre-quantized INT8 encoder for this variant, as published
+    /// in the pinned GitHub Release (`PREQUANT_RELEASE_BASE`). Produced by
+    /// gigastt's deterministic quantizer; bump this together with the release
+    /// tag if the model is ever re-quantized.
+    pub fn encoder_int8_checksum(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt => {
+                "c52665e9d96c4ca3a153c063d2ee9af6c567fe2975ca50fd038b75bbf2f60e7f"
+            }
+            ModelVariant::E2eRnnt => {
+                "cf51b300af47cea099e17c806f8fecce2c46e9e8deb4709ec203f8970a067389"
+            }
+        }
+    }
+
+    /// Files in the pre-quantized bundle published on GitHub Releases: the INT8
+    /// encoder (no FP32 download, no on-device quantization) plus the decoder,
+    /// joiner, and vocab. The engine runs from these alone — it prefers the INT8
+    /// encoder when present.
+    pub fn prequantized_files(self) -> [&'static str; 4] {
+        [
+            self.encoder_int8_file(),
+            self.decoder_file(),
+            self.joint_file(),
+            self.vocab_file(),
+        ]
+    }
+
+    /// Pinned SHA-256 for a pre-quantized bundle file. The INT8 encoder uses
+    /// [`ModelVariant::encoder_int8_checksum`]; the decoder/joiner/vocab are
+    /// byte-identical to the FP32 download set, so they reuse
+    /// [`ModelVariant::checksum`].
+    pub fn prequantized_checksum(self, filename: &str) -> Option<&'static str> {
+        if filename == self.encoder_int8_file() {
+            Some(self.encoder_int8_checksum())
+        } else {
+            self.checksum(filename)
+        }
     }
 
     /// Detect which variant's files are present in `dir` by probing for the
@@ -493,6 +542,60 @@ pub async fn ensure_model_variant(
     Ok(variant)
 }
 
+/// Ensure the **pre-quantized** INT8 model bundle for `requested` (or the
+/// variant already on disk, else the default `Rnnt`) exists in `model_dir`,
+/// downloading it from the pinned GitHub Release if missing.
+///
+/// This is the lean integration path: it fetches the INT8 encoder + decoder +
+/// joiner + vocab directly, so integrators skip the ~844 MB FP32 encoder
+/// download AND the ~2-minute on-device quantization (and need no `protoc`).
+/// Each file is SHA-256-verified and atomically renamed, reusing the same
+/// download primitive as [`ensure_model_variant`].
+///
+/// If a usable model (pre-quantized OR FP32 set) is already present, it is used
+/// as-is and no network request is made. Returns the ready variant.
+#[cfg(feature = "net")]
+pub async fn ensure_prequantized_model_variant(
+    requested: Option<ModelVariant>,
+    model_dir: &str,
+) -> Result<ModelVariant> {
+    let dir = Path::new(model_dir);
+    let variant = requested
+        .or_else(|| ModelVariant::detect_in_dir(dir))
+        .unwrap_or_default();
+
+    if is_prequantized_present(variant, dir) || is_model_present(variant, dir) {
+        tracing::info!("Using existing {variant:?} model at {model_dir}");
+        return Ok(variant);
+    }
+
+    std::fs::create_dir_all(dir).context("Failed to create model directory")?;
+
+    #[cfg(unix)]
+    let _lock = acquire_download_lock(dir)?;
+
+    // Re-check after acquiring the lock in case another process finished.
+    if is_prequantized_present(variant, dir) {
+        tracing::info!("Pre-quantized {variant:?} model found at {model_dir} after lock");
+        return Ok(variant);
+    }
+
+    tracing::info!("Downloading pre-quantized {variant:?} model from {PREQUANT_RELEASE_BASE}...");
+
+    for file in variant.prequantized_files() {
+        let final_dest = dir.join(file);
+        if final_dest.exists() {
+            continue;
+        }
+        let url = format!("{PREQUANT_RELEASE_BASE}/{file}");
+        let expected = variant.prequantized_checksum(file);
+        stream_to_partial_then_finalize(&url, &final_dest, expected, file).await?;
+    }
+
+    tracing::info!("Pre-quantized model download complete");
+    Ok(variant)
+}
+
 /// Ensure the speaker diarization model exists in `model_dir`, downloading from HuggingFace if missing.
 ///
 /// Downloads `wespeaker_resnet34.onnx` from `onnx-community/wespeaker-voxceleb-resnet34-LM`
@@ -612,6 +715,16 @@ pub async fn ensure_vad_model(vad_model_dir: &str) -> Result<()> {
 pub fn is_model_present(variant: ModelVariant, dir: &Path) -> bool {
     variant
         .download_files()
+        .iter()
+        .all(|f| dir.join(f).exists())
+}
+
+/// True when every file in `variant`'s pre-quantized bundle (INT8 encoder,
+/// decoder, joiner, vocab) is present in `dir`. The engine runs from this set
+/// alone — no FP32 encoder required.
+pub fn is_prequantized_present(variant: ModelVariant, dir: &Path) -> bool {
+    variant
+        .prequantized_files()
         .iter()
         .all(|f| dir.join(f).exists())
 }
@@ -1546,5 +1659,100 @@ mod tests {
             .await
             .expect("nested complete install must be used as-is");
         assert_eq!(variant, ModelVariant::Rnnt);
+    }
+
+    // ── pre-quantized bundle ────────────────────────────────────────────────
+
+    #[test]
+    fn test_prequantized_files_mapping() {
+        assert_eq!(
+            ModelVariant::Rnnt.prequantized_files(),
+            [
+                "v3_rnnt_encoder_int8.onnx",
+                "v3_rnnt_decoder.onnx",
+                "v3_rnnt_joint.onnx",
+                "v3_vocab.txt",
+            ]
+        );
+        assert_eq!(
+            ModelVariant::E2eRnnt.prequantized_files(),
+            [
+                "v3_e2e_rnnt_encoder_int8.onnx",
+                "v3_e2e_rnnt_decoder.onnx",
+                "v3_e2e_rnnt_joint.onnx",
+                "v3_e2e_rnnt_vocab.txt",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_encoder_int8_checksums_are_pinned() {
+        for variant in [ModelVariant::Rnnt, ModelVariant::E2eRnnt] {
+            let sum = variant.encoder_int8_checksum();
+            assert_eq!(
+                sum.len(),
+                64,
+                "{variant:?} INT8 checksum must be 64 hex chars, got: {sum}"
+            );
+            assert!(
+                sum.chars()
+                    .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+                "{variant:?} INT8 checksum must be lowercase hex, got: {sum}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_prequantized_checksum_int8_encoder_and_reuses_fp32_for_rest() {
+        let v = ModelVariant::Rnnt;
+        // Encoder → the INT8-specific checksum.
+        assert_eq!(
+            v.prequantized_checksum(v.encoder_int8_file()),
+            Some(v.encoder_int8_checksum())
+        );
+        // Decoder/joiner/vocab → the same pins as the FP32 download set.
+        for f in [v.decoder_file(), v.joint_file(), v.vocab_file()] {
+            assert_eq!(v.prequantized_checksum(f), v.checksum(f));
+            assert!(v.prequantized_checksum(f).is_some(), "{f} must be pinned");
+        }
+    }
+
+    #[test]
+    fn test_is_prequantized_present() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        assert!(!is_prequantized_present(ModelVariant::Rnnt, dir));
+        for f in ModelVariant::Rnnt.prequantized_files() {
+            std::fs::write(dir.join(f), b"x").unwrap();
+        }
+        assert!(is_prequantized_present(ModelVariant::Rnnt, dir));
+        // The FP32 set is absent (no FP32 encoder), yet the prequantized set is
+        // complete — the two presence checks are independent.
+        assert!(!is_model_present(ModelVariant::Rnnt, dir));
+    }
+
+    /// `ensure_prequantized_model_variant` short-circuits (no network, no
+    /// `.partial`) when the pre-quantized set is already present.
+    #[tokio::test]
+    async fn test_ensure_prequantized_present_no_download() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        for f in ModelVariant::Rnnt.prequantized_files() {
+            std::fs::write(dir.join(f), b"stub").unwrap();
+        }
+
+        let variant = ensure_prequantized_model_variant(None, dir.to_str().unwrap())
+            .await
+            .expect("present prequantized set must short-circuit");
+        assert_eq!(variant, ModelVariant::Rnnt);
+
+        let has_partial = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".partial"));
+        assert!(
+            !has_partial,
+            "no download when the prequantized set is present"
+        );
     }
 }

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -283,6 +283,14 @@ enum Commands {
         /// Opt out when you need the FP32 encoder for debugging.
         #[arg(long, env = "GIGASTT_SKIP_QUANTIZE", default_value_t = false)]
         skip_quantize: bool,
+
+        /// Fetch the pre-quantized INT8 bundle from the pinned GitHub Release
+        /// instead of the FP32 set + on-device quantization. The lean path:
+        /// no ~844 MB FP32 download, no ~2-minute quantize, no `protoc`.
+        /// Mutually exclusive with `--skip-quantize` (which only applies to the
+        /// FP32 download path).
+        #[arg(long, default_value_t = false)]
+        prequantized: bool,
     },
 
     /// Quantize encoder model to INT8 (replaces scripts/quantize.py)
@@ -964,18 +972,25 @@ async fn main() -> anyhow::Result<()> {
             #[cfg(feature = "diarization")]
             skip_diarization,
             skip_quantize,
+            prequantized,
         } => {
-            // `download` is an explicit action: None here maps to the default
-            // (Rnnt) so a bare `gigastt download` fetches something useful.
-            let requested = Some(model_variant);
-            let resolved = model::ensure_model_variant(requested, &model_dir).await?;
+            // `download` is an explicit action: the requested variant maps to
+            // the default (Rnnt) so a bare `gigastt download` fetches something
+            // useful.
+            if prequantized {
+                // Lean path: fetch the INT8 bundle from the pinned Release — no
+                // FP32 download, no on-device quantization, no protoc.
+                model::ensure_prequantized_model_variant(Some(model_variant), &model_dir).await?;
+            } else {
+                let resolved = model::ensure_model_variant(Some(model_variant), &model_dir).await?;
+                ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
+            }
             #[cfg(feature = "diarization")]
             {
                 if !skip_diarization {
                     model::ensure_speaker_model(&model_dir).await?;
                 }
             }
-            ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
             tracing::info!("Model ready at {model_dir}");
         }
         Commands::Quantize { model_dir, force } => {


### PR DESCRIPTION
Roadmap embedded wave, task 83 — keystone slice (pre-quantized model distribution). The remaining packaging pipelines (AAR / xcframework / wheels / npm prebuilds / ARM tarballs) follow as separate PRs.

## Why
Every binding's "no `protoc`, no build-time onnxruntime download, no on-device quantize" promise depends on a pre-quantized model being downloadable. This wires that path.

## What
Fetch a **pre-quantized INT8 bundle** (INT8 encoder + decoder + joiner + vocab) directly from a pinned GitHub Release, skipping the ~844 MB FP32 encoder download AND the ~2-minute on-device quantization (and the `protoc` build dependency).

- **`gigastt-core`**: `ModelVariant::{prequantized_files, encoder_int8_checksum, prequantized_checksum}` + `ensure_prequantized_model_variant` + `is_prequantized_present`. The decoder/joiner/vocab reuse the existing FP32 pins (byte-identical); only the two INT8-encoder checksums are new. Reuses the existing `stream_to_partial_then_finalize` (SHA-256 + atomic rename) primitive.
- **CLI**: `gigastt download --prequantized`.
- **`.github/workflows/release-model.yml`**: `workflow_dispatch` that quantizes both heads, assembles the bundle, computes `SHA256SUMS`, minisign-signs, and publishes to the pinned model release tag.
- **Docs**: the lean download path in CLAUDE.md.

## Verified
- **INT8-only loads**: a model dir with only `{encoder_int8, decoder, joint, vocab}` (no FP32) transcribes `golos_00.wav` correctly (RSS ~443 MB) — confirms the bundle definition is sufficient.
- Checksums computed from the deterministic-quantizer output; decoder/joiner/vocab match the existing pins exactly.
- Network-free unit tests: bundle file set, checksum pinning (64-hex), presence detection, no-download short-circuit. `cargo clippy` clean, `cargo fmt` clean.

## Maintainer action
Publishing the release (running `Release Model` with the `models-v3-2026-06-22` tag) is a maintainer step — it needs repo write + the optional `MINISIGN_*` secrets. Until then the `--prequantized` URL 404s; the default `download` path is unchanged. If the quantizer output ever changes, bump the release tag and the pinned INT8 checksums together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)