### PR TITLE
ci: drop x86_64-apple-darwin (no ort onnxruntime prebuilt)

### DIFF
--- a/.github/workflows/node-prebuilds.yml
+++ b/.github/workflows/node-prebuilds.yml
@@ -30,8 +30,8 @@ jobs:
         settings:
           - host: macos-14
             target: aarch64-apple-darwin
-          - host: macos-15-intel
-            target: x86_64-apple-darwin
+          # x86_64-apple-darwin (Intel Mac) omitted: ort provides no prebuilt
+          # onnxruntime for that target (build-from-source only).
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
           - host: ubuntu-24.04-arm

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -40,9 +40,9 @@ jobs:
           - host: macos-14
             platform: macos-arm64
             target: aarch64-apple-darwin
-          - host: macos-15-intel
-            platform: macos-x86_64
-            target: x86_64-apple-darwin
+          # x86_64-apple-darwin (Intel Mac) omitted: ort provides no prebuilt
+          # onnxruntime for that target (build-from-source only). Matches the
+          # release.yml stance — Intel-Mac users `pip install` from sdist/source.
           - host: windows-latest
             platform: windows-x64
             target: x86_64-pc-windows-msvc

--- a/crates/gigastt-node/package.json
+++ b/crates/gigastt-node/package.json
@@ -17,7 +17,6 @@
     "binaryName": "gigastt-node",
     "targets": [
       "aarch64-apple-darwin",
-      "x86_64-apple-darwin",
       "x86_64-unknown-linux-gnu",
       "aarch64-unknown-linux-gnu",
       "x86_64-pc-windows-msvc"


### PR DESCRIPTION
Final fix from the publish=false dry runs. After the manylinux-openssl + macos-13 fixes (#109), the only remaining failure in both Python Wheels and Node Prebuilds was the Intel-macOS job:

```
error: ort-sys@2.0.0-rc.12: ort does not provide prebuilt binaries for the target `x86_64-apple-darwin`
```

ort/onnxruntime ship **no Intel-mac prebuilt** (build-from-source only) — this is independent of the runner (the `macos-15-intel` runner ran fine, the build itself can't get onnxruntime). `release.yml` already omits Intel Mac for exactly this reason.

Removes `x86_64-apple-darwin` from the Python wheel + Node prebuild matrices and from `gigastt-node`'s `napi.targets`. Remaining platforms — **macos-arm64, linux x86_64-gnu, linux aarch64-gnu, windows-x64** — all built green in the dry run. Intel-Mac users install from source/sdist.

actionlint clean; package.json valid. Will re-run both dry runs after merge to confirm fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)