### PR TITLE
ci(node): cross-platform npm prebuilds for gigastt-node

### DIFF
--- a/.github/workflows/node-prebuilds.yml
+++ b/.github/workflows/node-prebuilds.yml
@@ -1,0 +1,118 @@
+# Cross-platform prebuilt npm packages for the gigastt-node addon (napi-rs).
+#
+# Manual (`workflow_dispatch`). Builds the `.node` addon on a NATIVE runner per
+# target (avoids ort's fragile cross-compile of the onnxruntime native lib), then
+# optionally publishes per-platform npm packages via napi-rs's optional-dependency
+# model so `npm install gigastt-node` needs no compiler / node-gyp.
+#
+# onnxruntime is statically linked into each `.node` (ort default), so no native
+# dylib is bundled — the addon is self-contained. The ~215 MB INT8 model is NOT
+# bundled; it is side-loaded at runtime (see `gigastt download --prequantized`).
+name: Node Prebuilds
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish per-platform packages to npm (requires NPM_TOKEN)'
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    working-directory: crates/gigastt-node
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-14
+            target: aarch64-apple-darwin
+          - host: macos-13
+            target: x86_64-apple-darwin
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+    name: Build ${{ matrix.settings.target }}
+    runs-on: ${{ matrix.settings.host }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.settings.target }}
+
+      # gigastt-core's build.rs shells out to protoc (prost-build).
+      - name: Install protoc (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protoc -y
+
+      - name: Install deps (@napi-rs/cli)
+        run: npm install
+
+      - name: Build addon
+        run: npx napi build --platform --release --target ${{ matrix.settings.target }}
+
+      # Sanity: the addon dlopen-loads (links + onnxruntime static-init OK).
+      # No model needed — Engine loads the model lazily, not on require().
+      - name: Load check
+        run: node -e "require('./index.js'); console.log('addon loaded OK')"
+
+      - name: Upload prebuilt
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-${{ matrix.settings.target }}
+          path: crates/gigastt-node/*.node
+          if-no-files-found: error
+
+  publish:
+    name: Publish to npm
+    needs: build
+    if: ${{ inputs.publish }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance
+    env:
+      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && 'true' || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install deps (@napi-rs/cli)
+        run: npm install
+      - name: Download all prebuilts
+        uses: actions/download-artifact@v4
+        with:
+          path: crates/gigastt-node/artifacts
+          pattern: bindings-*
+          merge-multiple: true
+      - name: Move prebuilts into per-platform npm dirs
+        run: npm run artifacts
+      - name: Warn on missing npm token
+        if: env.HAS_NPM_TOKEN != 'true'
+        run: echo "::warning ::NPM_TOKEN not configured — skipping npm publish."
+      - name: Publish
+        if: env.HAS_NPM_TOKEN == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm config set provenance true
+          # prepublishOnly (napi prepublish -t npm) publishes the per-platform
+          # sub-packages and injects optionalDependencies, then the root publishes.
+          npm publish --access public

--- a/crates/gigastt-node/README.md
+++ b/crates/gigastt-node/README.md
@@ -50,7 +50,11 @@ Inference runs on libuv's worker threadpool (default 4 threads, shared with Node
 
 ## Packaging
 
-Per-platform prebuilt npm packages (optional-dependency model, `npm install` with no compiler) are produced by the release pipeline (prebuilt-artifacts task), not by this crate's local build.
+Per-platform prebuilt npm packages follow napi-rs's optional-dependency model: a JS-only root package (`gigastt-node`) plus one binary sub-package per platform (`gigastt-node-darwin-arm64`, `gigastt-node-linux-x64-gnu`, …) listed under `optionalDependencies`, so `npm install gigastt-node` pulls exactly the matching binary — no compiler, no node-gyp, no postinstall download. onnxruntime is statically linked into each `.node`, so there is no native dylib to locate (and no `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` setup).
+
+The prebuilts are produced and published by the **Node Prebuilds** workflow (`.github/workflows/node-prebuilds.yml`, manual `workflow_dispatch`): it builds the addon on a native runner per target — `darwin-arm64`, `darwin-x64`, `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc` — and, when `publish` is set and `NPM_TOKEN` is configured, publishes all packages via `napi prepublish`.
+
+The ~215 MB INT8 model is **not** bundled in the npm package; side-load it at runtime (e.g. `gigastt download --prequantized`).
 
 ## License
 

--- a/crates/gigastt-node/package.json
+++ b/crates/gigastt-node/package.json
@@ -4,9 +4,12 @@
   "description": "napi-rs Node.js binding for gigastt — on-device Russian speech-to-text (GigaAM v3)",
   "license": "MIT",
   "repository": "https://github.com/ekhodzitsky/gigastt",
-  "private": true,
   "main": "index.js",
   "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "engines": {
     "node": ">=18"
   },
@@ -24,8 +27,11 @@
     "@napi-rs/cli": "^3.7.2"
   },
   "scripts": {
+    "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
+    "prepublishOnly": "napi prepublish -t npm",
+    "version": "napi version",
     "smoke": "node __test__/smoke.cjs"
   }
 }


### PR DESCRIPTION
Roadmap task 83, item 5 (npm prebuilds). Builds on the gigastt-node crate (#102).

## What
The napi-rs optional-dependency prebuild + publish pipeline so consumers get `npm install gigastt-node` with **no compiler / node-gyp**.

- **`.github/workflows/node-prebuilds.yml`** (`workflow_dispatch`): builds the `.node` addon on a **native runner per target** (`darwin-arm64`, `darwin-x64`, `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc`). Native runners deliberately avoid ort's fragile cross-compile of the onnxruntime native lib. `protoc` installed per-OS; a `require()` load check guards each prebuilt. The publish job gathers artifacts (`napi artifacts`) and, when `NPM_TOKEN` is set, publishes the per-platform packages (`napi prepublish`).
- **`package.json`**: drop `private`, add napi publish scripts (`artifacts` / `prepublishOnly` / `version`) + `files`.
- **README**: document the optional-dependency install model.

## Distribution model
A JS-only root package (`gigastt-node`) + one binary sub-package per platform (`gigastt-node-<platform>`) under `optionalDependencies`; the package manager pulls only the matching binary. **onnxruntime is statically linked** into each `.node` (ort default), so no native dylib is bundled and there is no `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` setup (a documented sherpa-onnx pain point). The ~215 MB INT8 model is side-loaded, not bundled.

## Verified locally
- `napi create-npm-dirs` emits correct per-platform `os`/`cpu`/`libc` stubs for all five targets; `package.json` is valid and the napi config resolves.
- The addon build + `require()` load were already proven for `darwin-arm64` (#102).

## Maintainer action
Publishing needs the `NPM_TOKEN` secret + running the workflow with `publish: true`. The build matrix is `workflow_dispatch` (doesn't run on PRs) since the cross-platform prebuilds can't be exercised on a single PR runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)