### PR TITLE
feat(runtime): isolate ort behind runtime abstraction layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,38 +27,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check ort is isolated to runtime/ort
         run: |
-          python3 - <<'PY'
-          import re
-          import sys
-          from pathlib import Path
-
-          root = Path("crates/gigastt-core/src")
-          violations = []
-
-          for path in root.rglob("*.rs"):
-              if "runtime/ort" in path.as_posix():
-                  continue
-              for i, line in enumerate(path.read_text().splitlines(), 1):
-                  stripped = line.strip()
-                  # Direct import of the ort crate.
-                  if re.match(r"use\s+ort::", stripped):
-                      violations.append((path, i, stripped))
-                  # Direct ort crate usage that is not part of the runtime::ort module.
-                  elif (
-                      "runtime::ort" not in stripped
-                      and re.search(r"(?<![a-zA-Z0-9_:])ort::", stripped)
-                      # Allow bare module-path components inside use crate::runtime::{ ... }.
-                      and not re.match(r"ort::\w+(::\w+)*,?$", stripped)
-                  ):
-                      violations.append((path, i, stripped))
-
-          if violations:
-              print("ERROR: direct ort crate usage found outside runtime/ort/")
-              for path, i, line in violations:
-                  print(f"  {path}:{i}: {line}")
-              sys.exit(1)
-          print("OK: ort is isolated")
-          PY
+          set -e
+          violations=$(rg "^use ort::" crates/gigastt-core/src --type rust | grep -v "runtime/ort" || true)
+          if [ -n "$violations" ]; then
+            echo "ERROR: direct use ort:: import outside runtime/ort"
+            echo "$violations"
+            exit 1
+          fi
+          violations=$(rg "^extern crate ort" crates/gigastt-core/src --type rust | grep -v "runtime/ort" || true)
+          if [ -n "$violations" ]; then
+            echo "ERROR: extern crate ort outside runtime/ort"
+            echo "$violations"
+            exit 1
+          fi
+          echo "OK: ort is isolated"
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,46 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  runtime-isolation:
+    runs-on: ubuntu-latest
+    name: Runtime Isolation
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check ort is isolated to runtime/ort
+        run: |
+          python3 - <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          root = Path("crates/gigastt-core/src")
+          violations = []
+
+          for path in root.rglob("*.rs"):
+              if "runtime/ort" in path.as_posix():
+                  continue
+              for i, line in enumerate(path.read_text().splitlines(), 1):
+                  stripped = line.strip()
+                  # Direct import of the ort crate.
+                  if re.match(r"use\s+ort::", stripped):
+                      violations.append((path, i, stripped))
+                  # Direct ort crate usage that is not part of the runtime::ort module.
+                  elif (
+                      "runtime::ort" not in stripped
+                      and re.search(r"(?<![a-zA-Z0-9_:])ort::", stripped)
+                      # Allow bare module-path components inside use crate::runtime::{ ... }.
+                      and not re.match(r"ort::\w+(::\w+)*,?$", stripped)
+                  ):
+                      violations.append((path, i, stripped))
+
+          if violations:
+              print("ERROR: direct ort crate usage found outside runtime/ort/")
+              for path, i, line in violations:
+                  print(f"  {path}:{i}: {line}")
+              sys.exit(1)
+          print("OK: ort is isolated")
+          PY
+
   clippy:
     runs-on: ubuntu-latest
     name: Clippy

--- a/crates/gigastt-core/src/error.rs
+++ b/crates/gigastt-core/src/error.rs
@@ -133,6 +133,20 @@ impl GigasttError {
     }
 }
 
