### PR TITLE
feat(python): pip-installable wheels via maturin (uniffi)

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -1,0 +1,120 @@
+# Build + publish Python wheels for gigastt (UniFFI bindings via maturin).
+#
+# Manual (`workflow_dispatch`). UniFFI Python is ctypes-based, so each wheel is
+# `py3-none-<platform>` — one wheel per platform across all Python 3.x (no
+# per-version matrix). onnxruntime is statically linked (ort default), so the
+# wheel is self-contained; the ~215 MB model is side-loaded at runtime.
+#
+#   pip install gigastt
+#   import gigastt_uniffi as g
+name: Python Wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to PyPI (requires MATURIN_PYPI_TOKEN)'
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    working-directory: crates/gigastt-uniffi
+
+jobs:
+  wheels:
+    name: Wheel ${{ matrix.platform }}
+    runs-on: ${{ matrix.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: ubuntu-latest
+            platform: linux-x86_64
+            target: x86_64-unknown-linux-gnu
+            manylinux: '2_28'
+          - host: ubuntu-24.04-arm
+            platform: linux-aarch64
+            target: aarch64-unknown-linux-gnu
+            manylinux: '2_28'
+          - host: macos-14
+            platform: macos-arm64
+            target: aarch64-apple-darwin
+          - host: macos-13
+            platform: macos-x86_64
+            target: x86_64-apple-darwin
+          - host: windows-latest
+            platform: windows-x64
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v4
+
+      # protoc for non-Linux hosts (Linux gets it inside the manylinux container
+      # via before-script-linux below).
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protoc -y
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: crates/gigastt-uniffi
+          target: ${{ matrix.target }}
+          # `--release` honours the workspace LTO profile; `-b uniffi` is also in
+          # pyproject but passed explicitly for clarity.
+          args: --release --out dist -b uniffi
+          manylinux: ${{ matrix.manylinux }}
+          # Download a protoc binary matching the container arch (manylinux_2_28
+          # has no protobuf-compiler package). Runs before each Linux build.
+          before-script-linux: |
+            set -eu
+            PV=25.1
+            case "$(uname -m)" in
+              x86_64) PA=x86_64 ;;
+              aarch64) PA=aarch_64 ;;
+              *) echo "unsupported arch $(uname -m)"; exit 1 ;;
+            esac
+            curl -fsSL -o /tmp/protoc.zip \
+              "https://github.com/protocolbuffers/protobuf/releases/download/v${PV}/protoc-${PV}-linux-${PA}.zip"
+            (command -v unzip || (yum install -y unzip || dnf install -y unzip)) >/dev/null 2>&1 || true
+            unzip -o /tmp/protoc.zip -d /usr/local
+            protoc --version
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.platform }}
+          path: crates/gigastt-uniffi/dist/*.whl
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: wheels
+    if: ${{ inputs.publish }}
+    runs-on: ubuntu-latest
+    env:
+      HAS_PYPI_TOKEN: ${{ secrets.MATURIN_PYPI_TOKEN != '' && 'true' || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: wheels
+          pattern: wheel-*
+          merge-multiple: true
+      - name: List wheels
+        working-directory: wheels
+        run: ls -la
+      - name: Warn on missing PyPI token
+        if: env.HAS_PYPI_TOKEN != 'true'
+        run: echo "::warning ::MATURIN_PYPI_TOKEN not configured — skipping PyPI publish."
+      - name: Publish
+        if: env.HAS_PYPI_TOKEN == 'true'
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.MATURIN_PYPI_TOKEN }}
+        with:
+          command: upload
+          args: --skip-existing wheels/*.whl

--- a/crates/gigastt-uniffi/.gitignore
+++ b/crates/gigastt-uniffi/.gitignore
@@ -1,2 +1,6 @@
 # Generated UniFFI bindings are build artifacts (regenerate via uniffi-bindgen).
 /bindings/
+# maturin / Python wheel build outputs.
+/dist/
+*.whl
+__pycache__/

--- a/crates/gigastt-uniffi/README.md
+++ b/crates/gigastt-uniffi/README.md
@@ -32,8 +32,13 @@ Generated bindings are build artifacts (`bindings/` is git-ignored). Packaging t
 
 ## Python (quickstart, verified)
 
+Install the prebuilt wheel — `pip install gigastt` — no compiler, no `protoc`, no
+onnxruntime download (it is statically linked; the wheel is `py3-none-<platform>`,
+one per platform across all Python 3.x). The ~215 MB model is side-loaded at
+runtime. Wheels are built + published by `.github/workflows/python-wheels.yml`.
+
 ```python
-import sys; sys.path.insert(0, "bindings/python")   # + libgigastt_uniffi.dylib on the path
+# pip install gigastt
 import gigastt_uniffi as g
 
 engine = g.Engine("/path/to/gigastt/models")        # side-loaded model dir

--- a/crates/gigastt-uniffi/pyproject.toml
+++ b/crates/gigastt-uniffi/pyproject.toml
@@ -1,0 +1,46 @@
+# Python packaging for the gigastt UniFFI bindings (maturin, uniffi mode).
+#
+# Builds a self-contained wheel: maturin compiles the cdylib (onnxruntime is
+# statically linked via ort's default), runs this crate's pinned uniffi-bindgen
+# in library mode to generate the ctypes Python module, and packages both.
+# UniFFI Python is ctypes-based, so wheels are `py3-none-<platform>` — one wheel
+# per platform across all Python 3.x (broader than abi3).
+#
+#   pip install gigastt            # the published distribution
+#   import gigastt_uniffi as g     # the generated module (UniFFI namespace)
+#
+# Build locally:  maturin build --release   (run in this directory)
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "gigastt"
+description = "On-device Russian speech-to-text (GigaAM v3) — Python bindings (no cloud, no API keys)"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.8"
+keywords = ["stt", "speech-recognition", "gigaam", "russian", "asr"]
+authors = [{ name = "ekhodzitsky" }]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3",
+    "Topic :: Multimedia :: Sound/Audio :: Speech",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+]
+dynamic = ["version"]
+
+[project.urls]
+Repository = "https://github.com/ekhodzitsky/gigastt"
+Homepage = "https://github.com/ekhodzitsky/gigastt"
+
+[tool.maturin]
+# UniFFI bindings: maturin invokes this crate's [[bin]] uniffi-bindgen in
+# library mode (proc-macro / setup_scaffolding, no .udl).
+bindings = "uniffi"
+# Pull the version from the crate's Cargo metadata (workspace = 2.3.0).


### PR DESCRIPTION
Roadmap task 83, item 4 (Python wheels). Packages the existing UniFFI Python binding (#101) as `pip install gigastt`.

## What
- **`pyproject.toml`**: maturin uniffi bindings; distribution `gigastt`, version pulled from Cargo (2.3.0). maturin invokes this crate's pinned `uniffi-bindgen` in **library mode** (proc-macro / `setup_scaffolding`, no `.udl`).
- **`.github/workflows/python-wheels.yml`** (`workflow_dispatch`): native-runner matrix — linux x86_64 + aarch64 (manylinux_2_28), macOS arm64 + x86_64, Windows x64 — with `protoc` per host (downloaded by arch inside the manylinux container). Publish to PyPI gated on `MATURIN_PYPI_TOKEN`.
- **README**: pip-install quickstart.

## Why py3-none (not abi3)
UniFFI Python is **ctypes**-based, so each wheel is `py3-none-<platform>` — one wheel per platform across **all** Python 3.x, no per-version build. onnxruntime is statically linked (ort default), so the wheel is self-contained; the ~215 MB model is side-loaded at runtime, not bundled.

## Verified locally (end-to-end, macOS arm64)
Built `gigastt-2.3.0-py3-none-macosx_11_0_arm64.whl`, `pip install`ed it into a fresh Python 3.13 env, `import gigastt_uniffi`, transcribed `golos_00.wav` → `«шестьдесят тысяч тенге сколько будет стоить»` (6 words), and caught the typed `ModelNotFound` error. Confirms maturin's uniffi library-mode path works for our proc-macro crate.

## Maintainer action
Publishing needs the `MATURIN_PYPI_TOKEN` secret + running the workflow with `publish: true`. The cross-platform matrix is `workflow_dispatch` (can't be exercised on a single PR runner); the macOS arm64 wheel is proven locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)