### PR TITLE
feat(ios): xcframework + SwiftPM package (C-ABI staticlib)

### DIFF
--- a/.github/workflows/ios-xcframework.yml
+++ b/.github/workflows/ios-xcframework.yml
@@ -1,0 +1,160 @@
+name: iOS xcframework
+
+# Builds GigasttFFI.xcframework (device arm64 + simulator arm64/x86_64),
+# attaches the zip to a GitHub release, and prints the SwiftPM binaryTarget
+# url + checksum for packaging/swift/Package.swift.
+#
+# The release tag passed as input must already exist (create the tag/release
+# first, then dispatch this workflow against it).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to attach GigasttFFI.xcframework to (e.g. v0.9.0)"
+        required: true
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build-xcframework:
+    name: Build GigasttFFI.xcframework
+    runs-on: macos-14
+    env:
+      # GitHub Actions forbids referencing `secrets.*` in `if:` conditions
+      # directly; expose presence as a boolean env var at job scope instead.
+      HAS_MINISIGN_KEY: ${{ secrets.MINISIGN_SECRET_KEY != '' && 'true' || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Install protoc
+        run: brew install protobuf
+
+      - name: Install cbindgen
+        run: cargo install --locked --version 0.29.4 cbindgen
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ios
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # Each iOS target produces a self-contained static archive: ONNX Runtime
+      # is statically linked by `ort`, so no vendored native library is needed.
+      - name: Build staticlib (device arm64)
+        run: cargo build --release -p gigastt-ffi --target aarch64-apple-ios
+
+      - name: Build staticlib (simulator arm64)
+        run: cargo build --release -p gigastt-ffi --target aarch64-apple-ios-sim
+
+      - name: Build staticlib (simulator x86_64)
+        run: cargo build --release -p gigastt-ffi --target x86_64-apple-ios
+
+      # Regenerate the C header from the FFI crate, then stage a Headers/ dir
+      # (gigastt.h + module.modulemap) shared by every xcframework slice.
+      - name: Generate header + stage Headers/
+        run: |
+          set -euo pipefail
+          mkdir -p build/Headers
+          cbindgen \
+            --config crates/gigastt-ffi/cbindgen.toml \
+            --crate gigastt-ffi \
+            --output build/Headers/gigastt.h \
+            crates/gigastt-ffi
+          cp packaging/swift/module/module.modulemap build/Headers/module.modulemap
+          cat build/Headers/gigastt.h
+
+      # Fuse the two simulator slices (arm64 + x86_64) into a single fat
+      # simulator archive; xcframework requires one library per platform.
+      - name: Create fat simulator library
+        run: |
+          set -euo pipefail
+          mkdir -p build/sim
+          lipo -create \
+            target/aarch64-apple-ios-sim/release/libgigastt_ffi.a \
+            target/x86_64-apple-ios/release/libgigastt_ffi.a \
+            -output build/sim/libgigastt_ffi.a
+          lipo -info build/sim/libgigastt_ffi.a
+
+      - name: Create xcframework
+        run: |
+          set -euo pipefail
+          rm -rf GigasttFFI.xcframework
+          xcodebuild -create-xcframework \
+            -library target/aarch64-apple-ios/release/libgigastt_ffi.a \
+            -headers build/Headers \
+            -library build/sim/libgigastt_ffi.a \
+            -headers build/Headers \
+            -output GigasttFFI.xcframework
+          plutil -p GigasttFFI.xcframework/Info.plist
+
+      - name: Zip xcframework
+        run: |
+          set -euo pipefail
+          ditto -c -k --keepParent GigasttFFI.xcframework GigasttFFI.xcframework.zip
+          ls -la GigasttFFI.xcframework.zip
+
+      - name: Compute SwiftPM checksum
+        id: checksum
+        run: |
+          set -euo pipefail
+          CHECKSUM="$(swift package --package-path packaging/swift compute-checksum GigasttFFI.xcframework.zip)"
+          echo "checksum=${CHECKSUM}" >> "$GITHUB_OUTPUT"
+          echo "Checksum: ${CHECKSUM}"
+
+      # Optional minisign signature for the zip. Degrades to a warning when the
+      # signing secret is absent (forks, preview runs) so the build never fails.
+      - name: Sign zip with minisign
+        if: env.HAS_MINISIGN_KEY == 'true'
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          brew install minisign
+          printf '%s\n' "$MINISIGN_SECRET_KEY" > minisign.key
+          chmod 600 minisign.key
+          printf '%s\n' "$MINISIGN_PASSWORD" | \
+            minisign -Sm GigasttFFI.xcframework.zip -s minisign.key \
+              -c "gigastt ios xcframework ${{ inputs.tag }}" \
+              -t "gigastt GigasttFFI.xcframework.zip ${{ inputs.tag }}"
+          rm -f minisign.key
+          ls -la GigasttFFI.xcframework.zip.minisig
+
+      - name: Warn on missing minisign secret
+        if: env.HAS_MINISIGN_KEY != 'true'
+        run: |
+          echo "::warning ::MINISIGN_SECRET_KEY not configured — GigasttFFI.xcframework.zip will not carry a minisign signature."
+
+      - name: Attach to release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.tag }}
+          fail_on_unmatched_files: true
+          files: |
+            GigasttFFI.xcframework.zip
+            GigasttFFI.xcframework.zip.minisig
+
+      # Print the exact url/checksum to paste into packaging/swift/Package.swift.
+      - name: Job summary
+        run: |
+          set -euo pipefail
+          URL="https://github.com/${{ github.repository }}/releases/download/${{ inputs.tag }}/GigasttFFI.xcframework.zip"
+          {
+            echo "## GigasttFFI.xcframework published"
+            echo ""
+            echo "Paste into \`packaging/swift/Package.swift\`:"
+            echo ""
+            echo '```swift'
+            echo ".binaryTarget("
+            echo "    name: \"GigasttFFI\","
+            echo "    url: \"${URL}\","
+            echo "    checksum: \"${{ steps.checksum.outputs.checksum }}\""
+            echo ")"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packaging/swift/.gitignore
+++ b/packaging/swift/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts produced by the ios-xcframework workflow and local dev.
+*.xcframework
+*.zip
+.build/
+Package.resolved

--- a/packaging/swift/Package.swift
+++ b/packaging/swift/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "GigaSTT",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(name: "GigaSTT", targets: ["GigaSTT"])
+    ],
+    targets: [
+        // Prebuilt C-ABI static library, shipped as an xcframework attached to
+        // a GitHub release by .github/workflows/ios-xcframework.yml.
+        //
+        // After the first workflow run, paste the printed `url:` and
+        // `checksum:` into the binary target below.
+        .binaryTarget(
+            name: "GigasttFFI",
+            url: "REPLACE_WITH_URL",
+            checksum: "REPLACE_WITH_CHECKSUM"
+        ),
+        // --- Local development -------------------------------------------------
+        // To build against a locally produced xcframework instead of the
+        // released zip, comment out the `.binaryTarget(... url: ...)` above and
+        // uncomment the path form below, then drop GigasttFFI.xcframework next
+        // to this Package.swift:
+        //
+        // .binaryTarget(
+        //     name: "GigasttFFI",
+        //     path: "GigasttFFI.xcframework"
+        // ),
+        // -----------------------------------------------------------------------
+        .target(
+            name: "GigaSTT",
+            dependencies: ["GigasttFFI"]
+        )
+    ]
+)

