### PR TITLE
feat(node): single npm package (one gigastt, on-demand binary)

### DIFF
--- a/.github/workflows/node-prebuilds.yml
+++ b/.github/workflows/node-prebuilds.yml
@@ -61,7 +61,9 @@ jobs:
         run: choco install protoc -y
 
       - name: Install deps (@napi-rs/cli)
-        run: npm install
+        # --ignore-scripts: skip our postinstall (install.js) — the binary is
+        # built below by napi, not downloaded.
+        run: npm install --ignore-scripts
 
       - name: Build addon
         run: npx napi build --platform --release --target ${{ matrix.settings.target }}
@@ -69,7 +71,7 @@ jobs:
       # Sanity: the addon dlopen-loads (links + onnxruntime static-init OK).
       # No model needed — Engine loads the model lazily, not on require().
       - name: Load check
-        run: node -e "require('./index.js'); console.log('addon loaded OK')"
+        run: node -e "require('./loader.js'); console.log('addon loaded OK')"
 
       - name: Upload prebuilt
         uses: actions/upload-artifact@v4
@@ -84,7 +86,7 @@ jobs:
     if: ${{ inputs.publish }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # create the node-v<version> release that hosts the .node binaries
       id-token: write # npm provenance
     env:
       HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' && 'true' || 'false' }}
@@ -94,30 +96,44 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
-      - name: Install deps (@napi-rs/cli)
-        run: npm install
-      - name: Download all prebuilts
+
+      - name: Download all prebuilt .node binaries
         uses: actions/download-artifact@v4
         with:
           path: crates/gigastt-node/artifacts
           pattern: bindings-*
           merge-multiple: true
-      - name: Move prebuilts into per-platform npm dirs
-        # create-npm-dirs first: `napi artifacts` writes each .node into
-        # npm/<platform>/ but does NOT create those dirs (they are git-ignored),
-        # so without this it fails with ENOENT on the first platform dir.
-        run: |
-          npx napi create-npm-dirs
-          npm run artifacts
+      - name: List prebuilts
+        run: ls -la artifacts
+
+      - name: Read package version
+        id: ver
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      # Host the per-platform native binaries on a dedicated release; the npm
+      # package's postinstall (install.js) downloads exactly one of these.
+      - name: Publish native binaries to node-v* release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: node-v${{ steps.ver.outputs.version }}
+          name: gigastt Node native binaries (v${{ steps.ver.outputs.version }})
+          body: |
+            Per-platform native addons for the `gigastt` npm package. The package
+            is a single JS-only package; its postinstall downloads exactly one of
+            these `.node` files (the one matching the install platform).
+          files: crates/gigastt-node/artifacts/*.node
+
       - name: Warn on missing npm token
         if: env.HAS_NPM_TOKEN != 'true'
         run: echo "::warning ::NPM_TOKEN not configured — skipping npm publish."
-      - name: Publish
+
+      # Single package: only loader.js + install.js + gigastt.d.ts are published
+      # (no bundled binaries, no per-platform sub-packages). `files` in
+      # package.json enforces that; `npm publish` here ships just `gigastt`.
+      - name: Publish gigastt to npm
         if: env.HAS_NPM_TOKEN == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm config set provenance true
-          # prepublishOnly (napi prepublish -t npm) publishes the per-platform
-          # sub-packages and injects optionalDependencies, then the root publishes.
           npm publish --access public

--- a/crates/gigastt-node/README.md
+++ b/crates/gigastt-node/README.md
@@ -42,7 +42,7 @@ npm run build               # napi build --release -> index.js + index.d.ts + *.
 GIGASTT_MODEL_DIR=~/.gigastt/models npm run smoke   # transcribes the golos_00.wav fixture
 ```
 
-`npm run build` auto-generates the JS loader (`index.js`), the TypeScript types (`index.d.ts`), and the native `.node` addon; all are git-ignored build artifacts.
+`npm run build` produces the native `gigastt.<platform>.node` addon (git-ignored); `loader.js`, `install.js`, and `gigastt.d.ts` are the committed, published package files.
 
 ## Performance note
 
@@ -50,11 +50,11 @@ Inference runs on libuv's worker threadpool (default 4 threads, shared with Node
 
 ## Packaging
 
-Per-platform prebuilt npm packages follow napi-rs's optional-dependency model: a JS-only root package (`gigastt`) plus one binary sub-package per platform (`gigastt-darwin-arm64`, `gigastt-linux-x64-gnu`, …) listed under `optionalDependencies`, so `npm install gigastt` pulls exactly the matching binary — no compiler, no node-gyp, no postinstall download. onnxruntime is statically linked into each `.node`, so there is no native dylib to locate (and no `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` setup).
+**Single npm package.** `gigastt` is one JS-only package (`loader.js` + `install.js` + `gigastt.d.ts`) — no per-platform sub-packages. On `npm install gigastt`, the postinstall (`install.js`) downloads exactly **one** native binary — the `gigastt.<platform>.node` matching the install platform — from the `node-v<version>` GitHub release, so only ~47 MB is fetched (not all platforms). `loader.js` then loads it. onnxruntime is statically linked into each `.node`, so there is no native dylib to locate (no `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`).
 
-The prebuilts are produced and published by the **Node Prebuilds** workflow (`.github/workflows/node-prebuilds.yml`, manual `workflow_dispatch`): it builds the addon on a native runner per target — `darwin-arm64`, `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc` — and, when `publish` is set and `NPM_TOKEN` is configured, publishes all packages via `napi prepublish`. (Intel macOS is omitted: ort ships no prebuilt onnxruntime for it.)
+Supported prebuilt platforms: `darwin-arm64`, `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc` (Intel macOS omitted — ort ships no onnxruntime for it). The binaries are built per native runner and attached to the `node-v<version>` release by the **Node Prebuilds** workflow (`.github/workflows/node-prebuilds.yml`, `workflow_dispatch`); the single `gigastt` package is then published.
 
-The ~215 MB INT8 model is **not** bundled in the npm package; side-load it at runtime (e.g. `gigastt download --prequantized`).
+Caveat: `npm install --ignore-scripts` skips the postinstall, so the binary is not fetched — `require('gigastt')` then errors with instructions to run `node install.js`. The ~215 MB INT8 model is **not** bundled either; side-load it at runtime (e.g. `gigastt download --prequantized`).
 
 ## License
 

--- a/crates/gigastt-node/__test__/smoke.cjs
+++ b/crates/gigastt-node/__test__/smoke.cjs
@@ -4,7 +4,7 @@
 // word timings, and that a missing model throws a typed JS error.
 const os = require('os');
 const path = require('path');
-const { Engine, Stream } = require('../index.js');
+const { Engine, Stream } = require('../loader.js');
 
 const modelDir =
   process.env.GIGASTT_MODEL_DIR || path.join(os.homedir(), '.gigastt', 'models');

--- a/crates/gigastt-node/gigastt.d.ts
+++ b/crates/gigastt-node/gigastt.d.ts
@@ -1,0 +1,42 @@
+/** A recognized word with timing, confidence, and optional speaker label. */
+export interface Word {
+  text: string
+  startS: number
+  endS: number
+  confidence: number
+  speaker?: number
+}
+
+/** A transcript segment (interim or final) with its words. */
+export interface TranscriptSegment {
+  text: string
+  words: Array<Word>
+  isFinal: boolean
+}
+
+/** The full result of transcribing a file. */
+export interface Transcript {
+  text: string
+  words: Array<Word>
+  durationS: number
+}
+
+/**
+ * On-device speech-recognition engine. Loads the GigaAM v3 model from a
+ * side-loaded directory. Thread-safe; share one instance across streams.
+ */
+export declare class Engine {
+  /** Load the model from `modelDir` with an optional session-pool size. */
+  constructor(modelDir: string, poolSize?: number | undefined | null)
+  /** Transcribe an audio file (WAV / MP3 / M4A / OGG / FLAC) to text + timings. */
+  transcribeFile(path: string): Promise<Transcript>
+}
+
+/** A streaming transcription session bound to an {@link Engine}. */
+export declare class Stream {
+  constructor(engine: Engine)
+  /** Feed little-endian mono PCM16; `sampleRate` is resampled to 16 kHz. */
+  processChunk(pcm16: Uint8Array, sampleRate: number): Promise<Array<TranscriptSegment>>
+  /** Flush buffered audio and return any final segment(s). */
+  flush(): Promise<Array<TranscriptSegment>>
+}

--- a/crates/gigastt-node/install.js
+++ b/crates/gigastt-node/install.js
@@ -1,0 +1,78 @@
+'use strict'
+// postinstall: download ONLY the native addon for THIS platform from the
+// GitHub release, into the package directory. Keeps the npm package a single
+// JS-only package while installing just one ~47 MB binary per machine.
+//
+// Node built-ins only (runs before the consumer's deps are available). Honors
+// GIGASTT_NODE_TAG to override the release tag (default `node-v<version>`).
+const fs = require('fs')
+const path = require('path')
+const https = require('https')
+
+const { version } = require('./package.json')
+
+function platformKey() {
+  const { platform, arch } = process
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64'
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64-gnu'
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64-gnu'
+  if (platform === 'win32' && arch === 'x64') return 'win32-x64-msvc'
+  return null
+}
+
+const key = platformKey()
+if (!key) {
+  console.error(
+    `gigastt: no prebuilt binary for ${process.platform}-${process.arch}; ` +
+      `build from source (https://github.com/ekhodzitsky/gigastt).`
+  )
+  // Don't hard-fail install on unsupported platforms; loading will error clearly.
+  process.exit(0)
+}
+
+const file = `gigastt.${key}.node`
+const dest = path.join(__dirname, file)
+if (fs.existsSync(dest)) {
+  console.log(`gigastt: ${file} already present`)
+  process.exit(0)
+}
+
+const tag = process.env.GIGASTT_NODE_TAG || `node-v${version}`
+const url = `https://github.com/ekhodzitsky/gigastt/releases/download/${tag}/${file}`
+
+function download(u, redirects, cb) {
+  https
+    .get(u, { headers: { 'user-agent': 'gigastt-installer' } }, (res) => {
+      const { statusCode, headers } = res
+      if ([301, 302, 303, 307, 308].includes(statusCode) && headers.location && redirects < 6) {
+        res.resume()
+        return download(headers.location, redirects + 1, cb)
+      }
+      if (statusCode !== 200) {
+        res.resume()
+        return cb(new Error(`HTTP ${statusCode} for ${u}`))
+      }
+      const tmp = `${dest}.download`
+      const out = fs.createWriteStream(tmp)
+      res.pipe(out)
+      out.on('finish', () => out.close(() => {
+        fs.renameSync(tmp, dest)
+        cb()
+      }))
+      out.on('error', cb)
+    })
+    .on('error', cb)
+}
+
+console.log(`gigastt: downloading ${file} from ${tag} ...`)
+download(url, 0, (err) => {
+  if (err) {
+    // Don't hard-fail the install (this also runs during local dev/CI before
+    // the binary is built or the release exists). loader.js raises a clear
+    // error at require-time if the binary is genuinely missing.
+    console.warn(`gigastt: could not download ${file}: ${err.message}`)
+    console.warn(`gigastt: tried ${url}`)
+    process.exit(0)
+  }
+  console.log(`gigastt: installed ${file}`)
+})

--- a/crates/gigastt-node/loader.js
+++ b/crates/gigastt-node/loader.js
@@ -1,0 +1,33 @@
+'use strict'
+// Single-package loader: resolves the one native addon for THIS platform.
+// The matching `gigastt.<platform>.node` is fetched at install time by
+// install.js (postinstall) from the GitHub release; it is not bundled, so only
+// one binary is downloaded per machine (not all platforms).
+const fs = require('fs')
+const path = require('path')
+
+function platformKey() {
+  const { platform, arch } = process
+  if (platform === 'darwin' && arch === 'arm64') return 'darwin-arm64'
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64-gnu'
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64-gnu'
+  if (platform === 'win32' && arch === 'x64') return 'win32-x64-msvc'
+  throw new Error(
+    `gigastt: unsupported platform ${platform}-${arch}. ` +
+      `Prebuilt binaries: darwin-arm64, linux-x64-gnu, linux-arm64-gnu, win32-x64-msvc. ` +
+      `See https://github.com/ekhodzitsky/gigastt to build from source.`
+  )
+}
+
+const binary = path.join(__dirname, `gigastt.${platformKey()}.node`)
+
+if (!fs.existsSync(binary)) {
+  throw new Error(
+    `gigastt: native binary not found at ${binary}. ` +
+      `The postinstall download was likely skipped (e.g. \`npm install --ignore-scripts\`). ` +
+      `Run \`node ${path.join(__dirname, 'install.js')}\` to fetch it.`
+  )
+}
+
+module.exports = require(binary)
+module.exports.platformKey = platformKey

--- a/crates/gigastt-node/package.json
+++ b/crates/gigastt-node/package.json
@@ -1,14 +1,15 @@
 {
   "name": "gigastt",
   "version": "2.3.0",
-  "description": "napi-rs Node.js binding for gigastt — on-device Russian speech-to-text (GigaAM v3)",
+  "description": "On-device Russian speech-to-text (GigaAM v3) — Node.js binding",
   "license": "MIT",
   "repository": "https://github.com/ekhodzitsky/gigastt",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "loader.js",
+  "types": "gigastt.d.ts",
   "files": [
-    "index.js",
-    "index.d.ts"
+    "loader.js",
+    "install.js",
+    "gigastt.d.ts"
   ],
   "engines": {
     "node": ">=18"
@@ -26,11 +27,9 @@
     "@napi-rs/cli": "^3.7.2"
   },
   "scripts": {
-    "artifacts": "napi artifacts",
+    "postinstall": "node install.js",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "prepublishOnly": "napi prepublish -t npm",
-    "version": "napi version",
     "smoke": "node __test__/smoke.cjs"
   }
 }


### PR DESCRIPTION
Replaces napi-rs's per-platform optional-dependency model (which published 5 packages: `gigastt` + 4 `gigastt-<platform>`) with a **single `gigastt` npm package** that downloads only the matching binary at install time.

## How
- `loader.js` — resolves and `require`s `gigastt.<platform>.node` for the running platform; clear error if missing.
- `install.js` (postinstall) — downloads exactly **one** `gigastt.<platform>.node` (~47 MB, not all platforms) from the `node-v<version>` GitHub release; graceful on failure (so dev/CI `npm install` doesn't break before the binary exists, and `--ignore-scripts` degrades to a clear require-time error).
- `gigastt.d.ts` — hand-written types.
- `package.json` — `main`/`types`/`files` point at the committed JS; `postinstall` runs `install.js`; **no** `napi prepublish`/`artifacts` (so no sub-packages).
- `node-prebuilds.yml` — the publish job attaches the 4 `.node` to a `node-v<version>` release, then publishes the single `gigastt` package.

## Result
Only **one** package (`gigastt`) on npm; only one binary fetched per machine. Verified locally: `napi build` → `gigastt.darwin-arm64.node`, `loader.js` loads it, smoke transcribes `golos_00.wav` (6 words) + typed error. Caveat documented: `--ignore-scripts` skips the binary download.

(The previously-published `gigastt-node*` / `gigastt-*` sub-packages are unpublished separately — needs the maintainer's npm OTP.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)