### PR TITLE
ci(node): create npm platform dirs before napi artifacts

### DIFF
--- a/.github/workflows/node-prebuilds.yml
+++ b/.github/workflows/node-prebuilds.yml
@@ -103,7 +103,12 @@ jobs:
           pattern: bindings-*
           merge-multiple: true
       - name: Move prebuilts into per-platform npm dirs
-        run: npm run artifacts
+        # create-npm-dirs first: `napi artifacts` writes each .node into
+        # npm/<platform>/ but does NOT create those dirs (they are git-ignored),
+        # so without this it fails with ENOENT on the first platform dir.
+        run: |
+          npx napi create-npm-dirs
+          npm run artifacts
       - name: Warn on missing npm token
         if: env.HAS_NPM_TOKEN != 'true'
         run: echo "::warning ::NPM_TOKEN not configured — skipping npm publish."


### PR DESCRIPTION
The `publish=true` Node run failed at the `napi artifacts` step:
```
ENOENT: no such file or directory, open '.../npm/win32-x64-msvc/gigastt-node.win32-x64-msvc.node'
```
`napi artifacts` copies each prebuilt `.node` into `npm/<platform>/`, but those dirs are git-ignored and weren't created in the publish job. Add `napi create-npm-dirs` before `npm run artifacts`.

The failure was before `npm publish`, so nothing was published to npm — clean retry. (PyPI `gigastt` already published successfully.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)