--- a/packaging/swift/README.md
+++ b/packaging/swift/README.md
@@ -1,0 +1,112 @@
+# GigaSTT for Swift
+
+On-device Russian speech-to-text for iOS, powered by GigaAM v3 and ONNX Runtime.
+No cloud APIs, no network calls at inference time, full privacy.
+
+This package wraps the gigastt C ABI in a safe Swift interface. The native code
+ships as a prebuilt `GigasttFFI.xcframework` (device `arm64` + simulator
+`arm64`), with ONNX Runtime statically linked into each slice — there is no
+separate runtime to bundle.
+
+## Requirements
+
+- iOS 15 or later
+- Xcode 15 or later (Swift 5.9 tools)
+
+## Installation
+
+### Swift Package Manager (Xcode)
+
+File -> Add Package Dependencies, then enter the repository URL:
+
+```
+https://github.com/ekhodzitsky/gigastt
+```
+
+Point the package to the `packaging/swift` directory and add the `GigaSTT`
+product to your target.
+
+### Package.swift
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/ekhodzitsky/gigastt", from: "0.9.0")
+],
+targets: [
+    .target(name: "MyApp", dependencies: [
+        .product(name: "GigaSTT", package: "gigastt")
+    ])
+]
+```
+
+## Shipping the model
+
+The xcframework contains only the inference code. The GigaAM v3 model
+(~215 MB INT8, or ~850 MB FP32) is not embedded — download it once on a
+developer machine and bundle the directory with your app (or fetch it on
+first launch and cache it).
+
+Download the prequantized model with the gigastt CLI:
+
+```sh
+gigastt download --prequantized
+```
+
+This writes the model directory to `~/.gigastt/models/`. Copy that directory
+into your app bundle as a folder reference (so the file layout is preserved),
+then pass its on-device path to `Engine(modelDir:)`.
+
+```swift
+import GigaSTT
+
+guard let modelDir = Bundle.main.url(
+    forResource: "models", withExtension: nil
+)?.path else {
+    fatalError("bundle the model directory as a folder reference")
+}
+
+// poolSize: 1 keeps RAM around ~350 MB, recommended on device.
+let engine = try Engine(modelDir: modelDir, poolSize: 1)
+```
+
+## File transcription
+
+```swift
+// Path is relative to the current working directory; absolute paths and ".."
+// are rejected by the engine.
+let text = try engine.transcribeFile(path: "audio.wav")
+print(text)
+```
+
+## Real-time streaming
+
+Feed little-endian mono PCM16 chunks at your capture sample rate. Audio is
+resampled to 16 kHz internally.
+
+```swift
+let stream = try Stream(engine: engine)
+
+// pcm16: Data of little-endian Int16 mono samples at 48 kHz.
+for segment in try stream.processChunk(pcm16, sampleRate: 48000) {
+    print(segment.text, segment.isFinal)
+}
+
+// Drain the tail at end-of-stream.
+for segment in try stream.flush() {
+    print(segment.text)
+}
+```
+
+`processChunk` and `flush` return `[TranscriptSegment]`, where each segment
+carries `text`, `words` (per-word `start`/`end`/`confidence` and an optional
+`speaker`), `isFinal`, and a `timestamp`.
+
+## Memory management
+
+`Engine` and `Stream` own their native handles and free them in `deinit`.
+Strings returned by the C ABI are copied and freed internally — there is
+nothing to release manually.
+
+## License
+
+MIT. See the repository root for details.

--- a/packaging/swift/Sources/GigaSTT/GigaSTT.swift
+++ b/packaging/swift/Sources/GigaSTT/GigaSTT.swift
@@ -1,0 +1,219 @@
+import Foundation
+import GigasttFFI
+
+/// Errors surfaced by the GigaSTT Swift wrapper.
+///
+/// The underlying C ABI signals failure with `NULL` returns and does not
+/// expose a structured error channel, so these cases describe *where* the
+/// failure happened rather than carrying an engine-side message.
+public enum GigasttError: Error {
+    /// `gigastt_engine_new` / `gigastt_engine_new_with_pool_size` returned `NULL`.
+    /// Usually a missing or unreadable model directory.
+    case engineLoadFailed(modelDir: String)
+    /// `gigastt_stream_new` returned `NULL` (pool checkout failed).
+    case streamCreationFailed
+    /// A transcription / streaming call returned `NULL`.
+    case inferenceFailed
+    /// The C function returned a string that was not valid UTF-8, or the
+    /// returned JSON could not be decoded into `[TranscriptSegment]`.
+    case decodingFailed(underlying: Error?)
+}
+
+/// A single recognized word with timing and confidence metadata.
+///
+/// Field names mirror the engine's `WordInfo` serde representation exactly:
+/// `word`, `start`, `end`, `confidence`, and an optional `speaker`.
+public struct Word: Codable, Sendable, Equatable {
+    /// The recognized word text.
+    public let word: String
+    /// Start time in seconds from the beginning of the audio stream.
+    public let start: Double
+    /// End time in seconds from the beginning of the audio stream.
+    public let end: Double
+    /// Softmax confidence score in `0.0...1.0`.
+    public let confidence: Double
+    /// Speaker label from diarization (zero-based). `nil` when diarization is off.
+    public let speaker: UInt32?
+
+    public init(word: String, start: Double, end: Double, confidence: Double, speaker: UInt32? = nil) {
+        self.word = word
+        self.start = start
+        self.end = end
+        self.confidence = confidence
+        self.speaker = speaker
+    }
+}
+
+/// A transcript segment emitted by the streaming engine.
+///
+/// Mirrors the engine's `TranscriptSegment` serde representation: `text`,
+/// `words`, `is_final`, `timestamp`. Partial segments (`isFinal == false`)
+/// are interim and may change; final segments are completed utterances.
+public struct TranscriptSegment: Codable, Sendable, Equatable {
+    /// Recognized text for this segment.
+    public let text: String
+    /// Individual words with timing and confidence metadata.
+    public let words: [Word]
+    /// Whether this segment is final (utterance complete) or partial (interim).
+    public let isFinal: Bool
+    /// Unix timestamp (seconds since epoch) when this segment was produced.
+    public let timestamp: Double
+
+    private enum CodingKeys: String, CodingKey {
+        case text
+        case words
+        case isFinal = "is_final"
+        case timestamp
+    }
+
+    public init(text: String, words: [Word], isFinal: Bool, timestamp: Double) {
+        self.text = text
+        self.words = words
+        self.isFinal = isFinal
+        self.timestamp = timestamp
+    }
+}
+
+/// Decode a JSON array string of `TranscriptSegment` values.
+///
+/// The engine's `gigastt_stream_process_chunk` / `gigastt_stream_flush`
+/// return `serde_json::to_string(&Vec<TranscriptSegment>)`.
+private func decodeSegments(_ json: String) throws -> [TranscriptSegment] {
+    guard let data = json.data(using: .utf8) else {
+        throw GigasttError.decodingFailed(underlying: nil)
+    }
+    do {
+        return try JSONDecoder().decode([TranscriptSegment].self, from: data)
+    } catch {
+        throw GigasttError.decodingFailed(underlying: error)
+    }
+}
+
+/// Take ownership of a `char*` returned by the C ABI, copy it into a Swift
+/// `String`, and free it via `gigastt_string_free`. Returns `nil` if the
+/// pointer is `NULL` (the engine's failure sentinel).
+private func takeOwnedCString(_ ptr: UnsafeMutablePointer<CChar>?) -> String? {
+    guard let ptr else { return nil }
+    defer { gigastt_string_free(ptr) }
+    return String(cString: ptr)
+}
+
+/// A loaded GigaAM inference engine.
+///
+/// Wraps the opaque `GigasttEngine` C handle with RAII: `deinit` calls
+/// `gigastt_engine_free`. Not thread-safe per the C ABI contract — use one
+/// `Engine` (and its `Stream`s) from a single thread at a time, or guard
+/// access externally.
+public final class Engine {
+    /// Non-null for the lifetime of the instance; freed exactly once in `deinit`.
+    fileprivate let handle: OpaquePointer
+
+    /// Load the ONNX models from `modelDir` using the default pool size.
+    ///
+    /// - Throws: ``GigasttError/engineLoadFailed(modelDir:)`` if the engine
+    ///   cannot be loaded (missing models, unreadable directory).
+    public convenience init(modelDir: String) throws {
+        try self.init(modelDir: modelDir, poolSize: nil)
+    }
+
+    /// Load the ONNX models from `modelDir` with an explicit session pool size.
+    ///
+    /// Each pooled session loads the full encoder, so RAM scales with
+    /// `poolSize`. On iOS prefer `poolSize: 1` (~350 MB).
+    public convenience init(modelDir: String, poolSize: Int) throws {
+        try self.init(modelDir: modelDir, poolSize: Optional(poolSize))
+    }
+
+    private init(modelDir: String, poolSize: Int?) throws {
+        let created: OpaquePointer? = modelDir.withCString { cDir in
+            if let poolSize {
+                return gigastt_engine_new_with_pool_size(cDir, UInt(poolSize))
+            }
+            return gigastt_engine_new(cDir)
+        }
+        guard let created else {
+            throw GigasttError.engineLoadFailed(modelDir: modelDir)
+        }
+        self.handle = created
+    }
+
+    /// Transcribe an audio file and return the recognized transcript.
+    ///
+    /// The C ABI requires `path` to be a relative path inside the current
+    /// working directory (absolute paths and `..` are rejected engine-side).
+    ///
+    /// - Returns: The transcript text (the engine returns plain text here,
+    ///   not JSON).
+    /// - Throws: ``GigasttError/inferenceFailed`` on a `NULL` return.
+    public func transcribeFile(path: String) throws -> String {
+        let result: String? = path.withCString { cPath in
+            takeOwnedCString(gigastt_transcribe_file(handle, cPath))
+        }
+        guard let result else {
+            throw GigasttError.inferenceFailed
+        }
+        return result
+    }
+
+    deinit {
+        gigastt_engine_free(handle)
+    }
+}
+
+/// A real-time streaming transcription session bound to an ``Engine``.
+///
+/// Wraps the opaque `GigasttStream` C handle with RAII: `deinit` calls
+/// `gigastt_stream_free`, returning the inference triplet to the engine pool.
+/// Holds a strong reference to its ``Engine`` so the engine outlives the
+/// stream (the C ABI dereferences both handles on every call).
+public final class Stream {
+    private let engine: Engine
+    private let handle: OpaquePointer
+
+    /// Open a new streaming session against `engine`.
+    ///
+    /// - Throws: ``GigasttError/streamCreationFailed`` if the engine pool
+    ///   could not provide an inference session.
+    public init(engine: Engine) throws {
+        guard let created = gigastt_stream_new(engine.handle) else {
+            throw GigasttError.streamCreationFailed
+        }
+        self.engine = engine
+        self.handle = created
+    }
+
+    /// Feed a chunk of little-endian mono PCM16 audio at `sampleRate`.
+    ///
+    /// Audio is resampled to 16 kHz internally when `sampleRate != 16000`.
+    ///
+    /// - Returns: The transcript segments produced by this chunk (possibly empty).
+    /// - Throws: ``GigasttError/inferenceFailed`` on a `NULL` return, or
+    ///   ``GigasttError/decodingFailed(underlying:)`` if the JSON is malformed.
+    public func processChunk(_ pcm16: Data, sampleRate: UInt32) throws -> [TranscriptSegment] {
+        let json: String? = pcm16.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> String? in
+            let base = raw.bindMemory(to: UInt8.self).baseAddress
+            let ptr = gigastt_stream_process_chunk(engine.handle, handle, base, UInt(pcm16.count), sampleRate)
+            return takeOwnedCString(ptr)
+        }
+        guard let json else {
+            throw GigasttError.inferenceFailed
+        }
+        return try decodeSegments(json)
+    }
+
+    /// Signal end-of-stream and drain any final segment(s).
+    ///
+    /// - Returns: The final transcript segments (possibly empty).
+    /// - Throws: ``GigasttError/inferenceFailed`` on a `NULL` return, or
+    ///   ``GigasttError/decodingFailed(underlying:)`` if the JSON is malformed.
+    public func flush() throws -> [TranscriptSegment] {
+        guard let json = takeOwnedCString(gigastt_stream_flush(engine.handle, handle)) else {
+            throw GigasttError.inferenceFailed
+        }
+        return try decodeSegments(json)
+    }
+
+    deinit {
+        gigastt_stream_free(handle)
+    }
+}

--- a/packaging/swift/module/module.modulemap
+++ b/packaging/swift/module/module.modulemap
@@ -1,0 +1,4 @@
+module GigasttFFI {
+    header "gigastt.h"
+    export *
+}


### PR DESCRIPTION
Roadmap task 83, item 3. Ships gigastt to iOS as a SwiftPM package over the `gigastt-ffi` static library.

## Approach
C-ABI staticlib → clang module → `.xcframework` → SwiftPM `.binaryTarget` + a thin Swift wrapper. **onnxruntime is statically linked** into the staticlib — verified locally that `cargo build -p gigastt-ffi --target aarch64-apple-ios` succeeds, so each xcframework slice is self-contained (no vendored onnxruntime / no load-dynamic).

## Contents
- `packaging/swift/Package.swift` — `.binaryTarget` wrapping `GigasttFFI.xcframework` (url+checksum filled by the workflow after the first run; commented local-path form for dev) + a `GigaSTT` Swift target. swift-tools 5.9, iOS 15.
- `packaging/swift/Sources/GigaSTT/GigaSTT.swift` — safe Swift wrapper: `Engine` (`transcribeFile -> String`) and `Stream` (`processChunk`/`flush -> [TranscriptSegment]`) with RAII (deinit frees handles; every `char*` freed via `gigastt_string_free`), typed `GigasttError`, and `Codable` structs matching the streaming serde JSON exactly (`Word{word,start,end,confidence,speaker}`; `TranscriptSegment{text,words,is_final,timestamp}`).
- `packaging/swift/module/module.modulemap` — plain C module (static library, not a framework).
- `.github/workflows/ios-xcframework.yml` (`workflow_dispatch`): builds the staticlib for device + simulator, regenerates the header, `xcodebuild -create-xcframework`, computes the SwiftPM checksum, attaches the zip to the release, optionally minisign-signs, prints url+checksum.

## Verified locally (macOS)
- `aarch64-apple-ios` staticlib builds (`libgigastt_ffi.a`, onnxruntime baked in).
- The regenerated cbindgen header passes `clang -fsyntax-only` (depends on the header fix in #106).
- `swift package dump-package` parses (GigaSTT + GigasttFFI targets).
- actionlint clean.

## Maintainer action
Run the `ios-xcframework` workflow against an existing release tag, then paste the printed `url:`/`checksum:` into `Package.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)