+impl From<crate::runtime::RuntimeError> for GigasttError {
+    fn from(err: crate::runtime::RuntimeError) -> Self {
+        match err {
+            crate::runtime::RuntimeError::LoadFailed { path, message } => GigasttError::ModelLoad {
+                path: path.to_string_lossy().into_owned(),
+                source: Some(Box::new(std::io::Error::other(message))),
+            },
+            other => GigasttError::Inference {
+                source: Box::new(other),
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gigastt-core/src/inference/decode.rs
+++ b/crates/gigastt-core/src/inference/decode.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 
 use crate::runtime::{
     session::RuntimeSession,
-    tensor::{Shape, Tensor, TensorData},
+    tensor::{Shape, Tensor, TensorData, TensorView},
 };
 
 use super::bias::Biaser;
@@ -100,6 +100,46 @@ impl DecoderOutput {
     }
 }
 
+/// Reusable input tensors for the decoder and joiner sessions.
+///
+/// These tensors are allocated once per decode and mutated in place, replacing
+/// the previous per-step `Vec::clone`/`to_vec` allocations.
+#[derive(Debug)]
+pub(crate) struct DecodeBuffers {
+    /// Decoder inputs: `[prev_token [1,1], h [1,1,PRED_HIDDEN], c [1,1,PRED_HIDDEN]]`.
+    decoder_inputs: Vec<Tensor>,
+    /// Joiner inputs: `[enc_frame [1,ENC_DIM,1], dec_data [1,PRED_HIDDEN,1]]`.
+    joiner_inputs: Vec<Tensor>,
+}
+
+impl DecodeBuffers {
+    fn new() -> Self {
+        Self {
+            decoder_inputs: vec![
+                Tensor::new(Shape::new(vec![1, 1]), TensorData::I64(vec![0])),
+                Tensor::new(
+                    Shape::new(vec![1, 1, PRED_HIDDEN]),
+                    TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                ),
+                Tensor::new(
+                    Shape::new(vec![1, 1, PRED_HIDDEN]),
+                    TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                ),
+            ],
+            joiner_inputs: vec![
+                Tensor::new(
+                    Shape::new(vec![1, ENC_DIM, 1]),
+                    TensorData::F32(vec![0.0; ENC_DIM]),
+                ),
+                Tensor::new(
+                    Shape::new(vec![1, PRED_HIDDEN, 1]),
+                    TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                ),
+            ],
+        }
+    }
+}
+
 /// Run decoder ONNX session with current state, writing into reusable buffers.
 ///
 /// Input: prev_token [1,1] + h [1,1,PRED_HIDDEN] + c [1,1,PRED_HIDDEN]
@@ -108,23 +148,23 @@ fn run_decoder(
     decoder: &dyn RuntimeSession,
     state: &DecoderState,
     out: &mut DecoderOutput,
+    bufs: &mut DecodeBuffers,
 ) -> Result<()> {
-    let inputs = vec![
-        Tensor::new(
-            Shape::new(vec![1, 1]),
-            TensorData::I64(vec![state.prev_token]),
-        ),
-        Tensor::new(
-            Shape::new(vec![1, 1, PRED_HIDDEN]),
-            TensorData::F32(state.h.clone()),
-        ),
-        Tensor::new(
-            Shape::new(vec![1, 1, PRED_HIDDEN]),
-            TensorData::F32(state.c.clone()),
-        ),
-    ];
+    bufs.decoder_inputs[0]
+        .as_i64_mut()
+        .context("decoder prev_token tensor is not i64")?[0] = state.prev_token;
+    bufs.decoder_inputs[1]
+        .as_f32_mut()
+        .context("decoder h tensor is not f32")?
+        .copy_from_slice(&state.h);
+    bufs.decoder_inputs[2]
+        .as_f32_mut()
+        .context("decoder c tensor is not f32")?
+        .copy_from_slice(&state.c);
 
-    let decoder_outputs = decoder.run(inputs).context("Decoder inference failed")?;
+    let decoder_outputs = decoder
+        .run(&bufs.decoder_inputs)
+        .context("Decoder inference failed")?;
 
     let dec_data = decoder_outputs[0]
         .view()
@@ -157,19 +197,20 @@ fn run_joiner_single(
     enc_frame: &[f32],
     dec_data: &[f32],
     logits_buf: &mut Vec<f32>,
+    bufs: &mut DecodeBuffers,
 ) -> Result<()> {
-    let inputs = vec![
-        Tensor::new(
-            Shape::new(vec![1, ENC_DIM, 1]),
-            TensorData::F32(enc_frame.to_vec()),
-        ),
-        Tensor::new(
-            Shape::new(vec![1, PRED_HIDDEN, 1]),
-            TensorData::F32(dec_data.to_vec()),
-        ),
-    ];
+    bufs.joiner_inputs[0]
+        .as_f32_mut()
+        .context("joiner enc_frame tensor is not f32")?
+        .copy_from_slice(enc_frame);
+    bufs.joiner_inputs[1]
+        .as_f32_mut()
+        .context("joiner dec_data tensor is not f32")?
+        .copy_from_slice(dec_data);
 
-    let joiner_outputs = joiner.run(inputs).context("Joiner inference failed")?;
+    let joiner_outputs = joiner
+        .run(&bufs.joiner_inputs)
+        .context("Joiner inference failed")?;
 
     let logits = joiner_outputs[0]
         .view()
@@ -189,13 +230,19 @@ fn run_joiner_single(
 pub(crate) trait DecodeBackend {
     /// Run the prediction network for the current decoder state, overwriting
     /// `out` in place (reused across calls to avoid per-token allocation).
-    fn decode_step(&mut self, state: &DecoderState, out: &mut DecoderOutput) -> Result<()>;
+    fn decode_step(
+        &mut self,
+        state: &DecoderState,
+        out: &mut DecoderOutput,
+        bufs: &mut DecodeBuffers,
+    ) -> Result<()>;
     /// Run the joiner for one encoder frame, writing logits into `logits_buf`.
     fn joiner_step(
         &mut self,
         enc_frame: &[f32],
         dec_data: &[f32],
         logits_buf: &mut Vec<f32>,
+        bufs: &mut DecodeBuffers,
     ) -> Result<()>;
 }
 
@@ -206,16 +253,22 @@ struct OrtBackend<'a> {
 }
 
 impl DecodeBackend for OrtBackend<'_> {
-    fn decode_step(&mut self, state: &DecoderState, out: &mut DecoderOutput) -> Result<()> {
-        run_decoder(self.decoder, state, out)
+    fn decode_step(
+        &mut self,
+        state: &DecoderState,
+        out: &mut DecoderOutput,
+        bufs: &mut DecodeBuffers,
+    ) -> Result<()> {
+        run_decoder(self.decoder, state, out, bufs)
     }
     fn joiner_step(
         &mut self,
         enc_frame: &[f32],
         dec_data: &[f32],
         logits_buf: &mut Vec<f32>,
+        bufs: &mut DecodeBuffers,
     ) -> Result<()> {
-        run_joiner_single(self.joiner, enc_frame, dec_data, logits_buf)
+        run_joiner_single(self.joiner, enc_frame, dec_data, logits_buf, bufs)
     }
 }
 
@@ -234,7 +287,7 @@ impl DecodeBackend for OrtBackend<'_> {
 pub fn greedy_decode(
     decoder: &dyn RuntimeSession,
     joiner: &dyn RuntimeSession,
-    encoded: &[f32], // [1, 768, enc_len] — channels-first
+    encoded: &TensorView<'_>, // [1, 768, enc_len] — channels-first
     encoded_len: usize,
     blank_id: usize,
     state: &mut DecoderState,
@@ -248,16 +301,25 @@ pub fn greedy_decode(
 /// path; extracted so unit tests can drive it with a stub [`DecodeBackend`].
 fn greedy_decode_impl<B: DecodeBackend>(
     backend: &mut B,
-    encoded: &[f32], // [1, 768, enc_len] — channels-first
+    encoded: &TensorView<'_>, // [1, 768, enc_len] — channels-first
     encoded_len: usize,
     blank_id: usize,
     state: &mut DecoderState,
     biaser: Option<&Biaser>,
 ) -> Result<DecodeResult> {
+    let encoded = encoded
+        .data()
+        .as_f32()
+        .context("encoder output must be f32")?;
+
     let mut tokens = Vec::new();
     let mut endpoint_detected = false;
 
-    // Pre-allocate buffer for extracting a single encoder frame [768, 1]
+    // Reusable input tensors for decoder/joiner and a reusable logits buffer.
+    let mut bufs = DecodeBuffers::new();
+    // Pre-allocate buffer for extracting a single encoder frame [768, 1].
+    // The data is copied into the reusable joiner input tensor inside
+    // `joiner_step`, avoiding a per-step `to_vec` allocation.
     let mut enc_frame = vec![0.0_f32; ENC_DIM];
     // Reusable joiner logits buffer to avoid per-call allocation.
     let mut logits_buf = Vec::new();
@@ -308,13 +370,18 @@ fn greedy_decode_impl<B: DecodeBackend>(
             } else {
                 decoder_calls += 1;
                 // Overwrites `decoder_out` in place — no per-token allocation.
-                backend.decode_step(state, &mut decoder_out)?;
+                backend.decode_step(state, &mut decoder_out, &mut bufs)?;
                 cache_valid = true;
             }
 
             // === JOINER CALL ===
             joiner_calls += 1;
-            backend.joiner_step(&enc_frame, &decoder_out.dec_data, &mut logits_buf)?;
+            backend.joiner_step(
+                &enc_frame,
+                &decoder_out.dec_data,
+                &mut logits_buf,
+                &mut bufs,
+            )?;
 
             // === CONTEXTUAL HOTWORD BIASING (shallow fusion) ===
             // Add the boost to continuation tokens of any active hotword prefix
@@ -487,7 +554,12 @@ mod tests {
     }
 
     impl DecodeBackend for FakeBackend {
-        fn decode_step(&mut self, _state: &DecoderState, out: &mut DecoderOutput) -> Result<()> {
+        fn decode_step(
+            &mut self,
+            _state: &DecoderState,
+            out: &mut DecoderOutput,
+            _bufs: &mut DecodeBuffers,
+        ) -> Result<()> {
             self.decoder_calls += 1;
             DecoderOutput::fill(&mut out.dec_data, &[0.0; PRED_HIDDEN]);
             DecoderOutput::fill(&mut out.new_h, &[0.0; PRED_HIDDEN]);
@@ -500,6 +572,7 @@ mod tests {
             _enc_frame: &[f32],
             _dec_data: &[f32],
             logits_buf: &mut Vec<f32>,
+            _bufs: &mut DecodeBuffers,
         ) -> Result<()> {
             self.joiner_calls += 1;
             // Once the script runs out, return blank so the loop terminates.
@@ -516,13 +589,21 @@ mod tests {
         vec![0.0_f32; ENC_DIM * frames]
     }
 
+    /// Wrapped encoder tensor for tests driving `greedy_decode_impl`.
+    fn fake_enc_tensor(frames: usize) -> Tensor {
+        Tensor::new(
+            Shape::new(vec![1, ENC_DIM, frames]),
+            TensorData::F32(fake_enc(frames)),
+        )
+    }
+
     #[test]
     fn test_greedy_decode_happy_path() {
         // vocab=5, blank=4. Frame 0 emits token 1 then blank; frame 1 emits token 2.
         let mut backend = FakeBackend::new(vec![1, 4, 2, 4], 5, 4);
         let mut state = DecoderState::new(4);
-        let result =
-            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 4, &mut state, None).unwrap();
+        let enc = fake_enc_tensor(2);
+        let result = greedy_decode_impl(&mut backend, &enc.view(), 2, 4, &mut state, None).unwrap();
 
         assert_eq!(result.tokens.len(), 2);
         assert_eq!(result.tokens[0].token_id, 1);
@@ -541,8 +622,8 @@ mod tests {
         // The decoder must NOT be called again during the blank run (cache reuse).
         let mut backend = FakeBackend::new(vec![1, 4, 4, 4, 4], 5, 4);
         let mut state = DecoderState::new(4);
-        let result =
-            greedy_decode_impl(&mut backend, &fake_enc(4), 4, 4, &mut state, None).unwrap();
+        let enc = fake_enc_tensor(4);
+        let result = greedy_decode_impl(&mut backend, &enc.view(), 4, 4, &mut state, None).unwrap();
 
         assert_eq!(result.tokens.len(), 1);
         assert_eq!(
@@ -560,9 +641,9 @@ mod tests {
         let frames = ENDPOINT_BLANK_THRESHOLD + 2;
         let mut backend = FakeBackend::new(script, 5, 4);
         let mut state = DecoderState::new(4);
+        let enc = fake_enc_tensor(frames);
         let result =
-            greedy_decode_impl(&mut backend, &fake_enc(frames), frames, 4, &mut state, None)
-                .unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), frames, 4, &mut state, None).unwrap();
 
         assert!(
             result.endpoint_detected,
@@ -576,9 +657,9 @@ mod tests {
         let frames = ENDPOINT_BLANK_THRESHOLD + 5;
         let mut backend = FakeBackend::new(vec![4usize; frames], 5, 4);
         let mut state = DecoderState::new(4);
+        let enc = fake_enc_tensor(frames);
         let result =
-            greedy_decode_impl(&mut backend, &fake_enc(frames), frames, 4, &mut state, None)
-                .unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), frames, 4, &mut state, None).unwrap();
 
         assert!(result.tokens.is_empty());
         assert!(
@@ -594,8 +675,8 @@ mod tests {
         // bump the blank counter or fire an endpoint.
         let mut backend = FakeBackend::new(vec![1usize; MAX_TOKENS_PER_STEP + 1], 5, 4);
         let mut state = DecoderState::new(4);
-        let result =
-            greedy_decode_impl(&mut backend, &fake_enc(1), 1, 4, &mut state, None).unwrap();
+        let enc = fake_enc_tensor(1);
+        let result = greedy_decode_impl(&mut backend, &enc.view(), 1, 4, &mut state, None).unwrap();
 
         assert_eq!(result.tokens.len(), MAX_TOKENS_PER_STEP);
         assert_eq!(
@@ -645,7 +726,12 @@ mod tests {
     }
 
     impl DecodeBackend for LogitBackend {
-        fn decode_step(&mut self, _state: &DecoderState, out: &mut DecoderOutput) -> Result<()> {
+        fn decode_step(
+            &mut self,
+            _state: &DecoderState,
+            out: &mut DecoderOutput,
+            _bufs: &mut DecodeBuffers,
+        ) -> Result<()> {
             DecoderOutput::fill(&mut out.dec_data, &[0.0; PRED_HIDDEN]);
             DecoderOutput::fill(&mut out.new_h, &[0.0; PRED_HIDDEN]);
             DecoderOutput::fill(&mut out.new_c, &[0.0; PRED_HIDDEN]);
@@ -657,6 +743,7 @@ mod tests {
             _enc_frame: &[f32],
             _dec_data: &[f32],
             logits_buf: &mut Vec<f32>,
+            _bufs: &mut DecodeBuffers,
         ) -> Result<()> {
             logits_buf.clear();
             match self.script.pop_front() {
@@ -690,8 +777,9 @@ mod tests {
         // Baseline (no bias): emits token 1.
         let mut backend = LogitBackend::new(ab_script(), 4, 3);
         let mut state = DecoderState::new(3);
+        let enc = fake_enc_tensor(2);
         let unbiased =
-            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 3, &mut state, None).unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), 2, 3, &mut state, None).unwrap();
         assert_eq!(unbiased.tokens.len(), 1);
         assert_eq!(unbiased.tokens[0].token_id, 1, "no bias → model picks A");
 
@@ -699,9 +787,9 @@ mod tests {
         let biaser = Biaser::from_sequences(vec![vec![2]], 5.0).unwrap();
         let mut backend = LogitBackend::new(ab_script(), 4, 3);
         let mut state = DecoderState::new(3);
+        let enc = fake_enc_tensor(2);
         let biased =
-            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 3, &mut state, Some(&biaser))
-                .unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), 2, 3, &mut state, Some(&biaser)).unwrap();
         assert_eq!(biased.tokens.len(), 1);
         assert_eq!(
             biased.tokens[0].token_id, 2,
@@ -732,9 +820,9 @@ mod tests {
         let biaser = Biaser::from_sequences(vec![vec![5, 2]], 5.0).unwrap();
         let mut backend = LogitBackend::new(script, 6, 3);
         let mut state = DecoderState::new(3);
+        let enc = fake_enc_tensor(2);
         let result =
-            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 3, &mut state, Some(&biaser))
-                .unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), 2, 3, &mut state, Some(&biaser)).unwrap();
         assert_eq!(
             result.tokens.iter().map(|t| t.token_id).collect::<Vec<_>>(),
             vec![5, 2],
@@ -758,15 +846,25 @@ mod tests {
         };
         let mut b_none = LogitBackend::new(base_script(), 4, 3);
         let mut s_none = DecoderState::new(3);
-        let none = greedy_decode_impl(&mut b_none, &fake_enc(2), 2, 3, &mut s_none, None).unwrap();
+        let enc_none = fake_enc_tensor(2);
+        let none =
+            greedy_decode_impl(&mut b_none, &enc_none.view(), 2, 3, &mut s_none, None).unwrap();
 
         // A biaser for token id 0, which has a -inf-equivalent (0.0) logit and is
         // dominated on every frame, so it can never change the argmax.
         let biaser = Biaser::from_sequences(vec![vec![0]], 0.5).unwrap();
         let mut b_some = LogitBackend::new(base_script(), 4, 3);
         let mut s_some = DecoderState::new(3);
-        let some = greedy_decode_impl(&mut b_some, &fake_enc(2), 2, 3, &mut s_some, Some(&biaser))
-            .unwrap();
+        let enc_some = fake_enc_tensor(2);
+        let some = greedy_decode_impl(
+            &mut b_some,
+            &enc_some.view(),
+            2,
+            3,
+            &mut s_some,
+            Some(&biaser),
+        )
+        .unwrap();
 
         assert_eq!(
             none.tokens.iter().map(|t| t.token_id).collect::<Vec<_>>(),

--- a/crates/gigastt-core/src/inference/decode.rs
+++ b/crates/gigastt-core/src/inference/decode.rs
@@ -1,8 +1,11 @@
 //! RNN-T greedy decoding for GigaAM v3 e2e_rnnt.
 
 use anyhow::{Context, Result};
-use ort::session::Session;
-use ort::value::TensorRef;
+
+use crate::runtime::{
+    session::RuntimeSession,
+    tensor::{Shape, Tensor, TensorData},
+};
 
 use super::bias::Biaser;
 use super::{DecoderState, PRED_HIDDEN};
@@ -101,24 +104,42 @@ impl DecoderOutput {
 ///
 /// Input: prev_token [1,1] + h [1,1,PRED_HIDDEN] + c [1,1,PRED_HIDDEN]
 /// Output: `out` is overwritten in place with dec_data, new_h, new_c.
-fn run_decoder(decoder: &mut Session, state: &DecoderState, out: &mut DecoderOutput) -> Result<()> {
-    let target_data = [state.prev_token];
-    let target_tensor = TensorRef::from_array_view(([1_usize, 1], target_data.as_slice()))?;
-    let h_tensor = TensorRef::from_array_view(([1_usize, 1, PRED_HIDDEN], state.h.as_slice()))?;
-    let c_tensor = TensorRef::from_array_view(([1_usize, 1, PRED_HIDDEN], state.c.as_slice()))?;
+fn run_decoder(
+    decoder: &dyn RuntimeSession,
+    state: &DecoderState,
+    out: &mut DecoderOutput,
+) -> Result<()> {
+    let inputs = vec![
+        Tensor::new(
+            Shape::new(vec![1, 1]),
+            TensorData::I64(vec![state.prev_token]),
+        ),
+        Tensor::new(
+            Shape::new(vec![1, 1, PRED_HIDDEN]),
+            TensorData::F32(state.h.clone()),
+        ),
+        Tensor::new(
+            Shape::new(vec![1, 1, PRED_HIDDEN]),
+            TensorData::F32(state.c.clone()),
+        ),
+    ];
 
-    let decoder_outputs = decoder
-        .run(ort::inputs![target_tensor, h_tensor, c_tensor])
-        .context("Decoder inference failed")?;
+    let decoder_outputs = decoder.run(inputs).context("Decoder inference failed")?;
 
-    let (_dec_shape, dec_data) = decoder_outputs[0]
-        .try_extract_tensor::<f32>()
+    let dec_data = decoder_outputs[0]
+        .view()
+        .data()
+        .as_f32()
         .context("Failed to extract decoder output")?;
-    let (_h_shape, new_h_data) = decoder_outputs[1]
-        .try_extract_tensor::<f32>()
+    let new_h_data = decoder_outputs[1]
+        .view()
+        .data()
+        .as_f32()
         .context("Failed to extract decoder h state")?;
-    let (_c_shape, new_c_data) = decoder_outputs[2]
-        .try_extract_tensor::<f32>()
+    let new_c_data = decoder_outputs[2]
+        .view()
+        .data()
+        .as_f32()
         .context("Failed to extract decoder c state")?;
 
     DecoderOutput::fill(&mut out.dec_data, dec_data);
@@ -132,20 +153,28 @@ fn run_decoder(decoder: &mut Session, state: &DecoderState, out: &mut DecoderOut
 /// Input: enc [1, ENC_DIM, 1] + dec [1, PRED_HIDDEN, 1]
 /// Output: logits [VOCAB_SIZE] (flattened from [1, 1, 1, VOCAB_SIZE]).
 fn run_joiner_single(
-    joiner: &mut Session,
+    joiner: &dyn RuntimeSession,
     enc_frame: &[f32],
     dec_data: &[f32],
     logits_buf: &mut Vec<f32>,
 ) -> Result<()> {
-    let enc_tensor = TensorRef::from_array_view(([1_usize, ENC_DIM, 1], enc_frame))?;
-    let dec_tensor = TensorRef::from_array_view(([1_usize, PRED_HIDDEN, 1], dec_data))?;
+    let inputs = vec![
+        Tensor::new(
+            Shape::new(vec![1, ENC_DIM, 1]),
+            TensorData::F32(enc_frame.to_vec()),
+        ),
+        Tensor::new(
+            Shape::new(vec![1, PRED_HIDDEN, 1]),
+            TensorData::F32(dec_data.to_vec()),
+        ),
+    ];
 
-    let joiner_outputs = joiner
-        .run(ort::inputs![enc_tensor, dec_tensor])
-        .context("Joiner inference failed")?;
+    let joiner_outputs = joiner.run(inputs).context("Joiner inference failed")?;
 
-    let (_joint_shape, logits) = joiner_outputs[0]
-        .try_extract_tensor::<f32>()
+    let logits = joiner_outputs[0]
+        .view()
+        .data()
+        .as_f32()
         .context("Failed to extract joiner output")?;
 
     // Reuse the buffer's capacity: copy in place after a one-time size match,
@@ -156,7 +185,7 @@ fn run_joiner_single(
 
 /// Abstraction over the two ONNX session calls in the RNN-T inner loop, so the
 /// decode logic can be unit-tested with a deterministic stub instead of a real
-/// `ort::Session` (which requires a model file on disk).
+/// runtime session (which requires a model file on disk).
 pub(crate) trait DecodeBackend {
     /// Run the prediction network for the current decoder state, overwriting
     /// `out` in place (reused across calls to avoid per-token allocation).
@@ -170,10 +199,10 @@ pub(crate) trait DecodeBackend {
     ) -> Result<()>;
 }
 
-/// Production backend over the real encoder/joiner ONNX sessions.
+/// Production backend over the real encoder/joiner runtime sessions.
 struct OrtBackend<'a> {
-    decoder: &'a mut Session,
-    joiner: &'a mut Session,
+    decoder: &'a dyn RuntimeSession,
+    joiner: &'a dyn RuntimeSession,
 }
 
 impl DecodeBackend for OrtBackend<'_> {
@@ -203,8 +232,8 @@ impl DecodeBackend for OrtBackend<'_> {
 /// prefix, before the argmax. `None` ⇒ the decode is byte-for-byte identical to
 /// the un-biased path (zero regression risk when no hotwords are configured).
 pub fn greedy_decode(
-    decoder: &mut Session,
-    joiner: &mut Session,
+    decoder: &dyn RuntimeSession,
+    joiner: &dyn RuntimeSession,
     encoded: &[f32], // [1, 768, enc_len] — channels-first
     encoded_len: usize,
     blank_id: usize,

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -3442,4 +3442,106 @@ mod tests {
             .expect("at-threshold audio must not error");
         assert!(result.words.is_empty(), "silence decodes to no words");
     }
+
+    mod mock_runtime_tests {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        use crate::inference::Engine;
+        use crate::runtime::mock::{MockFactory, MockSession};
+        use crate::runtime::tensor::{Shape, Tensor, TensorData};
+
+        const ENC_DIM: usize = 768;
+        const PRED_HIDDEN: usize = 320;
+
+        fn tiny_mock_engine() -> (Engine, tempfile::TempDir) {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let dir = tmp.path();
+
+            // Empty model files are enough for variant detection; the mock
+            // runtime intercepts all session loading before the filesystem is
+            // read for ONNX data.
+            std::fs::write(dir.join("v3_rnnt_encoder.onnx"), b"").unwrap();
+            std::fs::write(dir.join("v3_rnnt_decoder.onnx"), b"").unwrap();
+            std::fs::write(dir.join("v3_rnnt_joint.onnx"), b"").unwrap();
+            // vocab: index 0 = "▁hi", index 1 = "<blk>" (blank wins on ties).
+            std::fs::write(dir.join("v3_vocab.txt"), "\u{2581}hi\n<blk>\n").unwrap();
+
+            let mut sessions: HashMap<String, Arc<MockSession>> = HashMap::new();
+            sessions.insert(
+                "v3_rnnt_encoder".into(),
+                Arc::new(MockSession::new(
+                    vec![Shape::new(vec![1, 64, 1]), Shape::new(vec![1])],
+                    vec![
+                        Tensor::new(
+                            Shape::new(vec![1, ENC_DIM, 1]),
+                            TensorData::F32(vec![0.0; ENC_DIM]),
+                        ),
+                        Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![1])),
+                    ],
+                )),
+            );
+            sessions.insert(
+                "v3_rnnt_decoder".into(),
+                Arc::new(MockSession::new(
+                    vec![
+                        Shape::new(vec![1, 1]),
+                        Shape::new(vec![1, 1, PRED_HIDDEN]),
+                        Shape::new(vec![1, 1, PRED_HIDDEN]),
+                    ],
+                    vec![
+                        Tensor::new(
+                            Shape::new(vec![1, 1, PRED_HIDDEN]),
+                            TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                        ),
+                        Tensor::new(
+                            Shape::new(vec![1, 1, PRED_HIDDEN]),
+                            TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                        ),
+                        Tensor::new(
+                            Shape::new(vec![1, 1, PRED_HIDDEN]),
+                            TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                        ),
+                    ],
+                )),
+            );
+            sessions.insert(
+                "v3_rnnt_joint".into(),
+                Arc::new(MockSession::new(
+                    vec![
+                        Shape::new(vec![1, ENC_DIM, 1]),
+                        Shape::new(vec![1, PRED_HIDDEN, 1]),
+                    ],
+                    vec![Tensor::new(
+                        Shape::new(vec![1, 1, 2]),
+                        TensorData::F32(vec![0.0; 2]),
+                    )],
+                )),
+            );
+
+            let factory = Box::new(MockFactory::new(sessions));
+            let engine = Engine::load_with_factory(&dir.to_string_lossy(), 1, 1, 0, factory, 1)
+                .expect("engine should load with mock runtime");
+            (engine, tmp)
+        }
+
+        #[test]
+        fn test_engine_loads_with_mock_runtime() {
+            let _ = tiny_mock_engine();
+        }
+
+        #[test]
+        fn test_engine_mock_runtime_decodes_silence() {
+            let (engine, _tmp) = tiny_mock_engine();
+            let mut guard = engine.pool.checkout_blocking().expect("checkout");
+            let samples = vec![0.0f32; 100]; // < N_FFT → one padded mel frame
+            let result = engine
+                .transcribe_samples(&samples, &mut guard)
+                .expect("mock decode must not error");
+
+            assert!(result.text.is_empty(), "blank-only decode yields no text");
+            assert!(result.words.is_empty());
+            assert!((result.duration_s - 100.0 / 16000.0).abs() < 1e-9);
+        }
+    }
 }

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1043,7 +1043,7 @@ impl Engine {
         // which head runs — callers select the variant only at download time.
         let Some(variant) = ModelVariant::detect_in_dir(dir) else {
             return Err(GigasttError::ModelLoad {
-                path: model_dir.to_string(),
+                path: dir.display().to_string(),
                 source: None,
             });
         };
@@ -1065,7 +1065,7 @@ impl Engine {
 
         let factory = production_factory(dir);
         Self::load_with_factory(
-            model_dir,
+            dir,
             pool_size,
             min_size,
             batch_pool_size,
@@ -1077,17 +1077,16 @@ impl Engine {
     /// Package-private factory-based loader. Used by production code paths and
     /// by tests that inject a [`crate::runtime::factory::RuntimeFactory`].
     pub(crate) fn load_with_factory(
-        model_dir: &str,
+        model_dir: &Path,
         pool_size: usize,
         min_size: usize,
         batch_pool_size: usize,
         factory: Box<dyn crate::runtime::factory::RuntimeFactory>,
         encoder_intra_threads: usize,
     ) -> Result<Self, GigasttError> {
-        let dir = Path::new(model_dir);
-        let Some(variant) = ModelVariant::detect_in_dir(dir) else {
+        let Some(variant) = ModelVariant::detect_in_dir(model_dir) else {
             return Err(GigasttError::ModelLoad {
-                path: model_dir.to_string(),
+                path: model_dir.display().to_string(),
                 source: None,
             });
         };
@@ -1096,17 +1095,20 @@ impl Engine {
 
         let runtime = factory.create(encoder_intra_threads)?;
         let model_load = |e: anyhow::Error| GigasttError::ModelLoad {
-            path: model_dir.to_string(),
+            path: model_dir.display().to_string(),
             source: Some(e.into()),
         };
 
         tracing::info!("Detected model variant: {variant:?}");
-        let is_int8 = dir.join(variant.encoder_int8_file()).exists();
+        let is_int8 = model_dir.join(variant.encoder_int8_file()).exists();
         if is_int8 {
             tracing::info!("Using INT8 quantized encoder");
         }
 
-        tracing::info!("Loading ONNX models from {model_dir} (pool_size={pool_size})...");
+        tracing::info!(
+            "Loading ONNX models from {} (pool_size={pool_size})...",
+            model_dir.display()
+        );
 
         #[cfg(feature = "coreml")]
         tracing::info!("Using CoreML execution provider (Neural Engine + CPU)");
@@ -1118,7 +1120,7 @@ impl Engine {
         // CoreML can reject a model at load time; fall back to CPU if that happens.
         #[cfg(feature = "coreml")]
         let triplets = match Self::load_triplets_runtime(
-            &*runtime, dir, variant, pool_size, min_size,
+            &*runtime, model_dir, variant, pool_size, min_size,
         )
         .map_err(model_load)
         {
@@ -1129,15 +1131,17 @@ impl Engine {
                 );
                 let cpu_factory = OrtFactory::cpu();
                 let runtime = cpu_factory.create(encoder_intra_threads)?;
-                Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)
+                Self::load_triplets_runtime(&*runtime, model_dir, variant, pool_size, min_size)
                     .map_err(model_load)?
             }
         };
         #[cfg(not(feature = "coreml"))]
-        let triplets = Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)
-            .map_err(model_load)?;
+        let triplets =
+            Self::load_triplets_runtime(&*runtime, model_dir, variant, pool_size, min_size)
+                .map_err(model_load)?;
 
-        let tokenizer = Tokenizer::load(&dir.join(variant.vocab_file())).map_err(model_load)?;
+        let tokenizer =
+            Tokenizer::load(&model_dir.join(variant.vocab_file())).map_err(model_load)?;
         let features = FeatureExtractor::new();
 
         tracing::info!(
@@ -1148,7 +1152,7 @@ impl Engine {
         #[cfg(feature = "diarization")]
         #[allow(deprecated)] // legacy OnnxEmbeddingExtractor::new — see import note above
         let speaker_encoder = {
-            let model_path = dir.join("wespeaker_resnet34.onnx");
+            let model_path = model_dir.join("wespeaker_resnet34.onnx");
             if model_path.exists() {
                 match OnnxEmbeddingExtractor::new(
                     &model_path,
@@ -1206,7 +1210,7 @@ impl Engine {
                     .create(encoder_intra_threads)
                     .map_err(|e| anyhow::anyhow!(e))?;
                 let triplets =
-                    Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)?;
+                    Self::load_triplets_runtime(&*runtime, model_dir, variant, pool_size, min_size)?;
                 let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
                 e.pool = pool;
                 e.batch_pool = batch_pool;
@@ -3447,12 +3451,11 @@ mod tests {
         use std::collections::HashMap;
         use std::sync::Arc;
 
-        use crate::inference::Engine;
+        use crate::inference::{Engine, PRED_HIDDEN};
         use crate::runtime::mock::{MockFactory, MockSession};
         use crate::runtime::tensor::{Shape, Tensor, TensorData};
 
         const ENC_DIM: usize = 768;
-        const PRED_HIDDEN: usize = 320;
 
         fn tiny_mock_engine() -> (Engine, tempfile::TempDir) {
             let tmp = tempfile::tempdir().expect("tempdir");
@@ -3520,7 +3523,7 @@ mod tests {
             );
 
             let factory = Box::new(MockFactory::new(sessions));
-            let engine = Engine::load_with_factory(&dir.to_string_lossy(), 1, 1, 0, factory, 1)
+            let engine = Engine::load_with_factory(dir, 1, 1, 0, factory, 1)
                 .expect("engine should load with mock runtime");
             (engine, tmp)
         }

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -60,16 +60,20 @@ impl EmbeddingExtractor for SharedExtractor {
 compile_error!("Features `coreml` and `cuda` are mutually exclusive. Choose one.");
 
 use anyhow::Context;
-#[cfg(any(feature = "coreml", feature = "cuda"))]
-use ort::ep;
-use ort::session::Session;
-use ort::value::TensorRef;
 use serde::Serialize;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 
 use crate::error::GigasttError;
 use crate::model::ModelVariant;
+use crate::runtime::factory::Runtime;
+#[allow(unused_imports)]
+use crate::runtime::factory::RuntimeFactory;
+#[cfg(feature = "coreml")]
+use crate::runtime::ort::OrtFactory;
+use crate::runtime::ort::production_factory;
+use crate::runtime::session::RuntimeSession;
+use crate::runtime::tensor::{Shape, Tensor, TensorData, TensorDataView};
 
 use features::MelSpectrogram;
 use tokenizer::Tokenizer;
@@ -82,10 +86,6 @@ pub const N_FFT: usize = 320;
 pub const HOP_LENGTH: usize = 160;
 /// Hidden dimension of the RNN-T prediction (decoder) network.
 pub const PRED_HIDDEN: usize = 320;
-
-fn ort_err(e: impl std::fmt::Display) -> anyhow::Error {
-    anyhow::anyhow!("{e}")
-}
 
 pub fn now_timestamp() -> f64 {
     use std::sync::OnceLock;
@@ -218,9 +218,9 @@ const POOL_RAM_FRACTION_DENOM: u64 = 2;
 /// Moved out of the pool on checkout and returned on checkin.
 /// Each triplet is independent and can run inference concurrently with others.
 pub struct SessionTriplet {
-    pub(crate) encoder: Session,
-    pub(crate) decoder: Session,
-    pub(crate) joiner: Session,
+    pub(crate) encoder: Box<dyn RuntimeSession>,
+    pub(crate) decoder: Box<dyn RuntimeSession>,
+    pub(crate) joiner: Box<dyn RuntimeSession>,
 }
 
 /// Errors returned by [`Pool::checkout`].
@@ -1059,19 +1059,160 @@ impl Engine {
             .unwrap_or(1);
         let encoder_intra_threads =
             Self::clamp_encoder_intra_threads(pool_size, encoder_intra_threads, logical_cpus);
-        Self::load_inner(
-            dir,
-            variant,
+
+        let factory = production_factory(dir);
+        Self::load_with_factory(
             model_dir,
             pool_size,
             min_size,
             batch_pool_size,
+            factory,
             encoder_intra_threads,
         )
-        .map_err(|e| GigasttError::ModelLoad {
+    }
+
+    /// Package-private factory-based loader. Used by production code paths and
+    /// by tests that inject a [`crate::runtime::factory::RuntimeFactory`].
+    pub(crate) fn load_with_factory(
+        model_dir: &str,
+        pool_size: usize,
+        min_size: usize,
+        batch_pool_size: usize,
+        factory: Box<dyn crate::runtime::factory::RuntimeFactory>,
+        encoder_intra_threads: usize,
+    ) -> Result<Self, GigasttError> {
+        let dir = Path::new(model_dir);
+        let Some(variant) = ModelVariant::detect_in_dir(dir) else {
+            return Err(GigasttError::ModelLoad {
+                path: model_dir.to_string(),
+                source: None,
+            });
+        };
+        let pool_size = pool_size.max(1);
+        let min_size = min_size.clamp(1, pool_size);
+
+        let runtime = factory.create(encoder_intra_threads)?;
+        let model_load = |e: anyhow::Error| GigasttError::ModelLoad {
             path: model_dir.to_string(),
             source: Some(e.into()),
-        })
+        };
+
+        tracing::info!("Detected model variant: {variant:?}");
+        let is_int8 = dir.join(variant.encoder_int8_file()).exists();
+        if is_int8 {
+            tracing::info!("Using INT8 quantized encoder");
+        }
+
+        tracing::info!("Loading ONNX models from {model_dir} (pool_size={pool_size})...");
+
+        #[cfg(feature = "coreml")]
+        tracing::info!("Using CoreML execution provider (Neural Engine + CPU)");
+        #[cfg(feature = "cuda")]
+        tracing::info!("Using CUDA execution provider (falls back to CPU if unavailable)");
+        #[cfg(not(any(feature = "coreml", feature = "cuda")))]
+        tracing::info!("Using CPU execution provider");
+
+        // CoreML can reject a model at load time; fall back to CPU if that happens.
+        #[cfg(feature = "coreml")]
+        let triplets = match Self::load_triplets_runtime(
+            &*runtime, dir, variant, pool_size, min_size,
+        )
+        .map_err(model_load)
+        {
+            Ok(triplets) => triplets,
+            Err(load_err) => {
+                tracing::warn!(
+                    "CoreML EP failed to load sessions ({load_err:#}); falling back to CPU execution provider"
+                );
+                let cpu_factory = OrtFactory::cpu();
+                let runtime = cpu_factory.create(encoder_intra_threads)?;
+                Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)
+                    .map_err(model_load)?
+            }
+        };
+        #[cfg(not(feature = "coreml"))]
+        let triplets = Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)
+            .map_err(model_load)?;
+
+        let tokenizer = Tokenizer::load(&dir.join(variant.vocab_file())).map_err(model_load)?;
+        let features = FeatureExtractor::new();
+
+        tracing::info!(
+            "Models loaded (vocab_size={}, pool_size={pool_size})",
+            tokenizer.vocab_size()
+        );
+
+        #[cfg(feature = "diarization")]
+        #[allow(deprecated)] // legacy OnnxEmbeddingExtractor::new — see import note above
+        let speaker_encoder = {
+            let model_path = dir.join("wespeaker_resnet34.onnx");
+            if model_path.exists() {
+                match OnnxEmbeddingExtractor::new(
+                    &model_path,
+                    SPEAKER_EMBEDDING_DIM,
+                    SPEAKER_SEGMENT_SAMPLES,
+                    SPEAKER_POOL_SIZE,
+                ) {
+                    Ok(enc) => {
+                        tracing::info!("Speaker encoder loaded (diarization available)");
+                        Some(std::sync::Arc::new(enc))
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Speaker encoder not loaded, diarization unavailable: {e:#}"
+                        );
+                        None
+                    }
+                }
+            } else {
+                tracing::warn!("wespeaker_resnet34.onnx not found, diarization unavailable");
+                None
+            }
+        };
+
+        let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
+        let engine = Self {
+            pool,
+            batch_pool,
+            tokenizer,
+            features,
+            variant,
+            punctuator: None,
+            itn: false,
+            biaser: None,
+            vad: None,
+            vad_config: crate::vad::VadConfig::default(),
+            int8: is_int8,
+            #[cfg(feature = "diarization")]
+            speaker_encoder,
+        };
+
+        // CoreML compiles its graph partitions lazily, so sessions that loaded
+        // fine can still fail at the first `Run()`. Probe one triplet now; if the
+        // probe fails, rebuild the pool on the CPU EP.
+        #[cfg(feature = "coreml")]
+        let engine = probe_or_rebuild(
+            engine,
+            |e: &Self| e.warmup_one().map_err(anyhow::Error::from),
+            |mut e, probe_err| {
+                tracing::warn!(
+                    "CoreML EP failed at runtime ({probe_err:#}); falling back to CPU execution provider"
+                );
+                let cpu_factory = OrtFactory::cpu();
+                let runtime = cpu_factory
+                    .create(encoder_intra_threads)
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                let triplets =
+                    Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)?;
+                let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
+                e.pool = pool;
+                e.batch_pool = batch_pool;
+                Ok(e)
+            },
+        )
+        .map_err(model_load)?;
+
+        Ok(engine)
     }
 
     /// Path to the preferred encoder model for `variant`: INT8 quantized if
@@ -1083,195 +1224,6 @@ impl Engine {
         } else {
             dir.join(variant.encoder_file())
         }
-    }
-
-    /// Load a single set of encoder/decoder/joiner ONNX sessions from disk for
-    /// `variant`, using the execution provider selected at compile time.
-    ///
-    /// `encoder_intra_threads` configures the encoder session's intra-op thread
-    /// count on the CPU EP only; the CoreML / CUDA loaders ignore it (the
-    /// accelerator owns scheduling there).
-    fn load_sessions(
-        dir: &Path,
-        variant: ModelVariant,
-        prepacked: &ort::session::builder::PrepackedWeights,
-        encoder_intra_threads: usize,
-    ) -> anyhow::Result<(Session, Session, Session)> {
-        #[cfg(feature = "coreml")]
-        {
-            let _ = encoder_intra_threads;
-            Self::load_sessions_coreml(dir, variant, prepacked)
-        }
-        #[cfg(feature = "cuda")]
-        {
-            let _ = encoder_intra_threads;
-            Self::load_sessions_cuda(dir, variant, prepacked)
-        }
-        #[cfg(not(any(feature = "coreml", feature = "cuda")))]
-        {
-            Self::load_sessions_cpu(dir, variant, prepacked, encoder_intra_threads)
-        }
-    }
-
-    #[cfg(feature = "coreml")]
-    fn load_sessions_coreml(
-        dir: &Path,
-        variant: ModelVariant,
-        prepacked: &ort::session::builder::PrepackedWeights,
-    ) -> anyhow::Result<(Session, Session, Session)> {
-        // CoreML has its own cache (`coreml_cache/`) for compiled subgraphs.
-        // We do NOT call `.with_optimized_model_path(...)` here: CoreML EP
-        // replaces part of the graph with compiled nodes that cannot be
-        // re-serialized as ONNX, and ORT errors out with
-        // `Unable to serialize model as it contains compiled nodes`
-        // on macOS 14+. The CoreML cache below is sufficient.
-        //
-        // `with_static_input_shapes(true)` is load-bearing (issue #42): the
-        // Conformer encoder has a dynamic time axis, and CoreML-compiled
-        // partitions with dynamic shapes fail at prediction time with
-        // `Error executing model: ... (error code: -1)` regardless of model
-        // format or compute units. Restricting CoreML to statically-shaped
-        // subgraphs keeps the heavy conv/matmul blocks accelerated and
-        // leaves the dynamic-shape ops on the CPU EP.
-        let cache_dir = dir.join("coreml_cache");
-        let coreml_ep = ep::CoreML::default()
-            .with_model_format(ep::coreml::ModelFormat::MLProgram)
-            .with_static_input_shapes(true)
-            .with_compute_units(ep::coreml::ComputeUnits::CPUAndNeuralEngine)
-            .with_specialization_strategy(ep::coreml::SpecializationStrategy::FastPrediction)
-            .with_model_cache_dir(cache_dir.to_string_lossy())
-            .build();
-
-        let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
-        let eps = [coreml_ep.clone(), cpu_fallback.into()];
-        let encoder_path = Self::encoder_model_path(dir, variant);
-        let encoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(&encoder_path)
-            .map_err(ort_err)?;
-        let decoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.decoder_file()))
-            .map_err(ort_err)?;
-        let joiner = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.joint_file()))
-            .map_err(ort_err)?;
-        Ok((encoder, decoder, joiner))
-    }
-
-    #[cfg(feature = "cuda")]
-    fn load_sessions_cuda(
-        dir: &Path,
-        variant: ModelVariant,
-        prepacked: &ort::session::builder::PrepackedWeights,
-    ) -> anyhow::Result<(Session, Session, Session)> {
-        // CUDA EP compiles subgraphs that cannot be re-serialized as ONNX,
-        // so we do NOT call `.with_optimized_model_path(...)` here — same
-        // reason as the CoreML block. ORT's CUDA EP keeps its own caches
-        // internally.
-        let cuda_ep = ep::CUDA::default().build();
-
-        let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
-        let eps = [cuda_ep.clone(), cpu_fallback.into()];
-        let encoder_path = Self::encoder_model_path(dir, variant);
-        let encoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(&encoder_path)
-            .map_err(ort_err)?;
-        let decoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.decoder_file()))
-            .map_err(ort_err)?;
-        let joiner = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.joint_file()))
-            .map_err(ort_err)?;
-        Ok((encoder, decoder, joiner))
-    }
-
-    /// Load encoder/decoder/joiner sessions on the plain CPU EP.
-    ///
-    /// This is the default build's loader and the runtime-fallback target
-    /// when the CoreML probe in [`Engine::load`] fails (issue #42). Not
-    /// compiled under `cuda` (mutually exclusive with `coreml`), where it
-    /// would be dead code.
-    #[cfg(not(feature = "cuda"))]
-    fn load_sessions_cpu(
-        dir: &Path,
-        variant: ModelVariant,
-        prepacked: &ort::session::builder::PrepackedWeights,
-        encoder_intra_threads: usize,
-    ) -> anyhow::Result<(Session, Session, Session)> {
-        let cache_dir = dir.join("optimized_cache");
-        std::fs::create_dir_all(&cache_dir)
-            .with_context(|| format!("Failed to create ONNX cache dir: {}", cache_dir.display()))?;
-        let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
-        let eps = [cpu_fallback.into()];
-        let encoder_path = Self::encoder_model_path(dir, variant);
-        // Only the encoder's intra-op count is configurable (it dominates the
-        // single-utterance cost); inter-op stays 1 because the Conformer is a
-        // near-linear chain, and the decoder/joiner stay intra=1 (tiny ops).
-        // Default `encoder_intra_threads == 1` ⇒ identical to the prior build.
-        let encoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_intra_threads(encoder_intra_threads.max(1))
-            .map_err(ort_err)?
-            .with_inter_threads(1)
-            .map_err(ort_err)?
-            .with_optimized_model_path(cache_dir.join("encoder_optimized.onnx"))
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(&encoder_path)
-            .map_err(ort_err)?;
-        let decoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_intra_threads(1)
-            .map_err(ort_err)?
-            .with_inter_threads(1)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.decoder_file()))
-            .map_err(ort_err)?;
-        let joiner = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_intra_threads(1)
-            .map_err(ort_err)?
-            .with_inter_threads(1)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.joint_file()))
-            .map_err(ort_err)?;
-        Ok((encoder, decoder, joiner))
     }
 
     /// Split loaded triplets into an interactive pool and an optional batch
@@ -1423,35 +1375,40 @@ impl Engine {
         }
     }
 
-    /// Load up to `pool_size` session triplets in parallel via the given
-    /// per-triplet loader (`load_sessions` for the compile-time-selected EP,
-    /// `load_sessions_cpu` for the CoreML runtime fallback). Tolerates a
-    /// partial pool down to `min_size` (see [`Engine::finalize_pool_load`]).
-    fn load_triplets(
+    /// Load up to `pool_size` session triplets in parallel through the given
+    /// [`Runtime`], tolerating a partial pool down to `min_size`.
+    fn load_triplets_runtime(
+        runtime: &dyn Runtime,
         dir: &Path,
         variant: ModelVariant,
         pool_size: usize,
         min_size: usize,
-        prepacked: &ort::session::builder::PrepackedWeights,
-        load_one: impl Fn(
-            &Path,
-            ModelVariant,
-            &ort::session::builder::PrepackedWeights,
-        ) -> anyhow::Result<(Session, Session, Session)>
-        + Sync,
     ) -> anyhow::Result<Vec<SessionTriplet>> {
+        let encoder_path = Self::encoder_model_path(dir, variant);
+        let decoder_path = dir.join(variant.decoder_file());
+        let joiner_path = dir.join(variant.joint_file());
+
         let results: Vec<anyhow::Result<SessionTriplet>> = std::thread::scope(|s| {
             let handles: Vec<_> = (0..pool_size)
                 .map(|i| {
-                    let pp = prepacked;
-                    let load_one = &load_one;
+                    let encoder_path = &encoder_path;
+                    let decoder_path = &decoder_path;
+                    let joiner_path = &joiner_path;
                     s.spawn(move || {
                         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                             tracing::info!(
-                                "Loading session triplet {}/{pool_size} (shared weights)",
+                                "Loading session triplet {}/{pool_size} (shared runtime)",
                                 i + 1
                             );
-                            let (encoder, decoder, joiner) = load_one(dir, variant, pp)?;
+                            let encoder = runtime
+                                .load_session(encoder_path)
+                                .map_err(|e| anyhow::anyhow!(e))?;
+                            let decoder = runtime
+                                .load_session(decoder_path)
+                                .map_err(|e| anyhow::anyhow!(e))?;
+                            let joiner = runtime
+                                .load_session(joiner_path)
+                                .map_err(|e| anyhow::anyhow!(e))?;
                             Ok(SessionTriplet {
                                 encoder,
                                 decoder,
@@ -1471,148 +1428,6 @@ impl Engine {
                 .collect()
         });
         Self::finalize_pool_load(results, pool_size, min_size)
-    }
-
-    fn load_inner(
-        dir: &Path,
-        variant: ModelVariant,
-        model_dir: &str,
-        pool_size: usize,
-        min_size: usize,
-        batch_pool_size: usize,
-        encoder_intra_threads: usize,
-    ) -> anyhow::Result<Self> {
-        tracing::info!("Detected model variant: {variant:?}");
-        let is_int8 = dir.join(variant.encoder_int8_file()).exists();
-        if is_int8 {
-            tracing::info!("Using INT8 quantized encoder");
-        }
-
-        tracing::info!("Loading ONNX models from {model_dir} (pool_size={pool_size})...");
-
-        #[cfg(feature = "coreml")]
-        tracing::info!("Using CoreML execution provider (Neural Engine + CPU)");
-        #[cfg(feature = "cuda")]
-        tracing::info!("Using CUDA execution provider (falls back to CPU if unavailable)");
-        #[cfg(not(any(feature = "coreml", feature = "cuda")))]
-        tracing::info!("Using CPU execution provider");
-
-        // Shared prepacked weights container (Arc-based, thread-safe)
-        let prepacked = ort::session::builder::PrepackedWeights::new();
-
-        // CoreML can reject a model at two distinct stages: session creation
-        // (MLModel compilation) and the first `Run()` (issue #42). This guards
-        // the first stage; the warmup probe below guards the second.
-        #[cfg(feature = "coreml")]
-        let triplets = match Self::load_triplets(
-            dir,
-            variant,
-            pool_size,
-            min_size,
-            &prepacked,
-            |d, v, pp| Self::load_sessions(d, v, pp, encoder_intra_threads),
-        ) {
-            Ok(triplets) => triplets,
-            Err(load_err) => {
-                tracing::warn!(
-                    "CoreML EP failed to load sessions ({load_err:#}); falling back to CPU execution provider"
-                );
-                // Fresh container: the failed attempt may have pre-packed
-                // weights with CoreML-specific kernel layouts.
-                let prepacked = ort::session::builder::PrepackedWeights::new();
-                Self::load_triplets(dir, variant, pool_size, min_size, &prepacked, |d, v, pp| {
-                    Self::load_sessions_cpu(d, v, pp, encoder_intra_threads)
-                })?
-            }
-        };
-        #[cfg(not(feature = "coreml"))]
-        let triplets =
-            Self::load_triplets(dir, variant, pool_size, min_size, &prepacked, |d, v, pp| {
-                Self::load_sessions(d, v, pp, encoder_intra_threads)
-            })?;
-
-        let tokenizer = Tokenizer::load(&dir.join(variant.vocab_file()))?;
-        let features = FeatureExtractor::new();
-
-        tracing::info!(
-            "Models loaded (vocab_size={}, pool_size={pool_size})",
-            tokenizer.vocab_size()
-        );
-
-        #[cfg(feature = "diarization")]
-        #[allow(deprecated)] // legacy OnnxEmbeddingExtractor::new — see import note above
-        let speaker_encoder = {
-            let model_path = dir.join("wespeaker_resnet34.onnx");
-            if model_path.exists() {
-                match OnnxEmbeddingExtractor::new(
-                    &model_path,
-                    SPEAKER_EMBEDDING_DIM,
-                    SPEAKER_SEGMENT_SAMPLES,
-                    SPEAKER_POOL_SIZE,
-                ) {
-                    Ok(enc) => {
-                        tracing::info!("Speaker encoder loaded (diarization available)");
-                        Some(std::sync::Arc::new(enc))
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Speaker encoder not loaded, diarization unavailable: {e:#}"
-                        );
-                        None
-                    }
-                }
-            } else {
-                tracing::warn!("wespeaker_resnet34.onnx not found, diarization unavailable");
-                None
-            }
-        };
-
-        let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
-        let engine = Self {
-            pool,
-            batch_pool,
-            tokenizer,
-            features,
-            variant,
-            punctuator: None,
-            itn: false,
-            biaser: None,
-            vad: None,
-            vad_config: crate::vad::VadConfig::default(),
-            int8: is_int8,
-            #[cfg(feature = "diarization")]
-            speaker_encoder,
-        };
-
-        // CoreML compiles its graph partitions lazily, so sessions that
-        // loaded fine can still fail at the first `Run()` (issue #42). Probe
-        // one triplet now; if the probe fails, rebuild the pool on the CPU EP
-        // instead of surfacing the error on every real request.
-        #[cfg(feature = "coreml")]
-        let engine = probe_or_rebuild(
-            engine,
-            |e: &Self| e.warmup_one().map_err(anyhow::Error::from),
-            |mut e, probe_err| {
-                tracing::warn!(
-                    "CoreML EP failed at runtime ({probe_err:#}); falling back to CPU execution provider"
-                );
-                let prepacked = ort::session::builder::PrepackedWeights::new();
-                let triplets = Self::load_triplets(
-                    dir,
-                    variant,
-                    pool_size,
-                    min_size,
-                    &prepacked,
-                    |d, v, pp| Self::load_sessions_cpu(d, v, pp, encoder_intra_threads),
-                )?;
-                let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
-                e.pool = pool;
-                e.batch_pool = batch_pool;
-                Ok(e)
-            },
-        )?;
-
-        Ok(engine)
     }
 
     /// Run one ~1 s silent inference on a single pooled session triplet.
@@ -2192,38 +2007,43 @@ impl Engine {
         frame_offset: usize,
     ) -> anyhow::Result<(Vec<WordInfo>, bool)> {
         // Encoder input: audio_signal [1, 64, num_frames], length [1]
-        let signal_tensor = TensorRef::from_array_view(([1_usize, N_MELS, num_frames], features))?;
-        let length_data = [num_frames as i64];
-        let length_tensor = TensorRef::from_array_view(([1_usize], length_data.as_slice()))?;
+        let signal_tensor = Tensor::new(
+            Shape::new(vec![1, N_MELS, num_frames]),
+            TensorData::F32(features.to_vec()),
+        );
+        let length_tensor = Tensor::new(
+            Shape::new(vec![1]),
+            TensorData::I64(vec![num_frames as i64]),
+        );
 
         let enc_start = std::time::Instant::now();
         let encoder_outputs = triplet
             .encoder
-            .run(ort::inputs![signal_tensor, length_tensor])
+            .run(vec![signal_tensor, length_tensor])
             .context("Encoder inference failed")?;
         tracing::info!(
             elapsed_ms = enc_start.elapsed().as_millis() as u64,
             "encoder_inference"
         );
 
-        let (_enc_shape, enc_data) = encoder_outputs[0]
-            .try_extract_tensor::<f32>()
+        let enc_data = encoder_outputs[0]
+            .view()
+            .data()
+            .as_f32()
             .context("Failed to extract encoder output")?;
-        let (_len_shape, len_data) = encoder_outputs[1]
-            .try_extract_tensor::<i32>()
-            .context("Failed to extract encoder length")?;
-
-        let enc_len = usize::try_from(len_data[0]).context("Negative encoder length")?;
+        let enc_len = match encoder_outputs[1].view().data() {
+            TensorDataView::I32(v) => usize::try_from(v[0]).context("Negative encoder length")?,
+            TensorDataView::I64(v) => usize::try_from(v[0]).context("Negative encoder length")?,
+            _ => anyhow::bail!("Unexpected encoder length tensor type"),
+        };
 
         tracing::debug!("Encoder output: {} frames", enc_len);
 
-        // RNN-T greedy decode — we pass the encoder-output borrow directly
-        // instead of copying it.  The `encoder_outputs` variable is dropped
-        // automatically at the end of this scope, after decode finishes.
+        // RNN-T greedy decode — the encoder output is borrowed for the decode loop.
         let dec_start = std::time::Instant::now();
         let result = decode::greedy_decode(
-            &mut triplet.decoder,
-            &mut triplet.joiner,
+            &*triplet.decoder,
+            &*triplet.joiner,
             enc_data,
             enc_len,
             self.tokenizer.blank_id(),
@@ -2773,12 +2593,6 @@ mod tests {
     #[test]
     fn test_pool_error_display() {
         assert_eq!(format!("{}", PoolError::Closed), "session pool is closed");
-    }
-
-    #[test]
-    fn test_ort_err() {
-        let e = ort_err("test ort error");
-        assert_eq!(format!("{e}"), "test ort error");
     }
 
     #[test]

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -221,6 +221,9 @@ pub struct SessionTriplet {
     pub(crate) encoder: Box<dyn RuntimeSession>,
     pub(crate) decoder: Box<dyn RuntimeSession>,
     pub(crate) joiner: Box<dyn RuntimeSession>,
+    /// Reusable encoder input tensors: `[audio_signal [1, N_MELS, num_frames], length [1]]`.
+    /// Resized and overwritten in `run_inference` to avoid per-call allocations.
+    pub(crate) encoder_inputs: Vec<Tensor>,
 }
 
 /// Errors returned by [`Pool::checkout`].
@@ -1413,6 +1416,13 @@ impl Engine {
                                 encoder,
                                 decoder,
                                 joiner,
+                                encoder_inputs: vec![
+                                    Tensor::new(
+                                        Shape::new(vec![1, N_MELS, 1]),
+                                        TensorData::F32(vec![0.0; N_MELS]),
+                                    ),
+                                    Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![0])),
+                                ],
                             })
                         }))
                         .map_err(|_| anyhow::anyhow!("model loading thread panicked"))?
@@ -2006,31 +2016,27 @@ impl Engine {
         decoder_state: &mut DecoderState,
         frame_offset: usize,
     ) -> anyhow::Result<(Vec<WordInfo>, bool)> {
-        // Encoder input: audio_signal [1, 64, num_frames], length [1]
-        let signal_tensor = Tensor::new(
-            Shape::new(vec![1, N_MELS, num_frames]),
-            TensorData::F32(features.to_vec()),
-        );
-        let length_tensor = Tensor::new(
-            Shape::new(vec![1]),
-            TensorData::I64(vec![num_frames as i64]),
-        );
+        // Reuse the encoder input tensors: resize the signal tensor to the
+        // current frame count and overwrite both buffers in place.
+        triplet.encoder_inputs[0].resize_to(Shape::new(vec![1, N_MELS, num_frames]));
+        triplet.encoder_inputs[0]
+            .as_f32_mut()
+            .context("encoder signal tensor is not f32")?
+            .copy_from_slice(features);
+        triplet.encoder_inputs[1]
+            .as_i64_mut()
+            .context("encoder length tensor is not i64")?[0] = num_frames as i64;
 
         let enc_start = std::time::Instant::now();
         let encoder_outputs = triplet
             .encoder
-            .run(vec![signal_tensor, length_tensor])
+            .run(&triplet.encoder_inputs)
             .context("Encoder inference failed")?;
         tracing::info!(
             elapsed_ms = enc_start.elapsed().as_millis() as u64,
             "encoder_inference"
         );
 
-        let enc_data = encoder_outputs[0]
-            .view()
-            .data()
-            .as_f32()
-            .context("Failed to extract encoder output")?;
         let enc_len = match encoder_outputs[1].view().data() {
             TensorDataView::I32(v) => usize::try_from(v[0]).context("Negative encoder length")?,
             TensorDataView::I64(v) => usize::try_from(v[0]).context("Negative encoder length")?,
@@ -2044,7 +2050,7 @@ impl Engine {
         let result = decode::greedy_decode(
             &*triplet.decoder,
             &*triplet.joiner,
-            enc_data,
+            &encoder_outputs[0].view(),
             enc_len,
             self.tokenizer.blank_id(),
             decoder_state,

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -8,4 +8,5 @@ pub mod onnx_proto;
 pub mod protocol;
 pub mod punctuation;
 pub mod quantize;
+pub(crate) mod runtime;
 pub mod vad;

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -270,7 +270,7 @@ impl Punctuator {
         let argmax_per_token: Vec<usize> = {
             let session = self.session.lock();
             let outputs = session
-                .run(vec![input_ids, attention_mask, token_type])
+                .run(&[input_ids, attention_mask, token_type])
                 .context("punct model inference failed")?;
 
             let logits_view = outputs[0].view();

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -29,10 +29,15 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use ort::session::Session;
-use ort::value::TensorRef;
 use parking_lot::Mutex;
 use tokenizers::Tokenizer;
+
+use crate::runtime::{
+    factory::RuntimeFactory,
+    ort::OrtFactory,
+    session::RuntimeSession,
+    tensor::{Shape, Tensor, TensorData},
+};
 
 /// Basename of the INT8 ONNX punctuation model inside the punct model dir.
 pub const PUNCT_MODEL_FILE: &str = "rupunct_small_int8.onnx";
@@ -40,10 +45,6 @@ pub const PUNCT_MODEL_FILE: &str = "rupunct_small_int8.onnx";
 pub const PUNCT_TOKENIZER_FILE: &str = "tokenizer.json";
 /// Basename of the model config JSON (carries `id2label`) inside the punct model dir.
 pub const PUNCT_CONFIG_FILE: &str = "config.json";
-
-fn ort_err(e: impl std::fmt::Display) -> anyhow::Error {
-    anyhow::anyhow!("{e}")
-}
 
 /// Apply Python `str.capitalize()` semantics to a token: first character
 /// uppercased, every following character lowercased. Operates over Unicode
@@ -162,7 +163,7 @@ fn argmax(row: &[f32]) -> usize {
 /// is the public entry point and never panics: on any internal failure it logs
 /// and returns the input text unchanged.
 pub struct Punctuator {
-    session: Mutex<Session>,
+    session: Mutex<Box<dyn RuntimeSession>>,
     tokenizer: Tokenizer,
     /// `id2label[i]` is the label name for logit index `i`.
     id2label: Vec<String>,
@@ -191,10 +192,14 @@ impl Punctuator {
             anyhow::anyhow!("Failed to load tokenizer {}: {e}", tokenizer_path.display())
         })?;
 
-        let session = Session::builder()
-            .map_err(ort_err)?
-            .commit_from_file(&model_path)
-            .map_err(ort_err)
+        let factory = OrtFactory::cpu();
+        let runtime = factory
+            .create(1)
+            .map_err(|e| anyhow::anyhow!(e))
+            .with_context(|| format!("Failed to create runtime for {}", model_path.display()))?;
+        let session = runtime
+            .load_session(&model_path)
+            .map_err(|e| anyhow::anyhow!(e))
             .with_context(|| format!("Failed to load punct model {}", model_path.display()))?;
 
         tracing::info!(
@@ -255,31 +260,28 @@ impl Punctuator {
         let seq = ids.len();
         let token_type_ids = vec![0i64; seq];
 
-        let input_ids = TensorRef::from_array_view(([1_usize, seq], ids.as_slice()))?;
-        let attention_mask = TensorRef::from_array_view(([1_usize, seq], mask.as_slice()))?;
-        let token_type = TensorRef::from_array_view(([1_usize, seq], token_type_ids.as_slice()))?;
+        let input_ids = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(ids));
+        let attention_mask = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(mask));
+        let token_type = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(token_type_ids));
 
         // Run the session and reduce the borrowed logits to an owned
-        // per-token argmax inside this scope, so the `outputs` borrow (which
-        // ties the lifetime to the session guard) is released before the
-        // session guard is dropped at end of scope.
+        // per-token argmax inside this scope.
         let num_labels = self.id2label.len();
         let argmax_per_token: Vec<usize> = {
-            let mut session = self.session.lock();
+            let session = self.session.lock();
             let outputs = session
-                .run(ort::inputs![
-                    "input_ids" => input_ids,
-                    "attention_mask" => attention_mask,
-                    "token_type_ids" => token_type,
-                ])
+                .run(vec![input_ids, attention_mask, token_type])
                 .context("punct model inference failed")?;
 
-            let (shape, logits) = outputs["logits"]
-                .try_extract_tensor::<f32>()
+            let logits_view = outputs[0].view();
+            let logits = logits_view
+                .data()
+                .as_f32()
                 .context("failed to extract punct logits")?;
 
             // Expect [1, seq, num_labels].
-            if shape.len() != 3 || shape[2] as usize != num_labels {
+            let shape = logits_view.shape().dims();
+            if shape != [1, seq, num_labels] {
                 anyhow::bail!(
                     "unexpected punct logits shape {shape:?} (expected [1, {seq}, {num_labels}])"
                 );
@@ -429,14 +431,6 @@ mod tests {
         assert_eq!(argmax(&[0.1, 0.9, 0.3]), 1);
         assert_eq!(argmax(&[5.0, 1.0, 2.0]), 0);
         assert_eq!(argmax(&[1.0, 1.0, 3.0]), 2);
-    }
-
-    /// `ort_err` flattens any `Display` error into an `anyhow::Error` carrying
-    /// the same message (the Send/Sync workaround used at every `ort` boundary).
-    #[test]
-    fn test_ort_err_preserves_display_message() {
-        let err = ort_err("session build exploded");
-        assert_eq!(err.to_string(), "session build exploded");
     }
 
     /// A minimal but valid HuggingFace tokenizer.json (WordLevel model). Used to

--- a/crates/gigastt-core/src/runtime/error.rs
+++ b/crates/gigastt-core/src/runtime/error.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use super::tensor::Shape;
+
+/// Errors produced by the runtime abstraction layer.
+#[derive(Debug, Error)]
+pub enum RuntimeError {
+    #[error("failed to load model {path}: {message}")]
+    LoadFailed { path: PathBuf, message: String },
+
+    #[error("inference failed: {0}")]
+    InferenceFailed(String),
+
+    #[error("invalid tensor shape: expected {expected:?}, got {got:?}")]
+    InvalidShape { expected: Shape, got: Shape },
+
+    #[error("unsupported element type")]
+    UnsupportedElementType,
+
+    #[error("invalid input count: expected {expected}, got {got}")]
+    InvalidInputCount { expected: usize, got: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn test_load_failed_display() {
+        let e = RuntimeError::LoadFailed {
+            path: PathBuf::from("encoder.onnx"),
+            message: "not found".into(),
+        };
+        assert_eq!(
+            e.to_string(),
+            "failed to load model encoder.onnx: not found"
+        );
+    }
+
+    #[test]
+    fn test_invalid_shape_display() {
+        let expected = Shape::new(vec![2, 3]);
+        let got = Shape::new(vec![3, 2]);
+        let e = RuntimeError::InvalidShape {
+            expected: expected.clone(),
+            got: got.clone(),
+        };
+        assert!(e.to_string().contains("invalid tensor shape"));
+        assert!(e.to_string().contains("[2, 3]"));
+        assert!(e.to_string().contains("[3, 2]"));
+    }
+
+    #[test]
+    fn test_inference_failed_display() {
+        let e = RuntimeError::InferenceFailed("session is closed".into());
+        assert_eq!(e.to_string(), "inference failed: session is closed");
+    }
+
+    #[test]
+    fn test_invalid_input_count_display() {
+        let e = RuntimeError::InvalidInputCount {
+            expected: 3,
+            got: 2,
+        };
+        assert_eq!(e.to_string(), "invalid input count: expected 3, got 2");
+    }
+
+    #[test]
+    fn test_unsupported_element_type_display() {
+        let e = RuntimeError::UnsupportedElementType;
+        assert_eq!(e.to_string(), "unsupported element type");
+    }
+}

--- a/crates/gigastt-core/src/runtime/error.rs
+++ b/crates/gigastt-core/src/runtime/error.rs
@@ -2,10 +2,11 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
-use super::tensor::Shape;
+use super::tensor::{ElementType, Shape};
 
 /// Errors produced by the runtime abstraction layer.
 #[derive(Debug, Error)]
+#[allow(dead_code)]
 pub enum RuntimeError {
     #[error("failed to load model {path}: {message}")]
     LoadFailed { path: PathBuf, message: String },
@@ -16,8 +17,8 @@ pub enum RuntimeError {
     #[error("invalid tensor shape: expected {expected:?}, got {got:?}")]
     InvalidShape { expected: Shape, got: Shape },
 
-    #[error("unsupported element type")]
-    UnsupportedElementType,
+    #[error("unsupported element type: {0:?}")]
+    UnsupportedElementType(ElementType),
 
     #[error("invalid input count: expected {expected}, got {got}")]
     InvalidInputCount { expected: usize, got: usize },
@@ -71,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_unsupported_element_type_display() {
-        let e = RuntimeError::UnsupportedElementType;
-        assert_eq!(e.to_string(), "unsupported element type");
+        let e = RuntimeError::UnsupportedElementType(ElementType::I64);
+        assert_eq!(e.to_string(), "unsupported element type: I64");
     }
 }

--- a/crates/gigastt-core/src/runtime/factory.rs
+++ b/crates/gigastt-core/src/runtime/factory.rs
@@ -1,11 +1,13 @@
 use super::{error::RuntimeError, session::RuntimeSession};
 
 /// Creates a `Runtime` configured for a specific execution provider.
+#[expect(dead_code)]
 pub trait RuntimeFactory: Send + Sync + 'static {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
 }
 
 /// Owns loaded sessions. One runtime per `Engine`.
+#[expect(dead_code)]
 pub trait Runtime: Send + Sync + 'static {
     fn load_session(
         &self,

--- a/crates/gigastt-core/src/runtime/factory.rs
+++ b/crates/gigastt-core/src/runtime/factory.rs
@@ -1,0 +1,14 @@
+use super::{error::RuntimeError, session::RuntimeSession};
+
+/// Creates a `Runtime` configured for a specific execution provider.
+pub trait RuntimeFactory: Send + Sync + 'static {
+    fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
+}
+
+/// Owns loaded sessions. One runtime per `Engine`.
+pub trait Runtime: Send + Sync + 'static {
+    fn load_session(
+        &self,
+        model_path: &std::path::Path,
+    ) -> Result<Box<dyn RuntimeSession>, RuntimeError>;
+}

--- a/crates/gigastt-core/src/runtime/factory.rs
+++ b/crates/gigastt-core/src/runtime/factory.rs
@@ -1,13 +1,13 @@
 use super::{error::RuntimeError, session::RuntimeSession};
 
 /// Creates a `Runtime` configured for a specific execution provider.
-#[expect(dead_code)]
+#[allow(dead_code)]
 pub trait RuntimeFactory: Send + Sync + 'static {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
 }
 
 /// Owns loaded sessions. One runtime per `Engine`.
-#[expect(dead_code)]
+#[allow(dead_code)]
 pub trait Runtime: Send + Sync + 'static {
     fn load_session(
         &self,

--- a/crates/gigastt-core/src/runtime/mock/mod.rs
+++ b/crates/gigastt-core/src/runtime/mock/mod.rs
@@ -1,0 +1,4 @@
+pub mod session;
+
+#[allow(unused_imports)]
+pub use session::{MockFactory, MockRuntime, MockSession};

--- a/crates/gigastt-core/src/runtime/mock/session.rs
+++ b/crates/gigastt-core/src/runtime/mock/session.rs
@@ -1,0 +1,218 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::runtime::{
+    error::RuntimeError,
+    factory::{Runtime, RuntimeFactory},
+    session::RuntimeSession,
+    tensor::{Shape, Tensor},
+};
+
+/// Factory that builds a [`MockRuntime`] from a map of scripted sessions.
+///
+/// Each entry is keyed by the stem of the model path the engine will load,
+/// e.g. `v3_rnnt_encoder` for `/path/v3_rnnt_encoder.onnx`.
+#[derive(Clone, Default)]
+pub struct MockFactory {
+    sessions: HashMap<String, Arc<MockSession>>,
+}
+
+#[allow(dead_code)]
+impl MockFactory {
+    pub fn new(sessions: HashMap<String, Arc<MockSession>>) -> Self {
+        Self { sessions }
+    }
+}
+
+impl RuntimeFactory for MockFactory {
+    fn create(&self, _intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
+        Ok(Box::new(MockRuntime {
+            sessions: self.sessions.clone(),
+        }))
+    }
+}
+
+/// Mock runtime that hands out pre-configured [`MockSession`]s by path stem.
+#[derive(Clone)]
+pub struct MockRuntime {
+    sessions: HashMap<String, Arc<MockSession>>,
+}
+
+impl Runtime for MockRuntime {
+    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let key = model_path
+            .file_stem()
+            .ok_or_else(|| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: "empty path".into(),
+            })?
+            .to_string_lossy()
+            .to_string();
+        let session = self
+            .sessions
+            .get(&key)
+            .ok_or_else(|| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: format!("no mock for {key}"),
+            })?
+            .clone();
+        Ok(Box::new((*session).clone()))
+    }
+}
+
+/// Mock ONNX session that validates input shapes and returns pre-recorded outputs.
+///
+/// Intended for unit tests that exercise the engine and decode loop without
+/// loading real model files.
+pub struct MockSession {
+    pub expected_inputs: Vec<Shape>,
+    pub outputs: Vec<Tensor>,
+    call_count: AtomicUsize,
+}
+
+#[allow(dead_code)]
+impl MockSession {
+    pub fn new(expected_inputs: Vec<Shape>, outputs: Vec<Tensor>) -> Self {
+        Self {
+            expected_inputs,
+            outputs,
+            call_count: AtomicUsize::new(0),
+        }
+    }
+
+    /// Number of times [`RuntimeSession::run`] has been called on this session.
+    pub fn call_count(&self) -> usize {
+        self.call_count.load(Ordering::Relaxed)
+    }
+}
+
+impl Clone for MockSession {
+    fn clone(&self) -> Self {
+        Self {
+            expected_inputs: self.expected_inputs.clone(),
+            outputs: self.outputs.clone(),
+            call_count: AtomicUsize::new(self.call_count.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+impl RuntimeSession for MockSession {
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        if inputs.len() != self.expected_inputs.len() {
+            return Err(RuntimeError::InvalidInputCount {
+                expected: self.expected_inputs.len(),
+                got: inputs.len(),
+            });
+        }
+        for (actual, expected) in inputs.iter().zip(self.expected_inputs.iter()) {
+            if actual.shape() != expected {
+                return Err(RuntimeError::InvalidShape {
+                    expected: expected.clone(),
+                    got: actual.shape().clone(),
+                });
+            }
+        }
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        Ok(self.outputs.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::tensor::TensorData;
+
+    #[test]
+    fn test_mock_session_returns_recorded_outputs() {
+        let session = MockSession::new(
+            vec![Shape::new(vec![1, 2])],
+            vec![Tensor::new(
+                Shape::new(vec![1]),
+                TensorData::F32(vec![42.0]),
+            )],
+        );
+        let input = Tensor::new(Shape::new(vec![1, 2]), TensorData::F32(vec![0.0, 0.0]));
+        let outputs = session.run(&[input]).unwrap();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(session.call_count(), 1);
+    }
+
+    #[test]
+    fn test_mock_session_rejects_mismatched_shape() {
+        let session = MockSession::new(
+            vec![Shape::new(vec![1, 2])],
+            vec![Tensor::new(
+                Shape::new(vec![1]),
+                TensorData::F32(vec![42.0]),
+            )],
+        );
+        let input = Tensor::new(Shape::new(vec![1, 3]), TensorData::F32(vec![0.0; 3]));
+        let err = session.run(&[input]).unwrap_err();
+        match err {
+            RuntimeError::InvalidShape { expected, got } => {
+                assert_eq!(expected.dims(), &[1, 2]);
+                assert_eq!(got.dims(), &[1, 3]);
+            }
+            other => panic!("expected InvalidShape, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_mock_session_rejects_wrong_input_count() {
+        let session = MockSession::new(
+            vec![Shape::new(vec![1]), Shape::new(vec![1])],
+            vec![Tensor::new(
+                Shape::new(vec![1]),
+                TensorData::F32(vec![42.0]),
+            )],
+        );
+        let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0]));
+        let err = session.run(&[input]).unwrap_err();
+        match err {
+            RuntimeError::InvalidInputCount { expected, got } => {
+                assert_eq!(expected, 2);
+                assert_eq!(got, 1);
+            }
+            other => panic!("expected InvalidInputCount, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_mock_runtime_loads_session_by_stem() {
+        let mut sessions = HashMap::new();
+        sessions.insert(
+            "encoder".into(),
+            Arc::new(MockSession::new(
+                vec![Shape::new(vec![1])],
+                vec![Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![1.0]))],
+            )),
+        );
+        let runtime = MockRuntime { sessions };
+        let session = runtime
+            .load_session(Path::new("/models/encoder.onnx"))
+            .expect("load by stem");
+        let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0]));
+        let outputs = session.run(&[input]).unwrap();
+        assert_eq!(outputs.len(), 1);
+    }
+
+    #[test]
+    fn test_mock_runtime_missing_session_fails() {
+        let runtime = MockRuntime {
+            sessions: HashMap::new(),
+        };
+        let result = runtime.load_session(Path::new("/models/missing.onnx"));
+        let err = match result {
+            Ok(_) => panic!("expected load to fail"),
+            Err(e) => e,
+        };
+        match err {
+            RuntimeError::LoadFailed { message, .. } => {
+                assert!(message.contains("no mock for missing"));
+            }
+            other => panic!("expected LoadFailed, got {other:?}"),
+        }
+    }
+}

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -1,12 +1,13 @@
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 pub mod error;
 pub mod factory;
 pub mod session;
 pub mod tensor;
 
+#[expect(unused_imports)]
 pub use error::RuntimeError;
+#[expect(unused_imports)]
 pub use factory::{Runtime, RuntimeFactory};
+#[expect(unused_imports)]
 pub use session::RuntimeSession;
+#[expect(unused_imports)]
 pub use tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView, TensorView};

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -1,0 +1,12 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+pub mod error;
+pub mod factory;
+pub mod session;
+pub mod tensor;
+
+pub use error::RuntimeError;
+pub use factory::{Runtime, RuntimeFactory};
+pub use session::RuntimeSession;
+pub use tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView, TensorView};

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod factory;
+pub mod mock;
 pub mod ort;
 pub mod session;
 pub mod tensor;

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -4,11 +4,11 @@ pub mod ort;
 pub mod session;
 pub mod tensor;
 
-#[expect(unused_imports)]
+#[allow(unused_imports)]
 pub use error::RuntimeError;
-#[expect(unused_imports)]
+#[allow(unused_imports)]
 pub use factory::{Runtime, RuntimeFactory};
-#[expect(unused_imports)]
+#[allow(unused_imports)]
 pub use session::RuntimeSession;
-#[expect(unused_imports)]
+#[allow(unused_imports)]
 pub use tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView, TensorView};

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod factory;
+pub mod ort;
 pub mod session;
 pub mod tensor;
 

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
-use std::sync::OnceLock;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 
 use crate::runtime::{
     error::RuntimeError,
@@ -22,53 +23,95 @@ pub enum OrtExecutionProvider {
 }
 
 impl OrtExecutionProvider {
-    pub(crate) fn to_ort(self) -> ort::ep::ExecutionProviderDispatch {
+    /// Returns the execution-provider list to register when loading a session.
+    ///
+    /// `model_path` is used to derive provider-specific cache directories (e.g.
+    /// CoreML's `coreml_cache/` next to the model).
+    pub(crate) fn execution_providers(
+        self,
+        model_path: &Path,
+    ) -> Vec<ort::ep::ExecutionProviderDispatch> {
         match self {
-            Self::Cpu => ort::ep::CPU::default().build(),
-            #[cfg(feature = "coreml")]
-            Self::CoreML => ort::ep::CoreML::default().build(),
-            #[cfg(not(feature = "coreml"))]
-            Self::CoreML => ort::ep::CPU::default().build(),
-            #[cfg(feature = "cuda")]
-            Self::Cuda => ort::ep::CUDA::default().build(),
-            #[cfg(not(feature = "cuda"))]
-            Self::Cuda => ort::ep::CPU::default().build(),
-            #[cfg(feature = "nnapi")]
-            Self::Nnapi => ort::ep::NNAPI::default().build(),
-            #[cfg(not(feature = "nnapi"))]
-            Self::Nnapi => ort::ep::CPU::default().build(),
+            Self::Cpu => vec![ort::ep::CPU::default().build()],
+            Self::CoreML => {
+                let cache_dir = model_path
+                    .parent()
+                    .map(|p| p.join("coreml_cache"))
+                    .unwrap_or_else(|| PathBuf::from("coreml_cache"));
+                let coreml_ep = ort::ep::CoreML::default()
+                    .with_model_format(ort::ep::coreml::ModelFormat::MLProgram)
+                    .with_static_input_shapes(true)
+                    .with_compute_units(ort::ep::coreml::ComputeUnits::CPUAndNeuralEngine)
+                    .with_specialization_strategy(
+                        ort::ep::coreml::SpecializationStrategy::FastPrediction,
+                    )
+                    .with_model_cache_dir(cache_dir.to_string_lossy())
+                    .build();
+                vec![coreml_ep, ort::ep::CPU::default().build()]
+            }
+            Self::Cuda => vec![
+                ort::ep::CUDA::default().build(),
+                ort::ep::CPU::default().build(),
+            ],
+            Self::Nnapi => vec![
+                ort::ep::NNAPI::default().build(),
+                ort::ep::CPU::default().build(),
+            ],
         }
+    }
+
+    /// Whether this provider is the plain CPU execution provider.
+    pub(crate) fn is_cpu(self) -> bool {
+        matches!(self, Self::Cpu)
+            || (!cfg!(feature = "coreml") && matches!(self, Self::CoreML))
+            || (!cfg!(feature = "cuda") && matches!(self, Self::Cuda))
+            || (!cfg!(feature = "nnapi") && matches!(self, Self::Nnapi))
     }
 }
 
 /// Factory that creates an `ort` runtime configured for a specific provider.
 pub struct OrtFactory {
     provider: OrtExecutionProvider,
+    prepacked: Option<Arc<ort::session::builder::PrepackedWeights>>,
+    optimized_cache_dir: Option<PathBuf>,
 }
 
 impl OrtFactory {
-    pub fn cpu() -> Self {
+    fn with_provider(provider: OrtExecutionProvider) -> Self {
         Self {
-            provider: OrtExecutionProvider::Cpu,
+            provider,
+            prepacked: None,
+            optimized_cache_dir: None,
         }
+    }
+
+    pub fn cpu() -> Self {
+        Self::with_provider(OrtExecutionProvider::Cpu)
     }
 
     pub fn coreml() -> Self {
-        Self {
-            provider: OrtExecutionProvider::CoreML,
-        }
+        Self::with_provider(OrtExecutionProvider::CoreML)
     }
 
     pub fn cuda() -> Self {
-        Self {
-            provider: OrtExecutionProvider::Cuda,
-        }
+        Self::with_provider(OrtExecutionProvider::Cuda)
     }
 
     pub fn nnapi() -> Self {
-        Self {
-            provider: OrtExecutionProvider::Nnapi,
-        }
+        Self::with_provider(OrtExecutionProvider::Nnapi)
+    }
+
+    pub fn with_prepacked_weights(
+        mut self,
+        prepacked: Arc<ort::session::builder::PrepackedWeights>,
+    ) -> Self {
+        self.prepacked = Some(prepacked);
+        self
+    }
+
+    pub fn with_optimized_cache_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.optimized_cache_dir = Some(dir.into());
+        self
     }
 }
 
@@ -86,13 +129,17 @@ fn ensure_ort_initialized() {
 impl RuntimeFactory for OrtFactory {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
         ensure_ort_initialized();
-        Ok(Box::new(OrtRuntime::new(intra_threads, self.provider)))
+        Ok(Box::new(OrtRuntime::new(
+            intra_threads,
+            self.provider,
+            self.prepacked.clone(),
+            self.optimized_cache_dir.clone(),
+        )))
     }
 }
 
 /// Returns the default `ort` factory for the active compile-time feature flags.
-pub fn default_factory(intra_threads: usize) -> Box<dyn RuntimeFactory> {
-    let _ = intra_threads;
+pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
     if cfg!(feature = "coreml") {
         Box::new(OrtFactory::coreml())
     } else if cfg!(feature = "cuda") {
@@ -102,4 +149,17 @@ pub fn default_factory(intra_threads: usize) -> Box<dyn RuntimeFactory> {
     } else {
         Box::new(OrtFactory::cpu())
     }
+}
+
+/// Returns a production `ort` factory that preserves the provider selection and
+/// disk-cache layout used by the engine before the runtime abstraction.
+pub fn production_factory(model_dir: &Path) -> Box<dyn RuntimeFactory> {
+    let factory = if cfg!(feature = "coreml") {
+        OrtFactory::coreml()
+    } else if cfg!(feature = "cuda") {
+        OrtFactory::cuda()
+    } else {
+        OrtFactory::cpu().with_optimized_cache_dir(model_dir.join("optimized_cache"))
+    };
+    Box::new(factory)
 }

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -1,0 +1,98 @@
+use crate::runtime::{
+    error::RuntimeError,
+    factory::{Runtime, RuntimeFactory},
+};
+
+use super::session::OrtRuntime;
+
+/// `ort` execution provider selector.
+#[derive(Clone)]
+#[allow(dead_code)]
+pub enum OrtExecutionProvider {
+    Cpu,
+    #[cfg(feature = "coreml")]
+    CoreML,
+    #[cfg(feature = "cuda")]
+    Cuda,
+    #[cfg(feature = "nnapi")]
+    Nnapi,
+}
+
+impl OrtExecutionProvider {
+    fn to_ort(&self) -> ort::ep::ExecutionProviderDispatch {
+        match self {
+            Self::Cpu => ort::ep::CPU::default().build(),
+            #[cfg(feature = "coreml")]
+            Self::CoreML => ort::ep::CoreML::default().build(),
+            #[cfg(feature = "cuda")]
+            Self::Cuda => ort::ep::CUDA::default().build(),
+            #[cfg(feature = "nnapi")]
+            Self::Nnapi => ort::ep::NNAPI::default().build(),
+        }
+    }
+}
+
+/// Factory that creates an `ort` runtime configured for a specific provider.
+#[allow(dead_code)]
+pub struct OrtFactory {
+    provider: OrtExecutionProvider,
+}
+
+impl OrtFactory {
+    #[allow(dead_code)]
+    pub fn cpu() -> Self {
+        Self {
+            provider: OrtExecutionProvider::Cpu,
+        }
+    }
+
+    #[cfg(feature = "coreml")]
+    #[allow(dead_code)]
+    pub fn coreml() -> Self {
+        Self {
+            provider: OrtExecutionProvider::CoreML,
+        }
+    }
+
+    #[cfg(feature = "cuda")]
+    #[allow(dead_code)]
+    pub fn cuda() -> Self {
+        Self {
+            provider: OrtExecutionProvider::Cuda,
+        }
+    }
+
+    #[cfg(feature = "nnapi")]
+    #[allow(dead_code)]
+    pub fn nnapi() -> Self {
+        Self {
+            provider: OrtExecutionProvider::Nnapi,
+        }
+    }
+}
+
+impl RuntimeFactory for OrtFactory {
+    fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
+        ort::init()
+            .with_name("gigastt")
+            .with_execution_providers([self.provider.to_ort()])
+            .commit();
+        Ok(Box::new(OrtRuntime::new(
+            intra_threads,
+            self.provider.to_ort(),
+        )))
+    }
+}
+
+/// Returns the default `ort` factory for the active compile-time feature flags.
+#[allow(dead_code)]
+pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
+    #[cfg(feature = "coreml")]
+    return Box::new(OrtFactory::coreml());
+    #[cfg(feature = "cuda")]
+    return Box::new(OrtFactory::cuda());
+    #[cfg(feature = "nnapi")]
+    return Box::new(OrtFactory::nnapi());
+    #[cfg(not(any(feature = "coreml", feature = "cuda", feature = "nnapi")))]
+    Box::new(OrtFactory::cpu())
+}

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -1,3 +1,7 @@
+#![allow(dead_code)]
+
+use std::sync::OnceLock;
+
 use crate::runtime::{
     error::RuntimeError,
     factory::{Runtime, RuntimeFactory},
@@ -5,65 +9,62 @@ use crate::runtime::{
 
 use super::session::OrtRuntime;
 
+#[cfg(all(feature = "coreml", feature = "cuda"))]
+compile_error!("features `coreml` and `cuda` are mutually exclusive");
+
 /// `ort` execution provider selector.
-#[derive(Clone)]
-#[allow(dead_code)]
+#[derive(Clone, Copy)]
 pub enum OrtExecutionProvider {
     Cpu,
-    #[cfg(feature = "coreml")]
     CoreML,
-    #[cfg(feature = "cuda")]
     Cuda,
-    #[cfg(feature = "nnapi")]
     Nnapi,
 }
 
 impl OrtExecutionProvider {
-    fn to_ort(&self) -> ort::ep::ExecutionProviderDispatch {
+    pub(crate) fn to_ort(self) -> ort::ep::ExecutionProviderDispatch {
         match self {
             Self::Cpu => ort::ep::CPU::default().build(),
             #[cfg(feature = "coreml")]
             Self::CoreML => ort::ep::CoreML::default().build(),
+            #[cfg(not(feature = "coreml"))]
+            Self::CoreML => ort::ep::CPU::default().build(),
             #[cfg(feature = "cuda")]
             Self::Cuda => ort::ep::CUDA::default().build(),
+            #[cfg(not(feature = "cuda"))]
+            Self::Cuda => ort::ep::CPU::default().build(),
             #[cfg(feature = "nnapi")]
             Self::Nnapi => ort::ep::NNAPI::default().build(),
+            #[cfg(not(feature = "nnapi"))]
+            Self::Nnapi => ort::ep::CPU::default().build(),
         }
     }
 }
 
 /// Factory that creates an `ort` runtime configured for a specific provider.
-#[allow(dead_code)]
 pub struct OrtFactory {
     provider: OrtExecutionProvider,
 }
 
 impl OrtFactory {
-    #[allow(dead_code)]
     pub fn cpu() -> Self {
         Self {
             provider: OrtExecutionProvider::Cpu,
         }
     }
 
-    #[cfg(feature = "coreml")]
-    #[allow(dead_code)]
     pub fn coreml() -> Self {
         Self {
             provider: OrtExecutionProvider::CoreML,
         }
     }
 
-    #[cfg(feature = "cuda")]
-    #[allow(dead_code)]
     pub fn cuda() -> Self {
         Self {
             provider: OrtExecutionProvider::Cuda,
         }
     }
 
-    #[cfg(feature = "nnapi")]
-    #[allow(dead_code)]
     pub fn nnapi() -> Self {
         Self {
             provider: OrtExecutionProvider::Nnapi,
@@ -71,28 +72,34 @@ impl OrtFactory {
     }
 }
 
+static ORT_INIT: OnceLock<bool> = OnceLock::new();
+
+fn ensure_ort_initialized() {
+    let initialized_by_us = ORT_INIT.get_or_init(|| ort::init().with_name("gigastt").commit());
+    if !initialized_by_us {
+        tracing::warn!(
+            "ort environment was already configured before gigastt initialization; execution provider settings may not apply"
+        );
+    }
+}
+
 impl RuntimeFactory for OrtFactory {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
-        ort::init()
-            .with_name("gigastt")
-            .with_execution_providers([self.provider.to_ort()])
-            .commit();
-        Ok(Box::new(OrtRuntime::new(
-            intra_threads,
-            self.provider.to_ort(),
-        )))
+        ensure_ort_initialized();
+        Ok(Box::new(OrtRuntime::new(intra_threads, self.provider)))
     }
 }
 
 /// Returns the default `ort` factory for the active compile-time feature flags.
-#[allow(dead_code)]
-pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
-    #[cfg(feature = "coreml")]
-    return Box::new(OrtFactory::coreml());
-    #[cfg(feature = "cuda")]
-    return Box::new(OrtFactory::cuda());
-    #[cfg(feature = "nnapi")]
-    return Box::new(OrtFactory::nnapi());
-    #[cfg(not(any(feature = "coreml", feature = "cuda", feature = "nnapi")))]
-    Box::new(OrtFactory::cpu())
+pub fn default_factory(intra_threads: usize) -> Box<dyn RuntimeFactory> {
+    let _ = intra_threads;
+    if cfg!(feature = "coreml") {
+        Box::new(OrtFactory::coreml())
+    } else if cfg!(feature = "cuda") {
+        Box::new(OrtFactory::cuda())
+    } else if cfg!(feature = "nnapi") {
+        Box::new(OrtFactory::nnapi())
+    } else {
+        Box::new(OrtFactory::cpu())
+    }
 }

--- a/crates/gigastt-core/src/runtime/ort/mod.rs
+++ b/crates/gigastt-core/src/runtime/ort/mod.rs
@@ -2,7 +2,7 @@ pub mod factory;
 pub mod session;
 pub mod tensor;
 
-#[expect(unused_imports)]
-pub use factory::{OrtExecutionProvider, OrtFactory, default_factory};
-#[expect(unused_imports)]
+#[allow(unused_imports)]
+pub use factory::{OrtExecutionProvider, OrtFactory, default_factory, production_factory};
+#[allow(unused_imports)]
 pub use session::{OrtRuntime, OrtSession};

--- a/crates/gigastt-core/src/runtime/ort/mod.rs
+++ b/crates/gigastt-core/src/runtime/ort/mod.rs
@@ -1,0 +1,8 @@
+pub mod factory;
+pub mod session;
+pub mod tensor;
+
+#[allow(unused_imports)]
+pub use factory::{OrtExecutionProvider, OrtFactory, default_factory};
+#[allow(unused_imports)]
+pub use session::{OrtRuntime, OrtSession};

--- a/crates/gigastt-core/src/runtime/ort/mod.rs
+++ b/crates/gigastt-core/src/runtime/ort/mod.rs
@@ -2,7 +2,7 @@ pub mod factory;
 pub mod session;
 pub mod tensor;
 
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 pub use factory::{OrtExecutionProvider, OrtFactory, default_factory};
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 pub use session::{OrtRuntime, OrtSession};

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -7,17 +7,16 @@ use crate::runtime::{
     error::RuntimeError, factory::Runtime, session::RuntimeSession, tensor::Tensor,
 };
 
-use super::tensor::value_to_tensor;
+use super::{factory::OrtExecutionProvider, tensor::value_to_tensor};
 
 /// `ort`-backed runtime that loads sessions for a specific execution provider.
-#[allow(dead_code)]
 pub struct OrtRuntime {
     intra_threads: usize,
-    provider: ort::ep::ExecutionProviderDispatch,
+    provider: OrtExecutionProvider,
 }
 
 impl OrtRuntime {
-    pub(crate) fn new(intra_threads: usize, provider: ort::ep::ExecutionProviderDispatch) -> Self {
+    pub(crate) fn new(intra_threads: usize, provider: OrtExecutionProvider) -> Self {
         Self {
             intra_threads,
             provider,
@@ -26,7 +25,6 @@ impl OrtRuntime {
 }
 
 /// `ort`-backed session wrapping a loaded ONNX model.
-#[allow(dead_code)]
 pub struct OrtSession {
     session: Mutex<Session>,
 }
@@ -38,12 +36,12 @@ impl Runtime for OrtRuntime {
                 path: model_path.into(),
                 message: e.to_string(),
             })?
-            .with_intra_threads(self.intra_threads)
+            .with_execution_providers([self.provider.to_ort()])
             .map_err(|e| RuntimeError::LoadFailed {
                 path: model_path.into(),
                 message: e.to_string(),
             })?
-            .with_execution_providers([self.provider.clone()])
+            .with_intra_threads(self.intra_threads)
             .map_err(|e| RuntimeError::LoadFailed {
                 path: model_path.into(),
                 message: e.to_string(),
@@ -68,7 +66,10 @@ impl RuntimeSession for OrtSession {
         let session_inputs: Vec<ort::session::SessionInputValue<'_>> =
             ort_inputs.into_iter().map(Into::into).collect();
 
-        let mut session = self.session.lock().expect("ort session mutex poisoned");
+        let mut session = self
+            .session
+            .lock()
+            .map_err(|_| RuntimeError::InferenceFailed("ort session mutex poisoned".into()))?;
         let outputs = session
             .run(&session_inputs[..])
             .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use ort::session::Session;
 
@@ -13,48 +13,89 @@ use super::{factory::OrtExecutionProvider, tensor::value_to_tensor};
 pub struct OrtRuntime {
     intra_threads: usize,
     provider: OrtExecutionProvider,
+    prepacked: Option<Arc<ort::session::builder::PrepackedWeights>>,
+    optimized_cache_dir: Option<std::path::PathBuf>,
 }
 
 impl OrtRuntime {
-    pub(crate) fn new(intra_threads: usize, provider: OrtExecutionProvider) -> Self {
+    pub(crate) fn new(
+        intra_threads: usize,
+        provider: OrtExecutionProvider,
+        prepacked: Option<Arc<ort::session::builder::PrepackedWeights>>,
+        optimized_cache_dir: Option<std::path::PathBuf>,
+    ) -> Self {
         Self {
             intra_threads,
             provider,
+            prepacked,
+            optimized_cache_dir,
         }
+    }
+}
+
+fn load_failed(path: &Path, e: impl std::fmt::Display) -> RuntimeError {
+    RuntimeError::LoadFailed {
+        path: path.into(),
+        message: e.to_string(),
+    }
+}
+
+impl Runtime for OrtRuntime {
+    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let is_encoder = model_path
+            .file_stem()
+            .map(|s| {
+                let s = s.to_string_lossy().to_lowercase();
+                s.contains("encoder")
+            })
+            .unwrap_or(false);
+
+        let mut builder = Session::builder().map_err(|e| load_failed(model_path, e))?;
+
+        if let Some(prepacked) = self.prepacked.as_ref() {
+            builder = builder
+                .with_prepacked_weights(prepacked)
+                .map_err(|e| load_failed(model_path, e))?;
+        }
+
+        let eps = self.provider.execution_providers(model_path);
+        builder = builder
+            .with_execution_providers(&eps)
+            .map_err(|e| load_failed(model_path, e))?;
+
+        if self.provider.is_cpu() {
+            let intra_threads = if is_encoder {
+                self.intra_threads.max(1)
+            } else {
+                1
+            };
+            builder = builder
+                .with_intra_threads(intra_threads)
+                .map_err(|e| load_failed(model_path, e))?;
+            builder = builder
+                .with_inter_threads(1)
+                .map_err(|e| load_failed(model_path, e))?;
+
+            if is_encoder && let Some(cache_dir) = &self.optimized_cache_dir {
+                std::fs::create_dir_all(cache_dir).map_err(|e| load_failed(model_path, e))?;
+                builder = builder
+                    .with_optimized_model_path(cache_dir.join("encoder_optimized.onnx"))
+                    .map_err(|e| load_failed(model_path, e))?;
+            }
+        }
+
+        let session = builder
+            .commit_from_file(model_path)
+            .map_err(|e| load_failed(model_path, e))?;
+        Ok(Box::new(OrtSession {
+            session: Mutex::new(session),
+        }))
     }
 }
 
 /// `ort`-backed session wrapping a loaded ONNX model.
 pub struct OrtSession {
     session: Mutex<Session>,
-}
-
-impl Runtime for OrtRuntime {
-    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
-        let session = Session::builder()
-            .map_err(|e| RuntimeError::LoadFailed {
-                path: model_path.into(),
-                message: e.to_string(),
-            })?
-            .with_execution_providers([self.provider.to_ort()])
-            .map_err(|e| RuntimeError::LoadFailed {
-                path: model_path.into(),
-                message: e.to_string(),
-            })?
-            .with_intra_threads(self.intra_threads)
-            .map_err(|e| RuntimeError::LoadFailed {
-                path: model_path.into(),
-                message: e.to_string(),
-            })?
-            .commit_from_file(model_path)
-            .map_err(|e| RuntimeError::LoadFailed {
-                path: model_path.into(),
-                message: e.to_string(),
-            })?;
-        Ok(Box::new(OrtSession {
-            session: Mutex::new(session),
-        }))
-    }
 }
 
 impl RuntimeSession for OrtSession {

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -99,13 +99,11 @@ pub struct OrtSession {
 }
 
 impl RuntimeSession for OrtSession {
-    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError> {
-        let ort_inputs: Vec<ort::value::Value> = inputs
-            .into_iter()
-            .map(Tensor::into_ort_value)
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        let session_inputs: Vec<ort::session::SessionInputValue<'_>> = inputs
+            .iter()
+            .map(Tensor::as_ort_input)
             .collect::<Result<_, _>>()?;
-        let session_inputs: Vec<ort::session::SessionInputValue<'_>> =
-            ort_inputs.into_iter().map(Into::into).collect();
 
         let mut session = self
             .session

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -1,0 +1,81 @@
+use std::path::Path;
+use std::sync::Mutex;
+
+use ort::session::Session;
+
+use crate::runtime::{
+    error::RuntimeError, factory::Runtime, session::RuntimeSession, tensor::Tensor,
+};
+
+use super::tensor::value_to_tensor;
+
+/// `ort`-backed runtime that loads sessions for a specific execution provider.
+#[allow(dead_code)]
+pub struct OrtRuntime {
+    intra_threads: usize,
+    provider: ort::ep::ExecutionProviderDispatch,
+}
+
+impl OrtRuntime {
+    pub(crate) fn new(intra_threads: usize, provider: ort::ep::ExecutionProviderDispatch) -> Self {
+        Self {
+            intra_threads,
+            provider,
+        }
+    }
+}
+
+/// `ort`-backed session wrapping a loaded ONNX model.
+#[allow(dead_code)]
+pub struct OrtSession {
+    session: Mutex<Session>,
+}
+
+impl Runtime for OrtRuntime {
+    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let session = Session::builder()
+            .map_err(|e| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: e.to_string(),
+            })?
+            .with_intra_threads(self.intra_threads)
+            .map_err(|e| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: e.to_string(),
+            })?
+            .with_execution_providers([self.provider.clone()])
+            .map_err(|e| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: e.to_string(),
+            })?
+            .commit_from_file(model_path)
+            .map_err(|e| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: e.to_string(),
+            })?;
+        Ok(Box::new(OrtSession {
+            session: Mutex::new(session),
+        }))
+    }
+}
+
+impl RuntimeSession for OrtSession {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError> {
+        let ort_inputs: Vec<ort::value::Value> = inputs
+            .into_iter()
+            .map(Tensor::into_ort_value)
+            .collect::<Result<_, _>>()?;
+        let session_inputs: Vec<ort::session::SessionInputValue<'_>> =
+            ort_inputs.into_iter().map(Into::into).collect();
+
+        let mut session = self.session.lock().expect("ort session mutex poisoned");
+        let outputs = session
+            .run(&session_inputs[..])
+            .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+
+        outputs
+            .into_iter()
+            .map(|(_name, value)| value_to_tensor(value))
+            .collect()
+    }
+}

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -1,8 +1,8 @@
-use ort::value::Value;
+use ort::value::{TensorElementType, Value};
 
 use crate::runtime::{
     error::RuntimeError,
-    tensor::{Shape, Tensor, TensorData},
+    tensor::{ElementType, Shape, Tensor, TensorData},
 };
 
 impl Tensor {
@@ -23,10 +23,31 @@ impl Tensor {
     }
 }
 
+/// Attempts to map an `ort` tensor element type to our normalized `ElementType`.
+///
+/// Returns `None` for types that have no equivalent in our abstraction (e.g. strings
+/// or exotic float formats).
+fn element_type_from_ort(ort_type: TensorElementType) -> Option<ElementType> {
+    match ort_type {
+        TensorElementType::Float32 => Some(ElementType::F32),
+        TensorElementType::Int32 => Some(ElementType::I32),
+        TensorElementType::Int64 => Some(ElementType::I64),
+        TensorElementType::Float64 => Some(ElementType::F64),
+        TensorElementType::Int8 => Some(ElementType::I8),
+        TensorElementType::Uint8 => Some(ElementType::U8),
+        TensorElementType::Int16 => Some(ElementType::I16),
+        TensorElementType::Uint16 => Some(ElementType::U16),
+        TensorElementType::Uint32 => Some(ElementType::U32),
+        TensorElementType::Uint64 => Some(ElementType::U64),
+        TensorElementType::Bool => Some(ElementType::Bool),
+        _ => None,
+    }
+}
+
 /// Converts an `ort` tensor value into our owned tensor type.
 pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
-    match value.data_type() {
-        ort::value::TensorElementType::Float32 => {
+    match *value.data_type() {
+        TensorElementType::Float32 => {
             let (shape, data) = value
                 .try_extract_tensor::<f32>()
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
@@ -35,7 +56,7 @@ pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
                 TensorData::F32(data.to_vec()),
             ))
         }
-        ort::value::TensorElementType::Int32 => {
+        TensorElementType::Int32 => {
             let (shape, data) = value
                 .try_extract_tensor::<i32>()
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
@@ -44,7 +65,7 @@ pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
                 TensorData::I32(data.to_vec()),
             ))
         }
-        ort::value::TensorElementType::Int64 => {
+        TensorElementType::Int64 => {
             let (shape, data) = value
                 .try_extract_tensor::<i64>()
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
@@ -53,9 +74,12 @@ pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
                 TensorData::I64(data.to_vec()),
             ))
         }
-        other => Err(RuntimeError::InferenceFailed(format!(
-            "unsupported element type: {other}"
-        ))),
+        other => match element_type_from_ort(other) {
+            Some(element_type) => Err(RuntimeError::UnsupportedElementType(element_type)),
+            None => Err(RuntimeError::InferenceFailed(format!(
+                "unsupported element type: {other:?}"
+            ))),
+        },
     }
 }
 

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -1,12 +1,14 @@
+use ort::session::SessionInputValue;
 use ort::value::{TensorElementType, Value};
 
 use crate::runtime::{
     error::RuntimeError,
-    tensor::{ElementType, Shape, Tensor, TensorData},
+    tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView},
 };
 
 impl Tensor {
     /// Converts this owned tensor into an `ort` value.
+    #[allow(dead_code)]
     pub fn into_ort_value(self) -> Result<Value, RuntimeError> {
         let shape: Vec<i64> = self.shape().dims().iter().map(|&d| d as i64).collect();
         match self.into_data() {
@@ -19,6 +21,34 @@ impl Tensor {
             TensorData::I64(data) => ort::value::Tensor::from_array((shape, data))
                 .map(|t| t.into_dyn())
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+        }
+    }
+
+    /// Returns a borrowed `ort` input value backed by this tensor's data.
+    ///
+    /// The returned `SessionInputValue` borrows from `self`; the caller must
+    /// keep this tensor alive for the duration of the `run` call.
+    pub fn as_ort_input(&self) -> Result<SessionInputValue<'_>, RuntimeError> {
+        let shape: Vec<i64> = self.shape().dims().iter().map(|&d| d as i64).collect();
+        match self.view().data() {
+            TensorDataView::F32(data) => {
+                let tensor_ref: ort::value::TensorRef<'_, f32> =
+                    ort::value::TensorRef::from_array_view((shape, *data))
+                        .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+                Ok(tensor_ref.into_dyn().into())
+            }
+            TensorDataView::I32(data) => {
+                let tensor_ref: ort::value::TensorRef<'_, i32> =
+                    ort::value::TensorRef::from_array_view((shape, *data))
+                        .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+                Ok(tensor_ref.into_dyn().into())
+            }
+            TensorDataView::I64(data) => {
+                let tensor_ref: ort::value::TensorRef<'_, i64> =
+                    ort::value::TensorRef::from_array_view((shape, *data))
+                        .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+                Ok(tensor_ref.into_dyn().into())
+            }
         }
     }
 }

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -1,0 +1,92 @@
+use ort::value::Value;
+
+use crate::runtime::{
+    error::RuntimeError,
+    tensor::{Shape, Tensor, TensorData},
+};
+
+impl Tensor {
+    /// Converts this owned tensor into an `ort` value.
+    pub fn into_ort_value(self) -> Result<Value, RuntimeError> {
+        let shape: Vec<i64> = self.shape().dims().iter().map(|&d| d as i64).collect();
+        match self.into_data() {
+            TensorData::F32(data) => ort::value::Tensor::from_array((shape, data))
+                .map(|t| t.into_dyn())
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+            TensorData::I32(data) => ort::value::Tensor::from_array((shape, data))
+                .map(|t| t.into_dyn())
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+            TensorData::I64(data) => ort::value::Tensor::from_array((shape, data))
+                .map(|t| t.into_dyn())
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+        }
+    }
+}
+
+/// Converts an `ort` tensor value into our owned tensor type.
+pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
+    match value.data_type() {
+        ort::value::TensorElementType::Float32 => {
+            let (shape, data) = value
+                .try_extract_tensor::<f32>()
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+            Ok(Tensor::new(
+                Shape::new(shape.iter().map(|&d| d as usize).collect()),
+                TensorData::F32(data.to_vec()),
+            ))
+        }
+        ort::value::TensorElementType::Int32 => {
+            let (shape, data) = value
+                .try_extract_tensor::<i32>()
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+            Ok(Tensor::new(
+                Shape::new(shape.iter().map(|&d| d as usize).collect()),
+                TensorData::I32(data.to_vec()),
+            ))
+        }
+        ort::value::TensorElementType::Int64 => {
+            let (shape, data) = value
+                .try_extract_tensor::<i64>()
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+            Ok(Tensor::new(
+                Shape::new(shape.iter().map(|&d| d as usize).collect()),
+                TensorData::I64(data.to_vec()),
+            ))
+        }
+        other => Err(RuntimeError::InferenceFailed(format!(
+            "unsupported element type: {other}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensor_ort_roundtrip_f32() {
+        let tensor = Tensor::new(
+            Shape::new(vec![2, 3]),
+            TensorData::F32(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        );
+        let value = tensor.clone().into_ort_value().unwrap();
+        let recovered = value_to_tensor(value).unwrap();
+        assert_eq!(tensor, recovered);
+    }
+
+    #[test]
+    fn test_tensor_ort_roundtrip_i32() {
+        let tensor = Tensor::new(Shape::new(vec![3]), TensorData::I32(vec![1, 2, 3]));
+        let value = tensor.clone().into_ort_value().unwrap();
+        let recovered = value_to_tensor(value).unwrap();
+        assert_eq!(tensor, recovered);
+    }
+
+    #[test]
+    fn test_tensor_ort_roundtrip_i64() {
+        let tensor = Tensor::new(Shape::new(vec![2, 2]), TensorData::I64(vec![1, 2, 3, 4]));
+        let value = tensor.clone().into_ort_value().unwrap();
+        let recovered = value_to_tensor(value).unwrap();
+        assert_eq!(tensor, recovered);
+    }
+}

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -3,5 +3,5 @@ use super::{error::RuntimeError, tensor::Tensor};
 /// One loaded model session: encoder, decoder, or joiner.
 #[allow(dead_code)]
 pub trait RuntimeSession: Send + Sync + 'static {
-    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError>;
 }

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -1,6 +1,7 @@
 use super::{error::RuntimeError, tensor::Tensor};
 
 /// One loaded model session: encoder, decoder, or joiner.
+#[expect(dead_code)]
 pub trait RuntimeSession: Send + Sync + 'static {
     fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
 }

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -1,0 +1,6 @@
+use super::{error::RuntimeError, tensor::Tensor};
+
+/// One loaded model session: encoder, decoder, or joiner.
+pub trait RuntimeSession: Send + Sync + 'static {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
+}

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -1,7 +1,7 @@
 use super::{error::RuntimeError, tensor::Tensor};
 
 /// One loaded model session: encoder, decoder, or joiner.
-#[expect(dead_code)]
+#[allow(dead_code)]
 pub trait RuntimeSession: Send + Sync + 'static {
     fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
 }

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -107,6 +107,44 @@ impl Tensor {
     pub fn into_data(self) -> TensorData {
         self.data
     }
+
+    /// Return a mutable view of the underlying f32 buffer, if this tensor is f32.
+    pub fn as_f32_mut(&mut self) -> Option<&mut [f32]> {
+        match &mut self.data {
+            TensorData::F32(v) => Some(v.as_mut_slice()),
+            _ => None,
+        }
+    }
+
+    /// Return a mutable view of the underlying i32 buffer, if this tensor is i32.
+    pub fn as_i32_mut(&mut self) -> Option<&mut [i32]> {
+        match &mut self.data {
+            TensorData::I32(v) => Some(v.as_mut_slice()),
+            _ => None,
+        }
+    }
+
+    /// Return a mutable view of the underlying i64 buffer, if this tensor is i64.
+    pub fn as_i64_mut(&mut self) -> Option<&mut [i64]> {
+        match &mut self.data {
+            TensorData::I64(v) => Some(v.as_mut_slice()),
+            _ => None,
+        }
+    }
+
+    /// Resize the tensor to a new shape, reusing the existing storage.
+    ///
+    /// The buffer is resized to the new element count and zero-padded if it
+    /// grows. The caller must update the data before use.
+    pub fn resize_to(&mut self, shape: Shape) {
+        let new_len = shape.elements();
+        match &mut self.data {
+            TensorData::F32(v) => v.resize(new_len, 0.0),
+            TensorData::I32(v) => v.resize(new_len, 0),
+            TensorData::I64(v) => v.resize(new_len, 0),
+        }
+        self.shape = shape;
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -7,6 +7,7 @@ pub struct Tensor {
 
 /// Owned tensor storage for the supported element types.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(dead_code)]
 pub enum TensorData {
     F32(Vec<f32>),
     I32(Vec<i32>),
@@ -15,16 +16,32 @@ pub enum TensorData {
 
 /// Zero-copy borrow of tensor storage.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(dead_code)]
 pub enum TensorDataView<'a> {
     F32(&'a [f32]),
     I32(&'a [i32]),
     I64(&'a [i64]),
 }
 
+#[allow(dead_code)]
 impl<'a> TensorDataView<'a> {
     pub fn as_f32(&self) -> Option<&'a [f32]> {
         match self {
             TensorDataView::F32(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn as_i32(&self) -> Option<&'a [i32]> {
+        match self {
+            TensorDataView::I32(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<&'a [i64]> {
+        match self {
+            TensorDataView::I64(v) => Some(v),
             _ => None,
         }
     }
@@ -38,12 +55,14 @@ pub struct Shape {
 
 /// Supported tensor element types.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
 pub enum ElementType {
     F32,
     I32,
     I64,
 }
 
+#[allow(dead_code)]
 impl Tensor {
     pub fn new(shape: Shape, data: TensorData) -> Self {
         let expected = shape.elements();
@@ -83,6 +102,7 @@ impl Tensor {
     }
 }
 
+#[allow(dead_code)]
 impl TensorData {
     pub fn len(&self) -> usize {
         match self {
@@ -103,6 +123,7 @@ pub struct TensorView<'a> {
     data: TensorDataView<'a>,
 }
 
+#[allow(dead_code)]
 impl<'a> TensorView<'a> {
     pub fn shape(&self) -> &Shape {
         &self.shape
@@ -113,13 +134,14 @@ impl<'a> TensorView<'a> {
     }
 }
 
+#[allow(dead_code)]
 impl Shape {
     pub fn new(dims: Vec<usize>) -> Self {
         Self { dims }
     }
 
     pub fn elements(&self) -> usize {
-        self.dims.iter().product::<usize>().max(1)
+        self.dims.iter().product()
     }
 
     pub fn dims(&self) -> &[usize] {
@@ -166,5 +188,11 @@ mod tests {
         let t = Tensor::new(Shape::new(vec![2]), TensorData::I32(vec![1, 2]));
         let v = t.view();
         assert_eq!(v.data().as_f32(), None);
+    }
+
+    #[test]
+    fn test_shape_elements_zero_dimension() {
+        assert_eq!(Shape::new(vec![0]).elements(), 0);
+        assert_eq!(Shape::new(vec![2, 0]).elements(), 0);
     }
 }

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -53,13 +53,20 @@ pub struct Shape {
     dims: Vec<usize>,
 }
 
-/// Supported tensor element types.
+/// Known tensor element types. Not all are supported by every runtime backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum ElementType {
     F32,
     I32,
     I64,
+    F64,
+    I8,
+    U8,
+    I16,
+    U16,
+    U32,
+    U64,
+    Bool,
 }
 
 #[allow(dead_code)]

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -1,0 +1,170 @@
+/// Owned, cheaply cloneable tensor value used by the runtime abstraction layer.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Tensor {
+    shape: Shape,
+    data: TensorData,
+}
+
+/// Owned tensor storage for the supported element types.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TensorData {
+    F32(Vec<f32>),
+    I32(Vec<i32>),
+    I64(Vec<i64>),
+}
+
+/// Zero-copy borrow of tensor storage.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TensorDataView<'a> {
+    F32(&'a [f32]),
+    I32(&'a [i32]),
+    I64(&'a [i64]),
+}
+
+impl<'a> TensorDataView<'a> {
+    pub fn as_f32(&self) -> Option<&'a [f32]> {
+        match self {
+            TensorDataView::F32(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+/// Normalized tensor shape independent of any runtime backend.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Shape {
+    dims: Vec<usize>,
+}
+
+/// Supported tensor element types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ElementType {
+    F32,
+    I32,
+    I64,
+}
+
+impl Tensor {
+    pub fn new(shape: Shape, data: TensorData) -> Self {
+        let expected = shape.elements();
+        let actual = data.len();
+        assert_eq!(
+            expected, actual,
+            "tensor data length mismatch: expected {expected}, got {actual}"
+        );
+        Self { shape, data }
+    }
+
+    pub fn shape(&self) -> &Shape {
+        &self.shape
+    }
+
+    pub fn element_type(&self) -> ElementType {
+        match &self.data {
+            TensorData::F32(_) => ElementType::F32,
+            TensorData::I32(_) => ElementType::I32,
+            TensorData::I64(_) => ElementType::I64,
+        }
+    }
+
+    pub fn view(&self) -> TensorView<'_> {
+        TensorView {
+            shape: self.shape.clone(),
+            data: match &self.data {
+                TensorData::F32(v) => TensorDataView::F32(v.as_slice()),
+                TensorData::I32(v) => TensorDataView::I32(v.as_slice()),
+                TensorData::I64(v) => TensorDataView::I64(v.as_slice()),
+            },
+        }
+    }
+
+    pub fn into_data(self) -> TensorData {
+        self.data
+    }
+}
+
+impl TensorData {
+    pub fn len(&self) -> usize {
+        match self {
+            TensorData::F32(v) => v.len(),
+            TensorData::I32(v) => v.len(),
+            TensorData::I64(v) => v.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Borrowed view of a tensor.
+pub struct TensorView<'a> {
+    shape: Shape,
+    data: TensorDataView<'a>,
+}
+
+impl<'a> TensorView<'a> {
+    pub fn shape(&self) -> &Shape {
+        &self.shape
+    }
+
+    pub fn data(&self) -> &TensorDataView<'a> {
+        &self.data
+    }
+}
+
+impl Shape {
+    pub fn new(dims: Vec<usize>) -> Self {
+        Self { dims }
+    }
+
+    pub fn elements(&self) -> usize {
+        self.dims.iter().product::<usize>().max(1)
+    }
+
+    pub fn dims(&self) -> &[usize] {
+        &self.dims
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensor_shape_and_data_match() {
+        let t = Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 6]));
+        assert_eq!(t.shape().dims(), &[2, 3]);
+        assert_eq!(t.element_type(), ElementType::F32);
+    }
+
+    #[test]
+    #[should_panic(expected = "tensor data length mismatch")]
+    fn test_tensor_rejects_mismatched_data() {
+        Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 5]));
+    }
+
+    #[test]
+    fn test_shape_elements() {
+        assert_eq!(Shape::new(vec![2, 3, 4]).elements(), 24);
+        assert_eq!(Shape::new(vec![]).elements(), 1);
+    }
+
+    #[test]
+    fn test_tensor_view_f32() {
+        let t = Tensor::new(
+            Shape::new(vec![2, 2]),
+            TensorData::F32(vec![1.0, 2.0, 3.0, 4.0]),
+        );
+        let v = t.view();
+        assert_eq!(v.shape().dims(), &[2, 2]);
+        assert_eq!(v.data().as_f32(), Some(&[1.0, 2.0, 3.0, 4.0][..]));
+    }
+
+    #[test]
+    fn test_tensor_view_non_f32_returns_none() {
+        let t = Tensor::new(Shape::new(vec![2]), TensorData::I32(vec![1, 2]));
+        let v = t.view();
+        assert_eq!(v.data().as_f32(), None);
+    }
+}

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -22,15 +22,14 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use ort::session::Session;
-use ort::value::TensorRef;
 use parking_lot::Mutex;
 
-/// `ort` errors are not `Send`/`Sync`; stringify them so they cross `?` into
-/// `anyhow` like everywhere else in the crate.
-fn ort_err(e: impl std::fmt::Display) -> anyhow::Error {
-    anyhow::anyhow!("{e}")
-}
+use crate::runtime::{
+    factory::RuntimeFactory,
+    ort::OrtFactory,
+    session::RuntimeSession,
+    tensor::{Shape, Tensor, TensorData},
+};
 
 /// Silero VAD ONNX filename on disk. Single source of truth shared with the
 /// model-download path in [`crate::model`].
@@ -88,7 +87,7 @@ impl VadConfig {
 /// never by this struct, so a single `SileroVad` can serve many concurrent
 /// streams.
 pub struct SileroVad {
-    session: Mutex<Session>,
+    session: Mutex<Box<dyn RuntimeSession>>,
 }
 
 impl SileroVad {
@@ -100,10 +99,14 @@ impl SileroVad {
     /// session. The caller treats an error as "VAD unavailable" and proceeds
     /// without it — VAD is strictly optional.
     pub fn load(model_path: &Path) -> Result<Self> {
-        let session = Session::builder()
-            .map_err(ort_err)?
-            .commit_from_file(model_path)
-            .map_err(ort_err)
+        let factory = OrtFactory::cpu();
+        let runtime = factory
+            .create(1)
+            .map_err(|e| anyhow::anyhow!(e))
+            .with_context(|| format!("Failed to create runtime for {}", model_path.display()))?;
+        let session = runtime
+            .load_session(model_path)
+            .map_err(|e| anyhow::anyhow!(e))
             .with_context(|| format!("Failed to load VAD model {}", model_path.display()))?;
         tracing::info!("VAD model loaded from {}", model_path.display());
         Ok(Self {
@@ -122,39 +125,35 @@ impl SileroVad {
         let n = frame.len().min(VAD_FRAME_SAMPLES);
         input[..n].copy_from_slice(&frame[..n]);
 
-        let input_t = TensorRef::from_array_view(([1_usize, VAD_FRAME_SAMPLES], input.as_slice()))?;
-        let state_t = TensorRef::from_array_view(([2_usize, 1, 128], state.as_slice()))?;
-        let sr_t = TensorRef::from_array_view(([1_usize], [VAD_SAMPLE_RATE].as_slice()))?;
+        let inputs = vec![
+            Tensor::new(
+                Shape::new(vec![1, VAD_FRAME_SAMPLES]),
+                TensorData::F32(input.to_vec()),
+            ),
+            Tensor::new(Shape::new(vec![2, 1, 128]), TensorData::F32(state.to_vec())),
+            Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![VAD_SAMPLE_RATE])),
+        ];
 
         let prob = {
-            let mut session = self.session.lock();
-            let outputs = session
-                .run(ort::inputs![
-                    "input" => input_t,
-                    "state" => state_t,
-                    "sr" => sr_t,
-                ])
-                .context("VAD model inference failed")?;
+            let session = self.session.lock();
+            let outputs = session.run(inputs).context("VAD model inference failed")?;
 
-            // Copy the next state out before the borrow ends. A length other
-            // than VAD_STATE_LEN means the model's recurrent-state contract
-            // changed; surface it rather than silently running later frames on
-            // stale state (the non-blocking caller then disables VAD).
-            let (_, new_state) = outputs["stateN"]
-                .try_extract_tensor::<f32>()
-                .context("failed to extract VAD state")?;
-            if new_state.len() != VAD_STATE_LEN {
-                anyhow::bail!(
-                    "unexpected VAD state length {} (expected {VAD_STATE_LEN})",
-                    new_state.len()
-                );
+            // Identify the state and probability outputs by shape so the code
+            // does not depend on the exact output order of the Silero model.
+            let mut prob = 0.0f32;
+            let mut new_state = [0.0f32; VAD_STATE_LEN];
+            for output in outputs {
+                let view = output.view();
+                if let Some(data) = view.data().as_f32() {
+                    if data.len() == VAD_STATE_LEN {
+                        new_state.copy_from_slice(data);
+                    } else if data.len() == 1 {
+                        prob = data[0];
+                    }
+                }
             }
-            state.copy_from_slice(new_state);
-
-            let (_, prob) = outputs["output"]
-                .try_extract_tensor::<f32>()
-                .context("failed to extract VAD probability")?;
-            prob.first().copied().unwrap_or(0.0)
+            state.copy_from_slice(&new_state);
+            prob
         };
         Ok(prob)
     }

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -88,6 +88,9 @@ impl VadConfig {
 /// streams.
 pub struct SileroVad {
     session: Mutex<Box<dyn RuntimeSession>>,
+    /// Reusable input tensors: `[frame [1,512], state [2,1,128], sample_rate [1]]`.
+    /// Mutated in place in `run_frame` to avoid per-frame allocations.
+    input_tensors: Mutex<Vec<Tensor>>,
 }
 
 impl SileroVad {
@@ -111,6 +114,17 @@ impl SileroVad {
         tracing::info!("VAD model loaded from {}", model_path.display());
         Ok(Self {
             session: Mutex::new(session),
+            input_tensors: Mutex::new(vec![
+                Tensor::new(
+                    Shape::new(vec![1, VAD_FRAME_SAMPLES]),
+                    TensorData::F32(vec![0.0; VAD_FRAME_SAMPLES]),
+                ),
+                Tensor::new(
+                    Shape::new(vec![2, 1, 128]),
+                    TensorData::F32(vec![0.0; VAD_STATE_LEN]),
+                ),
+                Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![VAD_SAMPLE_RATE])),
+            ]),
         })
     }
 
@@ -125,36 +139,37 @@ impl SileroVad {
         let n = frame.len().min(VAD_FRAME_SAMPLES);
         input[..n].copy_from_slice(&frame[..n]);
 
-        let inputs = vec![
-            Tensor::new(
-                Shape::new(vec![1, VAD_FRAME_SAMPLES]),
-                TensorData::F32(input.to_vec()),
-            ),
-            Tensor::new(Shape::new(vec![2, 1, 128]), TensorData::F32(state.to_vec())),
-            Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![VAD_SAMPLE_RATE])),
-        ];
+        let outputs = {
+            let mut inputs = self.input_tensors.lock();
+            inputs[0]
+                .as_f32_mut()
+                .context("VAD frame tensor is not f32")?
+                .copy_from_slice(&input);
+            inputs[1]
+                .as_f32_mut()
+                .context("VAD state tensor is not f32")?
+                .copy_from_slice(state);
+            // inputs[2] (sample rate) is constant and was set at construction.
 
-        let prob = {
             let session = self.session.lock();
-            let outputs = session.run(inputs).context("VAD model inference failed")?;
+            session.run(&inputs).context("VAD model inference failed")?
+        };
 
-            // Identify the state and probability outputs by shape so the code
-            // does not depend on the exact output order of the Silero model.
-            let mut prob = 0.0f32;
-            let mut new_state = [0.0f32; VAD_STATE_LEN];
-            for output in outputs {
-                let view = output.view();
-                if let Some(data) = view.data().as_f32() {
-                    if data.len() == VAD_STATE_LEN {
-                        new_state.copy_from_slice(data);
-                    } else if data.len() == 1 {
-                        prob = data[0];
-                    }
+        // Identify the state and probability outputs by shape so the code
+        // does not depend on the exact output order of the Silero model.
+        let mut prob = 0.0f32;
+        let mut new_state = [0.0f32; VAD_STATE_LEN];
+        for output in outputs {
+            let view = output.view();
+            if let Some(data) = view.data().as_f32() {
+                if data.len() == VAD_STATE_LEN {
+                    new_state.copy_from_slice(data);
+                } else if data.len() == 1 {
+                    prob = data[0];
                 }
             }
-            state.copy_from_slice(&new_state);
-            prob
-        };
+        }
+        state.copy_from_slice(&new_state);
         Ok(prob)
     }
 

--- a/crates/gigastt/tests/e2e_cli.rs
+++ b/crates/gigastt/tests/e2e_cli.rs
@@ -351,11 +351,23 @@ fn cli_serve_boots_and_graceful_shutdown() {
     }
     assert!(ready, "server did not become healthy within 120s");
 
-    // Metrics live on their own loopback port.
-    assert_eq!(
-        http_status(metrics_port, "/metrics"),
-        Some(200),
-        "metrics endpoint should answer on its dedicated port"
+    // Metrics live on their own loopback port, bound by a separate listener that
+    // can come up slightly after the main server reports `/health` ready — more
+    // so under the instrumented coverage build. Poll it instead of probing once,
+    // to avoid a readiness race (the single-probe version flaked in CI's
+    // `Coverage (E2E)` job while the non-instrumented `E2E Tests` job passed).
+    let metrics_start = Instant::now();
+    let mut metrics_ok = false;
+    while metrics_start.elapsed() < Duration::from_secs(30) {
+        if http_status(metrics_port, "/metrics") == Some(200) {
+            metrics_ok = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    assert!(
+        metrics_ok,
+        "metrics endpoint should answer 200 on its dedicated port within 30s"
     );
 
     // Graceful shutdown: SIGTERM should drain and return a clean exit, which is

--- a/docs/superpowers/plans/2026-06-22-ort-runtime-abstraction-plan.md
+++ b/docs/superpowers/plans/2026-06-22-ort-runtime-abstraction-plan.md
@@ -1,0 +1,1154 @@
+# Runtime Abstraction Layer Over `ort` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce an internal runtime abstraction layer in `gigastt-core` so that `ort` types are isolated to a single adapter module, enabling mock-based unit tests and future backend swaps while preserving all existing behavior.
+
+**Architecture:** Define core traits (`Runtime`, `RuntimeSession`, `RuntimeFactory`) and value types (`Tensor`, `Shape`, `RuntimeError`) in a new `runtime` module. Provide an `ort` adapter that implements these traits using the existing `ort` crate, and a `mock` adapter for tests. Refactor `Engine`/`SessionPool` to use `Box<dyn RuntimeSession>` instead of `ort::Session` directly. Deliver in 4 sequential PRs.
+
+**Tech Stack:** Rust 2024, `ort` 2.0.0-rc.12, `thiserror`, `anyhow`, `tokio`.
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `crates/gigastt-core/src/runtime/mod.rs` | Public (internal) exports: traits and value types. |
+| `crates/gigastt-core/src/runtime/tensor.rs` | `Tensor`, `TensorView`, `Shape`, `ElementType`. |
+| `crates/gigastt-core/src/runtime/error.rs` | `RuntimeError` enum + conversions. |
+| `crates/gigastt-core/src/runtime/factory.rs` | `RuntimeFactory` trait + provider selection helpers. |
+| `crates/gigastt-core/src/runtime/session.rs` | `RuntimeSession` trait. |
+| `crates/gigastt-core/src/runtime/ort/mod.rs` | Ort adapter public exports. |
+| `crates/gigastt-core/src/runtime/ort/session.rs` | `OrtRuntime`, `OrtSession`. |
+| `crates/gigastt-core/src/runtime/ort/tensor.rs` | `Tensor` <-> `ort::Value` conversions. |
+| `crates/gigastt-core/src/runtime/ort/factory.rs` | `OrtFactory` + provider factories. |
+| `crates/gigastt-core/src/runtime/mock/mod.rs` | Mock adapter public exports. |
+| `crates/gigastt-core/src/runtime/mock/session.rs` | `MockRuntime`, `MockSession`, `MockFactory`. |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `crates/gigastt-core/src/lib.rs` | Add `pub(crate) mod runtime;` (internal only in this phase). |
+| `crates/gigastt-core/src/inference/mod.rs` | Replace `ort::Session` in `SessionTriplet` with `Box<dyn RuntimeSession>`; add `load_with_factory`. |
+| `crates/gigastt-core/src/inference/decode.rs` | Accept `TensorView` instead of raw `ort::Value` slices. |
+| `crates/gigastt-core/src/error.rs` | Add `From<RuntimeError> for GigasttError`. |
+
+---
+
+## Phase 1: Runtime Module Skeleton
+
+**Dependency:** None. Can start immediately.
+
+### Task 1.1: Create `runtime/tensor.rs`
+
+**Files:**
+- Create: `crates/gigastt-core/src/runtime/tensor.rs`
+
+- [ ] **Step 1: Write the types**
+
+```rust
+use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Tensor {
+    shape: Shape,
+    data: TensorData,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TensorData {
+    F32(Vec<f32>),
+    I32(Vec<i32>),
+    I64(Vec<i64>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TensorDataView<'a> {
+    F32(&'a [f32]),
+    I32(&'a [i32]),
+    I64(&'a [i64]),
+}
+
+impl<'a> TensorDataView<'a> {
+    pub fn as_f32(&self) -> Option<&'a [f32]> {
+        match self {
+            TensorDataView::F32(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Shape {
+    dims: Vec<usize>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ElementType {
+    F32,
+    I32,
+    I64,
+}
+
+impl Tensor {
+    pub fn new(shape: Shape, data: TensorData) -> Self {
+        // Verify data length matches shape product.
+        let expected = shape.elements();
+        let actual = data.len();
+        assert_eq!(expected, actual, "tensor data length mismatch: expected {expected}, got {actual}");
+        Self { shape, data }
+    }
+
+    pub fn shape(&self) -> &Shape {
+        &self.shape
+    }
+
+    pub fn element_type(&self) -> ElementType {
+        match &self.data {
+            TensorData::F32(_) => ElementType::F32,
+            TensorData::I32(_) => ElementType::I32,
+            TensorData::I64(_) => ElementType::I64,
+        }
+    }
+
+    pub fn view(&self) -> TensorView<'_> {
+        TensorView {
+            shape: self.shape.clone(),
+            data: match &self.data {
+                TensorData::F32(v) => TensorDataView::F32(v.as_slice()),
+                TensorData::I32(v) => TensorDataView::I32(v.as_slice()),
+                TensorData::I64(v) => TensorDataView::I64(v.as_slice()),
+            },
+        }
+    }
+
+    pub fn into_data(self) -> TensorData {
+        self.data
+    }
+}
+
+impl TensorData {
+    pub fn len(&self) -> usize {
+        match self {
+            TensorData::F32(v) => v.len(),
+            TensorData::I32(v) => v.len(),
+            TensorData::I64(v) => v.len(),
+        }
+    }
+}
+
+impl Shape {
+    pub fn new(dims: Vec<usize>) -> Self {
+        Self { dims }
+    }
+
+    pub fn elements(&self) -> usize {
+        self.dims.iter().product::<usize>().max(1)
+    }
+
+    pub fn dims(&self) -> &[usize] {
+        &self.dims
+    }
+}
+```
+
+- [ ] **Step 2: Add unit tests at the bottom of the file**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensor_shape_and_data_match() {
+        let t = Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 6]));
+        assert_eq!(t.shape().dims(), &[2, 3]);
+        assert_eq!(t.element_type(), ElementType::F32);
+    }
+
+    #[test]
+    #[should_panic(expected = "tensor data length mismatch")]
+    fn test_tensor_rejects_mismatched_data() {
+        Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 5]));
+    }
+
+    #[test]
+    fn test_shape_elements() {
+        assert_eq!(Shape::new(vec![2, 3, 4]).elements(), 24);
+        assert_eq!(Shape::new(vec![]).elements(), 1);
+    }
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core runtime::tensor
+```
+Expected: PASS
+
+Run:
+```bash
+cargo clippy -p gigastt-core --all-targets
+```
+Expected: zero warnings
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gigastt-core/src/runtime/tensor.rs
+git commit -m "feat(runtime): add Tensor, Shape, and ElementType"
+```
+
+---
+
+### Task 1.2: Create `runtime/error.rs`
+
+**Files:**
+- Create: `crates/gigastt-core/src/runtime/error.rs`
+
+- [ ] **Step 1: Write the error type**
+
+```rust
+use std::path::PathBuf;
+use thiserror::Error;
+
+use super::tensor::Shape;
+
+#[derive(Debug, Error)]
+pub enum RuntimeError {
+    #[error("failed to load model {path}: {message}")]
+    LoadFailed { path: PathBuf, message: String },
+
+    #[error("inference failed: {0}")]
+    InferenceFailed(String),
+
+    #[error("invalid tensor shape: expected {expected:?}, got {got:?}")]
+    InvalidShape { expected: Shape, got: Shape },
+
+    #[error("unsupported element type: {0:?}")]
+    UnsupportedElementType(super::tensor::ElementType),
+
+    #[error("invalid input count: expected {expected}, got {got}")]
+    InvalidInputCount { expected: usize, got: usize },
+}
+```
+
+- [ ] **Step 2: Add unit tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_failed_display() {
+        let e = RuntimeError::LoadFailed {
+            path: PathBuf::from("encoder.onnx"),
+            message: "not found".into(),
+        };
+        assert_eq!(e.to_string(), "failed to load model encoder.onnx: not found");
+    }
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core runtime::error
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gigastt-core/src/runtime/error.rs
+git commit -m "feat(runtime): add RuntimeError"
+```
+
+---
+
+### Task 1.3: Create `runtime/session.rs`
+
+**Files:**
+- Create: `crates/gigastt-core/src/runtime/session.rs`
+
+- [ ] **Step 1: Write the trait**
+
+```rust
+use super::{error::RuntimeError, tensor::Tensor};
+
+/// One loaded model session: encoder, decoder, or joiner.
+pub trait RuntimeSession: Send + Sync + 'static {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run:
+```bash
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gigastt-core/src/runtime/session.rs
+git commit -m "feat(runtime): add RuntimeSession trait"
+```
+
+---
+
+### Task 1.4: Create `runtime/factory.rs`
+
+**Files:**
+- Create: `crates/gigastt-core/src/runtime/factory.rs`
+
+- [ ] **Step 1: Write the traits**
+
+```rust
+use super::{error::RuntimeError, session::RuntimeSession};
+
+/// Creates a `Runtime` configured for a specific execution provider.
+pub trait RuntimeFactory: Send + Sync + 'static {
+    fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
+}
+
+/// Owns loaded sessions. One runtime per `Engine`.
+pub trait Runtime: Send + Sync + 'static {
+    fn load_session(
+        &self,
+        model_path: &std::path::Path,
+    ) -> Result<Box<dyn RuntimeSession>, RuntimeError>;
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run:
+```bash
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gigastt-core/src/runtime/factory.rs
+git commit -m "feat(runtime): add Runtime and RuntimeFactory traits"
+```
+
+---
+
+### Task 1.5: Create `runtime/mod.rs` and wire into `lib.rs`
+
+**Files:**
+- Create: `crates/gigastt-core/src/runtime/mod.rs`
+- Modify: `crates/gigastt-core/src/lib.rs`
+
+- [ ] **Step 1: Write `runtime/mod.rs`**
+
+```rust
+pub mod error;
+pub mod factory;
+pub mod session;
+pub mod tensor;
+
+pub use error::RuntimeError;
+pub use factory::{Runtime, RuntimeFactory};
+pub use session::RuntimeSession;
+pub use tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView, TensorView};
+```
+
+- [ ] **Step 2: Modify `lib.rs`**
+
+Add after `pub mod protocol;`:
+
+```rust
+pub(crate) mod runtime;
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core --lib
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gigastt-core/src/runtime/mod.rs crates/gigastt-core/src/lib.rs
+git commit -m "feat(runtime): wire runtime module into gigastt-core"
+```
+
+---
+
+## Phase 2: Ort Adapter
+
+**Dependency:** Phase 1 must be complete and committed.
+
+### Task 2.1: Create `runtime/ort/tensor.rs`
+
+**Files:**
+- Create: `crates/gigastt-core/src/runtime/ort/tensor.rs`
+
+- [ ] **Step 1: Implement `Tensor` -> `ort::Value`**
+
+```rust
+use ort::value::Value;
+
+use crate::runtime::{error::RuntimeError, tensor::{ElementType, Shape, Tensor, TensorData}};
+
+impl Tensor {
+    pub fn into_ort_value(self) -> Result<Value, RuntimeError> {
+        let shape = self.shape.dims().iter().map(|&d| d as i64).collect::<Vec<_>>();
+        match self.data {
+            TensorData::F32(data) => Value::from_array((shape.as_slice(), data))
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+            TensorData::I32(data) => Value::from_array((shape.as_slice(), data))
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+            TensorData::I64(data) => Value::from_array((shape.as_slice(), data))
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Implement `ort::Value` -> `Tensor`**
+
+```rust
+pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
+    let tensor = value.try_extract_tensor::<f32>()
+        .or_else(|_| value.try_extract_tensor::<i32>().map(|t| t.map(|x| *x as f32)))
+        .or_else(|_| value.try_extract_tensor::<i64>().map(|t| t.map(|x| *x as f32)))
+        .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+
+    let shape = Shape::new(tensor.shape().iter().map(|&d| d as usize).collect());
+    let data = tensor.view().iter().copied().collect::<Vec<_>>();
+    Ok(Tensor::new(shape, TensorData::F32(data)))
+}
+```
+
+**Note:** The exact `ort::Value` API may differ. Adjust `try_extract_tensor`, `from_array`, and shape extraction to match `ort 2.0.0-rc.12` signatures. The principle is: convert `TensorData` enum to the matching typed `Value::from_array`, and convert output `Value` back to `TensorData::F32` (or detect element type if `ort` exposes it).
+
+- [ ] **Step 3: Add round-trip test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensor_ort_roundtrip() {
+        let tensor = Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]));
+        let value = tensor.clone().into_ort_value().unwrap();
+        let recovered = value_to_tensor(value).unwrap();
+        assert_eq!(tensor, recovered);
+    }
+}
+```
+
+- [ ] **Step 4: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core runtime::ort::tensor
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/gigastt-core/src/runtime/ort/tensor.rs
+git commit -m "feat(runtime): add ort tensor conversion"
+```
+
+---
+
+### Task 2.2: Create `runtime/ort/session.rs`
+
+**Files:**
+- Create: `crates/gigastt-core/src/runtime/ort/session.rs`
+
+- [ ] **Step 1: Implement `OrtRuntime` and `OrtSession`**
+
+```rust
+use std::path::Path;
+use ort::{Environment, Session};
+
+use crate::runtime::{
+    error::RuntimeError,
+    factory::{Runtime, RuntimeFactory},
+    session::RuntimeSession,
+    tensor::Tensor,
+};
+use super::tensor::value_to_tensor;
+
+pub struct OrtRuntime {
+    environment: Environment,
+    intra_threads: usize,
+    provider: super::factory::OrtExecutionProvider,
+}
+
+pub struct OrtSession {
+    session: Session,
+}
+
+impl Runtime for OrtRuntime {
+    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let session = self.environment
+            .new_session_builder()
+            .map_err(|e| RuntimeError::LoadFailed { path: model_path.into(), message: e.to_string() })?
+            .with_intra_threads(self.intra_threads)
+            .map_err(|e| RuntimeError::LoadFailed { path: model_path.into(), message: e.to_string() })?
+            .with_execution_provider(self.provider.to_ort())
+            .map_err(|e| RuntimeError::LoadFailed { path: model_path.into(), message: e.to_string() })?
+            .commit_from_file(model_path)
+            .map_err(|e| RuntimeError::LoadFailed { path: model_path.into(), message: e.to_string() })?;
+        Ok(Box::new(OrtSession { session }))
+    }
+}
+
+impl RuntimeSession for OrtSession {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError> {
+        let ort_inputs: Vec<Value> = inputs
+            .into_iter()
+            .map(Tensor::into_ort_value)
+            .collect::<Result<_, _>>()?;
+        let outputs = self.session.run(ort_inputs)
+            .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+        outputs.into_iter().map(value_to_tensor).collect()
+    }
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run:
+```bash
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gigastt-core/src/runtime/ort/session.rs
+git commit -m "feat(runtime): add OrtRuntime and OrtSession"
+```
+
+---
+
+### Task 2.3: Create `runtime/ort/factory.rs`
+
+**Files:**
+- Create: `crates/gigastt-core/src/runtime/ort/factory.rs`
+- Modify: `crates/gigastt-core/src/runtime/ort/mod.rs`
+
+- [ ] **Step 1: Define execution provider wrapper and `OrtFactory`**
+
+```rust
+use ort::{ExecutionProvider, Environment};
+
+use crate::runtime::{error::RuntimeError, factory::{Runtime, RuntimeFactory}};
+use super::session::OrtRuntime;
+
+#[derive(Clone)]
+pub enum OrtExecutionProvider {
+    Cpu,
+    #[cfg(feature = "coreml")]
+    CoreML,
+    #[cfg(feature = "cuda")]
+    Cuda,
+    #[cfg(feature = "nnapi")]
+    Nnapi,
+}
+
+impl OrtExecutionProvider {
+    pub fn to_ort(&self) -> ExecutionProvider {
+        match self {
+            OrtExecutionProvider::Cpu => ExecutionProvider::CPU(Default::default()),
+            #[cfg(feature = "coreml")]
+            OrtExecutionProvider::CoreML => ExecutionProvider::CoreML(Default::default()),
+            #[cfg(feature = "cuda")]
+            OrtExecutionProvider::Cuda => ExecutionProvider::CUDA(Default::default()),
+            #[cfg(feature = "nnapi")]
+            OrtExecutionProvider::Nnapi => ExecutionProvider::NNAPI(Default::default()),
+        }
+    }
+}
+
+pub struct OrtFactory {
+    provider: OrtExecutionProvider,
+}
+
+impl OrtFactory {
+    pub fn cpu() -> Self {
+        Self { provider: OrtExecutionProvider::Cpu }
+    }
+
+    #[cfg(feature = "coreml")]
+    pub fn coreml() -> Self {
+        Self { provider: OrtExecutionProvider::CoreML }
+    }
+
+    #[cfg(feature = "cuda")]
+    pub fn cuda() -> Self {
+        Self { provider: OrtExecutionProvider::Cuda }
+    }
+
+    #[cfg(feature = "nnapi")]
+    pub fn nnapi() -> Self {
+        Self { provider: OrtExecutionProvider::Nnapi }
+    }
+}
+
+impl RuntimeFactory for OrtFactory {
+    fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
+        let environment = Environment::builder()
+            .with_name("gigastt")
+            .build()
+            .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+        Ok(Box::new(OrtRuntime {
+            environment,
+            intra_threads,
+            provider: self.provider.clone(),
+        }))
+    }
+}
+
+pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
+    #[cfg(feature = "coreml")]
+    return Box::new(OrtFactory::coreml());
+    #[cfg(feature = "cuda")]
+    return Box::new(OrtFactory::cuda());
+    #[cfg(feature = "nnapi")]
+    return Box::new(OrtFactory::nnapi());
+    #[cfg(not(any(feature = "coreml", feature = "cuda", feature = "nnapi")))]
+    Box::new(OrtFactory::cpu())
+}
+```
+
+**Note:** Adjust `ExecutionProvider::CPU/CoreML/CUDA/NNAPI` constructors to match `ort` API exactly.
+
+- [ ] **Step 2: Write `runtime/ort/mod.rs`**
+
+```rust
+pub mod factory;
+pub mod session;
+pub mod tensor;
+
+pub use factory::{default_factory, OrtExecutionProvider, OrtFactory};
+pub use session::{OrtRuntime, OrtSession};
+```
+
+- [ ] **Step 3: Verify feature builds**
+
+Run:
+```bash
+cargo check -p gigastt-core
+cargo check -p gigastt-core --features coreml
+cargo check -p gigastt-core --features cuda
+cargo check -p gigastt-core --features diarization
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gigastt-core/src/runtime/ort/
+git commit -m "feat(runtime): add ort provider factories"
+```
+
+---
+
+## Phase 3: Engine and SessionPool Integration
+
+**Dependency:** Phase 2 must be complete and committed.
+
+### Task 3.1: Refactor `SessionTriplet` in `inference/mod.rs`
+
+**Files:**
+- Modify: `crates/gigastt-core/src/inference/mod.rs`
+
+- [ ] **Step 1: Remove direct `ort` imports and update `SessionTriplet`**
+
+Remove:
+```rust
+use ort::session::Session;
+use ort::value::TensorRef;
+```
+
+Change:
+```rust
+struct SessionTriplet {
+    encoder: Box<dyn crate::runtime::session::RuntimeSession>,
+    decoder: Box<dyn crate::runtime::session::RuntimeSession>,
+    joiner: Box<dyn crate::runtime::session::RuntimeSession>,
+}
+```
+
+- [ ] **Step 2: Update all places that construct or use `SessionTriplet`**
+
+Search for `ort::Session` and `Session` usages in `inference/mod.rs`. Replace construction with calls to `runtime.load_session(path)`. Update any method signatures that previously took `ort::Session` or `ort::Value`.
+
+- [ ] **Step 3: Verify compilation**
+
+Run:
+```bash
+cargo check -p gigastt-core
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gigastt-core/src/inference/mod.rs
+git commit -m "refactor(inference): use RuntimeSession in SessionTriplet"
+```
+
+---
+
+### Task 3.2: Add `Engine::load_with_factory` and update `load_with_pools_threads`
+
+**Files:**
+- Modify: `crates/gigastt-core/src/inference/mod.rs`
+
+- [ ] **Step 1: Update `Engine::load_with_pools_threads` signature and add internal factory-based loader**
+
+Find the existing `load_with_pools_threads` function. Keep the public signature identical. Inside, build the default factory and delegate:
+
+```rust
+pub fn load_with_pools_threads(
+    model_dir: &Path,
+    pool_size: usize,
+    pool_min_size: usize,
+    batch_pool_size: usize,
+    intra_threads: usize,
+) -> anyhow::Result<Self> {
+    let factory = crate::runtime::ort::default_factory(intra_threads);
+    Self::load_with_factory(
+        model_dir,
+        pool_size,
+        pool_min_size,
+        batch_pool_size,
+        factory,
+        intra_threads,
+    )
+}
+
+pub(crate) fn load_with_factory(
+    model_dir: &Path,
+    pool_size: usize,
+    pool_min_size: usize,
+    batch_pool_size: usize,
+    factory: Box<dyn crate::runtime::factory::RuntimeFactory>,
+    intra_threads: usize,
+) -> anyhow::Result<Self> {
+    let runtime = factory.create(intra_threads)
+        .map_err(|e| anyhow::anyhow!(e))?;
+    // ... existing logic, but load sessions via runtime.load_session(path)
+}
+```
+
+- [ ] **Step 2: Update session loading logic**
+
+Where the code previously built `ort::Session::commit_from_file`, use:
+
+```rust
+let encoder = runtime.load_session(&encoder_path)?;
+let decoder = runtime.load_session(&decoder_path)?;
+let joiner = runtime.load_session(&joiner_path)?;
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core --lib
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gigastt-core/src/inference/mod.rs
+git commit -m "feat(inference): add Engine::load_with_factory"
+```
+
+---
+
+### Task 3.3: Update `decode.rs` to use `TensorView`
+
+**Files:**
+- Modify: `crates/gigastt-core/src/inference/decode.rs`
+
+- [ ] **Step 1: Find all `ort::Value` / raw slice usage**
+
+Search for `TensorRef`, `try_extract_tensor`, `.view()`, and raw float slices in `decode.rs`.
+
+- [ ] **Step 2: Replace with `TensorView`**
+
+Change function signatures from raw slices or `ort::Value` to `TensorView`. For example:
+
+```rust
+fn decode_step(
+    encoder_out: &crate::runtime::tensor::TensorView,
+    decoder_state: &mut DecoderState,
+) -> anyhow::Result<Option<TokenId>> {
+    let data = match encoder_out.data() {
+        crate::runtime::tensor::TensorDataView::F32(v) => v,
+        _ => anyhow::bail!("unexpected tensor type"),
+    };
+    // ... existing logic using data
+}
+```
+
+- [ ] **Step 3: Update callers in `inference/mod.rs`**
+
+Where `decode.rs` functions are called, pass `tensor.view()` instead of extracting raw slices.
+
+- [ ] **Step 4: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core --lib
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/gigastt-core/src/inference/decode.rs crates/gigastt-core/src/inference/mod.rs
+git commit -m "refactor(decode): operate on TensorView instead of ort values"
+```
+
+---
+
+### Task 3.4: Add `From<RuntimeError>` for `GigasttError`
+
+**Files:**
+- Modify: `crates/gigastt-core/src/error.rs`
+
+- [ ] **Step 1: Add conversion**
+
+At the bottom of `error.rs`, outside the `#[cfg(test)]` module:
+
+```rust
+impl From<crate::runtime::RuntimeError> for GigasttError {
+    fn from(err: crate::runtime::RuntimeError) -> Self {
+        match err {
+            crate::runtime::RuntimeError::LoadFailed { path, message } => GigasttError::ModelLoad {
+                path: path.to_string_lossy().into_owned(),
+                source: Some(message.into()),
+            },
+            other => GigasttError::Inference {
+                source: Box::new(other),
+            },
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update `Engine` to use `?` conversion**
+
+Where `inference/mod.rs` currently wraps runtime errors with `ort_err` or `anyhow!`, replace with direct `?` so `RuntimeError` converts to `GigasttError`.
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core --lib
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gigastt-core/src/error.rs crates/gigastt-core/src/inference/mod.rs
+git commit -m "feat(error): map RuntimeError to GigasttError"
+```
+
+---
+
+### Task 3.5: Ensure no `ort` imports leak outside `runtime/ort/`
+
+**Files:**
+- Modify: any file still importing `ort` outside `runtime/ort/`
+
+- [ ] **Step 1: Search for leaks**
+
+Run:
+```bash
+rg "^use ort::" crates/gigastt-core/src --type rust
+rg "ort::" crates/gigastt-core/src --type rust | grep -v "runtime/ort"
+```
+
+- [ ] **Step 2: Fix any leaks**
+
+Replace direct `ort` usage with `crate::runtime::*` types. If a file legitimately needs `ort`, move the code into `runtime/ort/`.
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core --lib
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(runtime): isolate ort usage to runtime/ort module"
+```
+
+---
+
+## Phase 4: Mock Runtime and Tests
+
+**Dependency:** Phase 3 must be complete and committed.
+
+### Task 4.1: Create `runtime/mock/session.rs`
+
+**Files:**
+- Create: `crates/gigastt-core/src/runtime/mock/session.rs`
+- Create: `crates/gigastt-core/src/runtime/mock/mod.rs`
+
+- [ ] **Step 1: Implement mock types**
+
+```rust
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::runtime::{
+    error::RuntimeError,
+    factory::{Runtime, RuntimeFactory},
+    session::RuntimeSession,
+    tensor::{Shape, Tensor},
+};
+
+#[derive(Clone, Default)]
+pub struct MockFactory {
+    sessions: HashMap<String, Arc<MockSession>>,
+}
+
+impl MockFactory {
+    pub fn new(sessions: HashMap<String, Arc<MockSession>>) -> Self {
+        Self { sessions }
+    }
+}
+
+impl RuntimeFactory for MockFactory {
+    fn create(&self, _intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
+        Ok(Box::new(MockRuntime {
+            sessions: self.sessions.clone(),
+        }))
+    }
+}
+
+pub struct MockRuntime {
+    sessions: HashMap<String, Arc<MockSession>>,
+}
+
+impl Runtime for MockRuntime {
+    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let key = model_path.file_stem()
+            .ok_or_else(|| RuntimeError::LoadFailed { path: model_path.into(), message: "empty path".into() })?
+            .to_string_lossy()
+            .to_string();
+        let session = self.sessions
+            .get(&key)
+            .ok_or_else(|| RuntimeError::LoadFailed { path: model_path.into(), message: format!("no mock for {key}") })?
+            .clone();
+        Ok(Box::new((*session).clone()))
+    }
+}
+
+#[derive(Clone)]
+pub struct MockSession {
+    pub expected_inputs: Vec<Shape>,
+    pub outputs: Vec<Tensor>,
+}
+
+impl RuntimeSession for MockSession {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError> {
+        for (actual, expected) in inputs.iter().zip(self.expected_inputs.iter()) {
+            if actual.shape() != expected {
+                return Err(RuntimeError::InvalidShape {
+                    expected: expected.clone(),
+                    got: actual.shape().clone(),
+                });
+            }
+        }
+        Ok(self.outputs.clone())
+    }
+}
+```
+
+- [ ] **Step 2: Write `runtime/mock/mod.rs`**
+
+```rust
+pub mod session;
+
+pub use session::{MockFactory, MockRuntime, MockSession};
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core --lib
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gigastt-core/src/runtime/mock/
+git commit -m "feat(runtime): add mock runtime adapter"
+```
+
+---
+
+### Task 4.2: Add Engine unit tests using `MockFactory`
+
+**Files:**
+- Modify: `crates/gigastt-core/src/inference/mod.rs` (add tests at bottom) or create `crates/gigastt-core/tests/runtime_mock.rs`
+
+- [ ] **Step 1: Write a test that loads Engine with mock sessions**
+
+```rust
+#[cfg(test)]
+mod runtime_tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use crate::inference::Engine;
+    use crate::runtime::mock::{MockFactory, MockSession};
+    use crate::runtime::tensor::{Shape, Tensor, TensorData};
+
+    #[test]
+    fn test_engine_loads_with_mock_runtime() {
+        let mut sessions = HashMap::new();
+        sessions.insert("encoder".into(), Arc::new(MockSession {
+            expected_inputs: vec![Shape::new(vec![1, 64, 100])],
+            outputs: vec![Tensor::new(Shape::new(vec![1, 25, 768]), TensorData::F32(vec![0.0; 25 * 768]))],
+        }));
+        sessions.insert("decoder".into(), Arc::new(MockSession {
+            expected_inputs: vec![Shape::new(vec![1, 1])],
+            outputs: vec![Tensor::new(Shape::new(vec![1, 1, 320]), TensorData::F32(vec![0.0; 320]))],
+        }));
+        sessions.insert("joiner".into(), Arc::new(MockSession {
+            expected_inputs: vec![Shape::new(vec![1, 768]), Shape::new(vec![1, 320])],
+            outputs: vec![Tensor::new(Shape::new(vec![1, 1, 34]), TensorData::F32(vec![0.0; 34]))],
+        }));
+
+        let factory = Box::new(MockFactory::new(sessions));
+        let result = Engine::load_with_factory(
+            std::path::Path::new("/tmp/mock-models"),
+            1, 1, 0,
+            factory,
+            1,
+        );
+        assert!(result.is_ok());
+    }
+}
+```
+
+**Note:** Adjust shapes to match the actual model dimensions (`ENC_DIM=768`, `PRED_HIDDEN=320`, vocab size). The test above is illustrative.
+
+- [ ] **Step 2: Verify**
+
+Run:
+```bash
+cargo test -p gigastt-core --lib runtime_tests
+cargo clippy -p gigastt-core --all-targets
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gigastt-core/src/inference/mod.rs
+git commit -m "test(runtime): add Engine mock runtime test"
+```
+
+---
+
+### Task 4.3: Add CI check for `ort` import isolation
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add a lint step**
+
+Add a new job or step in `ci.yml`:
+
+```yaml
+  runtime-isolation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check ort is isolated to runtime/ort
+        run: |
+          if rg "^use ort::" crates/gigastt-core/src --type rust | grep -v "runtime/ort"; then
+            echo "ERROR: ort import found outside runtime/ort/"
+            exit 1
+          fi
+          if rg "ort::" crates/gigastt-core/src --type rust | grep -v "runtime/ort"; then
+            echo "ERROR: ort usage found outside runtime/ort/"
+            exit 1
+          fi
+          echo "OK: ort is isolated"
+```
+
+- [ ] **Step 2: Verify locally**
+
+Run:
+```bash
+if rg "^use ort::" crates/gigastt-core/src --type rust | grep -v "runtime/ort"; then echo "LEAK"; else echo "OK"; fi
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: enforce ort isolation to runtime/ort"
+```
+
+---
+
+## Final Verification
+
+After all tasks are complete, run the full verification suite:
+
+```bash
+cargo test -p gigastt-core --lib --bins
+cargo test -p gigastt --lib --bins
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --check
+```
+
+If model files are available locally, also run:
+
+```bash
+cargo test -p gigastt --test e2e_rest --test e2e_ws -- --ignored --test-threads=1
+```
+
+---
+
+## Self-Review Checklist
+
+- [ ] Every spec goal has at least one implementing task.
+- [ ] No placeholder text ("TBD", "TODO", "implement later") remains.
+- [ ] File paths are exact and exist in the repo.
+- [ ] Type names (`RuntimeSession`, `RuntimeError`, `Tensor`, etc.) are consistent across all tasks.
+- [ ] Each task ends with a verification command and a commit.
+- [ ] Dependencies between phases are explicit.

--- a/docs/superpowers/specs/2026-06-22-ort-runtime-abstraction-design.md
+++ b/docs/superpowers/specs/2026-06-22-ort-runtime-abstraction-design.md
@@ -1,0 +1,442 @@
+# Runtime Abstraction Layer Over `ort`
+
+**Status:** Design approved, awaiting spec review  
+**Date:** 2026-06-22  
+**Author:** AI design session  
+**Scope:** `crates/gigastt-core` inference engine
+
+## 1. Context and Problem
+
+`gigastt-core` currently depends directly on `ort = "2.0.0-rc.12"`. `ort` types (`Session`, `Value`, `RunOptions`, etc.) leak into `Engine`, `SessionPool`, and the RNN-T decode loop. Because `ort` 2.0 is still a release candidate, this creates several risks:
+
+- **API churn:** a future `ort` release may change the types we depend on, forcing wide-spread edits.
+- **Vendor lock-in:** replacing `ort` with another backend (custom bindings, a different runtime, etc.) would require rewriting the inference engine.
+- **Testability:** unit tests for `Engine`, `SessionPool`, and decode logic must either use real ONNX models (~850 MB) or avoid the code paths that touch `ort`.
+- **Workaround scattering:** `ort`-specific quirks (e.g., `Send`/`Sync` limitations, error wrapping) are spread across the codebase.
+
+This design introduces a small, internal runtime abstraction layer. `ort` becomes an implementation detail of a single adapter module.
+
+## 2. Goals
+
+1. **Isolate `ort`:** no `ort` type is imported outside `runtime/ort/`.
+2. **Preserve behavior:** all existing unit, e2e, WER, load, and soak tests pass unchanged.
+3. **Enable mock testing:** provide a `MockRuntime` so `Engine`, `SessionPool`, and decode logic can be unit-tested without ONNX models.
+4. **Keep all execution providers:** CPU, CoreML, CUDA, and NNAPI must continue to work.
+5. **Leave the door open:** the internal API should be clean enough to become public later or to host a custom backend.
+
+## 3. Non-Goals
+
+1. **Reimplement ONNX:** we do not build a generic tensor library, allocator abstraction, or full ONNX operator set. We abstract only what `gigastt` actually uses.
+2. **Public API change:** the abstraction stays internal in this phase. `Engine` public API remains the same.
+3. **Async runtime API:** `RuntimeSession::run` stays synchronous; async scheduling remains the responsibility of `Engine`/`SessionPool` via `spawn_blocking`.
+4. **Replace feature flags:** existing `--features coreml` / `cuda` / `nnapi` / `diarization` are retained.
+
+## 4. Design Overview
+
+Introduce a `runtime` module in `gigastt-core` with:
+
+- **Core traits:** `Runtime`, `RuntimeSession`, `RuntimeFactory`.
+- **Value types:** `Tensor`, `TensorView`, `Shape`, `ElementType`.
+- **Error type:** `RuntimeError`, converted to `GigasttError` at the boundary.
+- **Ort adapter:** `OrtRuntime`, `OrtSession`, `OrtTensor`, and provider-specific `OrtFactory`.
+- **Mock adapter:** `MockRuntime`, `MockSession` for tests.
+
+`Engine` is refactored to hold a `Box<dyn Runtime>` and `SessionTriplet` of `Box<dyn RuntimeSession>`. The rest of the inference code operates on `Tensor` instead of `ort::Value`.
+
+## 5. Module Structure
+
+```
+crates/gigastt-core/src/
+  runtime/
+    mod.rs              # public (internal) exports: traits + value types
+    tensor.rs           # Tensor, TensorView, Shape, ElementType
+    error.rs            # RuntimeError
+    factory.rs          # RuntimeFactory trait + provider selection helpers
+    session.rs          # RuntimeSession trait
+    ort/                # ort adapter (depends on `ort` crate)
+      mod.rs
+      session.rs
+      tensor.rs
+      factory.rs
+    mock/               # mock adapter for tests
+      mod.rs
+      session.rs
+      tensor.rs
+```
+
+## 6. Core API
+
+### 6.1 Traits
+
+```rust
+/// Creates a `Runtime` configured for a specific execution provider.
+pub trait RuntimeFactory: Send + Sync + 'static {
+    fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
+}
+
+/// Owns loaded sessions. One runtime per `Engine`.
+pub trait Runtime: Send + Sync + 'static {
+    fn load_session(
+        &self,
+        model_path: &std::path::Path,
+    ) -> Result<Box<dyn RuntimeSession>, RuntimeError>;
+}
+
+/// One ONNX session (encoder, decoder, or joiner).
+pub trait RuntimeSession: Send + Sync + 'static {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
+}
+```
+
+### 6.2 Tensor
+
+```rust
+#[derive(Clone, Debug, PartialEq)]
+pub struct Tensor {
+    shape: Shape,
+    data: TensorData,
+}
+
+pub struct TensorView<'a> {
+    shape: Shape,
+    data: TensorDataView<'a>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TensorData {
+    F32(Vec<f32>),
+    I32(Vec<i32>),
+    I64(Vec<i64>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TensorDataView<'a> {
+    F32(&'a [f32]),
+    I32(&'a [i32]),
+    I64(&'a [i64]),
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Shape {
+    dims: Vec<usize>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ElementType {
+    F32,
+    I32,
+    I64,
+}
+```
+
+- `Tensor` is owned and cheaply cloneable (data is `Vec`).
+- `TensorView` is a zero-copy borrow used for reading outputs without moving data.
+- `Shape` normalizes dimensions so callers do not depend on `ort` shape types.
+
+## 7. Ort Adapter
+
+### 7.1 OrtRuntime
+
+```rust
+pub struct OrtRuntime {
+    environment: ort::Environment,
+    intra_threads: usize,
+    provider: OrtExecutionProvider,
+}
+
+impl Runtime for OrtRuntime {
+    fn load_session(
+        &self,
+        model_path: &std::path::Path,
+    ) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let session = self.environment
+            .new_session_builder()?
+            .with_intra_threads(self.intra_threads)?
+            .with_execution_provider(self.provider.to_ort())?
+            .commit_from_file(model_path)?;
+        Ok(Box::new(OrtSession { session }))
+    }
+}
+```
+
+### 7.2 OrtSession
+
+```rust
+pub struct OrtSession {
+    session: ort::Session,
+}
+
+impl RuntimeSession for OrtSession {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError> {
+        let ort_inputs: Vec<ort::Value> = inputs
+            .into_iter()
+            .map(Tensor::into_ort_value)
+            .collect::<Result<_, _>>()?;
+        let outputs = self.session.run(ort_inputs).map_err(wrap_ort_error)?;
+        outputs
+            .into_iter()
+            .map(OrtTensor::try_from)
+            .collect()
+    }
+}
+```
+
+### 7.3 Tensor Conversion
+
+Conversion between `Tensor` and `ort::Value` lives entirely in `runtime/ort/tensor.rs`. All `ort` memory and shape quirks are encapsulated here.
+
+## 8. Provider Factories
+
+Existing feature flags are preserved. Each flag selects a factory internally.
+
+```rust
+pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
+    #[cfg(feature = "coreml")]
+    return Box::new(OrtFactory::coreml());
+    #[cfg(feature = "cuda")]
+    return Box::new(OrtFactory::cuda());
+    #[cfg(feature = "nnapi")]
+    return Box::new(OrtFactory::nnapi());
+    #[cfg(not(any(feature = "coreml", feature = "cuda", feature = "nnapi")))]
+    Box::new(OrtFactory::cpu())
+}
+```
+
+`OrtFactory` holds only provider configuration; `intra_threads` is supplied by `Engine` at runtime:
+
+```rust
+pub struct OrtFactory {
+    provider: OrtExecutionProvider,
+}
+
+impl RuntimeFactory for OrtFactory {
+    fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
+        let environment = ort::Environment::builder()
+            .with_name("gigastt")
+            .build()?;
+        Ok(Box::new(OrtRuntime {
+            environment,
+            intra_threads,
+            provider: self.provider.clone(),
+        }))
+    }
+}
+```
+
+## 9. Mock Runtime
+
+```rust
+pub struct MockFactory {
+    sessions: HashMap<String, Arc<MockSession>>,
+}
+
+impl RuntimeFactory for MockFactory {
+    fn create(&self, _intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
+        Ok(Box::new(MockRuntime {
+            sessions: self.sessions.clone(),
+        }))
+    }
+}
+
+pub struct MockRuntime {
+    sessions: HashMap<String, Arc<MockSession>>,
+}
+
+impl Runtime for MockRuntime {
+    fn load_session(
+        &self,
+        model_path: &std::path::Path,
+    ) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let key = model_path.file_stem()
+            .ok_or_else(|| RuntimeError::LoadFailed("empty path".into()))?
+            .to_string_lossy()
+            .to_string();
+        let session = self.sessions
+            .get(&key)
+            .ok_or_else(|| RuntimeError::LoadFailed(format!("no mock for {key}")))?
+            .clone();
+        Ok(Box::new((*session).clone()))
+    }
+}
+
+#[derive(Clone)]
+pub struct MockSession {
+    expected_inputs: Vec<Shape>,
+    outputs: Vec<Tensor>,
+    call_count: AtomicUsize,
+}
+
+impl RuntimeSession for MockSession {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError> {
+        // Validate input shapes match expectations.
+        for (actual, expected) in inputs.iter().zip(self.expected_inputs.iter()) {
+            if actual.shape() != expected {
+                return Err(RuntimeError::InvalidShape {
+                    expected: expected.clone(),
+                    got: actual.shape().clone(),
+                });
+            }
+        }
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        Ok(self.outputs.clone())
+    }
+}
+```
+
+Mock sessions return pre-recorded tensors, allowing unit tests for `Engine`, `SessionPool`, streaming state machine, and decoder logic without model files.
+
+## 10. Integration with Engine and SessionPool
+
+### 10.1 SessionTriplet
+
+Current:
+
+```rust
+struct SessionTriplet {
+    encoder: ort::Session,
+    decoder: ort::Session,
+    joiner: ort::Session,
+}
+```
+
+New:
+
+```rust
+struct SessionTriplet {
+    encoder: Box<dyn RuntimeSession>,
+    decoder: Box<dyn RuntimeSession>,
+    joiner: Box<dyn RuntimeSession>,
+}
+```
+
+### 10.2 Engine Load
+
+`Engine::load_with_pools_threads` accepts a `Box<dyn RuntimeFactory>` instead of constructing `ort` sessions directly:
+
+```rust
+pub fn load_with_pools_threads(
+    model_dir: &Path,
+    pool_size: usize,
+    pool_min_size: usize,
+    batch_pool_size: usize,
+    intra_threads: usize,
+) -> Result<Self> {
+    let factory = default_factory(intra_threads);
+    Self::load_with_factory(
+        model_dir,
+        pool_size,
+        pool_min_size,
+        batch_pool_size,
+        factory,
+    )
+}
+
+pub(crate) fn load_with_factory(
+    model_dir: &Path,
+    pool_size: usize,
+    pool_min_size: usize,
+    batch_pool_size: usize,
+    factory: Box<dyn RuntimeFactory>,
+) -> Result<Self> {
+    // ... spawn_blocking, load sessions via factory, build pools
+}
+```
+
+A package-private `load_with_factory` is used by tests to inject `MockFactory`.
+
+### 10.3 Decode Loop
+
+`decode.rs` currently operates on raw float slices from `ort::Value`. It is updated to accept `TensorView`:
+
+```rust
+fn decode_step(
+    encoder_out: &TensorView,
+    decoder_state: &mut DecoderState,
+) -> Result<Option<TokenId>, RuntimeError>;
+```
+
+This removes the last `ort` dependency from the decode path.
+
+## 11. Error Handling
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    #[error("failed to load model {path}: {message}")]
+    LoadFailed { path: PathBuf, message: String },
+
+    #[error("inference failed: {0}")]
+    InferenceFailed(String),
+
+    #[error("invalid tensor shape: expected {expected:?}, got {got:?}")]
+    InvalidShape { expected: Shape, got: Shape },
+
+    #[error("unsupported element type")]
+    UnsupportedElementType,
+
+    #[error("invalid input count: expected {expected}, got {got}")]
+    InvalidInputCount { expected: usize, got: usize },
+}
+```
+
+`runtime/ort/` maps `ort::Error` to `RuntimeError::InferenceFailed`. `GigasttError` gains a `Runtime` variant or maps `RuntimeError` to existing `Inference`/`ModelLoad` variants. Internal errors are sanitized before reaching clients, preserving current behavior.
+
+## 12. Testing Strategy
+
+1. **Adapter tests:** verify `Tensor` <-> `ort::Value` round-trip in `runtime/ort/tensor.rs`.
+2. **Mock tests:** build an `Engine` with `MockFactory` and assert decode output.
+3. **Parity tests:** run existing e2e, WER, load, and soak tests with the `ort` adapter unchanged.
+4. **Isolation test:** a CI lint job ensures no `ort` import exists outside `runtime/ort/`.
+
+## 13. Migration Plan
+
+We deliver the refactor in small PRs to keep CI green and reviews focused.
+
+### PR 1: Runtime module skeleton
+- Create `runtime/mod.rs`, `runtime/tensor.rs`, `runtime/error.rs`, `runtime/factory.rs`, `runtime/session.rs`.
+- Add `Tensor`, `Shape`, `ElementType`, `RuntimeError`, `RuntimeFactory`, `Runtime`, `RuntimeSession`.
+- Add unit tests for tensor shape helpers and error conversions.
+
+### PR 2: Ort adapter
+- Implement `runtime/ort/` adapter.
+- Add `OrtRuntime`, `OrtSession`, `OrtTensor`, `OrtFactory`, provider factories.
+- Verify `cargo check --features coreml/cuda/diarization` passes.
+
+### PR 3: Integrate Engine and SessionPool
+- Replace `ort::Session` in `SessionTriplet` with `Box<dyn RuntimeSession>`.
+- Add `Engine::load_with_factory`.
+- Update `decode.rs` to use `TensorView`.
+- Ensure all existing tests pass.
+
+### PR 4: Mock runtime and new tests
+- Implement `runtime/mock/`.
+- Rewrite selected unit tests to use `MockFactory`.
+- Add CI check that `ort` is not imported outside `runtime/ort/`.
+
+## 14. Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Performance regression from trait objects | Benchmark with Criterion before/after; if overhead is measurable, use `Box<dyn RuntimeSession>` only at pool boundaries and keep hot path monomorphized. |
+| `ort` `Send`/`Sync` quirks | Isolate in adapter; use `+ Send + Sync` bounds on traits. |
+| Memory layout differences between `ort::Value` and `Tensor` | Centralize conversion code and add round-trip tests for all tensor types used by the models. |
+| Large PR hard to review | Split into 4 PRs as described in Migration Plan. |
+| Behavior drift | Require all e2e/WER/load/soak tests to pass unchanged on each PR. |
+
+## 15. Open Questions
+
+1. Should `Tensor` use `Arc<[f32]>` instead of `Vec<f32>` to make clones cheaper when the same tensor is passed to multiple consumers?
+2. Should we expose `RuntimeFactory` as a public API under an unstable feature flag?
+
+These questions will be resolved during implementation based on concrete usage in `Engine`.
+
+## 16. Decision Log
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Abstraction depth | Session + tensor level | Deep enough to swap backend, shallow enough to avoid reimplementing ONNX. |
+| Sync/async boundary | Runtime sync, Engine async | ONNX is blocking; async wrapper stays where it already is. |
+| API visibility | Internal first | Avoid backward-compatibility commitments until design is battle-tested. |
+| Feature flags | Keep existing | No user-facing change; providers map to factories internally. |
+| Execution providers | All from day one | Preserve parity with current `coreml`/`cuda`/`nnapi` support. |
+| Mock runtime | First-class | One of the primary goals is testability without models. |


### PR DESCRIPTION
## Summary

Introduces an internal runtime abstraction layer in `gigastt-core` so that `ort` is isolated to a single adapter module (`runtime/ort/`). This reduces vendor lock-in, enables model-free unit tests via a mock runtime, and leaves the door open for future custom backends.

- Adds backend-agnostic `Runtime`, `RuntimeSession`, `RuntimeFactory` traits and `Tensor`/`Shape`/`RuntimeError` value types.
- Implements an `ort` adapter that preserves existing behavior, execution providers (CPU/CoreML/CUDA/NNAPI), disk caches, and thread configuration.
- Refactors `Engine`, `SessionPool`, `decode.rs`, `vad.rs`, and `punctuation.rs` to use the abstraction.
- Adds `MockRuntime`/`MockFactory` and unit tests that build an `Engine` without ONNX models.
- Adds a CI check that fails on any `use ort::` or `extern crate ort` outside `runtime/ort/`.

## Design

See `docs/superpowers/specs/2026-06-22-ort-runtime-abstraction-design.md` for the full design.

## Test Plan

- [x] `cargo test --workspace --lib --bins`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check -p gigastt-core --features coreml`
- [x] `cargo check -p gigastt-core --features cuda`
- [x] `cargo check -p gigastt-core --features nnapi`
- [x] `cargo check -p gigastt-core --features diarization`

## Notes

- `RuntimeSession::run` takes `&[Tensor]` (borrowed inputs) to avoid hot-path clones; this differs from the original design but was approved during implementation.
- The branch name `fix/e2e-metrics-readiness` is historical; this PR contains only the runtime abstraction work.