### PR TITLE
ci: fix Python/Node wheel CI (manylinux openssl + retired macos-13 runner)

### DIFF
--- a/.github/workflows/node-prebuilds.yml
+++ b/.github/workflows/node-prebuilds.yml
@@ -30,7 +30,7 @@ jobs:
         settings:
           - host: macos-14
             target: aarch64-apple-darwin
-          - host: macos-13
+          - host: macos-15-intel
             target: x86_64-apple-darwin
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -40,7 +40,7 @@ jobs:
           - host: macos-14
             platform: macos-arm64
             target: aarch64-apple-darwin
-          - host: macos-13
+          - host: macos-15-intel
             platform: macos-x86_64
             target: x86_64-apple-darwin
           - host: windows-latest

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -71,6 +71,13 @@ jobs:
           # has no protobuf-compiler package). Runs before each Linux build.
           before-script-linux: |
             set -eu
+            # manylinux_2_28 (AlmaLinux 8) is a minimal image. ort-sys's
+            # build-time onnxruntime downloader (ureq -> native-tls) links
+            # openssl on Linux, so it needs openssl-devel + pkgconfig; unzip is
+            # for protoc. These are BUILD-only deps — the runtime wheel/.so does
+            # not link openssl (verified: openssl-sys is a build-dependency of
+            # ort-sys only). Ubuntu/macOS runners ship these, manylinux does not.
+            (dnf install -y openssl-devel pkgconfig unzip || yum install -y openssl-devel pkgconfig unzip)
             PV=25.1
             case "$(uname -m)" in
               x86_64) PA=x86_64 ;;
@@ -79,7 +86,6 @@ jobs:
             esac
             curl -fsSL -o /tmp/protoc.zip \
               "https://github.com/protocolbuffers/protobuf/releases/download/v${PV}/protoc-${PV}-linux-${PA}.zip"
-            (command -v unzip || (yum install -y unzip || dnf install -y unzip)) >/dev/null 2>&1 || true
             unzip -o /tmp/protoc.zip -d /usr/local
             protoc --version
 


### PR DESCRIPTION
A `publish=false` dry run of **Python Wheels** caught a real bug: the Linux (manylinux_2_28) wheel jobs failed on `openssl-sys` — `Package openssl was not found in the pkg-config search path`.

## Root cause
`ort-sys`'s build-time onnxruntime downloader pulls `ureq -> native-tls`, which links **openssl-sys on Linux** (on macOS `native-tls` uses Security.framework, so macOS wheels + the local macOS wheel built fine). The minimal manylinux_2_28 (AlmaLinux 8) image has no `openssl-devel`/`pkgconfig`; Ubuntu/macOS runners ship them, which is why Node prebuilds + the macOS wheel passed.

## Fix
Install `openssl-devel` + `pkgconfig` (+ `unzip` for protoc) in `before-script-linux`. These are **build-only** deps (`openssl-sys` is a build-dependency of `ort-sys`); the runtime wheel/.so does not link openssl, so the lean runtime graph is unchanged.

actionlint clean. Will re-run the Python Wheels dry run after merge to confirm all five platforms build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)