### PR TITLE
feat(runtime): isolate ort behind runtime abstraction layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,38 +27,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check ort is isolated to runtime/ort
         run: |
-          python3 - <<'PY'
-          import re
-          import sys
-          from pathlib import Path
-
-          root = Path("crates/gigastt-core/src")
-          violations = []
-
-          for path in root.rglob("*.rs"):
-              if "runtime/ort" in path.as_posix():
-                  continue
-              for i, line in enumerate(path.read_text().splitlines(), 1):
-                  stripped = line.strip()
-                  # Direct import of the ort crate.
-                  if re.match(r"use\s+ort::", stripped):
-                      violations.append((path, i, stripped))
-                  # Direct ort crate usage that is not part of the runtime::ort module.
-                  elif (
-                      "runtime::ort" not in stripped
-                      and re.search(r"(?<![a-zA-Z0-9_:])ort::", stripped)
-                      # Allow bare module-path components inside use crate::runtime::{ ... }.
-                      and not re.match(r"ort::\w+(::\w+)*,?$", stripped)
-                  ):
-                      violations.append((path, i, stripped))
-
-          if violations:
-              print("ERROR: direct ort crate usage found outside runtime/ort/")
-              for path, i, line in violations:
-                  print(f"  {path}:{i}: {line}")
-              sys.exit(1)
-          print("OK: ort is isolated")
-          PY
+          set -e
+          violations=$(rg "^use ort::" crates/gigastt-core/src --type rust | grep -v "runtime/ort" || true)
+          if [ -n "$violations" ]; then
+            echo "ERROR: direct use ort:: import outside runtime/ort"
+            echo "$violations"
+            exit 1
+          fi
+          violations=$(rg "^extern crate ort" crates/gigastt-core/src --type rust | grep -v "runtime/ort" || true)
+          if [ -n "$violations" ]; then
+            echo "ERROR: extern crate ort outside runtime/ort"
+            echo "$violations"
+            exit 1
+          fi
+          echo "OK: ort is isolated"
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,46 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all --check
 
+  runtime-isolation:
+    runs-on: ubuntu-latest
+    name: Runtime Isolation
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check ort is isolated to runtime/ort
+        run: |
+          python3 - <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          root = Path("crates/gigastt-core/src")
+          violations = []
+
+          for path in root.rglob("*.rs"):
+              if "runtime/ort" in path.as_posix():
+                  continue
+              for i, line in enumerate(path.read_text().splitlines(), 1):
+                  stripped = line.strip()
+                  # Direct import of the ort crate.
+                  if re.match(r"use\s+ort::", stripped):
+                      violations.append((path, i, stripped))
+                  # Direct ort crate usage that is not part of the runtime::ort module.
+                  elif (
+                      "runtime::ort" not in stripped
+                      and re.search(r"(?<![a-zA-Z0-9_:])ort::", stripped)
+                      # Allow bare module-path components inside use crate::runtime::{ ... }.
+                      and not re.match(r"ort::\w+(::\w+)*,?$", stripped)
+                  ):
+                      violations.append((path, i, stripped))
+
+          if violations:
+              print("ERROR: direct ort crate usage found outside runtime/ort/")
+              for path, i, line in violations:
+                  print(f"  {path}:{i}: {line}")
+              sys.exit(1)
+          print("OK: ort is isolated")
+          PY
+
   clippy:
     runs-on: ubuntu-latest
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           shared-key: ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo clippy --workspace --all-targets -- -D warnings -A dead_code
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,79 @@ jobs:
       - name: Check ort is isolated to runtime/ort
         run: |
           set -e
-          violations=$(rg "^use ort::" crates/gigastt-core/src --type rust | grep -v "runtime/ort" || true)
-          if [ -n "$violations" ]; then
-            echo "ERROR: direct use ort:: import outside runtime/ort"
-            echo "$violations"
-            exit 1
-          fi
-          violations=$(rg "^extern crate ort" crates/gigastt-core/src --type rust | grep -v "runtime/ort" || true)
-          if [ -n "$violations" ]; then
-            echo "ERROR: extern crate ort outside runtime/ort"
-            echo "$violations"
-            exit 1
-          fi
-          echo "OK: ort is isolated"
+          python3 - <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          # ort types must not leak outside the runtime/ort implementation.
+          # Test code (dedicated test files and #[cfg(test)] mod tests blocks)
+          # is allowed to import concrete ort helpers.
+          PATTERNS = [
+              r"^use ort::",
+              r"^extern crate ort",
+              r"runtime::ort",
+              r"\bOrtFactory\b",
+              r"\bOrtRuntime\b",
+              r"\bOrtSession\b",
+              r"\bOrtExecutionProvider\b",
+          ]
+          COMBINED_RE = re.compile("|".join(f"(?:{p})" for p in PATTERNS))
+          CFG_TEST_RE = re.compile(r"^#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]\s*$")
+          MOD_TESTS_RE = re.compile(r"^mod tests\b")
+
+          def count_braces(line):
+              """Net brace delta on a line, ignoring // comments."""
+              if "//" in line:
+                  line = line.split("//", 1)[0]
+              return line.count("{") - line.count("}")
+
+          def test_line_indices(lines):
+              """Return 1-based line numbers inside #[cfg(test)] mod tests { ... }."""
+              indices = set()
+              i = 0
+              while i < len(lines):
+                  if CFG_TEST_RE.match(lines[i].strip()):
+                      j = i + 1
+                      while j < len(lines) and not lines[j].strip():
+                          j += 1
+                      if j < len(lines) and MOD_TESTS_RE.match(lines[j].strip()):
+                          depth = count_braces(lines[j])
+                          for k in range(i, j + 1):
+                              indices.add(k + 1)
+                          k = j + 1
+                          while k < len(lines) and depth > 0:
+                              indices.add(k + 1)
+                              depth += count_braces(lines[k])
+                              k += 1
+                          i = k
+                          continue
+                  i += 1
+              return indices
+
+          violations = []
+          for path in Path("crates").rglob("*.rs"):
+              if any(a == "runtime" and b == "ort"
+                     for a, b in zip(path.parts, path.parts[1:])):
+                  continue
+              if "tests" in path.parts:
+                  continue
+
+              lines = path.read_text(encoding="utf-8").splitlines()
+              test_indices = test_line_indices(lines)
+              for lineno, line in enumerate(lines, start=1):
+                  if lineno in test_indices:
+                      continue
+                  if COMBINED_RE.search(line):
+                      violations.append(f"{path}:{lineno}:{line}")
+
+          if violations:
+              print("ERROR: ort runtime leaks detected outside runtime/ort:")
+              for v in violations:
+                  print(v)
+              sys.exit(1)
+          print("OK: ort is isolated")
+          PY
 
   clippy:
     runs-on: ubuntu-latest

--- a/crates/gigastt-core/src/error.rs
+++ b/crates/gigastt-core/src/error.rs
@@ -133,6 +133,20 @@ impl GigasttError {
     }
 }
 
+impl From<crate::runtime::RuntimeError> for GigasttError {
+    fn from(err: crate::runtime::RuntimeError) -> Self {
+        match err {
+            crate::runtime::RuntimeError::LoadFailed { path, message } => GigasttError::ModelLoad {
+                path: path.to_string_lossy().into_owned(),
+                source: Some(Box::new(std::io::Error::other(message))),
+            },
+            other => GigasttError::Inference {
+                source: Box::new(other),
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gigastt-core/src/inference/decode.rs
+++ b/crates/gigastt-core/src/inference/decode.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 
 use crate::runtime::{
     session::RuntimeSession,
-    tensor::{Shape, Tensor, TensorData},
+    tensor::{Shape, Tensor, TensorData, TensorView},
 };
 
 use super::bias::Biaser;
@@ -100,6 +100,46 @@ impl DecoderOutput {
     }
 }
 
+/// Reusable input tensors for the decoder and joiner sessions.
+///
+/// These tensors are allocated once per decode and mutated in place, replacing
+/// the previous per-step `Vec::clone`/`to_vec` allocations.
+#[derive(Debug)]
+pub(crate) struct DecodeBuffers {
+    /// Decoder inputs: `[prev_token [1,1], h [1,1,PRED_HIDDEN], c [1,1,PRED_HIDDEN]]`.
+    decoder_inputs: Vec<Tensor>,
+    /// Joiner inputs: `[enc_frame [1,ENC_DIM,1], dec_data [1,PRED_HIDDEN,1]]`.
+    joiner_inputs: Vec<Tensor>,
+}
+
+impl DecodeBuffers {
+    fn new() -> Self {
+        Self {
+            decoder_inputs: vec![
+                Tensor::new(Shape::new(vec![1, 1]), TensorData::I64(vec![0])),
+                Tensor::new(
+                    Shape::new(vec![1, 1, PRED_HIDDEN]),
+                    TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                ),
+                Tensor::new(
+                    Shape::new(vec![1, 1, PRED_HIDDEN]),
+                    TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                ),
+            ],
+            joiner_inputs: vec![
+                Tensor::new(
+                    Shape::new(vec![1, ENC_DIM, 1]),
+                    TensorData::F32(vec![0.0; ENC_DIM]),
+                ),
+                Tensor::new(
+                    Shape::new(vec![1, PRED_HIDDEN, 1]),
+                    TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                ),
+            ],
+        }
+    }
+}
+
 /// Run decoder ONNX session with current state, writing into reusable buffers.
 ///
 /// Input: prev_token [1,1] + h [1,1,PRED_HIDDEN] + c [1,1,PRED_HIDDEN]
@@ -108,23 +148,23 @@ fn run_decoder(
     decoder: &dyn RuntimeSession,
     state: &DecoderState,
     out: &mut DecoderOutput,
+    bufs: &mut DecodeBuffers,
 ) -> Result<()> {
-    let inputs = vec![
-        Tensor::new(
-            Shape::new(vec![1, 1]),
-            TensorData::I64(vec![state.prev_token]),
-        ),
-        Tensor::new(
-            Shape::new(vec![1, 1, PRED_HIDDEN]),
-            TensorData::F32(state.h.clone()),
-        ),
-        Tensor::new(
-            Shape::new(vec![1, 1, PRED_HIDDEN]),
-            TensorData::F32(state.c.clone()),
-        ),
-    ];
+    bufs.decoder_inputs[0]
+        .as_i64_mut()
+        .context("decoder prev_token tensor is not i64")?[0] = state.prev_token;
+    bufs.decoder_inputs[1]
+        .as_f32_mut()
+        .context("decoder h tensor is not f32")?
+        .copy_from_slice(&state.h);
+    bufs.decoder_inputs[2]
+        .as_f32_mut()
+        .context("decoder c tensor is not f32")?
+        .copy_from_slice(&state.c);
 
-    let decoder_outputs = decoder.run(inputs).context("Decoder inference failed")?;
+    let decoder_outputs = decoder
+        .run(&bufs.decoder_inputs)
+        .context("Decoder inference failed")?;
 
     let dec_data = decoder_outputs[0]
         .view()
@@ -157,19 +197,20 @@ fn run_joiner_single(
     enc_frame: &[f32],
     dec_data: &[f32],
     logits_buf: &mut Vec<f32>,
+    bufs: &mut DecodeBuffers,
 ) -> Result<()> {
-    let inputs = vec![
-        Tensor::new(
-            Shape::new(vec![1, ENC_DIM, 1]),
-            TensorData::F32(enc_frame.to_vec()),
-        ),
-        Tensor::new(
-            Shape::new(vec![1, PRED_HIDDEN, 1]),
-            TensorData::F32(dec_data.to_vec()),
-        ),
-    ];
+    bufs.joiner_inputs[0]
+        .as_f32_mut()
+        .context("joiner enc_frame tensor is not f32")?
+        .copy_from_slice(enc_frame);
+    bufs.joiner_inputs[1]
+        .as_f32_mut()
+        .context("joiner dec_data tensor is not f32")?
+        .copy_from_slice(dec_data);
 
-    let joiner_outputs = joiner.run(inputs).context("Joiner inference failed")?;
+    let joiner_outputs = joiner
+        .run(&bufs.joiner_inputs)
+        .context("Joiner inference failed")?;
 
     let logits = joiner_outputs[0]
         .view()
@@ -189,13 +230,19 @@ fn run_joiner_single(
 pub(crate) trait DecodeBackend {
     /// Run the prediction network for the current decoder state, overwriting
     /// `out` in place (reused across calls to avoid per-token allocation).
-    fn decode_step(&mut self, state: &DecoderState, out: &mut DecoderOutput) -> Result<()>;
+    fn decode_step(
+        &mut self,
+        state: &DecoderState,
+        out: &mut DecoderOutput,
+        bufs: &mut DecodeBuffers,
+    ) -> Result<()>;
     /// Run the joiner for one encoder frame, writing logits into `logits_buf`.
     fn joiner_step(
         &mut self,
         enc_frame: &[f32],
         dec_data: &[f32],
         logits_buf: &mut Vec<f32>,
+        bufs: &mut DecodeBuffers,
     ) -> Result<()>;
 }
 
@@ -206,16 +253,22 @@ struct OrtBackend<'a> {
 }
 
 impl DecodeBackend for OrtBackend<'_> {
-    fn decode_step(&mut self, state: &DecoderState, out: &mut DecoderOutput) -> Result<()> {
-        run_decoder(self.decoder, state, out)
+    fn decode_step(
+        &mut self,
+        state: &DecoderState,
+        out: &mut DecoderOutput,
+        bufs: &mut DecodeBuffers,
+    ) -> Result<()> {
+        run_decoder(self.decoder, state, out, bufs)
     }
     fn joiner_step(
         &mut self,
         enc_frame: &[f32],
         dec_data: &[f32],
         logits_buf: &mut Vec<f32>,
+        bufs: &mut DecodeBuffers,
     ) -> Result<()> {
-        run_joiner_single(self.joiner, enc_frame, dec_data, logits_buf)
+        run_joiner_single(self.joiner, enc_frame, dec_data, logits_buf, bufs)
     }
 }
 
@@ -234,7 +287,7 @@ impl DecodeBackend for OrtBackend<'_> {
 pub fn greedy_decode(
     decoder: &dyn RuntimeSession,
     joiner: &dyn RuntimeSession,
-    encoded: &[f32], // [1, 768, enc_len] — channels-first
+    encoded: &TensorView<'_>, // [1, 768, enc_len] — channels-first
     encoded_len: usize,
     blank_id: usize,
     state: &mut DecoderState,
@@ -248,16 +301,25 @@ pub fn greedy_decode(
 /// path; extracted so unit tests can drive it with a stub [`DecodeBackend`].
 fn greedy_decode_impl<B: DecodeBackend>(
     backend: &mut B,
-    encoded: &[f32], // [1, 768, enc_len] — channels-first
+    encoded: &TensorView<'_>, // [1, 768, enc_len] — channels-first
     encoded_len: usize,
     blank_id: usize,
     state: &mut DecoderState,
     biaser: Option<&Biaser>,
 ) -> Result<DecodeResult> {
+    let encoded = encoded
+        .data()
+        .as_f32()
+        .context("encoder output must be f32")?;
+
     let mut tokens = Vec::new();
     let mut endpoint_detected = false;
 
-    // Pre-allocate buffer for extracting a single encoder frame [768, 1]
+    // Reusable input tensors for decoder/joiner and a reusable logits buffer.
+    let mut bufs = DecodeBuffers::new();
+    // Pre-allocate buffer for extracting a single encoder frame [768, 1].
+    // The data is copied into the reusable joiner input tensor inside
+    // `joiner_step`, avoiding a per-step `to_vec` allocation.
     let mut enc_frame = vec![0.0_f32; ENC_DIM];
     // Reusable joiner logits buffer to avoid per-call allocation.
     let mut logits_buf = Vec::new();
@@ -308,13 +370,18 @@ fn greedy_decode_impl<B: DecodeBackend>(
             } else {
                 decoder_calls += 1;
                 // Overwrites `decoder_out` in place — no per-token allocation.
-                backend.decode_step(state, &mut decoder_out)?;
+                backend.decode_step(state, &mut decoder_out, &mut bufs)?;
                 cache_valid = true;
             }
 
             // === JOINER CALL ===
             joiner_calls += 1;
-            backend.joiner_step(&enc_frame, &decoder_out.dec_data, &mut logits_buf)?;
+            backend.joiner_step(
+                &enc_frame,
+                &decoder_out.dec_data,
+                &mut logits_buf,
+                &mut bufs,
+            )?;
 
             // === CONTEXTUAL HOTWORD BIASING (shallow fusion) ===
             // Add the boost to continuation tokens of any active hotword prefix
@@ -487,7 +554,12 @@ mod tests {
     }
 
     impl DecodeBackend for FakeBackend {
-        fn decode_step(&mut self, _state: &DecoderState, out: &mut DecoderOutput) -> Result<()> {
+        fn decode_step(
+            &mut self,
+            _state: &DecoderState,
+            out: &mut DecoderOutput,
+            _bufs: &mut DecodeBuffers,
+        ) -> Result<()> {
             self.decoder_calls += 1;
             DecoderOutput::fill(&mut out.dec_data, &[0.0; PRED_HIDDEN]);
             DecoderOutput::fill(&mut out.new_h, &[0.0; PRED_HIDDEN]);
@@ -500,6 +572,7 @@ mod tests {
             _enc_frame: &[f32],
             _dec_data: &[f32],
             logits_buf: &mut Vec<f32>,
+            _bufs: &mut DecodeBuffers,
         ) -> Result<()> {
             self.joiner_calls += 1;
             // Once the script runs out, return blank so the loop terminates.
@@ -516,13 +589,21 @@ mod tests {
         vec![0.0_f32; ENC_DIM * frames]
     }
 
+    /// Wrapped encoder tensor for tests driving `greedy_decode_impl`.
+    fn fake_enc_tensor(frames: usize) -> Tensor {
+        Tensor::new(
+            Shape::new(vec![1, ENC_DIM, frames]),
+            TensorData::F32(fake_enc(frames)),
+        )
+    }
+
     #[test]
     fn test_greedy_decode_happy_path() {
         // vocab=5, blank=4. Frame 0 emits token 1 then blank; frame 1 emits token 2.
         let mut backend = FakeBackend::new(vec![1, 4, 2, 4], 5, 4);
         let mut state = DecoderState::new(4);
-        let result =
-            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 4, &mut state, None).unwrap();
+        let enc = fake_enc_tensor(2);
+        let result = greedy_decode_impl(&mut backend, &enc.view(), 2, 4, &mut state, None).unwrap();
 
         assert_eq!(result.tokens.len(), 2);
         assert_eq!(result.tokens[0].token_id, 1);
@@ -541,8 +622,8 @@ mod tests {
         // The decoder must NOT be called again during the blank run (cache reuse).
         let mut backend = FakeBackend::new(vec![1, 4, 4, 4, 4], 5, 4);
         let mut state = DecoderState::new(4);
-        let result =
-            greedy_decode_impl(&mut backend, &fake_enc(4), 4, 4, &mut state, None).unwrap();
+        let enc = fake_enc_tensor(4);
+        let result = greedy_decode_impl(&mut backend, &enc.view(), 4, 4, &mut state, None).unwrap();
 
         assert_eq!(result.tokens.len(), 1);
         assert_eq!(
@@ -560,9 +641,9 @@ mod tests {
         let frames = ENDPOINT_BLANK_THRESHOLD + 2;
         let mut backend = FakeBackend::new(script, 5, 4);
         let mut state = DecoderState::new(4);
+        let enc = fake_enc_tensor(frames);
         let result =
-            greedy_decode_impl(&mut backend, &fake_enc(frames), frames, 4, &mut state, None)
-                .unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), frames, 4, &mut state, None).unwrap();
 
         assert!(
             result.endpoint_detected,
@@ -576,9 +657,9 @@ mod tests {
         let frames = ENDPOINT_BLANK_THRESHOLD + 5;
         let mut backend = FakeBackend::new(vec![4usize; frames], 5, 4);
         let mut state = DecoderState::new(4);
+        let enc = fake_enc_tensor(frames);
         let result =
-            greedy_decode_impl(&mut backend, &fake_enc(frames), frames, 4, &mut state, None)
-                .unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), frames, 4, &mut state, None).unwrap();
 
         assert!(result.tokens.is_empty());
         assert!(
@@ -594,8 +675,8 @@ mod tests {
         // bump the blank counter or fire an endpoint.
         let mut backend = FakeBackend::new(vec![1usize; MAX_TOKENS_PER_STEP + 1], 5, 4);
         let mut state = DecoderState::new(4);
-        let result =
-            greedy_decode_impl(&mut backend, &fake_enc(1), 1, 4, &mut state, None).unwrap();
+        let enc = fake_enc_tensor(1);
+        let result = greedy_decode_impl(&mut backend, &enc.view(), 1, 4, &mut state, None).unwrap();
 
         assert_eq!(result.tokens.len(), MAX_TOKENS_PER_STEP);
         assert_eq!(
@@ -645,7 +726,12 @@ mod tests {
     }
 
     impl DecodeBackend for LogitBackend {
-        fn decode_step(&mut self, _state: &DecoderState, out: &mut DecoderOutput) -> Result<()> {
+        fn decode_step(
+            &mut self,
+            _state: &DecoderState,
+            out: &mut DecoderOutput,
+            _bufs: &mut DecodeBuffers,
+        ) -> Result<()> {
             DecoderOutput::fill(&mut out.dec_data, &[0.0; PRED_HIDDEN]);
             DecoderOutput::fill(&mut out.new_h, &[0.0; PRED_HIDDEN]);
             DecoderOutput::fill(&mut out.new_c, &[0.0; PRED_HIDDEN]);
@@ -657,6 +743,7 @@ mod tests {
             _enc_frame: &[f32],
             _dec_data: &[f32],
             logits_buf: &mut Vec<f32>,
+            _bufs: &mut DecodeBuffers,
         ) -> Result<()> {
             logits_buf.clear();
             match self.script.pop_front() {
@@ -690,8 +777,9 @@ mod tests {
         // Baseline (no bias): emits token 1.
         let mut backend = LogitBackend::new(ab_script(), 4, 3);
         let mut state = DecoderState::new(3);
+        let enc = fake_enc_tensor(2);
         let unbiased =
-            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 3, &mut state, None).unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), 2, 3, &mut state, None).unwrap();
         assert_eq!(unbiased.tokens.len(), 1);
         assert_eq!(unbiased.tokens[0].token_id, 1, "no bias → model picks A");
 
@@ -699,9 +787,9 @@ mod tests {
         let biaser = Biaser::from_sequences(vec![vec![2]], 5.0).unwrap();
         let mut backend = LogitBackend::new(ab_script(), 4, 3);
         let mut state = DecoderState::new(3);
+        let enc = fake_enc_tensor(2);
         let biased =
-            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 3, &mut state, Some(&biaser))
-                .unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), 2, 3, &mut state, Some(&biaser)).unwrap();
         assert_eq!(biased.tokens.len(), 1);
         assert_eq!(
             biased.tokens[0].token_id, 2,
@@ -732,9 +820,9 @@ mod tests {
         let biaser = Biaser::from_sequences(vec![vec![5, 2]], 5.0).unwrap();
         let mut backend = LogitBackend::new(script, 6, 3);
         let mut state = DecoderState::new(3);
+        let enc = fake_enc_tensor(2);
         let result =
-            greedy_decode_impl(&mut backend, &fake_enc(2), 2, 3, &mut state, Some(&biaser))
-                .unwrap();
+            greedy_decode_impl(&mut backend, &enc.view(), 2, 3, &mut state, Some(&biaser)).unwrap();
         assert_eq!(
             result.tokens.iter().map(|t| t.token_id).collect::<Vec<_>>(),
             vec![5, 2],
@@ -758,15 +846,25 @@ mod tests {
         };
         let mut b_none = LogitBackend::new(base_script(), 4, 3);
         let mut s_none = DecoderState::new(3);
-        let none = greedy_decode_impl(&mut b_none, &fake_enc(2), 2, 3, &mut s_none, None).unwrap();
+        let enc_none = fake_enc_tensor(2);
+        let none =
+            greedy_decode_impl(&mut b_none, &enc_none.view(), 2, 3, &mut s_none, None).unwrap();
 
         // A biaser for token id 0, which has a -inf-equivalent (0.0) logit and is
         // dominated on every frame, so it can never change the argmax.
         let biaser = Biaser::from_sequences(vec![vec![0]], 0.5).unwrap();
         let mut b_some = LogitBackend::new(base_script(), 4, 3);
         let mut s_some = DecoderState::new(3);
-        let some = greedy_decode_impl(&mut b_some, &fake_enc(2), 2, 3, &mut s_some, Some(&biaser))
-            .unwrap();
+        let enc_some = fake_enc_tensor(2);
+        let some = greedy_decode_impl(
+            &mut b_some,
+            &enc_some.view(),
+            2,
+            3,
+            &mut s_some,
+            Some(&biaser),
+        )
+        .unwrap();
 
         assert_eq!(
             none.tokens.iter().map(|t| t.token_id).collect::<Vec<_>>(),

--- a/crates/gigastt-core/src/inference/decode.rs
+++ b/crates/gigastt-core/src/inference/decode.rs
@@ -1,8 +1,11 @@
 //! RNN-T greedy decoding for GigaAM v3 e2e_rnnt.
 
 use anyhow::{Context, Result};
-use ort::session::Session;
-use ort::value::TensorRef;
+
+use crate::runtime::{
+    session::RuntimeSession,
+    tensor::{Shape, Tensor, TensorData},
+};
 
 use super::bias::Biaser;
 use super::{DecoderState, PRED_HIDDEN};
@@ -101,24 +104,42 @@ impl DecoderOutput {
 ///
 /// Input: prev_token [1,1] + h [1,1,PRED_HIDDEN] + c [1,1,PRED_HIDDEN]
 /// Output: `out` is overwritten in place with dec_data, new_h, new_c.
-fn run_decoder(decoder: &mut Session, state: &DecoderState, out: &mut DecoderOutput) -> Result<()> {
-    let target_data = [state.prev_token];
-    let target_tensor = TensorRef::from_array_view(([1_usize, 1], target_data.as_slice()))?;
-    let h_tensor = TensorRef::from_array_view(([1_usize, 1, PRED_HIDDEN], state.h.as_slice()))?;
-    let c_tensor = TensorRef::from_array_view(([1_usize, 1, PRED_HIDDEN], state.c.as_slice()))?;
+fn run_decoder(
+    decoder: &dyn RuntimeSession,
+    state: &DecoderState,
+    out: &mut DecoderOutput,
+) -> Result<()> {
+    let inputs = vec![
+        Tensor::new(
+            Shape::new(vec![1, 1]),
+            TensorData::I64(vec![state.prev_token]),
+        ),
+        Tensor::new(
+            Shape::new(vec![1, 1, PRED_HIDDEN]),
+            TensorData::F32(state.h.clone()),
+        ),
+        Tensor::new(
+            Shape::new(vec![1, 1, PRED_HIDDEN]),
+            TensorData::F32(state.c.clone()),
+        ),
+    ];
 
-    let decoder_outputs = decoder
-        .run(ort::inputs![target_tensor, h_tensor, c_tensor])
-        .context("Decoder inference failed")?;
+    let decoder_outputs = decoder.run(inputs).context("Decoder inference failed")?;
 
-    let (_dec_shape, dec_data) = decoder_outputs[0]
-        .try_extract_tensor::<f32>()
+    let dec_data = decoder_outputs[0]
+        .view()
+        .data()
+        .as_f32()
         .context("Failed to extract decoder output")?;
-    let (_h_shape, new_h_data) = decoder_outputs[1]
-        .try_extract_tensor::<f32>()
+    let new_h_data = decoder_outputs[1]
+        .view()
+        .data()
+        .as_f32()
         .context("Failed to extract decoder h state")?;
-    let (_c_shape, new_c_data) = decoder_outputs[2]
-        .try_extract_tensor::<f32>()
+    let new_c_data = decoder_outputs[2]
+        .view()
+        .data()
+        .as_f32()
         .context("Failed to extract decoder c state")?;
 
     DecoderOutput::fill(&mut out.dec_data, dec_data);
@@ -132,20 +153,28 @@ fn run_decoder(decoder: &mut Session, state: &DecoderState, out: &mut DecoderOut
 /// Input: enc [1, ENC_DIM, 1] + dec [1, PRED_HIDDEN, 1]
 /// Output: logits [VOCAB_SIZE] (flattened from [1, 1, 1, VOCAB_SIZE]).
 fn run_joiner_single(
-    joiner: &mut Session,
+    joiner: &dyn RuntimeSession,
     enc_frame: &[f32],
     dec_data: &[f32],
     logits_buf: &mut Vec<f32>,
 ) -> Result<()> {
-    let enc_tensor = TensorRef::from_array_view(([1_usize, ENC_DIM, 1], enc_frame))?;
-    let dec_tensor = TensorRef::from_array_view(([1_usize, PRED_HIDDEN, 1], dec_data))?;
+    let inputs = vec![
+        Tensor::new(
+            Shape::new(vec![1, ENC_DIM, 1]),
+            TensorData::F32(enc_frame.to_vec()),
+        ),
+        Tensor::new(
+            Shape::new(vec![1, PRED_HIDDEN, 1]),
+            TensorData::F32(dec_data.to_vec()),
+        ),
+    ];
 
-    let joiner_outputs = joiner
-        .run(ort::inputs![enc_tensor, dec_tensor])
-        .context("Joiner inference failed")?;
+    let joiner_outputs = joiner.run(inputs).context("Joiner inference failed")?;
 
-    let (_joint_shape, logits) = joiner_outputs[0]
-        .try_extract_tensor::<f32>()
+    let logits = joiner_outputs[0]
+        .view()
+        .data()
+        .as_f32()
         .context("Failed to extract joiner output")?;
 
     // Reuse the buffer's capacity: copy in place after a one-time size match,
@@ -156,7 +185,7 @@ fn run_joiner_single(
 
 /// Abstraction over the two ONNX session calls in the RNN-T inner loop, so the
 /// decode logic can be unit-tested with a deterministic stub instead of a real
-/// `ort::Session` (which requires a model file on disk).
+/// runtime session (which requires a model file on disk).
 pub(crate) trait DecodeBackend {
     /// Run the prediction network for the current decoder state, overwriting
     /// `out` in place (reused across calls to avoid per-token allocation).
@@ -170,10 +199,10 @@ pub(crate) trait DecodeBackend {
     ) -> Result<()>;
 }
 
-/// Production backend over the real encoder/joiner ONNX sessions.
+/// Production backend over the real encoder/joiner runtime sessions.
 struct OrtBackend<'a> {
-    decoder: &'a mut Session,
-    joiner: &'a mut Session,
+    decoder: &'a dyn RuntimeSession,
+    joiner: &'a dyn RuntimeSession,
 }
 
 impl DecodeBackend for OrtBackend<'_> {
@@ -203,8 +232,8 @@ impl DecodeBackend for OrtBackend<'_> {
 /// prefix, before the argmax. `None` ⇒ the decode is byte-for-byte identical to
 /// the un-biased path (zero regression risk when no hotwords are configured).
 pub fn greedy_decode(
-    decoder: &mut Session,
-    joiner: &mut Session,
+    decoder: &dyn RuntimeSession,
+    joiner: &dyn RuntimeSession,
     encoded: &[f32], // [1, 768, enc_len] — channels-first
     encoded_len: usize,
     blank_id: usize,

--- a/crates/gigastt-core/src/inference/decode.rs
+++ b/crates/gigastt-core/src/inference/decode.rs
@@ -116,22 +116,22 @@ impl DecodeBuffers {
     fn new() -> Self {
         Self {
             decoder_inputs: vec![
-                Tensor::new(Shape::new(vec![1, 1]), TensorData::I64(vec![0])),
-                Tensor::new(
+                Tensor::new_checked(Shape::new(vec![1, 1]), TensorData::I64(vec![0])),
+                Tensor::new_checked(
                     Shape::new(vec![1, 1, PRED_HIDDEN]),
                     TensorData::F32(vec![0.0; PRED_HIDDEN]),
                 ),
-                Tensor::new(
+                Tensor::new_checked(
                     Shape::new(vec![1, 1, PRED_HIDDEN]),
                     TensorData::F32(vec![0.0; PRED_HIDDEN]),
                 ),
             ],
             joiner_inputs: vec![
-                Tensor::new(
+                Tensor::new_checked(
                     Shape::new(vec![1, ENC_DIM, 1]),
                     TensorData::F32(vec![0.0; ENC_DIM]),
                 ),
-                Tensor::new(
+                Tensor::new_checked(
                     Shape::new(vec![1, PRED_HIDDEN, 1]),
                     TensorData::F32(vec![0.0; PRED_HIDDEN]),
                 ),
@@ -595,6 +595,7 @@ mod tests {
             Shape::new(vec![1, ENC_DIM, frames]),
             TensorData::F32(fake_enc(frames)),
         )
+        .unwrap()
     }
 
     #[test]

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -3442,4 +3442,106 @@ mod tests {
             .expect("at-threshold audio must not error");
         assert!(result.words.is_empty(), "silence decodes to no words");
     }
+
+    mod mock_runtime_tests {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        use crate::inference::Engine;
+        use crate::runtime::mock::{MockFactory, MockSession};
+        use crate::runtime::tensor::{Shape, Tensor, TensorData};
+
+        const ENC_DIM: usize = 768;
+        const PRED_HIDDEN: usize = 320;
+
+        fn tiny_mock_engine() -> (Engine, tempfile::TempDir) {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let dir = tmp.path();
+
+            // Empty model files are enough for variant detection; the mock
+            // runtime intercepts all session loading before the filesystem is
+            // read for ONNX data.
+            std::fs::write(dir.join("v3_rnnt_encoder.onnx"), b"").unwrap();
+            std::fs::write(dir.join("v3_rnnt_decoder.onnx"), b"").unwrap();
+            std::fs::write(dir.join("v3_rnnt_joint.onnx"), b"").unwrap();
+            // vocab: index 0 = "▁hi", index 1 = "<blk>" (blank wins on ties).
+            std::fs::write(dir.join("v3_vocab.txt"), "\u{2581}hi\n<blk>\n").unwrap();
+
+            let mut sessions: HashMap<String, Arc<MockSession>> = HashMap::new();
+            sessions.insert(
+                "v3_rnnt_encoder".into(),
+                Arc::new(MockSession::new(
+                    vec![Shape::new(vec![1, 64, 1]), Shape::new(vec![1])],
+                    vec![
+                        Tensor::new(
+                            Shape::new(vec![1, ENC_DIM, 1]),
+                            TensorData::F32(vec![0.0; ENC_DIM]),
+                        ),
+                        Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![1])),
+                    ],
+                )),
+            );
+            sessions.insert(
+                "v3_rnnt_decoder".into(),
+                Arc::new(MockSession::new(
+                    vec![
+                        Shape::new(vec![1, 1]),
+                        Shape::new(vec![1, 1, PRED_HIDDEN]),
+                        Shape::new(vec![1, 1, PRED_HIDDEN]),
+                    ],
+                    vec![
+                        Tensor::new(
+                            Shape::new(vec![1, 1, PRED_HIDDEN]),
+                            TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                        ),
+                        Tensor::new(
+                            Shape::new(vec![1, 1, PRED_HIDDEN]),
+                            TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                        ),
+                        Tensor::new(
+                            Shape::new(vec![1, 1, PRED_HIDDEN]),
+                            TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                        ),
+                    ],
+                )),
+            );
+            sessions.insert(
+                "v3_rnnt_joint".into(),
+                Arc::new(MockSession::new(
+                    vec![
+                        Shape::new(vec![1, ENC_DIM, 1]),
+                        Shape::new(vec![1, PRED_HIDDEN, 1]),
+                    ],
+                    vec![Tensor::new(
+                        Shape::new(vec![1, 1, 2]),
+                        TensorData::F32(vec![0.0; 2]),
+                    )],
+                )),
+            );
+
+            let factory = Box::new(MockFactory::new(sessions));
+            let engine = Engine::load_with_factory(&dir.to_string_lossy(), 1, 1, 0, factory, 1)
+                .expect("engine should load with mock runtime");
+            (engine, tmp)
+        }
+
+        #[test]
+        fn test_engine_loads_with_mock_runtime() {
+            let _ = tiny_mock_engine();
+        }
+
+        #[test]
+        fn test_engine_mock_runtime_decodes_silence() {
+            let (engine, _tmp) = tiny_mock_engine();
+            let mut guard = engine.pool.checkout_blocking().expect("checkout");
+            let samples = vec![0.0f32; 100]; // < N_FFT → one padded mel frame
+            let result = engine
+                .transcribe_samples(&samples, &mut guard)
+                .expect("mock decode must not error");
+
+            assert!(result.text.is_empty(), "blank-only decode yields no text");
+            assert!(result.words.is_empty());
+            assert!((result.duration_s - 100.0 / 16000.0).abs() < 1e-9);
+        }
+    }
 }

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1043,7 +1043,7 @@ impl Engine {
         // which head runs — callers select the variant only at download time.
         let Some(variant) = ModelVariant::detect_in_dir(dir) else {
             return Err(GigasttError::ModelLoad {
-                path: model_dir.to_string(),
+                path: dir.display().to_string(),
                 source: None,
             });
         };
@@ -1065,7 +1065,7 @@ impl Engine {
 
         let factory = production_factory(dir);
         Self::load_with_factory(
-            model_dir,
+            dir,
             pool_size,
             min_size,
             batch_pool_size,
@@ -1077,17 +1077,16 @@ impl Engine {
     /// Package-private factory-based loader. Used by production code paths and
     /// by tests that inject a [`crate::runtime::factory::RuntimeFactory`].
     pub(crate) fn load_with_factory(
-        model_dir: &str,
+        model_dir: &Path,
         pool_size: usize,
         min_size: usize,
         batch_pool_size: usize,
         factory: Box<dyn crate::runtime::factory::RuntimeFactory>,
         encoder_intra_threads: usize,
     ) -> Result<Self, GigasttError> {
-        let dir = Path::new(model_dir);
-        let Some(variant) = ModelVariant::detect_in_dir(dir) else {
+        let Some(variant) = ModelVariant::detect_in_dir(model_dir) else {
             return Err(GigasttError::ModelLoad {
-                path: model_dir.to_string(),
+                path: model_dir.display().to_string(),
                 source: None,
             });
         };
@@ -1096,17 +1095,20 @@ impl Engine {
 
         let runtime = factory.create(encoder_intra_threads)?;
         let model_load = |e: anyhow::Error| GigasttError::ModelLoad {
-            path: model_dir.to_string(),
+            path: model_dir.display().to_string(),
             source: Some(e.into()),
         };
 
         tracing::info!("Detected model variant: {variant:?}");
-        let is_int8 = dir.join(variant.encoder_int8_file()).exists();
+        let is_int8 = model_dir.join(variant.encoder_int8_file()).exists();
         if is_int8 {
             tracing::info!("Using INT8 quantized encoder");
         }
 
-        tracing::info!("Loading ONNX models from {model_dir} (pool_size={pool_size})...");
+        tracing::info!(
+            "Loading ONNX models from {} (pool_size={pool_size})...",
+            model_dir.display()
+        );
 
         #[cfg(feature = "coreml")]
         tracing::info!("Using CoreML execution provider (Neural Engine + CPU)");
@@ -1118,7 +1120,7 @@ impl Engine {
         // CoreML can reject a model at load time; fall back to CPU if that happens.
         #[cfg(feature = "coreml")]
         let triplets = match Self::load_triplets_runtime(
-            &*runtime, dir, variant, pool_size, min_size,
+            &*runtime, model_dir, variant, pool_size, min_size,
         )
         .map_err(model_load)
         {
@@ -1129,15 +1131,17 @@ impl Engine {
                 );
                 let cpu_factory = OrtFactory::cpu();
                 let runtime = cpu_factory.create(encoder_intra_threads)?;
-                Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)
+                Self::load_triplets_runtime(&*runtime, model_dir, variant, pool_size, min_size)
                     .map_err(model_load)?
             }
         };
         #[cfg(not(feature = "coreml"))]
-        let triplets = Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)
-            .map_err(model_load)?;
+        let triplets =
+            Self::load_triplets_runtime(&*runtime, model_dir, variant, pool_size, min_size)
+                .map_err(model_load)?;
 
-        let tokenizer = Tokenizer::load(&dir.join(variant.vocab_file())).map_err(model_load)?;
+        let tokenizer =
+            Tokenizer::load(&model_dir.join(variant.vocab_file())).map_err(model_load)?;
         let features = FeatureExtractor::new();
 
         tracing::info!(
@@ -1148,7 +1152,7 @@ impl Engine {
         #[cfg(feature = "diarization")]
         #[allow(deprecated)] // legacy OnnxEmbeddingExtractor::new — see import note above
         let speaker_encoder = {
-            let model_path = dir.join("wespeaker_resnet34.onnx");
+            let model_path = model_dir.join("wespeaker_resnet34.onnx");
             if model_path.exists() {
                 match OnnxEmbeddingExtractor::new(
                     &model_path,
@@ -1206,7 +1210,7 @@ impl Engine {
                     .create(encoder_intra_threads)
                     .map_err(|e| anyhow::anyhow!(e))?;
                 let triplets =
-                    Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)?;
+                    Self::load_triplets_runtime(&*runtime, model_dir, variant, pool_size, min_size)?;
                 let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
                 e.pool = pool;
                 e.batch_pool = batch_pool;
@@ -3447,12 +3451,11 @@ mod tests {
         use std::collections::HashMap;
         use std::sync::Arc;
 
-        use crate::inference::Engine;
+        use crate::inference::{Engine, PRED_HIDDEN};
         use crate::runtime::mock::{MockFactory, MockSession};
         use crate::runtime::tensor::{Shape, Tensor, TensorData};
 
         const ENC_DIM: usize = 768;
-        const PRED_HIDDEN: usize = 320;
 
         fn tiny_mock_engine() -> (Engine, tempfile::TempDir) {
             let tmp = tempfile::tempdir().expect("tempdir");
@@ -3520,7 +3523,7 @@ mod tests {
             );
 
             let factory = Box::new(MockFactory::new(sessions));
-            let engine = Engine::load_with_factory(&dir.to_string_lossy(), 1, 1, 0, factory, 1)
+            let engine = Engine::load_with_factory(dir, 1, 1, 0, factory, 1)
                 .expect("engine should load with mock runtime");
             (engine, tmp)
         }

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -60,16 +60,20 @@ impl EmbeddingExtractor for SharedExtractor {
 compile_error!("Features `coreml` and `cuda` are mutually exclusive. Choose one.");
 
 use anyhow::Context;
-#[cfg(any(feature = "coreml", feature = "cuda"))]
-use ort::ep;
-use ort::session::Session;
-use ort::value::TensorRef;
 use serde::Serialize;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 
 use crate::error::GigasttError;
 use crate::model::ModelVariant;
+use crate::runtime::factory::Runtime;
+#[allow(unused_imports)]
+use crate::runtime::factory::RuntimeFactory;
+#[cfg(feature = "coreml")]
+use crate::runtime::ort::OrtFactory;
+use crate::runtime::ort::production_factory;
+use crate::runtime::session::RuntimeSession;
+use crate::runtime::tensor::{Shape, Tensor, TensorData, TensorDataView};
 
 use features::MelSpectrogram;
 use tokenizer::Tokenizer;
@@ -82,10 +86,6 @@ pub const N_FFT: usize = 320;
 pub const HOP_LENGTH: usize = 160;
 /// Hidden dimension of the RNN-T prediction (decoder) network.
 pub const PRED_HIDDEN: usize = 320;
-
-fn ort_err(e: impl std::fmt::Display) -> anyhow::Error {
-    anyhow::anyhow!("{e}")
-}
 
 pub fn now_timestamp() -> f64 {
     use std::sync::OnceLock;
@@ -218,9 +218,9 @@ const POOL_RAM_FRACTION_DENOM: u64 = 2;
 /// Moved out of the pool on checkout and returned on checkin.
 /// Each triplet is independent and can run inference concurrently with others.
 pub struct SessionTriplet {
-    pub(crate) encoder: Session,
-    pub(crate) decoder: Session,
-    pub(crate) joiner: Session,
+    pub(crate) encoder: Box<dyn RuntimeSession>,
+    pub(crate) decoder: Box<dyn RuntimeSession>,
+    pub(crate) joiner: Box<dyn RuntimeSession>,
 }
 
 /// Errors returned by [`Pool::checkout`].
@@ -1059,19 +1059,160 @@ impl Engine {
             .unwrap_or(1);
         let encoder_intra_threads =
             Self::clamp_encoder_intra_threads(pool_size, encoder_intra_threads, logical_cpus);
-        Self::load_inner(
-            dir,
-            variant,
+
+        let factory = production_factory(dir);
+        Self::load_with_factory(
             model_dir,
             pool_size,
             min_size,
             batch_pool_size,
+            factory,
             encoder_intra_threads,
         )
-        .map_err(|e| GigasttError::ModelLoad {
+    }
+
+    /// Package-private factory-based loader. Used by production code paths and
+    /// by tests that inject a [`crate::runtime::factory::RuntimeFactory`].
+    pub(crate) fn load_with_factory(
+        model_dir: &str,
+        pool_size: usize,
+        min_size: usize,
+        batch_pool_size: usize,
+        factory: Box<dyn crate::runtime::factory::RuntimeFactory>,
+        encoder_intra_threads: usize,
+    ) -> Result<Self, GigasttError> {
+        let dir = Path::new(model_dir);
+        let Some(variant) = ModelVariant::detect_in_dir(dir) else {
+            return Err(GigasttError::ModelLoad {
+                path: model_dir.to_string(),
+                source: None,
+            });
+        };
+        let pool_size = pool_size.max(1);
+        let min_size = min_size.clamp(1, pool_size);
+
+        let runtime = factory.create(encoder_intra_threads)?;
+        let model_load = |e: anyhow::Error| GigasttError::ModelLoad {
             path: model_dir.to_string(),
             source: Some(e.into()),
-        })
+        };
+
+        tracing::info!("Detected model variant: {variant:?}");
+        let is_int8 = dir.join(variant.encoder_int8_file()).exists();
+        if is_int8 {
+            tracing::info!("Using INT8 quantized encoder");
+        }
+
+        tracing::info!("Loading ONNX models from {model_dir} (pool_size={pool_size})...");
+
+        #[cfg(feature = "coreml")]
+        tracing::info!("Using CoreML execution provider (Neural Engine + CPU)");
+        #[cfg(feature = "cuda")]
+        tracing::info!("Using CUDA execution provider (falls back to CPU if unavailable)");
+        #[cfg(not(any(feature = "coreml", feature = "cuda")))]
+        tracing::info!("Using CPU execution provider");
+
+        // CoreML can reject a model at load time; fall back to CPU if that happens.
+        #[cfg(feature = "coreml")]
+        let triplets = match Self::load_triplets_runtime(
+            &*runtime, dir, variant, pool_size, min_size,
+        )
+        .map_err(model_load)
+        {
+            Ok(triplets) => triplets,
+            Err(load_err) => {
+                tracing::warn!(
+                    "CoreML EP failed to load sessions ({load_err:#}); falling back to CPU execution provider"
+                );
+                let cpu_factory = OrtFactory::cpu();
+                let runtime = cpu_factory.create(encoder_intra_threads)?;
+                Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)
+                    .map_err(model_load)?
+            }
+        };
+        #[cfg(not(feature = "coreml"))]
+        let triplets = Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)
+            .map_err(model_load)?;
+
+        let tokenizer = Tokenizer::load(&dir.join(variant.vocab_file())).map_err(model_load)?;
+        let features = FeatureExtractor::new();
+
+        tracing::info!(
+            "Models loaded (vocab_size={}, pool_size={pool_size})",
+            tokenizer.vocab_size()
+        );
+
+        #[cfg(feature = "diarization")]
+        #[allow(deprecated)] // legacy OnnxEmbeddingExtractor::new — see import note above
+        let speaker_encoder = {
+            let model_path = dir.join("wespeaker_resnet34.onnx");
+            if model_path.exists() {
+                match OnnxEmbeddingExtractor::new(
+                    &model_path,
+                    SPEAKER_EMBEDDING_DIM,
+                    SPEAKER_SEGMENT_SAMPLES,
+                    SPEAKER_POOL_SIZE,
+                ) {
+                    Ok(enc) => {
+                        tracing::info!("Speaker encoder loaded (diarization available)");
+                        Some(std::sync::Arc::new(enc))
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Speaker encoder not loaded, diarization unavailable: {e:#}"
+                        );
+                        None
+                    }
+                }
+            } else {
+                tracing::warn!("wespeaker_resnet34.onnx not found, diarization unavailable");
+                None
+            }
+        };
+
+        let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
+        let engine = Self {
+            pool,
+            batch_pool,
+            tokenizer,
+            features,
+            variant,
+            punctuator: None,
+            itn: false,
+            biaser: None,
+            vad: None,
+            vad_config: crate::vad::VadConfig::default(),
+            int8: is_int8,
+            #[cfg(feature = "diarization")]
+            speaker_encoder,
+        };
+
+        // CoreML compiles its graph partitions lazily, so sessions that loaded
+        // fine can still fail at the first `Run()`. Probe one triplet now; if the
+        // probe fails, rebuild the pool on the CPU EP.
+        #[cfg(feature = "coreml")]
+        let engine = probe_or_rebuild(
+            engine,
+            |e: &Self| e.warmup_one().map_err(anyhow::Error::from),
+            |mut e, probe_err| {
+                tracing::warn!(
+                    "CoreML EP failed at runtime ({probe_err:#}); falling back to CPU execution provider"
+                );
+                let cpu_factory = OrtFactory::cpu();
+                let runtime = cpu_factory
+                    .create(encoder_intra_threads)
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                let triplets =
+                    Self::load_triplets_runtime(&*runtime, dir, variant, pool_size, min_size)?;
+                let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
+                e.pool = pool;
+                e.batch_pool = batch_pool;
+                Ok(e)
+            },
+        )
+        .map_err(model_load)?;
+
+        Ok(engine)
     }
 
     /// Path to the preferred encoder model for `variant`: INT8 quantized if
@@ -1083,195 +1224,6 @@ impl Engine {
         } else {
             dir.join(variant.encoder_file())
         }
-    }
-
-    /// Load a single set of encoder/decoder/joiner ONNX sessions from disk for
-    /// `variant`, using the execution provider selected at compile time.
-    ///
-    /// `encoder_intra_threads` configures the encoder session's intra-op thread
-    /// count on the CPU EP only; the CoreML / CUDA loaders ignore it (the
-    /// accelerator owns scheduling there).
-    fn load_sessions(
-        dir: &Path,
-        variant: ModelVariant,
-        prepacked: &ort::session::builder::PrepackedWeights,
-        encoder_intra_threads: usize,
-    ) -> anyhow::Result<(Session, Session, Session)> {
-        #[cfg(feature = "coreml")]
-        {
-            let _ = encoder_intra_threads;
-            Self::load_sessions_coreml(dir, variant, prepacked)
-        }
-        #[cfg(feature = "cuda")]
-        {
-            let _ = encoder_intra_threads;
-            Self::load_sessions_cuda(dir, variant, prepacked)
-        }
-        #[cfg(not(any(feature = "coreml", feature = "cuda")))]
-        {
-            Self::load_sessions_cpu(dir, variant, prepacked, encoder_intra_threads)
-        }
-    }
-
-    #[cfg(feature = "coreml")]
-    fn load_sessions_coreml(
-        dir: &Path,
-        variant: ModelVariant,
-        prepacked: &ort::session::builder::PrepackedWeights,
-    ) -> anyhow::Result<(Session, Session, Session)> {
-        // CoreML has its own cache (`coreml_cache/`) for compiled subgraphs.
-        // We do NOT call `.with_optimized_model_path(...)` here: CoreML EP
-        // replaces part of the graph with compiled nodes that cannot be
-        // re-serialized as ONNX, and ORT errors out with
-        // `Unable to serialize model as it contains compiled nodes`
-        // on macOS 14+. The CoreML cache below is sufficient.
-        //
-        // `with_static_input_shapes(true)` is load-bearing (issue #42): the
-        // Conformer encoder has a dynamic time axis, and CoreML-compiled
-        // partitions with dynamic shapes fail at prediction time with
-        // `Error executing model: ... (error code: -1)` regardless of model
-        // format or compute units. Restricting CoreML to statically-shaped
-        // subgraphs keeps the heavy conv/matmul blocks accelerated and
-        // leaves the dynamic-shape ops on the CPU EP.
-        let cache_dir = dir.join("coreml_cache");
-        let coreml_ep = ep::CoreML::default()
-            .with_model_format(ep::coreml::ModelFormat::MLProgram)
-            .with_static_input_shapes(true)
-            .with_compute_units(ep::coreml::ComputeUnits::CPUAndNeuralEngine)
-            .with_specialization_strategy(ep::coreml::SpecializationStrategy::FastPrediction)
-            .with_model_cache_dir(cache_dir.to_string_lossy())
-            .build();
-
-        let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
-        let eps = [coreml_ep.clone(), cpu_fallback.into()];
-        let encoder_path = Self::encoder_model_path(dir, variant);
-        let encoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(&encoder_path)
-            .map_err(ort_err)?;
-        let decoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.decoder_file()))
-            .map_err(ort_err)?;
-        let joiner = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.joint_file()))
-            .map_err(ort_err)?;
-        Ok((encoder, decoder, joiner))
-    }
-
-    #[cfg(feature = "cuda")]
-    fn load_sessions_cuda(
-        dir: &Path,
-        variant: ModelVariant,
-        prepacked: &ort::session::builder::PrepackedWeights,
-    ) -> anyhow::Result<(Session, Session, Session)> {
-        // CUDA EP compiles subgraphs that cannot be re-serialized as ONNX,
-        // so we do NOT call `.with_optimized_model_path(...)` here — same
-        // reason as the CoreML block. ORT's CUDA EP keeps its own caches
-        // internally.
-        let cuda_ep = ep::CUDA::default().build();
-
-        let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
-        let eps = [cuda_ep.clone(), cpu_fallback.into()];
-        let encoder_path = Self::encoder_model_path(dir, variant);
-        let encoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(&encoder_path)
-            .map_err(ort_err)?;
-        let decoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.decoder_file()))
-            .map_err(ort_err)?;
-        let joiner = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.joint_file()))
-            .map_err(ort_err)?;
-        Ok((encoder, decoder, joiner))
-    }
-
-    /// Load encoder/decoder/joiner sessions on the plain CPU EP.
-    ///
-    /// This is the default build's loader and the runtime-fallback target
-    /// when the CoreML probe in [`Engine::load`] fails (issue #42). Not
-    /// compiled under `cuda` (mutually exclusive with `coreml`), where it
-    /// would be dead code.
-    #[cfg(not(feature = "cuda"))]
-    fn load_sessions_cpu(
-        dir: &Path,
-        variant: ModelVariant,
-        prepacked: &ort::session::builder::PrepackedWeights,
-        encoder_intra_threads: usize,
-    ) -> anyhow::Result<(Session, Session, Session)> {
-        let cache_dir = dir.join("optimized_cache");
-        std::fs::create_dir_all(&cache_dir)
-            .with_context(|| format!("Failed to create ONNX cache dir: {}", cache_dir.display()))?;
-        let cpu_fallback = ort::execution_providers::CPUExecutionProvider::default();
-        let eps = [cpu_fallback.into()];
-        let encoder_path = Self::encoder_model_path(dir, variant);
-        // Only the encoder's intra-op count is configurable (it dominates the
-        // single-utterance cost); inter-op stays 1 because the Conformer is a
-        // near-linear chain, and the decoder/joiner stay intra=1 (tiny ops).
-        // Default `encoder_intra_threads == 1` ⇒ identical to the prior build.
-        let encoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_intra_threads(encoder_intra_threads.max(1))
-            .map_err(ort_err)?
-            .with_inter_threads(1)
-            .map_err(ort_err)?
-            .with_optimized_model_path(cache_dir.join("encoder_optimized.onnx"))
-            .map_err(ort_err)?
-            .with_execution_providers(&eps)
-            .map_err(ort_err)?
-            .commit_from_file(&encoder_path)
-            .map_err(ort_err)?;
-        let decoder = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_intra_threads(1)
-            .map_err(ort_err)?
-            .with_inter_threads(1)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.decoder_file()))
-            .map_err(ort_err)?;
-        let joiner = Session::builder()
-            .map_err(ort_err)?
-            .with_prepacked_weights(prepacked)
-            .map_err(ort_err)?
-            .with_intra_threads(1)
-            .map_err(ort_err)?
-            .with_inter_threads(1)
-            .map_err(ort_err)?
-            .commit_from_file(dir.join(variant.joint_file()))
-            .map_err(ort_err)?;
-        Ok((encoder, decoder, joiner))
     }
 
     /// Split loaded triplets into an interactive pool and an optional batch
@@ -1423,35 +1375,40 @@ impl Engine {
         }
     }
 
-    /// Load up to `pool_size` session triplets in parallel via the given
-    /// per-triplet loader (`load_sessions` for the compile-time-selected EP,
-    /// `load_sessions_cpu` for the CoreML runtime fallback). Tolerates a
-    /// partial pool down to `min_size` (see [`Engine::finalize_pool_load`]).
-    fn load_triplets(
+    /// Load up to `pool_size` session triplets in parallel through the given
+    /// [`Runtime`], tolerating a partial pool down to `min_size`.
+    fn load_triplets_runtime(
+        runtime: &dyn Runtime,
         dir: &Path,
         variant: ModelVariant,
         pool_size: usize,
         min_size: usize,
-        prepacked: &ort::session::builder::PrepackedWeights,
-        load_one: impl Fn(
-            &Path,
-            ModelVariant,
-            &ort::session::builder::PrepackedWeights,
-        ) -> anyhow::Result<(Session, Session, Session)>
-        + Sync,
     ) -> anyhow::Result<Vec<SessionTriplet>> {
+        let encoder_path = Self::encoder_model_path(dir, variant);
+        let decoder_path = dir.join(variant.decoder_file());
+        let joiner_path = dir.join(variant.joint_file());
+
         let results: Vec<anyhow::Result<SessionTriplet>> = std::thread::scope(|s| {
             let handles: Vec<_> = (0..pool_size)
                 .map(|i| {
-                    let pp = prepacked;
-                    let load_one = &load_one;
+                    let encoder_path = &encoder_path;
+                    let decoder_path = &decoder_path;
+                    let joiner_path = &joiner_path;
                     s.spawn(move || {
                         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                             tracing::info!(
-                                "Loading session triplet {}/{pool_size} (shared weights)",
+                                "Loading session triplet {}/{pool_size} (shared runtime)",
                                 i + 1
                             );
-                            let (encoder, decoder, joiner) = load_one(dir, variant, pp)?;
+                            let encoder = runtime
+                                .load_session(encoder_path)
+                                .map_err(|e| anyhow::anyhow!(e))?;
+                            let decoder = runtime
+                                .load_session(decoder_path)
+                                .map_err(|e| anyhow::anyhow!(e))?;
+                            let joiner = runtime
+                                .load_session(joiner_path)
+                                .map_err(|e| anyhow::anyhow!(e))?;
                             Ok(SessionTriplet {
                                 encoder,
                                 decoder,
@@ -1471,148 +1428,6 @@ impl Engine {
                 .collect()
         });
         Self::finalize_pool_load(results, pool_size, min_size)
-    }
-
-    fn load_inner(
-        dir: &Path,
-        variant: ModelVariant,
-        model_dir: &str,
-        pool_size: usize,
-        min_size: usize,
-        batch_pool_size: usize,
-        encoder_intra_threads: usize,
-    ) -> anyhow::Result<Self> {
-        tracing::info!("Detected model variant: {variant:?}");
-        let is_int8 = dir.join(variant.encoder_int8_file()).exists();
-        if is_int8 {
-            tracing::info!("Using INT8 quantized encoder");
-        }
-
-        tracing::info!("Loading ONNX models from {model_dir} (pool_size={pool_size})...");
-
-        #[cfg(feature = "coreml")]
-        tracing::info!("Using CoreML execution provider (Neural Engine + CPU)");
-        #[cfg(feature = "cuda")]
-        tracing::info!("Using CUDA execution provider (falls back to CPU if unavailable)");
-        #[cfg(not(any(feature = "coreml", feature = "cuda")))]
-        tracing::info!("Using CPU execution provider");
-
-        // Shared prepacked weights container (Arc-based, thread-safe)
-        let prepacked = ort::session::builder::PrepackedWeights::new();
-
-        // CoreML can reject a model at two distinct stages: session creation
-        // (MLModel compilation) and the first `Run()` (issue #42). This guards
-        // the first stage; the warmup probe below guards the second.
-        #[cfg(feature = "coreml")]
-        let triplets = match Self::load_triplets(
-            dir,
-            variant,
-            pool_size,
-            min_size,
-            &prepacked,
-            |d, v, pp| Self::load_sessions(d, v, pp, encoder_intra_threads),
-        ) {
-            Ok(triplets) => triplets,
-            Err(load_err) => {
-                tracing::warn!(
-                    "CoreML EP failed to load sessions ({load_err:#}); falling back to CPU execution provider"
-                );
-                // Fresh container: the failed attempt may have pre-packed
-                // weights with CoreML-specific kernel layouts.
-                let prepacked = ort::session::builder::PrepackedWeights::new();
-                Self::load_triplets(dir, variant, pool_size, min_size, &prepacked, |d, v, pp| {
-                    Self::load_sessions_cpu(d, v, pp, encoder_intra_threads)
-                })?
-            }
-        };
-        #[cfg(not(feature = "coreml"))]
-        let triplets =
-            Self::load_triplets(dir, variant, pool_size, min_size, &prepacked, |d, v, pp| {
-                Self::load_sessions(d, v, pp, encoder_intra_threads)
-            })?;
-
-        let tokenizer = Tokenizer::load(&dir.join(variant.vocab_file()))?;
-        let features = FeatureExtractor::new();
-
-        tracing::info!(
-            "Models loaded (vocab_size={}, pool_size={pool_size})",
-            tokenizer.vocab_size()
-        );
-
-        #[cfg(feature = "diarization")]
-        #[allow(deprecated)] // legacy OnnxEmbeddingExtractor::new — see import note above
-        let speaker_encoder = {
-            let model_path = dir.join("wespeaker_resnet34.onnx");
-            if model_path.exists() {
-                match OnnxEmbeddingExtractor::new(
-                    &model_path,
-                    SPEAKER_EMBEDDING_DIM,
-                    SPEAKER_SEGMENT_SAMPLES,
-                    SPEAKER_POOL_SIZE,
-                ) {
-                    Ok(enc) => {
-                        tracing::info!("Speaker encoder loaded (diarization available)");
-                        Some(std::sync::Arc::new(enc))
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Speaker encoder not loaded, diarization unavailable: {e:#}"
-                        );
-                        None
-                    }
-                }
-            } else {
-                tracing::warn!("wespeaker_resnet34.onnx not found, diarization unavailable");
-                None
-            }
-        };
-
-        let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
-        let engine = Self {
-            pool,
-            batch_pool,
-            tokenizer,
-            features,
-            variant,
-            punctuator: None,
-            itn: false,
-            biaser: None,
-            vad: None,
-            vad_config: crate::vad::VadConfig::default(),
-            int8: is_int8,
-            #[cfg(feature = "diarization")]
-            speaker_encoder,
-        };
-
-        // CoreML compiles its graph partitions lazily, so sessions that
-        // loaded fine can still fail at the first `Run()` (issue #42). Probe
-        // one triplet now; if the probe fails, rebuild the pool on the CPU EP
-        // instead of surfacing the error on every real request.
-        #[cfg(feature = "coreml")]
-        let engine = probe_or_rebuild(
-            engine,
-            |e: &Self| e.warmup_one().map_err(anyhow::Error::from),
-            |mut e, probe_err| {
-                tracing::warn!(
-                    "CoreML EP failed at runtime ({probe_err:#}); falling back to CPU execution provider"
-                );
-                let prepacked = ort::session::builder::PrepackedWeights::new();
-                let triplets = Self::load_triplets(
-                    dir,
-                    variant,
-                    pool_size,
-                    min_size,
-                    &prepacked,
-                    |d, v, pp| Self::load_sessions_cpu(d, v, pp, encoder_intra_threads),
-                )?;
-                let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
-                e.pool = pool;
-                e.batch_pool = batch_pool;
-                Ok(e)
-            },
-        )?;
-
-        Ok(engine)
     }
 
     /// Run one ~1 s silent inference on a single pooled session triplet.
@@ -2192,38 +2007,43 @@ impl Engine {
         frame_offset: usize,
     ) -> anyhow::Result<(Vec<WordInfo>, bool)> {
         // Encoder input: audio_signal [1, 64, num_frames], length [1]
-        let signal_tensor = TensorRef::from_array_view(([1_usize, N_MELS, num_frames], features))?;
-        let length_data = [num_frames as i64];
-        let length_tensor = TensorRef::from_array_view(([1_usize], length_data.as_slice()))?;
+        let signal_tensor = Tensor::new(
+            Shape::new(vec![1, N_MELS, num_frames]),
+            TensorData::F32(features.to_vec()),
+        );
+        let length_tensor = Tensor::new(
+            Shape::new(vec![1]),
+            TensorData::I64(vec![num_frames as i64]),
+        );
 
         let enc_start = std::time::Instant::now();
         let encoder_outputs = triplet
             .encoder
-            .run(ort::inputs![signal_tensor, length_tensor])
+            .run(vec![signal_tensor, length_tensor])
             .context("Encoder inference failed")?;
         tracing::info!(
             elapsed_ms = enc_start.elapsed().as_millis() as u64,
             "encoder_inference"
         );
 
-        let (_enc_shape, enc_data) = encoder_outputs[0]
-            .try_extract_tensor::<f32>()
+        let enc_data = encoder_outputs[0]
+            .view()
+            .data()
+            .as_f32()
             .context("Failed to extract encoder output")?;
-        let (_len_shape, len_data) = encoder_outputs[1]
-            .try_extract_tensor::<i32>()
-            .context("Failed to extract encoder length")?;
-
-        let enc_len = usize::try_from(len_data[0]).context("Negative encoder length")?;
+        let enc_len = match encoder_outputs[1].view().data() {
+            TensorDataView::I32(v) => usize::try_from(v[0]).context("Negative encoder length")?,
+            TensorDataView::I64(v) => usize::try_from(v[0]).context("Negative encoder length")?,
+            _ => anyhow::bail!("Unexpected encoder length tensor type"),
+        };
 
         tracing::debug!("Encoder output: {} frames", enc_len);
 
-        // RNN-T greedy decode — we pass the encoder-output borrow directly
-        // instead of copying it.  The `encoder_outputs` variable is dropped
-        // automatically at the end of this scope, after decode finishes.
+        // RNN-T greedy decode — the encoder output is borrowed for the decode loop.
         let dec_start = std::time::Instant::now();
         let result = decode::greedy_decode(
-            &mut triplet.decoder,
-            &mut triplet.joiner,
+            &*triplet.decoder,
+            &*triplet.joiner,
             enc_data,
             enc_len,
             self.tokenizer.blank_id(),
@@ -2773,12 +2593,6 @@ mod tests {
     #[test]
     fn test_pool_error_display() {
         assert_eq!(format!("{}", PoolError::Closed), "session pool is closed");
-    }
-
-    #[test]
-    fn test_ort_err() {
-        let e = ort_err("test ort error");
-        assert_eq!(format!("{e}"), "test ort error");
     }
 
     #[test]

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -221,6 +221,9 @@ pub struct SessionTriplet {
     pub(crate) encoder: Box<dyn RuntimeSession>,
     pub(crate) decoder: Box<dyn RuntimeSession>,
     pub(crate) joiner: Box<dyn RuntimeSession>,
+    /// Reusable encoder input tensors: `[audio_signal [1, N_MELS, num_frames], length [1]]`.
+    /// Resized and overwritten in `run_inference` to avoid per-call allocations.
+    pub(crate) encoder_inputs: Vec<Tensor>,
 }
 
 /// Errors returned by [`Pool::checkout`].
@@ -1413,6 +1416,13 @@ impl Engine {
                                 encoder,
                                 decoder,
                                 joiner,
+                                encoder_inputs: vec![
+                                    Tensor::new(
+                                        Shape::new(vec![1, N_MELS, 1]),
+                                        TensorData::F32(vec![0.0; N_MELS]),
+                                    ),
+                                    Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![0])),
+                                ],
                             })
                         }))
                         .map_err(|_| anyhow::anyhow!("model loading thread panicked"))?
@@ -2006,31 +2016,27 @@ impl Engine {
         decoder_state: &mut DecoderState,
         frame_offset: usize,
     ) -> anyhow::Result<(Vec<WordInfo>, bool)> {
-        // Encoder input: audio_signal [1, 64, num_frames], length [1]
-        let signal_tensor = Tensor::new(
-            Shape::new(vec![1, N_MELS, num_frames]),
-            TensorData::F32(features.to_vec()),
-        );
-        let length_tensor = Tensor::new(
-            Shape::new(vec![1]),
-            TensorData::I64(vec![num_frames as i64]),
-        );
+        // Reuse the encoder input tensors: resize the signal tensor to the
+        // current frame count and overwrite both buffers in place.
+        triplet.encoder_inputs[0].resize_to(Shape::new(vec![1, N_MELS, num_frames]));
+        triplet.encoder_inputs[0]
+            .as_f32_mut()
+            .context("encoder signal tensor is not f32")?
+            .copy_from_slice(features);
+        triplet.encoder_inputs[1]
+            .as_i64_mut()
+            .context("encoder length tensor is not i64")?[0] = num_frames as i64;
 
         let enc_start = std::time::Instant::now();
         let encoder_outputs = triplet
             .encoder
-            .run(vec![signal_tensor, length_tensor])
+            .run(&triplet.encoder_inputs)
             .context("Encoder inference failed")?;
         tracing::info!(
             elapsed_ms = enc_start.elapsed().as_millis() as u64,
             "encoder_inference"
         );
 
-        let enc_data = encoder_outputs[0]
-            .view()
-            .data()
-            .as_f32()
-            .context("Failed to extract encoder output")?;
         let enc_len = match encoder_outputs[1].view().data() {
             TensorDataView::I32(v) => usize::try_from(v[0]).context("Negative encoder length")?,
             TensorDataView::I64(v) => usize::try_from(v[0]).context("Negative encoder length")?,
@@ -2044,7 +2050,7 @@ impl Engine {
         let result = decode::greedy_decode(
             &*triplet.decoder,
             &*triplet.joiner,
-            enc_data,
+            &encoder_outputs[0].view(),
             enc_len,
             self.tokenizer.blank_id(),
             decoder_state,

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1424,8 +1424,8 @@ impl Engine {
                                     Tensor::new(
                                         Shape::new(vec![1, N_MELS, 1]),
                                         TensorData::F32(vec![0.0; N_MELS]),
-                                    ),
-                                    Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![0])),
+                                    )?,
+                                    Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![0]))?,
                                 ],
                             })
                         }))
@@ -3479,8 +3479,9 @@ mod tests {
                         Tensor::new(
                             Shape::new(vec![1, ENC_DIM, 1]),
                             TensorData::F32(vec![0.0; ENC_DIM]),
-                        ),
-                        Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![1])),
+                        )
+                        .unwrap(),
+                        Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![1])).unwrap(),
                     ],
                 )),
             );
@@ -3496,15 +3497,18 @@ mod tests {
                         Tensor::new(
                             Shape::new(vec![1, 1, PRED_HIDDEN]),
                             TensorData::F32(vec![0.0; PRED_HIDDEN]),
-                        ),
+                        )
+                        .unwrap(),
                         Tensor::new(
                             Shape::new(vec![1, 1, PRED_HIDDEN]),
                             TensorData::F32(vec![0.0; PRED_HIDDEN]),
-                        ),
+                        )
+                        .unwrap(),
                         Tensor::new(
                             Shape::new(vec![1, 1, PRED_HIDDEN]),
                             TensorData::F32(vec![0.0; PRED_HIDDEN]),
-                        ),
+                        )
+                        .unwrap(),
                     ],
                 )),
             );
@@ -3515,10 +3519,10 @@ mod tests {
                         Shape::new(vec![1, ENC_DIM, 1]),
                         Shape::new(vec![1, PRED_HIDDEN, 1]),
                     ],
-                    vec![Tensor::new(
-                        Shape::new(vec![1, 1, 2]),
-                        TensorData::F32(vec![0.0; 2]),
-                    )],
+                    vec![
+                        Tensor::new(Shape::new(vec![1, 1, 2]), TensorData::F32(vec![0.0; 2]))
+                            .unwrap(),
+                    ],
                 )),
             );
 

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -69,9 +69,7 @@ use crate::model::ModelVariant;
 use crate::runtime::factory::Runtime;
 #[allow(unused_imports)]
 use crate::runtime::factory::RuntimeFactory;
-#[cfg(feature = "coreml")]
-use crate::runtime::ort::OrtFactory;
-use crate::runtime::ort::production_factory;
+use crate::runtime::production_factory;
 use crate::runtime::session::RuntimeSession;
 use crate::runtime::tensor::{Shape, Tensor, TensorData, TensorDataView};
 
@@ -1129,7 +1127,7 @@ impl Engine {
                 tracing::warn!(
                     "CoreML EP failed to load sessions ({load_err:#}); falling back to CPU execution provider"
                 );
-                let cpu_factory = OrtFactory::cpu();
+                let cpu_factory = factory.cpu_fallback();
                 let runtime = cpu_factory.create(encoder_intra_threads)?;
                 Self::load_triplets_runtime(&*runtime, model_dir, variant, pool_size, min_size)
                     .map_err(model_load)?
@@ -1205,7 +1203,7 @@ impl Engine {
                 tracing::warn!(
                     "CoreML EP failed at runtime ({probe_err:#}); falling back to CPU execution provider"
                 );
-                let cpu_factory = OrtFactory::cpu();
+                let cpu_factory = factory.cpu_fallback();
                 let runtime = cpu_factory
                     .create(encoder_intra_threads)
                     .map_err(|e| anyhow::anyhow!(e))?;
@@ -1408,13 +1406,13 @@ impl Engine {
                                 i + 1
                             );
                             let encoder = runtime
-                                .load_session(encoder_path)
+                                .load_session(encoder_path, true)
                                 .map_err(|e| anyhow::anyhow!(e))?;
                             let decoder = runtime
-                                .load_session(decoder_path)
+                                .load_session(decoder_path, false)
                                 .map_err(|e| anyhow::anyhow!(e))?;
                             let joiner = runtime
-                                .load_session(joiner_path)
+                                .load_session(joiner_path, false)
                                 .map_err(|e| anyhow::anyhow!(e))?;
                             Ok(SessionTriplet {
                                 encoder,

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -8,4 +8,5 @@ pub mod onnx_proto;
 pub mod protocol;
 pub mod punctuation;
 pub mod quantize;
+pub(crate) mod runtime;
 pub mod vad;

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -10,3 +10,5 @@ pub mod punctuation;
 pub mod quantize;
 pub(crate) mod runtime;
 pub mod vad;
+
+pub use runtime::cpu_factory;

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -270,7 +270,7 @@ impl Punctuator {
         let argmax_per_token: Vec<usize> = {
             let session = self.session.lock();
             let outputs = session
-                .run(vec![input_ids, attention_mask, token_type])
+                .run(&[input_ids, attention_mask, token_type])
                 .context("punct model inference failed")?;
 
             let logits_view = outputs[0].view();

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -29,10 +29,15 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use ort::session::Session;
-use ort::value::TensorRef;
 use parking_lot::Mutex;
 use tokenizers::Tokenizer;
+
+use crate::runtime::{
+    factory::RuntimeFactory,
+    ort::OrtFactory,
+    session::RuntimeSession,
+    tensor::{Shape, Tensor, TensorData},
+};
 
 /// Basename of the INT8 ONNX punctuation model inside the punct model dir.
 pub const PUNCT_MODEL_FILE: &str = "rupunct_small_int8.onnx";
@@ -40,10 +45,6 @@ pub const PUNCT_MODEL_FILE: &str = "rupunct_small_int8.onnx";
 pub const PUNCT_TOKENIZER_FILE: &str = "tokenizer.json";
 /// Basename of the model config JSON (carries `id2label`) inside the punct model dir.
 pub const PUNCT_CONFIG_FILE: &str = "config.json";
-
-fn ort_err(e: impl std::fmt::Display) -> anyhow::Error {
-    anyhow::anyhow!("{e}")
-}
 
 /// Apply Python `str.capitalize()` semantics to a token: first character
 /// uppercased, every following character lowercased. Operates over Unicode
@@ -162,7 +163,7 @@ fn argmax(row: &[f32]) -> usize {
 /// is the public entry point and never panics: on any internal failure it logs
 /// and returns the input text unchanged.
 pub struct Punctuator {
-    session: Mutex<Session>,
+    session: Mutex<Box<dyn RuntimeSession>>,
     tokenizer: Tokenizer,
     /// `id2label[i]` is the label name for logit index `i`.
     id2label: Vec<String>,
@@ -191,10 +192,14 @@ impl Punctuator {
             anyhow::anyhow!("Failed to load tokenizer {}: {e}", tokenizer_path.display())
         })?;
 
-        let session = Session::builder()
-            .map_err(ort_err)?
-            .commit_from_file(&model_path)
-            .map_err(ort_err)
+        let factory = OrtFactory::cpu();
+        let runtime = factory
+            .create(1)
+            .map_err(|e| anyhow::anyhow!(e))
+            .with_context(|| format!("Failed to create runtime for {}", model_path.display()))?;
+        let session = runtime
+            .load_session(&model_path)
+            .map_err(|e| anyhow::anyhow!(e))
             .with_context(|| format!("Failed to load punct model {}", model_path.display()))?;
 
         tracing::info!(
@@ -255,31 +260,28 @@ impl Punctuator {
         let seq = ids.len();
         let token_type_ids = vec![0i64; seq];
 
-        let input_ids = TensorRef::from_array_view(([1_usize, seq], ids.as_slice()))?;
-        let attention_mask = TensorRef::from_array_view(([1_usize, seq], mask.as_slice()))?;
-        let token_type = TensorRef::from_array_view(([1_usize, seq], token_type_ids.as_slice()))?;
+        let input_ids = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(ids));
+        let attention_mask = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(mask));
+        let token_type = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(token_type_ids));
 
         // Run the session and reduce the borrowed logits to an owned
-        // per-token argmax inside this scope, so the `outputs` borrow (which
-        // ties the lifetime to the session guard) is released before the
-        // session guard is dropped at end of scope.
+        // per-token argmax inside this scope.
         let num_labels = self.id2label.len();
         let argmax_per_token: Vec<usize> = {
-            let mut session = self.session.lock();
+            let session = self.session.lock();
             let outputs = session
-                .run(ort::inputs![
-                    "input_ids" => input_ids,
-                    "attention_mask" => attention_mask,
-                    "token_type_ids" => token_type,
-                ])
+                .run(vec![input_ids, attention_mask, token_type])
                 .context("punct model inference failed")?;
 
-            let (shape, logits) = outputs["logits"]
-                .try_extract_tensor::<f32>()
+            let logits_view = outputs[0].view();
+            let logits = logits_view
+                .data()
+                .as_f32()
                 .context("failed to extract punct logits")?;
 
             // Expect [1, seq, num_labels].
-            if shape.len() != 3 || shape[2] as usize != num_labels {
+            let shape = logits_view.shape().dims();
+            if shape != [1, seq, num_labels] {
                 anyhow::bail!(
                     "unexpected punct logits shape {shape:?} (expected [1, {seq}, {num_labels}])"
                 );
@@ -429,14 +431,6 @@ mod tests {
         assert_eq!(argmax(&[0.1, 0.9, 0.3]), 1);
         assert_eq!(argmax(&[5.0, 1.0, 2.0]), 0);
         assert_eq!(argmax(&[1.0, 1.0, 3.0]), 2);
-    }
-
-    /// `ort_err` flattens any `Display` error into an `anyhow::Error` carrying
-    /// the same message (the Send/Sync workaround used at every `ort` boundary).
-    #[test]
-    fn test_ort_err_preserves_display_message() {
-        let err = ort_err("session build exploded");
-        assert_eq!(err.to_string(), "session build exploded");
     }
 
     /// A minimal but valid HuggingFace tokenizer.json (WordLevel model). Used to

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -34,7 +34,6 @@ use tokenizers::Tokenizer;
 
 use crate::runtime::{
     factory::RuntimeFactory,
-    ort::OrtFactory,
     session::RuntimeSession,
     tensor::{Shape, Tensor, TensorData},
 };
@@ -180,7 +179,7 @@ impl Punctuator {
     /// Returns an error if any file is missing or fails to parse / load. The
     /// caller treats an error as "punctuation unavailable" and proceeds without
     /// it — restoration is optional post-processing.
-    pub fn load(model_dir: &Path) -> Result<Self> {
+    pub fn load(model_dir: &Path, factory: &dyn RuntimeFactory) -> Result<Self> {
         let model_path = model_dir.join(PUNCT_MODEL_FILE);
         let tokenizer_path = model_dir.join(PUNCT_TOKENIZER_FILE);
         let config_path = model_dir.join(PUNCT_CONFIG_FILE);
@@ -192,15 +191,16 @@ impl Punctuator {
             anyhow::anyhow!("Failed to load tokenizer {}: {e}", tokenizer_path.display())
         })?;
 
-        let factory = OrtFactory::cpu();
+        tracing::debug!("Loading punctuation model from {}", model_path.display());
         let runtime = factory
+            .cpu_fallback()
             .create(1)
             .map_err(|e| anyhow::anyhow!(e))
-            .with_context(|| format!("Failed to create runtime for {}", model_path.display()))?;
+            .context("Failed to create runtime for punctuation model")?;
         let session = runtime
-            .load_session(&model_path)
+            .load_session(&model_path, false)
             .map_err(|e| anyhow::anyhow!(e))
-            .with_context(|| format!("Failed to load punct model {}", model_path.display()))?;
+            .context("Failed to load punctuation model")?;
 
         tracing::info!(
             "Punctuation model loaded ({} labels) from {}",
@@ -350,6 +350,7 @@ fn load_id2label(config_path: &Path) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::ort::OrtFactory;
 
     #[test]
     fn test_capitalize_python_semantics() {
@@ -462,7 +463,7 @@ mod tests {
     fn test_load_missing_id2label_errors() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::write(tmp.path().join(PUNCT_CONFIG_FILE), r#"{"foo": 1}"#).unwrap();
-        assert!(Punctuator::load(tmp.path()).is_err());
+        assert!(Punctuator::load(tmp.path(), &OrtFactory::cpu()).is_err());
     }
 
     /// config.json parses but tokenizer.json is malformed: `load` must fail at
@@ -473,7 +474,7 @@ mod tests {
         std::fs::write(tmp.path().join(PUNCT_CONFIG_FILE), MINIMAL_CONFIG_JSON).unwrap();
         std::fs::write(tmp.path().join(PUNCT_TOKENIZER_FILE), "{ not valid json").unwrap();
         // `Punctuator` is not `Debug`, so match instead of `expect_err`.
-        match Punctuator::load(tmp.path()) {
+        match Punctuator::load(tmp.path(), &OrtFactory::cpu()) {
             Ok(_) => panic!("malformed tokenizer must error"),
             Err(e) => assert!(e.to_string().contains("tokenizer")),
         }
@@ -492,7 +493,7 @@ mod tests {
         )
         .unwrap();
         // No rupunct_small_int8.onnx written → session build must fail.
-        assert!(Punctuator::load(tmp.path()).is_err());
+        assert!(Punctuator::load(tmp.path(), &OrtFactory::cpu()).is_err());
     }
 
     #[test]
@@ -501,7 +502,7 @@ mod tests {
         // (the caller turns this into "punctuation disabled"), never panic.
         let tmp = tempfile::tempdir().expect("tempdir");
         let missing = tmp.path().join("does-not-exist");
-        assert!(Punctuator::load(&missing).is_err());
+        assert!(Punctuator::load(&missing, &OrtFactory::cpu()).is_err());
     }
 
     #[test]
@@ -536,7 +537,8 @@ mod tests {
     #[ignore = "requires punct model at ~/.gigastt/models/punct"]
     fn test_restore_reference_string() {
         let dir = default_punct_model_dir();
-        let punct = Punctuator::load(Path::new(&dir)).expect("load punct model");
+        let punct =
+            Punctuator::load(Path::new(&dir), &OrtFactory::cpu()).expect("load punct model");
         let out =
             punct.restore("привет меня зовут анна сколько будет стоить шестьдесят тысяч тенге");
         assert_eq!(

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -185,7 +185,7 @@ impl Punctuator {
     }
 
     /// Like [`Punctuator::load`], but loads the ONNX session through a
-    /// caller-supplied [`RuntimeFactory`] (e.g. a non-`ort` backend or a test
+    /// caller-supplied `RuntimeFactory` (e.g. a non-`ort` backend or a test
     /// mock) instead of the default CPU `ort` runtime.
     pub fn load_with_factory(model_dir: &Path, factory: &dyn RuntimeFactory) -> Result<Self> {
         let model_path = model_dir.join(PUNCT_MODEL_FILE);

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -179,7 +179,15 @@ impl Punctuator {
     /// Returns an error if any file is missing or fails to parse / load. The
     /// caller treats an error as "punctuation unavailable" and proceeds without
     /// it — restoration is optional post-processing.
-    pub fn load(model_dir: &Path, factory: &dyn RuntimeFactory) -> Result<Self> {
+    pub fn load(model_dir: &Path) -> Result<Self> {
+        let factory = crate::runtime::cpu_factory();
+        Self::load_with_factory(model_dir, factory.as_ref())
+    }
+
+    /// Like [`Punctuator::load`], but loads the ONNX session through a
+    /// caller-supplied [`RuntimeFactory`] (e.g. a non-`ort` backend or a test
+    /// mock) instead of the default CPU `ort` runtime.
+    pub fn load_with_factory(model_dir: &Path, factory: &dyn RuntimeFactory) -> Result<Self> {
         let model_path = model_dir.join(PUNCT_MODEL_FILE);
         let tokenizer_path = model_dir.join(PUNCT_TOKENIZER_FILE);
         let config_path = model_dir.join(PUNCT_CONFIG_FILE);
@@ -350,7 +358,6 @@ fn load_id2label(config_path: &Path) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::ort::OrtFactory;
 
     #[test]
     fn test_capitalize_python_semantics() {
@@ -463,7 +470,7 @@ mod tests {
     fn test_load_missing_id2label_errors() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::write(tmp.path().join(PUNCT_CONFIG_FILE), r#"{"foo": 1}"#).unwrap();
-        assert!(Punctuator::load(tmp.path(), &OrtFactory::cpu()).is_err());
+        assert!(Punctuator::load(tmp.path()).is_err());
     }
 
     /// config.json parses but tokenizer.json is malformed: `load` must fail at
@@ -474,7 +481,7 @@ mod tests {
         std::fs::write(tmp.path().join(PUNCT_CONFIG_FILE), MINIMAL_CONFIG_JSON).unwrap();
         std::fs::write(tmp.path().join(PUNCT_TOKENIZER_FILE), "{ not valid json").unwrap();
         // `Punctuator` is not `Debug`, so match instead of `expect_err`.
-        match Punctuator::load(tmp.path(), &OrtFactory::cpu()) {
+        match Punctuator::load(tmp.path()) {
             Ok(_) => panic!("malformed tokenizer must error"),
             Err(e) => assert!(e.to_string().contains("tokenizer")),
         }
@@ -493,7 +500,7 @@ mod tests {
         )
         .unwrap();
         // No rupunct_small_int8.onnx written → session build must fail.
-        assert!(Punctuator::load(tmp.path(), &OrtFactory::cpu()).is_err());
+        assert!(Punctuator::load(tmp.path()).is_err());
     }
 
     #[test]
@@ -502,7 +509,7 @@ mod tests {
         // (the caller turns this into "punctuation disabled"), never panic.
         let tmp = tempfile::tempdir().expect("tempdir");
         let missing = tmp.path().join("does-not-exist");
-        assert!(Punctuator::load(&missing, &OrtFactory::cpu()).is_err());
+        assert!(Punctuator::load(&missing).is_err());
     }
 
     #[test]
@@ -537,8 +544,7 @@ mod tests {
     #[ignore = "requires punct model at ~/.gigastt/models/punct"]
     fn test_restore_reference_string() {
         let dir = default_punct_model_dir();
-        let punct =
-            Punctuator::load(Path::new(&dir), &OrtFactory::cpu()).expect("load punct model");
+        let punct = Punctuator::load(Path::new(&dir)).expect("load punct model");
         let out =
             punct.restore("привет меня зовут анна сколько будет стоить шестьдесят тысяч тенге");
         assert_eq!(

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -260,9 +260,9 @@ impl Punctuator {
         let seq = ids.len();
         let token_type_ids = vec![0i64; seq];
 
-        let input_ids = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(ids));
-        let attention_mask = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(mask));
-        let token_type = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(token_type_ids));
+        let input_ids = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(ids))?;
+        let attention_mask = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(mask))?;
+        let token_type = Tensor::new(Shape::new(vec![1, seq]), TensorData::I64(token_type_ids))?;
 
         // Run the session and reduce the borrowed logits to an owned
         // per-token argmax inside this scope.

--- a/crates/gigastt-core/src/runtime/error.rs
+++ b/crates/gigastt-core/src/runtime/error.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use super::tensor::Shape;
+
+/// Errors produced by the runtime abstraction layer.
+#[derive(Debug, Error)]
+pub enum RuntimeError {
+    #[error("failed to load model {path}: {message}")]
+    LoadFailed { path: PathBuf, message: String },
+
+    #[error("inference failed: {0}")]
+    InferenceFailed(String),
+
+    #[error("invalid tensor shape: expected {expected:?}, got {got:?}")]
+    InvalidShape { expected: Shape, got: Shape },
+
+    #[error("unsupported element type")]
+    UnsupportedElementType,
+
+    #[error("invalid input count: expected {expected}, got {got}")]
+    InvalidInputCount { expected: usize, got: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn test_load_failed_display() {
+        let e = RuntimeError::LoadFailed {
+            path: PathBuf::from("encoder.onnx"),
+            message: "not found".into(),
+        };
+        assert_eq!(
+            e.to_string(),
+            "failed to load model encoder.onnx: not found"
+        );
+    }
+
+    #[test]
+    fn test_invalid_shape_display() {
+        let expected = Shape::new(vec![2, 3]);
+        let got = Shape::new(vec![3, 2]);
+        let e = RuntimeError::InvalidShape {
+            expected: expected.clone(),
+            got: got.clone(),
+        };
+        assert!(e.to_string().contains("invalid tensor shape"));
+        assert!(e.to_string().contains("[2, 3]"));
+        assert!(e.to_string().contains("[3, 2]"));
+    }
+
+    #[test]
+    fn test_inference_failed_display() {
+        let e = RuntimeError::InferenceFailed("session is closed".into());
+        assert_eq!(e.to_string(), "inference failed: session is closed");
+    }
+
+    #[test]
+    fn test_invalid_input_count_display() {
+        let e = RuntimeError::InvalidInputCount {
+            expected: 3,
+            got: 2,
+        };
+        assert_eq!(e.to_string(), "invalid input count: expected 3, got 2");
+    }
+
+    #[test]
+    fn test_unsupported_element_type_display() {
+        let e = RuntimeError::UnsupportedElementType;
+        assert_eq!(e.to_string(), "unsupported element type");
+    }
+}

--- a/crates/gigastt-core/src/runtime/error.rs
+++ b/crates/gigastt-core/src/runtime/error.rs
@@ -2,10 +2,11 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
-use super::tensor::Shape;
+use super::tensor::{ElementType, Shape};
 
 /// Errors produced by the runtime abstraction layer.
 #[derive(Debug, Error)]
+#[allow(dead_code)]
 pub enum RuntimeError {
     #[error("failed to load model {path}: {message}")]
     LoadFailed { path: PathBuf, message: String },
@@ -16,8 +17,8 @@ pub enum RuntimeError {
     #[error("invalid tensor shape: expected {expected:?}, got {got:?}")]
     InvalidShape { expected: Shape, got: Shape },
 
-    #[error("unsupported element type")]
-    UnsupportedElementType,
+    #[error("unsupported element type: {0:?}")]
+    UnsupportedElementType(ElementType),
 
     #[error("invalid input count: expected {expected}, got {got}")]
     InvalidInputCount { expected: usize, got: usize },
@@ -71,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_unsupported_element_type_display() {
-        let e = RuntimeError::UnsupportedElementType;
-        assert_eq!(e.to_string(), "unsupported element type");
+        let e = RuntimeError::UnsupportedElementType(ElementType::I64);
+        assert_eq!(e.to_string(), "unsupported element type: I64");
     }
 }

--- a/crates/gigastt-core/src/runtime/error.rs
+++ b/crates/gigastt-core/src/runtime/error.rs
@@ -6,7 +6,6 @@ use super::tensor::{ElementType, Shape};
 
 /// Errors produced by the runtime abstraction layer.
 #[derive(Debug, Error)]
-#[allow(dead_code)]
 pub enum RuntimeError {
     #[error("failed to load model: {message}")]
     LoadFailed { path: PathBuf, message: String },

--- a/crates/gigastt-core/src/runtime/error.rs
+++ b/crates/gigastt-core/src/runtime/error.rs
@@ -8,7 +8,7 @@ use super::tensor::{ElementType, Shape};
 #[derive(Debug, Error)]
 #[allow(dead_code)]
 pub enum RuntimeError {
-    #[error("failed to load model {path}: {message}")]
+    #[error("failed to load model: {message}")]
     LoadFailed { path: PathBuf, message: String },
 
     #[error("inference failed: {0}")]
@@ -22,6 +22,9 @@ pub enum RuntimeError {
 
     #[error("invalid input count: expected {expected}, got {got}")]
     InvalidInputCount { expected: usize, got: usize },
+
+    #[error("tensor data length mismatch: expected {expected}, got {got}")]
+    DataLengthMismatch { expected: usize, got: usize },
 }
 
 #[cfg(test)]
@@ -36,10 +39,11 @@ mod tests {
             path: PathBuf::from("encoder.onnx"),
             message: "not found".into(),
         };
-        assert_eq!(
-            e.to_string(),
-            "failed to load model encoder.onnx: not found"
+        assert!(
+            !e.to_string().contains("encoder.onnx"),
+            "display must not leak the model path"
         );
+        assert_eq!(e.to_string(), "failed to load model: not found");
     }
 
     #[test]

--- a/crates/gigastt-core/src/runtime/factory.rs
+++ b/crates/gigastt-core/src/runtime/factory.rs
@@ -1,11 +1,13 @@
 use super::{error::RuntimeError, session::RuntimeSession};
 
 /// Creates a `Runtime` configured for a specific execution provider.
+#[expect(dead_code)]
 pub trait RuntimeFactory: Send + Sync + 'static {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
 }
 
 /// Owns loaded sessions. One runtime per `Engine`.
+#[expect(dead_code)]
 pub trait Runtime: Send + Sync + 'static {
     fn load_session(
         &self,

--- a/crates/gigastt-core/src/runtime/factory.rs
+++ b/crates/gigastt-core/src/runtime/factory.rs
@@ -1,0 +1,14 @@
+use super::{error::RuntimeError, session::RuntimeSession};
+
+/// Creates a `Runtime` configured for a specific execution provider.
+pub trait RuntimeFactory: Send + Sync + 'static {
+    fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
+}
+
+/// Owns loaded sessions. One runtime per `Engine`.
+pub trait Runtime: Send + Sync + 'static {
+    fn load_session(
+        &self,
+        model_path: &std::path::Path,
+    ) -> Result<Box<dyn RuntimeSession>, RuntimeError>;
+}

--- a/crates/gigastt-core/src/runtime/factory.rs
+++ b/crates/gigastt-core/src/runtime/factory.rs
@@ -1,13 +1,13 @@
 use super::{error::RuntimeError, session::RuntimeSession};
 
 /// Creates a `Runtime` configured for a specific execution provider.
-#[expect(dead_code)]
+#[allow(dead_code)]
 pub trait RuntimeFactory: Send + Sync + 'static {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
 }
 
 /// Owns loaded sessions. One runtime per `Engine`.
-#[expect(dead_code)]
+#[allow(dead_code)]
 pub trait Runtime: Send + Sync + 'static {
     fn load_session(
         &self,

--- a/crates/gigastt-core/src/runtime/factory.rs
+++ b/crates/gigastt-core/src/runtime/factory.rs
@@ -1,7 +1,6 @@
 use super::{error::RuntimeError, session::RuntimeSession};
 
 /// Creates a `Runtime` configured for a specific execution provider.
-#[allow(dead_code)]
 pub trait RuntimeFactory: Send + Sync + 'static {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
 
@@ -10,7 +9,6 @@ pub trait RuntimeFactory: Send + Sync + 'static {
 }
 
 /// Owns loaded sessions. One runtime per `Engine`.
-#[allow(dead_code)]
 pub trait Runtime: Send + Sync + 'static {
     fn load_session(
         &self,

--- a/crates/gigastt-core/src/runtime/factory.rs
+++ b/crates/gigastt-core/src/runtime/factory.rs
@@ -4,6 +4,9 @@ use super::{error::RuntimeError, session::RuntimeSession};
 #[allow(dead_code)]
 pub trait RuntimeFactory: Send + Sync + 'static {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError>;
+
+    /// Returns a CPU-only factory suitable for small auxiliary models.
+    fn cpu_fallback(&self) -> Box<dyn RuntimeFactory>;
 }
 
 /// Owns loaded sessions. One runtime per `Engine`.
@@ -12,5 +15,6 @@ pub trait Runtime: Send + Sync + 'static {
     fn load_session(
         &self,
         model_path: &std::path::Path,
+        is_encoder: bool,
     ) -> Result<Box<dyn RuntimeSession>, RuntimeError>;
 }

--- a/crates/gigastt-core/src/runtime/mock/mod.rs
+++ b/crates/gigastt-core/src/runtime/mock/mod.rs
@@ -1,0 +1,4 @@
+pub mod session;
+
+#[allow(unused_imports)]
+pub use session::{MockFactory, MockRuntime, MockSession};

--- a/crates/gigastt-core/src/runtime/mock/session.rs
+++ b/crates/gigastt-core/src/runtime/mock/session.rs
@@ -1,0 +1,218 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::runtime::{
+    error::RuntimeError,
+    factory::{Runtime, RuntimeFactory},
+    session::RuntimeSession,
+    tensor::{Shape, Tensor},
+};
+
+/// Factory that builds a [`MockRuntime`] from a map of scripted sessions.
+///
+/// Each entry is keyed by the stem of the model path the engine will load,
+/// e.g. `v3_rnnt_encoder` for `/path/v3_rnnt_encoder.onnx`.
+#[derive(Clone, Default)]
+pub struct MockFactory {
+    sessions: HashMap<String, Arc<MockSession>>,
+}
+
+#[allow(dead_code)]
+impl MockFactory {
+    pub fn new(sessions: HashMap<String, Arc<MockSession>>) -> Self {
+        Self { sessions }
+    }
+}
+
+impl RuntimeFactory for MockFactory {
+    fn create(&self, _intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
+        Ok(Box::new(MockRuntime {
+            sessions: self.sessions.clone(),
+        }))
+    }
+}
+
+/// Mock runtime that hands out pre-configured [`MockSession`]s by path stem.
+#[derive(Clone)]
+pub struct MockRuntime {
+    sessions: HashMap<String, Arc<MockSession>>,
+}
+
+impl Runtime for MockRuntime {
+    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let key = model_path
+            .file_stem()
+            .ok_or_else(|| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: "empty path".into(),
+            })?
+            .to_string_lossy()
+            .to_string();
+        let session = self
+            .sessions
+            .get(&key)
+            .ok_or_else(|| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: format!("no mock for {key}"),
+            })?
+            .clone();
+        Ok(Box::new((*session).clone()))
+    }
+}
+
+/// Mock ONNX session that validates input shapes and returns pre-recorded outputs.
+///
+/// Intended for unit tests that exercise the engine and decode loop without
+/// loading real model files.
+pub struct MockSession {
+    pub expected_inputs: Vec<Shape>,
+    pub outputs: Vec<Tensor>,
+    call_count: AtomicUsize,
+}
+
+#[allow(dead_code)]
+impl MockSession {
+    pub fn new(expected_inputs: Vec<Shape>, outputs: Vec<Tensor>) -> Self {
+        Self {
+            expected_inputs,
+            outputs,
+            call_count: AtomicUsize::new(0),
+        }
+    }
+
+    /// Number of times [`RuntimeSession::run`] has been called on this session.
+    pub fn call_count(&self) -> usize {
+        self.call_count.load(Ordering::Relaxed)
+    }
+}
+
+impl Clone for MockSession {
+    fn clone(&self) -> Self {
+        Self {
+            expected_inputs: self.expected_inputs.clone(),
+            outputs: self.outputs.clone(),
+            call_count: AtomicUsize::new(self.call_count.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+impl RuntimeSession for MockSession {
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        if inputs.len() != self.expected_inputs.len() {
+            return Err(RuntimeError::InvalidInputCount {
+                expected: self.expected_inputs.len(),
+                got: inputs.len(),
+            });
+        }
+        for (actual, expected) in inputs.iter().zip(self.expected_inputs.iter()) {
+            if actual.shape() != expected {
+                return Err(RuntimeError::InvalidShape {
+                    expected: expected.clone(),
+                    got: actual.shape().clone(),
+                });
+            }
+        }
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        Ok(self.outputs.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::tensor::TensorData;
+
+    #[test]
+    fn test_mock_session_returns_recorded_outputs() {
+        let session = MockSession::new(
+            vec![Shape::new(vec![1, 2])],
+            vec![Tensor::new(
+                Shape::new(vec![1]),
+                TensorData::F32(vec![42.0]),
+            )],
+        );
+        let input = Tensor::new(Shape::new(vec![1, 2]), TensorData::F32(vec![0.0, 0.0]));
+        let outputs = session.run(&[input]).unwrap();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(session.call_count(), 1);
+    }
+
+    #[test]
+    fn test_mock_session_rejects_mismatched_shape() {
+        let session = MockSession::new(
+            vec![Shape::new(vec![1, 2])],
+            vec![Tensor::new(
+                Shape::new(vec![1]),
+                TensorData::F32(vec![42.0]),
+            )],
+        );
+        let input = Tensor::new(Shape::new(vec![1, 3]), TensorData::F32(vec![0.0; 3]));
+        let err = session.run(&[input]).unwrap_err();
+        match err {
+            RuntimeError::InvalidShape { expected, got } => {
+                assert_eq!(expected.dims(), &[1, 2]);
+                assert_eq!(got.dims(), &[1, 3]);
+            }
+            other => panic!("expected InvalidShape, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_mock_session_rejects_wrong_input_count() {
+        let session = MockSession::new(
+            vec![Shape::new(vec![1]), Shape::new(vec![1])],
+            vec![Tensor::new(
+                Shape::new(vec![1]),
+                TensorData::F32(vec![42.0]),
+            )],
+        );
+        let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0]));
+        let err = session.run(&[input]).unwrap_err();
+        match err {
+            RuntimeError::InvalidInputCount { expected, got } => {
+                assert_eq!(expected, 2);
+                assert_eq!(got, 1);
+            }
+            other => panic!("expected InvalidInputCount, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_mock_runtime_loads_session_by_stem() {
+        let mut sessions = HashMap::new();
+        sessions.insert(
+            "encoder".into(),
+            Arc::new(MockSession::new(
+                vec![Shape::new(vec![1])],
+                vec![Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![1.0]))],
+            )),
+        );
+        let runtime = MockRuntime { sessions };
+        let session = runtime
+            .load_session(Path::new("/models/encoder.onnx"))
+            .expect("load by stem");
+        let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0]));
+        let outputs = session.run(&[input]).unwrap();
+        assert_eq!(outputs.len(), 1);
+    }
+
+    #[test]
+    fn test_mock_runtime_missing_session_fails() {
+        let runtime = MockRuntime {
+            sessions: HashMap::new(),
+        };
+        let result = runtime.load_session(Path::new("/models/missing.onnx"));
+        let err = match result {
+            Ok(_) => panic!("expected load to fail"),
+            Err(e) => e,
+        };
+        match err {
+            RuntimeError::LoadFailed { message, .. } => {
+                assert!(message.contains("no mock for missing"));
+            }
+            other => panic!("expected LoadFailed, got {other:?}"),
+        }
+    }
+}

--- a/crates/gigastt-core/src/runtime/mock/session.rs
+++ b/crates/gigastt-core/src/runtime/mock/session.rs
@@ -32,6 +32,12 @@ impl RuntimeFactory for MockFactory {
             sessions: self.sessions.clone(),
         }))
     }
+
+    fn cpu_fallback(&self) -> Box<dyn RuntimeFactory> {
+        Box::new(MockFactory {
+            sessions: self.sessions.clone(),
+        })
+    }
 }
 
 /// Mock runtime that hands out pre-configured [`MockSession`]s by path stem.
@@ -41,7 +47,11 @@ pub struct MockRuntime {
 }
 
 impl Runtime for MockRuntime {
-    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+    fn load_session(
+        &self,
+        model_path: &Path,
+        _is_encoder: bool,
+    ) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
         let key = model_path
             .file_stem()
             .ok_or_else(|| RuntimeError::LoadFailed {
@@ -182,7 +192,7 @@ mod tests {
         );
         let runtime = MockRuntime { sessions };
         let session = runtime
-            .load_session(Path::new("/models/encoder.onnx"))
+            .load_session(Path::new("/models/encoder.onnx"), true)
             .expect("load by stem");
         let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0])).unwrap();
         let outputs = session.run(&[input]).unwrap();
@@ -194,7 +204,7 @@ mod tests {
         let runtime = MockRuntime {
             sessions: HashMap::new(),
         };
-        let result = runtime.load_session(Path::new("/models/missing.onnx"));
+        let result = runtime.load_session(Path::new("/models/missing.onnx"), false);
         let err = match result {
             Ok(_) => panic!("expected load to fail"),
             Err(e) => e,

--- a/crates/gigastt-core/src/runtime/mock/session.rs
+++ b/crates/gigastt-core/src/runtime/mock/session.rs
@@ -128,12 +128,9 @@ mod tests {
     fn test_mock_session_returns_recorded_outputs() {
         let session = MockSession::new(
             vec![Shape::new(vec![1, 2])],
-            vec![Tensor::new(
-                Shape::new(vec![1]),
-                TensorData::F32(vec![42.0]),
-            )],
+            vec![Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![42.0])).unwrap()],
         );
-        let input = Tensor::new(Shape::new(vec![1, 2]), TensorData::F32(vec![0.0, 0.0]));
+        let input = Tensor::new(Shape::new(vec![1, 2]), TensorData::F32(vec![0.0, 0.0])).unwrap();
         let outputs = session.run(&[input]).unwrap();
         assert_eq!(outputs.len(), 1);
         assert_eq!(session.call_count(), 1);
@@ -143,12 +140,9 @@ mod tests {
     fn test_mock_session_rejects_mismatched_shape() {
         let session = MockSession::new(
             vec![Shape::new(vec![1, 2])],
-            vec![Tensor::new(
-                Shape::new(vec![1]),
-                TensorData::F32(vec![42.0]),
-            )],
+            vec![Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![42.0])).unwrap()],
         );
-        let input = Tensor::new(Shape::new(vec![1, 3]), TensorData::F32(vec![0.0; 3]));
+        let input = Tensor::new(Shape::new(vec![1, 3]), TensorData::F32(vec![0.0; 3])).unwrap();
         let err = session.run(&[input]).unwrap_err();
         match err {
             RuntimeError::InvalidShape { expected, got } => {
@@ -163,12 +157,9 @@ mod tests {
     fn test_mock_session_rejects_wrong_input_count() {
         let session = MockSession::new(
             vec![Shape::new(vec![1]), Shape::new(vec![1])],
-            vec![Tensor::new(
-                Shape::new(vec![1]),
-                TensorData::F32(vec![42.0]),
-            )],
+            vec![Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![42.0])).unwrap()],
         );
-        let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0]));
+        let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0])).unwrap();
         let err = session.run(&[input]).unwrap_err();
         match err {
             RuntimeError::InvalidInputCount { expected, got } => {
@@ -186,14 +177,14 @@ mod tests {
             "encoder".into(),
             Arc::new(MockSession::new(
                 vec![Shape::new(vec![1])],
-                vec![Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![1.0]))],
+                vec![Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![1.0])).unwrap()],
             )),
         );
         let runtime = MockRuntime { sessions };
         let session = runtime
             .load_session(Path::new("/models/encoder.onnx"))
             .expect("load by stem");
-        let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0]));
+        let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0])).unwrap();
         let outputs = session.run(&[input]).unwrap();
         assert_eq!(outputs.len(), 1);
     }

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -1,12 +1,13 @@
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 pub mod error;
 pub mod factory;
 pub mod session;
 pub mod tensor;
 
+#[expect(unused_imports)]
 pub use error::RuntimeError;
+#[expect(unused_imports)]
 pub use factory::{Runtime, RuntimeFactory};
+#[expect(unused_imports)]
 pub use session::RuntimeSession;
+#[expect(unused_imports)]
 pub use tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView, TensorView};

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -1,0 +1,12 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+pub mod error;
+pub mod factory;
+pub mod session;
+pub mod tensor;
+
+pub use error::RuntimeError;
+pub use factory::{Runtime, RuntimeFactory};
+pub use session::RuntimeSession;
+pub use tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView, TensorView};

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod factory;
+pub mod mock;
 pub mod ort;
 pub mod session;
 pub mod tensor;

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -4,11 +4,11 @@ pub mod ort;
 pub mod session;
 pub mod tensor;
 
-#[expect(unused_imports)]
+#[allow(unused_imports)]
 pub use error::RuntimeError;
-#[expect(unused_imports)]
+#[allow(unused_imports)]
 pub use factory::{Runtime, RuntimeFactory};
-#[expect(unused_imports)]
+#[allow(unused_imports)]
 pub use session::RuntimeSession;
-#[expect(unused_imports)]
+#[allow(unused_imports)]
 pub use tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView, TensorView};

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod factory;
+pub mod ort;
 pub mod session;
 pub mod tensor;
 

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -10,6 +10,8 @@ pub use error::RuntimeError;
 #[allow(unused_imports)]
 pub use factory::{Runtime, RuntimeFactory};
 #[allow(unused_imports)]
+pub use ort::factory::{cpu_factory, production_factory};
+#[allow(unused_imports)]
 pub use session::RuntimeSession;
 #[allow(unused_imports)]
 pub use tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView, TensorView};

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
-use std::sync::OnceLock;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 
 use crate::runtime::{
     error::RuntimeError,
@@ -22,53 +23,95 @@ pub enum OrtExecutionProvider {
 }
 
 impl OrtExecutionProvider {
-    pub(crate) fn to_ort(self) -> ort::ep::ExecutionProviderDispatch {
+    /// Returns the execution-provider list to register when loading a session.
+    ///
+    /// `model_path` is used to derive provider-specific cache directories (e.g.
+    /// CoreML's `coreml_cache/` next to the model).
+    pub(crate) fn execution_providers(
+        self,
+        model_path: &Path,
+    ) -> Vec<ort::ep::ExecutionProviderDispatch> {
         match self {
-            Self::Cpu => ort::ep::CPU::default().build(),
-            #[cfg(feature = "coreml")]
-            Self::CoreML => ort::ep::CoreML::default().build(),
-            #[cfg(not(feature = "coreml"))]
-            Self::CoreML => ort::ep::CPU::default().build(),
-            #[cfg(feature = "cuda")]
-            Self::Cuda => ort::ep::CUDA::default().build(),
-            #[cfg(not(feature = "cuda"))]
-            Self::Cuda => ort::ep::CPU::default().build(),
-            #[cfg(feature = "nnapi")]
-            Self::Nnapi => ort::ep::NNAPI::default().build(),
-            #[cfg(not(feature = "nnapi"))]
-            Self::Nnapi => ort::ep::CPU::default().build(),
+            Self::Cpu => vec![ort::ep::CPU::default().build()],
+            Self::CoreML => {
+                let cache_dir = model_path
+                    .parent()
+                    .map(|p| p.join("coreml_cache"))
+                    .unwrap_or_else(|| PathBuf::from("coreml_cache"));
+                let coreml_ep = ort::ep::CoreML::default()
+                    .with_model_format(ort::ep::coreml::ModelFormat::MLProgram)
+                    .with_static_input_shapes(true)
+                    .with_compute_units(ort::ep::coreml::ComputeUnits::CPUAndNeuralEngine)
+                    .with_specialization_strategy(
+                        ort::ep::coreml::SpecializationStrategy::FastPrediction,
+                    )
+                    .with_model_cache_dir(cache_dir.to_string_lossy())
+                    .build();
+                vec![coreml_ep, ort::ep::CPU::default().build()]
+            }
+            Self::Cuda => vec![
+                ort::ep::CUDA::default().build(),
+                ort::ep::CPU::default().build(),
+            ],
+            Self::Nnapi => vec![
+                ort::ep::NNAPI::default().build(),
+                ort::ep::CPU::default().build(),
+            ],
         }
+    }
+
+    /// Whether this provider is the plain CPU execution provider.
+    pub(crate) fn is_cpu(self) -> bool {
+        matches!(self, Self::Cpu)
+            || (!cfg!(feature = "coreml") && matches!(self, Self::CoreML))
+            || (!cfg!(feature = "cuda") && matches!(self, Self::Cuda))
+            || (!cfg!(feature = "nnapi") && matches!(self, Self::Nnapi))
     }
 }
 
 /// Factory that creates an `ort` runtime configured for a specific provider.
 pub struct OrtFactory {
     provider: OrtExecutionProvider,
+    prepacked: Option<Arc<ort::session::builder::PrepackedWeights>>,
+    optimized_cache_dir: Option<PathBuf>,
 }
 
 impl OrtFactory {
-    pub fn cpu() -> Self {
+    fn with_provider(provider: OrtExecutionProvider) -> Self {
         Self {
-            provider: OrtExecutionProvider::Cpu,
+            provider,
+            prepacked: None,
+            optimized_cache_dir: None,
         }
+    }
+
+    pub fn cpu() -> Self {
+        Self::with_provider(OrtExecutionProvider::Cpu)
     }
 
     pub fn coreml() -> Self {
-        Self {
-            provider: OrtExecutionProvider::CoreML,
-        }
+        Self::with_provider(OrtExecutionProvider::CoreML)
     }
 
     pub fn cuda() -> Self {
-        Self {
-            provider: OrtExecutionProvider::Cuda,
-        }
+        Self::with_provider(OrtExecutionProvider::Cuda)
     }
 
     pub fn nnapi() -> Self {
-        Self {
-            provider: OrtExecutionProvider::Nnapi,
-        }
+        Self::with_provider(OrtExecutionProvider::Nnapi)
+    }
+
+    pub fn with_prepacked_weights(
+        mut self,
+        prepacked: Arc<ort::session::builder::PrepackedWeights>,
+    ) -> Self {
+        self.prepacked = Some(prepacked);
+        self
+    }
+
+    pub fn with_optimized_cache_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.optimized_cache_dir = Some(dir.into());
+        self
     }
 }
 
@@ -86,13 +129,17 @@ fn ensure_ort_initialized() {
 impl RuntimeFactory for OrtFactory {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
         ensure_ort_initialized();
-        Ok(Box::new(OrtRuntime::new(intra_threads, self.provider)))
+        Ok(Box::new(OrtRuntime::new(
+            intra_threads,
+            self.provider,
+            self.prepacked.clone(),
+            self.optimized_cache_dir.clone(),
+        )))
     }
 }
 
 /// Returns the default `ort` factory for the active compile-time feature flags.
-pub fn default_factory(intra_threads: usize) -> Box<dyn RuntimeFactory> {
-    let _ = intra_threads;
+pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
     if cfg!(feature = "coreml") {
         Box::new(OrtFactory::coreml())
     } else if cfg!(feature = "cuda") {
@@ -102,4 +149,17 @@ pub fn default_factory(intra_threads: usize) -> Box<dyn RuntimeFactory> {
     } else {
         Box::new(OrtFactory::cpu())
     }
+}
+
+/// Returns a production `ort` factory that preserves the provider selection and
+/// disk-cache layout used by the engine before the runtime abstraction.
+pub fn production_factory(model_dir: &Path) -> Box<dyn RuntimeFactory> {
+    let factory = if cfg!(feature = "coreml") {
+        OrtFactory::coreml()
+    } else if cfg!(feature = "cuda") {
+        OrtFactory::cuda()
+    } else {
+        OrtFactory::cpu().with_optimized_cache_dir(model_dir.join("optimized_cache"))
+    };
+    Box::new(factory)
 }

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -1,0 +1,98 @@
+use crate::runtime::{
+    error::RuntimeError,
+    factory::{Runtime, RuntimeFactory},
+};
+
+use super::session::OrtRuntime;
+
+/// `ort` execution provider selector.
+#[derive(Clone)]
+#[allow(dead_code)]
+pub enum OrtExecutionProvider {
+    Cpu,
+    #[cfg(feature = "coreml")]
+    CoreML,
+    #[cfg(feature = "cuda")]
+    Cuda,
+    #[cfg(feature = "nnapi")]
+    Nnapi,
+}
+
+impl OrtExecutionProvider {
+    fn to_ort(&self) -> ort::ep::ExecutionProviderDispatch {
+        match self {
+            Self::Cpu => ort::ep::CPU::default().build(),
+            #[cfg(feature = "coreml")]
+            Self::CoreML => ort::ep::CoreML::default().build(),
+            #[cfg(feature = "cuda")]
+            Self::Cuda => ort::ep::CUDA::default().build(),
+            #[cfg(feature = "nnapi")]
+            Self::Nnapi => ort::ep::NNAPI::default().build(),
+        }
+    }
+}
+
+/// Factory that creates an `ort` runtime configured for a specific provider.
+#[allow(dead_code)]
+pub struct OrtFactory {
+    provider: OrtExecutionProvider,
+}
+
+impl OrtFactory {
+    #[allow(dead_code)]
+    pub fn cpu() -> Self {
+        Self {
+            provider: OrtExecutionProvider::Cpu,
+        }
+    }
+
+    #[cfg(feature = "coreml")]
+    #[allow(dead_code)]
+    pub fn coreml() -> Self {
+        Self {
+            provider: OrtExecutionProvider::CoreML,
+        }
+    }
+
+    #[cfg(feature = "cuda")]
+    #[allow(dead_code)]
+    pub fn cuda() -> Self {
+        Self {
+            provider: OrtExecutionProvider::Cuda,
+        }
+    }
+
+    #[cfg(feature = "nnapi")]
+    #[allow(dead_code)]
+    pub fn nnapi() -> Self {
+        Self {
+            provider: OrtExecutionProvider::Nnapi,
+        }
+    }
+}
+
+impl RuntimeFactory for OrtFactory {
+    fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
+        ort::init()
+            .with_name("gigastt")
+            .with_execution_providers([self.provider.to_ort()])
+            .commit();
+        Ok(Box::new(OrtRuntime::new(
+            intra_threads,
+            self.provider.to_ort(),
+        )))
+    }
+}
+
+/// Returns the default `ort` factory for the active compile-time feature flags.
+#[allow(dead_code)]
+pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
+    #[cfg(feature = "coreml")]
+    return Box::new(OrtFactory::coreml());
+    #[cfg(feature = "cuda")]
+    return Box::new(OrtFactory::cuda());
+    #[cfg(feature = "nnapi")]
+    return Box::new(OrtFactory::nnapi());
+    #[cfg(not(any(feature = "coreml", feature = "cuda", feature = "nnapi")))]
+    Box::new(OrtFactory::cpu())
+}

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -1,3 +1,7 @@
+#![allow(dead_code)]
+
+use std::sync::OnceLock;
+
 use crate::runtime::{
     error::RuntimeError,
     factory::{Runtime, RuntimeFactory},
@@ -5,65 +9,62 @@ use crate::runtime::{
 
 use super::session::OrtRuntime;
 
+#[cfg(all(feature = "coreml", feature = "cuda"))]
+compile_error!("features `coreml` and `cuda` are mutually exclusive");
+
 /// `ort` execution provider selector.
-#[derive(Clone)]
-#[allow(dead_code)]
+#[derive(Clone, Copy)]
 pub enum OrtExecutionProvider {
     Cpu,
-    #[cfg(feature = "coreml")]
     CoreML,
-    #[cfg(feature = "cuda")]
     Cuda,
-    #[cfg(feature = "nnapi")]
     Nnapi,
 }
 
 impl OrtExecutionProvider {
-    fn to_ort(&self) -> ort::ep::ExecutionProviderDispatch {
+    pub(crate) fn to_ort(self) -> ort::ep::ExecutionProviderDispatch {
         match self {
             Self::Cpu => ort::ep::CPU::default().build(),
             #[cfg(feature = "coreml")]
             Self::CoreML => ort::ep::CoreML::default().build(),
+            #[cfg(not(feature = "coreml"))]
+            Self::CoreML => ort::ep::CPU::default().build(),
             #[cfg(feature = "cuda")]
             Self::Cuda => ort::ep::CUDA::default().build(),
+            #[cfg(not(feature = "cuda"))]
+            Self::Cuda => ort::ep::CPU::default().build(),
             #[cfg(feature = "nnapi")]
             Self::Nnapi => ort::ep::NNAPI::default().build(),
+            #[cfg(not(feature = "nnapi"))]
+            Self::Nnapi => ort::ep::CPU::default().build(),
         }
     }
 }
 
 /// Factory that creates an `ort` runtime configured for a specific provider.
-#[allow(dead_code)]
 pub struct OrtFactory {
     provider: OrtExecutionProvider,
 }
 
 impl OrtFactory {
-    #[allow(dead_code)]
     pub fn cpu() -> Self {
         Self {
             provider: OrtExecutionProvider::Cpu,
         }
     }
 
-    #[cfg(feature = "coreml")]
-    #[allow(dead_code)]
     pub fn coreml() -> Self {
         Self {
             provider: OrtExecutionProvider::CoreML,
         }
     }
 
-    #[cfg(feature = "cuda")]
-    #[allow(dead_code)]
     pub fn cuda() -> Self {
         Self {
             provider: OrtExecutionProvider::Cuda,
         }
     }
 
-    #[cfg(feature = "nnapi")]
-    #[allow(dead_code)]
     pub fn nnapi() -> Self {
         Self {
             provider: OrtExecutionProvider::Nnapi,
@@ -71,28 +72,34 @@ impl OrtFactory {
     }
 }
 
+static ORT_INIT: OnceLock<bool> = OnceLock::new();
+
+fn ensure_ort_initialized() {
+    let initialized_by_us = ORT_INIT.get_or_init(|| ort::init().with_name("gigastt").commit());
+    if !initialized_by_us {
+        tracing::warn!(
+            "ort environment was already configured before gigastt initialization; execution provider settings may not apply"
+        );
+    }
+}
+
 impl RuntimeFactory for OrtFactory {
     fn create(&self, intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
-        ort::init()
-            .with_name("gigastt")
-            .with_execution_providers([self.provider.to_ort()])
-            .commit();
-        Ok(Box::new(OrtRuntime::new(
-            intra_threads,
-            self.provider.to_ort(),
-        )))
+        ensure_ort_initialized();
+        Ok(Box::new(OrtRuntime::new(intra_threads, self.provider)))
     }
 }
 
 /// Returns the default `ort` factory for the active compile-time feature flags.
-#[allow(dead_code)]
-pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
-    #[cfg(feature = "coreml")]
-    return Box::new(OrtFactory::coreml());
-    #[cfg(feature = "cuda")]
-    return Box::new(OrtFactory::cuda());
-    #[cfg(feature = "nnapi")]
-    return Box::new(OrtFactory::nnapi());
-    #[cfg(not(any(feature = "coreml", feature = "cuda", feature = "nnapi")))]
-    Box::new(OrtFactory::cpu())
+pub fn default_factory(intra_threads: usize) -> Box<dyn RuntimeFactory> {
+    let _ = intra_threads;
+    if cfg!(feature = "coreml") {
+        Box::new(OrtFactory::coreml())
+    } else if cfg!(feature = "cuda") {
+        Box::new(OrtFactory::cuda())
+    } else if cfg!(feature = "nnapi") {
+        Box::new(OrtFactory::nnapi())
+    } else {
+        Box::new(OrtFactory::cpu())
+    }
 }

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -133,10 +133,14 @@ impl RuntimeFactory for OrtFactory {
             self.optimized_cache_dir.clone(),
         )))
     }
+
+    fn cpu_fallback(&self) -> Box<dyn RuntimeFactory> {
+        Box::new(OrtFactory::cpu())
+    }
 }
 
 /// Returns the default `ort` factory for the active compile-time feature flags.
-pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
+pub fn default_factory() -> Box<dyn RuntimeFactory> {
     if cfg!(feature = "coreml") {
         Box::new(OrtFactory::coreml())
     } else if cfg!(feature = "cuda") {
@@ -146,6 +150,11 @@ pub fn default_factory(_intra_threads: usize) -> Box<dyn RuntimeFactory> {
     } else {
         Box::new(OrtFactory::cpu())
     }
+}
+
+/// Returns a CPU-only `ort` factory for auxiliary models.
+pub fn cpu_factory() -> Box<dyn RuntimeFactory> {
+    Box::new(OrtFactory::cpu())
 }
 
 /// Returns a production `ort` factory that preserves the provider selection and

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -63,9 +63,6 @@ impl OrtExecutionProvider {
     /// Whether this provider is the plain CPU execution provider.
     pub(crate) fn is_cpu(self) -> bool {
         matches!(self, Self::Cpu)
-            || (!cfg!(feature = "coreml") && matches!(self, Self::CoreML))
-            || (!cfg!(feature = "cuda") && matches!(self, Self::Cuda))
-            || (!cfg!(feature = "nnapi") && matches!(self, Self::Nnapi))
     }
 }
 

--- a/crates/gigastt-core/src/runtime/ort/mod.rs
+++ b/crates/gigastt-core/src/runtime/ort/mod.rs
@@ -2,7 +2,7 @@ pub mod factory;
 pub mod session;
 pub mod tensor;
 
-#[expect(unused_imports)]
-pub use factory::{OrtExecutionProvider, OrtFactory, default_factory};
-#[expect(unused_imports)]
+#[allow(unused_imports)]
+pub use factory::{OrtExecutionProvider, OrtFactory, default_factory, production_factory};
+#[allow(unused_imports)]
 pub use session::{OrtRuntime, OrtSession};

--- a/crates/gigastt-core/src/runtime/ort/mod.rs
+++ b/crates/gigastt-core/src/runtime/ort/mod.rs
@@ -1,0 +1,8 @@
+pub mod factory;
+pub mod session;
+pub mod tensor;
+
+#[allow(unused_imports)]
+pub use factory::{OrtExecutionProvider, OrtFactory, default_factory};
+#[allow(unused_imports)]
+pub use session::{OrtRuntime, OrtSession};

--- a/crates/gigastt-core/src/runtime/ort/mod.rs
+++ b/crates/gigastt-core/src/runtime/ort/mod.rs
@@ -2,7 +2,7 @@ pub mod factory;
 pub mod session;
 pub mod tensor;
 
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 pub use factory::{OrtExecutionProvider, OrtFactory, default_factory};
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 pub use session::{OrtRuntime, OrtSession};

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -7,17 +7,16 @@ use crate::runtime::{
     error::RuntimeError, factory::Runtime, session::RuntimeSession, tensor::Tensor,
 };
 
-use super::tensor::value_to_tensor;
+use super::{factory::OrtExecutionProvider, tensor::value_to_tensor};
 
 /// `ort`-backed runtime that loads sessions for a specific execution provider.
-#[allow(dead_code)]
 pub struct OrtRuntime {
     intra_threads: usize,
-    provider: ort::ep::ExecutionProviderDispatch,
+    provider: OrtExecutionProvider,
 }
 
 impl OrtRuntime {
-    pub(crate) fn new(intra_threads: usize, provider: ort::ep::ExecutionProviderDispatch) -> Self {
+    pub(crate) fn new(intra_threads: usize, provider: OrtExecutionProvider) -> Self {
         Self {
             intra_threads,
             provider,
@@ -26,7 +25,6 @@ impl OrtRuntime {
 }
 
 /// `ort`-backed session wrapping a loaded ONNX model.
-#[allow(dead_code)]
 pub struct OrtSession {
     session: Mutex<Session>,
 }
@@ -38,12 +36,12 @@ impl Runtime for OrtRuntime {
                 path: model_path.into(),
                 message: e.to_string(),
             })?
-            .with_intra_threads(self.intra_threads)
+            .with_execution_providers([self.provider.to_ort()])
             .map_err(|e| RuntimeError::LoadFailed {
                 path: model_path.into(),
                 message: e.to_string(),
             })?
-            .with_execution_providers([self.provider.clone()])
+            .with_intra_threads(self.intra_threads)
             .map_err(|e| RuntimeError::LoadFailed {
                 path: model_path.into(),
                 message: e.to_string(),
@@ -68,7 +66,10 @@ impl RuntimeSession for OrtSession {
         let session_inputs: Vec<ort::session::SessionInputValue<'_>> =
             ort_inputs.into_iter().map(Into::into).collect();
 
-        let mut session = self.session.lock().expect("ort session mutex poisoned");
+        let mut session = self
+            .session
+            .lock()
+            .map_err(|_| RuntimeError::InferenceFailed("ort session mutex poisoned".into()))?;
         let outputs = session
             .run(&session_inputs[..])
             .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use ort::session::Session;
 
@@ -13,48 +13,89 @@ use super::{factory::OrtExecutionProvider, tensor::value_to_tensor};
 pub struct OrtRuntime {
     intra_threads: usize,
     provider: OrtExecutionProvider,
+    prepacked: Option<Arc<ort::session::builder::PrepackedWeights>>,
+    optimized_cache_dir: Option<std::path::PathBuf>,
 }
 
 impl OrtRuntime {
-    pub(crate) fn new(intra_threads: usize, provider: OrtExecutionProvider) -> Self {
+    pub(crate) fn new(
+        intra_threads: usize,
+        provider: OrtExecutionProvider,
+        prepacked: Option<Arc<ort::session::builder::PrepackedWeights>>,
+        optimized_cache_dir: Option<std::path::PathBuf>,
+    ) -> Self {
         Self {
             intra_threads,
             provider,
+            prepacked,
+            optimized_cache_dir,
         }
+    }
+}
+
+fn load_failed(path: &Path, e: impl std::fmt::Display) -> RuntimeError {
+    RuntimeError::LoadFailed {
+        path: path.into(),
+        message: e.to_string(),
+    }
+}
+
+impl Runtime for OrtRuntime {
+    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let is_encoder = model_path
+            .file_stem()
+            .map(|s| {
+                let s = s.to_string_lossy().to_lowercase();
+                s.contains("encoder")
+            })
+            .unwrap_or(false);
+
+        let mut builder = Session::builder().map_err(|e| load_failed(model_path, e))?;
+
+        if let Some(prepacked) = self.prepacked.as_ref() {
+            builder = builder
+                .with_prepacked_weights(prepacked)
+                .map_err(|e| load_failed(model_path, e))?;
+        }
+
+        let eps = self.provider.execution_providers(model_path);
+        builder = builder
+            .with_execution_providers(&eps)
+            .map_err(|e| load_failed(model_path, e))?;
+
+        if self.provider.is_cpu() {
+            let intra_threads = if is_encoder {
+                self.intra_threads.max(1)
+            } else {
+                1
+            };
+            builder = builder
+                .with_intra_threads(intra_threads)
+                .map_err(|e| load_failed(model_path, e))?;
+            builder = builder
+                .with_inter_threads(1)
+                .map_err(|e| load_failed(model_path, e))?;
+
+            if is_encoder && let Some(cache_dir) = &self.optimized_cache_dir {
+                std::fs::create_dir_all(cache_dir).map_err(|e| load_failed(model_path, e))?;
+                builder = builder
+                    .with_optimized_model_path(cache_dir.join("encoder_optimized.onnx"))
+                    .map_err(|e| load_failed(model_path, e))?;
+            }
+        }
+
+        let session = builder
+            .commit_from_file(model_path)
+            .map_err(|e| load_failed(model_path, e))?;
+        Ok(Box::new(OrtSession {
+            session: Mutex::new(session),
+        }))
     }
 }
 
 /// `ort`-backed session wrapping a loaded ONNX model.
 pub struct OrtSession {
     session: Mutex<Session>,
-}
-
-impl Runtime for OrtRuntime {
-    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
-        let session = Session::builder()
-            .map_err(|e| RuntimeError::LoadFailed {
-                path: model_path.into(),
-                message: e.to_string(),
-            })?
-            .with_execution_providers([self.provider.to_ort()])
-            .map_err(|e| RuntimeError::LoadFailed {
-                path: model_path.into(),
-                message: e.to_string(),
-            })?
-            .with_intra_threads(self.intra_threads)
-            .map_err(|e| RuntimeError::LoadFailed {
-                path: model_path.into(),
-                message: e.to_string(),
-            })?
-            .commit_from_file(model_path)
-            .map_err(|e| RuntimeError::LoadFailed {
-                path: model_path.into(),
-                message: e.to_string(),
-            })?;
-        Ok(Box::new(OrtSession {
-            session: Mutex::new(session),
-        }))
-    }
 }
 
 impl RuntimeSession for OrtSession {

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -99,13 +99,11 @@ pub struct OrtSession {
 }
 
 impl RuntimeSession for OrtSession {
-    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError> {
-        let ort_inputs: Vec<ort::value::Value> = inputs
-            .into_iter()
-            .map(Tensor::into_ort_value)
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        let session_inputs: Vec<ort::session::SessionInputValue<'_>> = inputs
+            .iter()
+            .map(Tensor::as_ort_input)
             .collect::<Result<_, _>>()?;
-        let session_inputs: Vec<ort::session::SessionInputValue<'_>> =
-            ort_inputs.into_iter().map(Into::into).collect();
 
         let mut session = self
             .session

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -1,0 +1,81 @@
+use std::path::Path;
+use std::sync::Mutex;
+
+use ort::session::Session;
+
+use crate::runtime::{
+    error::RuntimeError, factory::Runtime, session::RuntimeSession, tensor::Tensor,
+};
+
+use super::tensor::value_to_tensor;
+
+/// `ort`-backed runtime that loads sessions for a specific execution provider.
+#[allow(dead_code)]
+pub struct OrtRuntime {
+    intra_threads: usize,
+    provider: ort::ep::ExecutionProviderDispatch,
+}
+
+impl OrtRuntime {
+    pub(crate) fn new(intra_threads: usize, provider: ort::ep::ExecutionProviderDispatch) -> Self {
+        Self {
+            intra_threads,
+            provider,
+        }
+    }
+}
+
+/// `ort`-backed session wrapping a loaded ONNX model.
+#[allow(dead_code)]
+pub struct OrtSession {
+    session: Mutex<Session>,
+}
+
+impl Runtime for OrtRuntime {
+    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        let session = Session::builder()
+            .map_err(|e| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: e.to_string(),
+            })?
+            .with_intra_threads(self.intra_threads)
+            .map_err(|e| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: e.to_string(),
+            })?
+            .with_execution_providers([self.provider.clone()])
+            .map_err(|e| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: e.to_string(),
+            })?
+            .commit_from_file(model_path)
+            .map_err(|e| RuntimeError::LoadFailed {
+                path: model_path.into(),
+                message: e.to_string(),
+            })?;
+        Ok(Box::new(OrtSession {
+            session: Mutex::new(session),
+        }))
+    }
+}
+
+impl RuntimeSession for OrtSession {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError> {
+        let ort_inputs: Vec<ort::value::Value> = inputs
+            .into_iter()
+            .map(Tensor::into_ort_value)
+            .collect::<Result<_, _>>()?;
+        let session_inputs: Vec<ort::session::SessionInputValue<'_>> =
+            ort_inputs.into_iter().map(Into::into).collect();
+
+        let mut session = self.session.lock().expect("ort session mutex poisoned");
+        let outputs = session
+            .run(&session_inputs[..])
+            .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+
+        outputs
+            .into_iter()
+            .map(|(_name, value)| value_to_tensor(value))
+            .collect()
+    }
+}

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -78,8 +78,12 @@ impl Runtime for OrtRuntime {
 
             if is_encoder && let Some(cache_dir) = &self.optimized_cache_dir {
                 std::fs::create_dir_all(cache_dir).map_err(|e| load_failed(model_path, e))?;
+                let stem = model_path
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "encoder".into());
                 builder = builder
-                    .with_optimized_model_path(cache_dir.join("encoder_optimized.onnx"))
+                    .with_optimized_model_path(cache_dir.join(format!("{stem}_optimized.onnx")))
                     .map_err(|e| load_failed(model_path, e))?;
             }
         }

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -41,15 +41,11 @@ fn load_failed(path: &Path, e: impl std::fmt::Display) -> RuntimeError {
 }
 
 impl Runtime for OrtRuntime {
-    fn load_session(&self, model_path: &Path) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
-        let is_encoder = model_path
-            .file_stem()
-            .map(|s| {
-                let s = s.to_string_lossy().to_lowercase();
-                s.contains("encoder")
-            })
-            .unwrap_or(false);
-
+    fn load_session(
+        &self,
+        model_path: &Path,
+        is_encoder: bool,
+    ) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
         let mut builder = Session::builder().map_err(|e| load_failed(model_path, e))?;
 
         if let Some(prepacked) = self.prepacked.as_ref() {

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -1,8 +1,8 @@
-use ort::value::Value;
+use ort::value::{TensorElementType, Value};
 
 use crate::runtime::{
     error::RuntimeError,
-    tensor::{Shape, Tensor, TensorData},
+    tensor::{ElementType, Shape, Tensor, TensorData},
 };
 
 impl Tensor {
@@ -23,10 +23,31 @@ impl Tensor {
     }
 }
 
+/// Attempts to map an `ort` tensor element type to our normalized `ElementType`.
+///
+/// Returns `None` for types that have no equivalent in our abstraction (e.g. strings
+/// or exotic float formats).
+fn element_type_from_ort(ort_type: TensorElementType) -> Option<ElementType> {
+    match ort_type {
+        TensorElementType::Float32 => Some(ElementType::F32),
+        TensorElementType::Int32 => Some(ElementType::I32),
+        TensorElementType::Int64 => Some(ElementType::I64),
+        TensorElementType::Float64 => Some(ElementType::F64),
+        TensorElementType::Int8 => Some(ElementType::I8),
+        TensorElementType::Uint8 => Some(ElementType::U8),
+        TensorElementType::Int16 => Some(ElementType::I16),
+        TensorElementType::Uint16 => Some(ElementType::U16),
+        TensorElementType::Uint32 => Some(ElementType::U32),
+        TensorElementType::Uint64 => Some(ElementType::U64),
+        TensorElementType::Bool => Some(ElementType::Bool),
+        _ => None,
+    }
+}
+
 /// Converts an `ort` tensor value into our owned tensor type.
 pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
-    match value.data_type() {
-        ort::value::TensorElementType::Float32 => {
+    match *value.data_type() {
+        TensorElementType::Float32 => {
             let (shape, data) = value
                 .try_extract_tensor::<f32>()
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
@@ -35,7 +56,7 @@ pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
                 TensorData::F32(data.to_vec()),
             ))
         }
-        ort::value::TensorElementType::Int32 => {
+        TensorElementType::Int32 => {
             let (shape, data) = value
                 .try_extract_tensor::<i32>()
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
@@ -44,7 +65,7 @@ pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
                 TensorData::I32(data.to_vec()),
             ))
         }
-        ort::value::TensorElementType::Int64 => {
+        TensorElementType::Int64 => {
             let (shape, data) = value
                 .try_extract_tensor::<i64>()
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
@@ -53,9 +74,12 @@ pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
                 TensorData::I64(data.to_vec()),
             ))
         }
-        other => Err(RuntimeError::InferenceFailed(format!(
-            "unsupported element type: {other}"
-        ))),
+        other => match element_type_from_ort(other) {
+            Some(element_type) => Err(RuntimeError::UnsupportedElementType(element_type)),
+            None => Err(RuntimeError::InferenceFailed(format!(
+                "unsupported element type: {other:?}"
+            ))),
+        },
     }
 }
 

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -1,12 +1,14 @@
+use ort::session::SessionInputValue;
 use ort::value::{TensorElementType, Value};
 
 use crate::runtime::{
     error::RuntimeError,
-    tensor::{ElementType, Shape, Tensor, TensorData},
+    tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView},
 };
 
 impl Tensor {
     /// Converts this owned tensor into an `ort` value.
+    #[allow(dead_code)]
     pub fn into_ort_value(self) -> Result<Value, RuntimeError> {
         let shape: Vec<i64> = self.shape().dims().iter().map(|&d| d as i64).collect();
         match self.into_data() {
@@ -19,6 +21,34 @@ impl Tensor {
             TensorData::I64(data) => ort::value::Tensor::from_array((shape, data))
                 .map(|t| t.into_dyn())
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+        }
+    }
+
+    /// Returns a borrowed `ort` input value backed by this tensor's data.
+    ///
+    /// The returned `SessionInputValue` borrows from `self`; the caller must
+    /// keep this tensor alive for the duration of the `run` call.
+    pub fn as_ort_input(&self) -> Result<SessionInputValue<'_>, RuntimeError> {
+        let shape: Vec<i64> = self.shape().dims().iter().map(|&d| d as i64).collect();
+        match self.view().data() {
+            TensorDataView::F32(data) => {
+                let tensor_ref: ort::value::TensorRef<'_, f32> =
+                    ort::value::TensorRef::from_array_view((shape, *data))
+                        .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+                Ok(tensor_ref.into_dyn().into())
+            }
+            TensorDataView::I32(data) => {
+                let tensor_ref: ort::value::TensorRef<'_, i32> =
+                    ort::value::TensorRef::from_array_view((shape, *data))
+                        .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+                Ok(tensor_ref.into_dyn().into())
+            }
+            TensorDataView::I64(data) => {
+                let tensor_ref: ort::value::TensorRef<'_, i64> =
+                    ort::value::TensorRef::from_array_view((shape, *data))
+                        .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+                Ok(tensor_ref.into_dyn().into())
+            }
         }
     }
 }

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -1,0 +1,92 @@
+use ort::value::Value;
+
+use crate::runtime::{
+    error::RuntimeError,
+    tensor::{Shape, Tensor, TensorData},
+};
+
+impl Tensor {
+    /// Converts this owned tensor into an `ort` value.
+    pub fn into_ort_value(self) -> Result<Value, RuntimeError> {
+        let shape: Vec<i64> = self.shape().dims().iter().map(|&d| d as i64).collect();
+        match self.into_data() {
+            TensorData::F32(data) => ort::value::Tensor::from_array((shape, data))
+                .map(|t| t.into_dyn())
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+            TensorData::I32(data) => ort::value::Tensor::from_array((shape, data))
+                .map(|t| t.into_dyn())
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+            TensorData::I64(data) => ort::value::Tensor::from_array((shape, data))
+                .map(|t| t.into_dyn())
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string())),
+        }
+    }
+}
+
+/// Converts an `ort` tensor value into our owned tensor type.
+pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
+    match value.data_type() {
+        ort::value::TensorElementType::Float32 => {
+            let (shape, data) = value
+                .try_extract_tensor::<f32>()
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+            Ok(Tensor::new(
+                Shape::new(shape.iter().map(|&d| d as usize).collect()),
+                TensorData::F32(data.to_vec()),
+            ))
+        }
+        ort::value::TensorElementType::Int32 => {
+            let (shape, data) = value
+                .try_extract_tensor::<i32>()
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+            Ok(Tensor::new(
+                Shape::new(shape.iter().map(|&d| d as usize).collect()),
+                TensorData::I32(data.to_vec()),
+            ))
+        }
+        ort::value::TensorElementType::Int64 => {
+            let (shape, data) = value
+                .try_extract_tensor::<i64>()
+                .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+            Ok(Tensor::new(
+                Shape::new(shape.iter().map(|&d| d as usize).collect()),
+                TensorData::I64(data.to_vec()),
+            ))
+        }
+        other => Err(RuntimeError::InferenceFailed(format!(
+            "unsupported element type: {other}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensor_ort_roundtrip_f32() {
+        let tensor = Tensor::new(
+            Shape::new(vec![2, 3]),
+            TensorData::F32(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        );
+        let value = tensor.clone().into_ort_value().unwrap();
+        let recovered = value_to_tensor(value).unwrap();
+        assert_eq!(tensor, recovered);
+    }
+
+    #[test]
+    fn test_tensor_ort_roundtrip_i32() {
+        let tensor = Tensor::new(Shape::new(vec![3]), TensorData::I32(vec![1, 2, 3]));
+        let value = tensor.clone().into_ort_value().unwrap();
+        let recovered = value_to_tensor(value).unwrap();
+        assert_eq!(tensor, recovered);
+    }
+
+    #[test]
+    fn test_tensor_ort_roundtrip_i64() {
+        let tensor = Tensor::new(Shape::new(vec![2, 2]), TensorData::I64(vec![1, 2, 3, 4]));
+        let value = tensor.clone().into_ort_value().unwrap();
+        let recovered = value_to_tensor(value).unwrap();
+        assert_eq!(tensor, recovered);
+    }
+}

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -55,21 +55,13 @@ impl Tensor {
 
 /// Attempts to map an `ort` tensor element type to our normalized `ElementType`.
 ///
-/// Returns `None` for types that have no equivalent in our abstraction (e.g. strings
-/// or exotic float formats).
+/// Returns `None` for types that have no equivalent in our abstraction (e.g. strings,
+/// exotic float formats, or unsupported numeric widths).
 fn element_type_from_ort(ort_type: TensorElementType) -> Option<ElementType> {
     match ort_type {
         TensorElementType::Float32 => Some(ElementType::F32),
         TensorElementType::Int32 => Some(ElementType::I32),
         TensorElementType::Int64 => Some(ElementType::I64),
-        TensorElementType::Float64 => Some(ElementType::F64),
-        TensorElementType::Int8 => Some(ElementType::I8),
-        TensorElementType::Uint8 => Some(ElementType::U8),
-        TensorElementType::Int16 => Some(ElementType::I16),
-        TensorElementType::Uint16 => Some(ElementType::U16),
-        TensorElementType::Uint32 => Some(ElementType::U32),
-        TensorElementType::Uint64 => Some(ElementType::U64),
-        TensorElementType::Bool => Some(ElementType::Bool),
         _ => None,
     }
 }
@@ -81,28 +73,28 @@ pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
             let (shape, data) = value
                 .try_extract_tensor::<f32>()
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
-            Ok(Tensor::new(
+            Tensor::new(
                 Shape::new(shape.iter().map(|&d| d as usize).collect()),
                 TensorData::F32(data.to_vec()),
-            ))
+            )
         }
         TensorElementType::Int32 => {
             let (shape, data) = value
                 .try_extract_tensor::<i32>()
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
-            Ok(Tensor::new(
+            Tensor::new(
                 Shape::new(shape.iter().map(|&d| d as usize).collect()),
                 TensorData::I32(data.to_vec()),
-            ))
+            )
         }
         TensorElementType::Int64 => {
             let (shape, data) = value
                 .try_extract_tensor::<i64>()
                 .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
-            Ok(Tensor::new(
+            Tensor::new(
                 Shape::new(shape.iter().map(|&d| d as usize).collect()),
                 TensorData::I64(data.to_vec()),
-            ))
+            )
         }
         other => match element_type_from_ort(other) {
             Some(element_type) => Err(RuntimeError::UnsupportedElementType(element_type)),
@@ -122,7 +114,8 @@ mod tests {
         let tensor = Tensor::new(
             Shape::new(vec![2, 3]),
             TensorData::F32(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
-        );
+        )
+        .unwrap();
         let value = tensor.clone().into_ort_value().unwrap();
         let recovered = value_to_tensor(value).unwrap();
         assert_eq!(tensor, recovered);
@@ -130,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_tensor_ort_roundtrip_i32() {
-        let tensor = Tensor::new(Shape::new(vec![3]), TensorData::I32(vec![1, 2, 3]));
+        let tensor = Tensor::new(Shape::new(vec![3]), TensorData::I32(vec![1, 2, 3])).unwrap();
         let value = tensor.clone().into_ort_value().unwrap();
         let recovered = value_to_tensor(value).unwrap();
         assert_eq!(tensor, recovered);
@@ -138,7 +131,8 @@ mod tests {
 
     #[test]
     fn test_tensor_ort_roundtrip_i64() {
-        let tensor = Tensor::new(Shape::new(vec![2, 2]), TensorData::I64(vec![1, 2, 3, 4]));
+        let tensor =
+            Tensor::new(Shape::new(vec![2, 2]), TensorData::I64(vec![1, 2, 3, 4])).unwrap();
         let value = tensor.clone().into_ort_value().unwrap();
         let recovered = value_to_tensor(value).unwrap();
         assert_eq!(tensor, recovered);

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -8,7 +8,6 @@ use crate::runtime::{
 
 impl Tensor {
     /// Converts this owned tensor into an `ort` value.
-    #[allow(dead_code)]
     pub fn into_ort_value(self) -> Result<Value, RuntimeError> {
         let shape: Vec<i64> = self.shape().dims().iter().map(|&d| d as i64).collect();
         match self.into_data() {

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -3,7 +3,7 @@ use ort::value::{TensorElementType, Value};
 
 use crate::runtime::{
     error::RuntimeError,
-    tensor::{ElementType, Shape, Tensor, TensorData, TensorDataView},
+    tensor::{Shape, Tensor, TensorData, TensorDataView},
 };
 
 impl Tensor {
@@ -53,19 +53,6 @@ impl Tensor {
     }
 }
 
-/// Attempts to map an `ort` tensor element type to our normalized `ElementType`.
-///
-/// Returns `None` for types that have no equivalent in our abstraction (e.g. strings,
-/// exotic float formats, or unsupported numeric widths).
-fn element_type_from_ort(ort_type: TensorElementType) -> Option<ElementType> {
-    match ort_type {
-        TensorElementType::Float32 => Some(ElementType::F32),
-        TensorElementType::Int32 => Some(ElementType::I32),
-        TensorElementType::Int64 => Some(ElementType::I64),
-        _ => None,
-    }
-}
-
 /// Converts an `ort` tensor value into our owned tensor type.
 pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
     match *value.data_type() {
@@ -96,12 +83,9 @@ pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
                 TensorData::I64(data.to_vec()),
             )
         }
-        other => match element_type_from_ort(other) {
-            Some(element_type) => Err(RuntimeError::UnsupportedElementType(element_type)),
-            None => Err(RuntimeError::InferenceFailed(format!(
-                "unsupported element type: {other:?}"
-            ))),
-        },
+        other => Err(RuntimeError::InferenceFailed(format!(
+            "unsupported element type: {other:?}"
+        ))),
     }
 }
 

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -3,5 +3,5 @@ use super::{error::RuntimeError, tensor::Tensor};
 /// One loaded model session: encoder, decoder, or joiner.
 #[allow(dead_code)]
 pub trait RuntimeSession: Send + Sync + 'static {
-    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError>;
 }

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -1,6 +1,7 @@
 use super::{error::RuntimeError, tensor::Tensor};
 
 /// One loaded model session: encoder, decoder, or joiner.
+#[expect(dead_code)]
 pub trait RuntimeSession: Send + Sync + 'static {
     fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
 }

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -1,0 +1,6 @@
+use super::{error::RuntimeError, tensor::Tensor};
+
+/// One loaded model session: encoder, decoder, or joiner.
+pub trait RuntimeSession: Send + Sync + 'static {
+    fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
+}

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -1,7 +1,7 @@
 use super::{error::RuntimeError, tensor::Tensor};
 
 /// One loaded model session: encoder, decoder, or joiner.
-#[expect(dead_code)]
+#[allow(dead_code)]
 pub trait RuntimeSession: Send + Sync + 'static {
     fn run(&self, inputs: Vec<Tensor>) -> Result<Vec<Tensor>, RuntimeError>;
 }

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -1,7 +1,6 @@
 use super::{error::RuntimeError, tensor::Tensor};
 
 /// One loaded model session: encoder, decoder, or joiner.
-#[allow(dead_code)]
 pub trait RuntimeSession: Send + Sync + 'static {
     fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError>;
 }

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -107,6 +107,44 @@ impl Tensor {
     pub fn into_data(self) -> TensorData {
         self.data
     }
+
+    /// Return a mutable view of the underlying f32 buffer, if this tensor is f32.
+    pub fn as_f32_mut(&mut self) -> Option<&mut [f32]> {
+        match &mut self.data {
+            TensorData::F32(v) => Some(v.as_mut_slice()),
+            _ => None,
+        }
+    }
+
+    /// Return a mutable view of the underlying i32 buffer, if this tensor is i32.
+    pub fn as_i32_mut(&mut self) -> Option<&mut [i32]> {
+        match &mut self.data {
+            TensorData::I32(v) => Some(v.as_mut_slice()),
+            _ => None,
+        }
+    }
+
+    /// Return a mutable view of the underlying i64 buffer, if this tensor is i64.
+    pub fn as_i64_mut(&mut self) -> Option<&mut [i64]> {
+        match &mut self.data {
+            TensorData::I64(v) => Some(v.as_mut_slice()),
+            _ => None,
+        }
+    }
+
+    /// Resize the tensor to a new shape, reusing the existing storage.
+    ///
+    /// The buffer is resized to the new element count and zero-padded if it
+    /// grows. The caller must update the data before use.
+    pub fn resize_to(&mut self, shape: Shape) {
+        let new_len = shape.elements();
+        match &mut self.data {
+            TensorData::F32(v) => v.resize(new_len, 0.0),
+            TensorData::I32(v) => v.resize(new_len, 0),
+            TensorData::I64(v) => v.resize(new_len, 0),
+        }
+        self.shape = shape;
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -7,6 +7,7 @@ pub struct Tensor {
 
 /// Owned tensor storage for the supported element types.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(dead_code)]
 pub enum TensorData {
     F32(Vec<f32>),
     I32(Vec<i32>),
@@ -15,16 +16,32 @@ pub enum TensorData {
 
 /// Zero-copy borrow of tensor storage.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(dead_code)]
 pub enum TensorDataView<'a> {
     F32(&'a [f32]),
     I32(&'a [i32]),
     I64(&'a [i64]),
 }
 
+#[allow(dead_code)]
 impl<'a> TensorDataView<'a> {
     pub fn as_f32(&self) -> Option<&'a [f32]> {
         match self {
             TensorDataView::F32(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn as_i32(&self) -> Option<&'a [i32]> {
+        match self {
+            TensorDataView::I32(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<&'a [i64]> {
+        match self {
+            TensorDataView::I64(v) => Some(v),
             _ => None,
         }
     }
@@ -38,12 +55,14 @@ pub struct Shape {
 
 /// Supported tensor element types.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
 pub enum ElementType {
     F32,
     I32,
     I64,
 }
 
+#[allow(dead_code)]
 impl Tensor {
     pub fn new(shape: Shape, data: TensorData) -> Self {
         let expected = shape.elements();
@@ -83,6 +102,7 @@ impl Tensor {
     }
 }
 
+#[allow(dead_code)]
 impl TensorData {
     pub fn len(&self) -> usize {
         match self {
@@ -103,6 +123,7 @@ pub struct TensorView<'a> {
     data: TensorDataView<'a>,
 }
 
+#[allow(dead_code)]
 impl<'a> TensorView<'a> {
     pub fn shape(&self) -> &Shape {
         &self.shape
@@ -113,13 +134,14 @@ impl<'a> TensorView<'a> {
     }
 }
 
+#[allow(dead_code)]
 impl Shape {
     pub fn new(dims: Vec<usize>) -> Self {
         Self { dims }
     }
 
     pub fn elements(&self) -> usize {
-        self.dims.iter().product::<usize>().max(1)
+        self.dims.iter().product()
     }
 
     pub fn dims(&self) -> &[usize] {
@@ -166,5 +188,11 @@ mod tests {
         let t = Tensor::new(Shape::new(vec![2]), TensorData::I32(vec![1, 2]));
         let v = t.view();
         assert_eq!(v.data().as_f32(), None);
+    }
+
+    #[test]
+    fn test_shape_elements_zero_dimension() {
+        assert_eq!(Shape::new(vec![0]).elements(), 0);
+        assert_eq!(Shape::new(vec![2, 0]).elements(), 0);
     }
 }

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -53,13 +53,20 @@ pub struct Shape {
     dims: Vec<usize>,
 }
 
-/// Supported tensor element types.
+/// Known tensor element types. Not all are supported by every runtime backend.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum ElementType {
     F32,
     I32,
     I64,
+    F64,
+    I8,
+    U8,
+    I16,
+    U16,
+    U32,
+    U64,
+    Bool,
 }
 
 #[allow(dead_code)]

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -1,0 +1,170 @@
+/// Owned, cheaply cloneable tensor value used by the runtime abstraction layer.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Tensor {
+    shape: Shape,
+    data: TensorData,
+}
+
+/// Owned tensor storage for the supported element types.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TensorData {
+    F32(Vec<f32>),
+    I32(Vec<i32>),
+    I64(Vec<i64>),
+}
+
+/// Zero-copy borrow of tensor storage.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TensorDataView<'a> {
+    F32(&'a [f32]),
+    I32(&'a [i32]),
+    I64(&'a [i64]),
+}
+
+impl<'a> TensorDataView<'a> {
+    pub fn as_f32(&self) -> Option<&'a [f32]> {
+        match self {
+            TensorDataView::F32(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+/// Normalized tensor shape independent of any runtime backend.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Shape {
+    dims: Vec<usize>,
+}
+
+/// Supported tensor element types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ElementType {
+    F32,
+    I32,
+    I64,
+}
+
+impl Tensor {
+    pub fn new(shape: Shape, data: TensorData) -> Self {
+        let expected = shape.elements();
+        let actual = data.len();
+        assert_eq!(
+            expected, actual,
+            "tensor data length mismatch: expected {expected}, got {actual}"
+        );
+        Self { shape, data }
+    }
+
+    pub fn shape(&self) -> &Shape {
+        &self.shape
+    }
+
+    pub fn element_type(&self) -> ElementType {
+        match &self.data {
+            TensorData::F32(_) => ElementType::F32,
+            TensorData::I32(_) => ElementType::I32,
+            TensorData::I64(_) => ElementType::I64,
+        }
+    }
+
+    pub fn view(&self) -> TensorView<'_> {
+        TensorView {
+            shape: self.shape.clone(),
+            data: match &self.data {
+                TensorData::F32(v) => TensorDataView::F32(v.as_slice()),
+                TensorData::I32(v) => TensorDataView::I32(v.as_slice()),
+                TensorData::I64(v) => TensorDataView::I64(v.as_slice()),
+            },
+        }
+    }
+
+    pub fn into_data(self) -> TensorData {
+        self.data
+    }
+}
+
+impl TensorData {
+    pub fn len(&self) -> usize {
+        match self {
+            TensorData::F32(v) => v.len(),
+            TensorData::I32(v) => v.len(),
+            TensorData::I64(v) => v.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Borrowed view of a tensor.
+pub struct TensorView<'a> {
+    shape: Shape,
+    data: TensorDataView<'a>,
+}
+
+impl<'a> TensorView<'a> {
+    pub fn shape(&self) -> &Shape {
+        &self.shape
+    }
+
+    pub fn data(&self) -> &TensorDataView<'a> {
+        &self.data
+    }
+}
+
+impl Shape {
+    pub fn new(dims: Vec<usize>) -> Self {
+        Self { dims }
+    }
+
+    pub fn elements(&self) -> usize {
+        self.dims.iter().product::<usize>().max(1)
+    }
+
+    pub fn dims(&self) -> &[usize] {
+        &self.dims
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensor_shape_and_data_match() {
+        let t = Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 6]));
+        assert_eq!(t.shape().dims(), &[2, 3]);
+        assert_eq!(t.element_type(), ElementType::F32);
+    }
+
+    #[test]
+    #[should_panic(expected = "tensor data length mismatch")]
+    fn test_tensor_rejects_mismatched_data() {
+        Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 5]));
+    }
+
+    #[test]
+    fn test_shape_elements() {
+        assert_eq!(Shape::new(vec![2, 3, 4]).elements(), 24);
+        assert_eq!(Shape::new(vec![]).elements(), 1);
+    }
+
+    #[test]
+    fn test_tensor_view_f32() {
+        let t = Tensor::new(
+            Shape::new(vec![2, 2]),
+            TensorData::F32(vec![1.0, 2.0, 3.0, 4.0]),
+        );
+        let v = t.view();
+        assert_eq!(v.shape().dims(), &[2, 2]);
+        assert_eq!(v.data().as_f32(), Some(&[1.0, 2.0, 3.0, 4.0][..]));
+    }
+
+    #[test]
+    fn test_tensor_view_non_f32_returns_none() {
+        let t = Tensor::new(Shape::new(vec![2]), TensorData::I32(vec![1, 2]));
+        let v = t.view();
+        assert_eq!(v.data().as_f32(), None);
+    }
+}

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -53,32 +53,38 @@ pub struct Shape {
     dims: Vec<usize>,
 }
 
-/// Known tensor element types. Not all are supported by every runtime backend.
+/// Known tensor element types supported by the runtime abstraction.
+///
+/// Only types that have a corresponding [`TensorData`] variant are listed here;
+/// back-ends that produce other ONNX types must convert or reject them.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ElementType {
     F32,
     I32,
     I64,
-    F64,
-    I8,
-    U8,
-    I16,
-    U16,
-    U32,
-    U64,
-    Bool,
 }
 
 #[allow(dead_code)]
 impl Tensor {
-    pub fn new(shape: Shape, data: TensorData) -> Self {
+    /// Creates a tensor, validating that `data` length matches `shape`.
+    pub fn new(shape: Shape, data: TensorData) -> Result<Self, crate::runtime::RuntimeError> {
         let expected = shape.elements();
         let actual = data.len();
-        assert_eq!(
-            expected, actual,
-            "tensor data length mismatch: expected {expected}, got {actual}"
-        );
-        Self { shape, data }
+        if expected != actual {
+            return Err(crate::runtime::RuntimeError::DataLengthMismatch {
+                expected,
+                got: actual,
+            });
+        }
+        Ok(Self { shape, data })
+    }
+
+    /// Convenience constructor that panics on shape/data mismatch.
+    ///
+    /// Use only when dimensions are statically known; prefer [`Self::new`] for
+    /// runtime-sized tensors.
+    pub fn new_checked(shape: Shape, data: TensorData) -> Self {
+        Self::new(shape, data).expect("tensor data length mismatch")
     }
 
     pub fn shape(&self) -> &Shape {
@@ -200,15 +206,21 @@ mod tests {
 
     #[test]
     fn test_tensor_shape_and_data_match() {
-        let t = Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 6]));
+        let t = Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 6])).unwrap();
         assert_eq!(t.shape().dims(), &[2, 3]);
         assert_eq!(t.element_type(), ElementType::F32);
     }
 
     #[test]
-    #[should_panic(expected = "tensor data length mismatch")]
     fn test_tensor_rejects_mismatched_data() {
-        Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 5]));
+        let err = Tensor::new(Shape::new(vec![2, 3]), TensorData::F32(vec![0.0; 5])).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::runtime::RuntimeError::DataLengthMismatch {
+                expected: 6,
+                got: 5
+            }
+        ));
     }
 
     #[test]
@@ -222,7 +234,8 @@ mod tests {
         let t = Tensor::new(
             Shape::new(vec![2, 2]),
             TensorData::F32(vec![1.0, 2.0, 3.0, 4.0]),
-        );
+        )
+        .unwrap();
         let v = t.view();
         assert_eq!(v.shape().dims(), &[2, 2]);
         assert_eq!(v.data().as_f32(), Some(&[1.0, 2.0, 3.0, 4.0][..]));
@@ -230,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_tensor_view_non_f32_returns_none() {
-        let t = Tensor::new(Shape::new(vec![2]), TensorData::I32(vec![1, 2]));
+        let t = Tensor::new(Shape::new(vec![2]), TensorData::I32(vec![1, 2])).unwrap();
         let v = t.view();
         assert_eq!(v.data().as_f32(), None);
     }

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -7,7 +7,6 @@ pub struct Tensor {
 
 /// Owned tensor storage for the supported element types.
 #[derive(Clone, Debug, PartialEq)]
-#[allow(dead_code)]
 pub enum TensorData {
     F32(Vec<f32>),
     I32(Vec<i32>),
@@ -16,14 +15,12 @@ pub enum TensorData {
 
 /// Zero-copy borrow of tensor storage.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[allow(dead_code)]
 pub enum TensorDataView<'a> {
     F32(&'a [f32]),
     I32(&'a [i32]),
     I64(&'a [i64]),
 }
 
-#[allow(dead_code)]
 impl<'a> TensorDataView<'a> {
     pub fn as_f32(&self) -> Option<&'a [f32]> {
         match self {
@@ -64,7 +61,6 @@ pub enum ElementType {
     I64,
 }
 
-#[allow(dead_code)]
 impl Tensor {
     /// Creates a tensor, validating that `data` length matches `shape`.
     pub fn new(shape: Shape, data: TensorData) -> Result<Self, crate::runtime::RuntimeError> {
@@ -153,7 +149,6 @@ impl Tensor {
     }
 }
 
-#[allow(dead_code)]
 impl TensorData {
     pub fn len(&self) -> usize {
         match self {
@@ -175,7 +170,6 @@ pub struct TensorView<'a> {
     data: TensorDataView<'a>,
 }
 
-#[allow(dead_code)]
 impl<'a> TensorView<'a> {
     pub fn shape(&self) -> &Shape {
         self.shape
@@ -186,7 +180,6 @@ impl<'a> TensorView<'a> {
     }
 }
 
-#[allow(dead_code)]
 impl Shape {
     pub fn new(dims: Vec<usize>) -> Self {
         Self { dims }

--- a/crates/gigastt-core/src/runtime/tensor.rs
+++ b/crates/gigastt-core/src/runtime/tensor.rs
@@ -101,7 +101,7 @@ impl Tensor {
 
     pub fn view(&self) -> TensorView<'_> {
         TensorView {
-            shape: self.shape.clone(),
+            shape: &self.shape,
             data: match &self.data {
                 TensorData::F32(v) => TensorDataView::F32(v.as_slice()),
                 TensorData::I32(v) => TensorDataView::I32(v.as_slice()),
@@ -169,15 +169,16 @@ impl TensorData {
 }
 
 /// Borrowed view of a tensor.
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TensorView<'a> {
-    shape: Shape,
+    shape: &'a Shape,
     data: TensorDataView<'a>,
 }
 
 #[allow(dead_code)]
 impl<'a> TensorView<'a> {
     pub fn shape(&self) -> &Shape {
-        &self.shape
+        self.shape
     }
 
     pub fn data(&self) -> &TensorDataView<'a> {

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -22,15 +22,14 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use ort::session::Session;
-use ort::value::TensorRef;
 use parking_lot::Mutex;
 
-/// `ort` errors are not `Send`/`Sync`; stringify them so they cross `?` into
-/// `anyhow` like everywhere else in the crate.
-fn ort_err(e: impl std::fmt::Display) -> anyhow::Error {
-    anyhow::anyhow!("{e}")
-}
+use crate::runtime::{
+    factory::RuntimeFactory,
+    ort::OrtFactory,
+    session::RuntimeSession,
+    tensor::{Shape, Tensor, TensorData},
+};
 
 /// Silero VAD ONNX filename on disk. Single source of truth shared with the
 /// model-download path in [`crate::model`].
@@ -88,7 +87,7 @@ impl VadConfig {
 /// never by this struct, so a single `SileroVad` can serve many concurrent
 /// streams.
 pub struct SileroVad {
-    session: Mutex<Session>,
+    session: Mutex<Box<dyn RuntimeSession>>,
 }
 
 impl SileroVad {
@@ -100,10 +99,14 @@ impl SileroVad {
     /// session. The caller treats an error as "VAD unavailable" and proceeds
     /// without it — VAD is strictly optional.
     pub fn load(model_path: &Path) -> Result<Self> {
-        let session = Session::builder()
-            .map_err(ort_err)?
-            .commit_from_file(model_path)
-            .map_err(ort_err)
+        let factory = OrtFactory::cpu();
+        let runtime = factory
+            .create(1)
+            .map_err(|e| anyhow::anyhow!(e))
+            .with_context(|| format!("Failed to create runtime for {}", model_path.display()))?;
+        let session = runtime
+            .load_session(model_path)
+            .map_err(|e| anyhow::anyhow!(e))
             .with_context(|| format!("Failed to load VAD model {}", model_path.display()))?;
         tracing::info!("VAD model loaded from {}", model_path.display());
         Ok(Self {
@@ -122,39 +125,35 @@ impl SileroVad {
         let n = frame.len().min(VAD_FRAME_SAMPLES);
         input[..n].copy_from_slice(&frame[..n]);
 
-        let input_t = TensorRef::from_array_view(([1_usize, VAD_FRAME_SAMPLES], input.as_slice()))?;
-        let state_t = TensorRef::from_array_view(([2_usize, 1, 128], state.as_slice()))?;
-        let sr_t = TensorRef::from_array_view(([1_usize], [VAD_SAMPLE_RATE].as_slice()))?;
+        let inputs = vec![
+            Tensor::new(
+                Shape::new(vec![1, VAD_FRAME_SAMPLES]),
+                TensorData::F32(input.to_vec()),
+            ),
+            Tensor::new(Shape::new(vec![2, 1, 128]), TensorData::F32(state.to_vec())),
+            Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![VAD_SAMPLE_RATE])),
+        ];
 
         let prob = {
-            let mut session = self.session.lock();
-            let outputs = session
-                .run(ort::inputs![
-                    "input" => input_t,
-                    "state" => state_t,
-                    "sr" => sr_t,
-                ])
-                .context("VAD model inference failed")?;
+            let session = self.session.lock();
+            let outputs = session.run(inputs).context("VAD model inference failed")?;
 
-            // Copy the next state out before the borrow ends. A length other
-            // than VAD_STATE_LEN means the model's recurrent-state contract
-            // changed; surface it rather than silently running later frames on
-            // stale state (the non-blocking caller then disables VAD).
-            let (_, new_state) = outputs["stateN"]
-                .try_extract_tensor::<f32>()
-                .context("failed to extract VAD state")?;
-            if new_state.len() != VAD_STATE_LEN {
-                anyhow::bail!(
-                    "unexpected VAD state length {} (expected {VAD_STATE_LEN})",
-                    new_state.len()
-                );
+            // Identify the state and probability outputs by shape so the code
+            // does not depend on the exact output order of the Silero model.
+            let mut prob = 0.0f32;
+            let mut new_state = [0.0f32; VAD_STATE_LEN];
+            for output in outputs {
+                let view = output.view();
+                if let Some(data) = view.data().as_f32() {
+                    if data.len() == VAD_STATE_LEN {
+                        new_state.copy_from_slice(data);
+                    } else if data.len() == 1 {
+                        prob = data[0];
+                    }
+                }
             }
-            state.copy_from_slice(new_state);
-
-            let (_, prob) = outputs["output"]
-                .try_extract_tensor::<f32>()
-                .context("failed to extract VAD probability")?;
-            prob.first().copied().unwrap_or(0.0)
+            state.copy_from_slice(&new_state);
+            prob
         };
         Ok(prob)
     }

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -88,6 +88,9 @@ impl VadConfig {
 /// streams.
 pub struct SileroVad {
     session: Mutex<Box<dyn RuntimeSession>>,
+    /// Reusable input tensors: `[frame [1,512], state [2,1,128], sample_rate [1]]`.
+    /// Mutated in place in `run_frame` to avoid per-frame allocations.
+    input_tensors: Mutex<Vec<Tensor>>,
 }
 
 impl SileroVad {
@@ -111,6 +114,17 @@ impl SileroVad {
         tracing::info!("VAD model loaded from {}", model_path.display());
         Ok(Self {
             session: Mutex::new(session),
+            input_tensors: Mutex::new(vec![
+                Tensor::new(
+                    Shape::new(vec![1, VAD_FRAME_SAMPLES]),
+                    TensorData::F32(vec![0.0; VAD_FRAME_SAMPLES]),
+                ),
+                Tensor::new(
+                    Shape::new(vec![2, 1, 128]),
+                    TensorData::F32(vec![0.0; VAD_STATE_LEN]),
+                ),
+                Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![VAD_SAMPLE_RATE])),
+            ]),
         })
     }
 
@@ -125,36 +139,37 @@ impl SileroVad {
         let n = frame.len().min(VAD_FRAME_SAMPLES);
         input[..n].copy_from_slice(&frame[..n]);
 
-        let inputs = vec![
-            Tensor::new(
-                Shape::new(vec![1, VAD_FRAME_SAMPLES]),
-                TensorData::F32(input.to_vec()),
-            ),
-            Tensor::new(Shape::new(vec![2, 1, 128]), TensorData::F32(state.to_vec())),
-            Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![VAD_SAMPLE_RATE])),
-        ];
+        let outputs = {
+            let mut inputs = self.input_tensors.lock();
+            inputs[0]
+                .as_f32_mut()
+                .context("VAD frame tensor is not f32")?
+                .copy_from_slice(&input);
+            inputs[1]
+                .as_f32_mut()
+                .context("VAD state tensor is not f32")?
+                .copy_from_slice(state);
+            // inputs[2] (sample rate) is constant and was set at construction.
 
-        let prob = {
             let session = self.session.lock();
-            let outputs = session.run(inputs).context("VAD model inference failed")?;
+            session.run(&inputs).context("VAD model inference failed")?
+        };
 
-            // Identify the state and probability outputs by shape so the code
-            // does not depend on the exact output order of the Silero model.
-            let mut prob = 0.0f32;
-            let mut new_state = [0.0f32; VAD_STATE_LEN];
-            for output in outputs {
-                let view = output.view();
-                if let Some(data) = view.data().as_f32() {
-                    if data.len() == VAD_STATE_LEN {
-                        new_state.copy_from_slice(data);
-                    } else if data.len() == 1 {
-                        prob = data[0];
-                    }
+        // Identify the state and probability outputs by shape so the code
+        // does not depend on the exact output order of the Silero model.
+        let mut prob = 0.0f32;
+        let mut new_state = [0.0f32; VAD_STATE_LEN];
+        for output in outputs {
+            let view = output.view();
+            if let Some(data) = view.data().as_f32() {
+                if data.len() == VAD_STATE_LEN {
+                    new_state.copy_from_slice(data);
+                } else if data.len() == 1 {
+                    prob = data[0];
                 }
             }
-            state.copy_from_slice(&new_state);
-            prob
-        };
+        }
+        state.copy_from_slice(&new_state);
         Ok(prob)
     }
 

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -100,7 +100,15 @@ impl SileroVad {
     /// Returns an error if the file is missing or `ort` fails to build the
     /// session. The caller treats an error as "VAD unavailable" and proceeds
     /// without it — VAD is strictly optional.
-    pub fn load(model_path: &Path, factory: &dyn RuntimeFactory) -> Result<Self> {
+    pub fn load(model_path: &Path) -> Result<Self> {
+        let factory = crate::runtime::cpu_factory();
+        Self::load_with_factory(model_path, factory.as_ref())
+    }
+
+    /// Like [`SileroVad::load`], but loads the ONNX session through a
+    /// caller-supplied [`RuntimeFactory`] (e.g. a non-`ort` backend or a test
+    /// mock) instead of the default CPU `ort` runtime.
+    pub fn load_with_factory(model_path: &Path, factory: &dyn RuntimeFactory) -> Result<Self> {
         tracing::debug!("Loading VAD model from {}", model_path.display());
         let runtime = factory
             .cpu_fallback()
@@ -406,7 +414,6 @@ impl Hangover {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::ort::OrtFactory;
 
     fn cfg(
         threshold: f32,
@@ -592,7 +599,7 @@ mod tests {
             eprintln!("skipping {}: Silero VAD model not present", path.display());
             return;
         }
-        let vad = SileroVad::load(&path, &OrtFactory::cpu()).expect("load silero");
+        let vad = SileroVad::load(&path).expect("load silero");
 
         // 1 s of pure silence → several frames, all low probability.
         let silence = vec![0.0f32; 16000];
@@ -646,7 +653,7 @@ mod tests {
             eprintln!("skipping {}: Silero VAD model not present", path.display());
             return;
         }
-        let vad = SileroVad::load(&path, &OrtFactory::cpu()).expect("load silero");
+        let vad = SileroVad::load(&path).expect("load silero");
         let c = VadConfig::default();
         let mut ep = VadEndpointer::new(&c);
 
@@ -675,7 +682,7 @@ mod tests {
             eprintln!("skipping {}: Silero VAD model not present", path.display());
             return;
         }
-        let vad = SileroVad::load(&path, &OrtFactory::cpu()).expect("load silero");
+        let vad = SileroVad::load(&path).expect("load silero");
         let c = VadConfig::default();
         let mut ep = VadEndpointer::new(&c);
 

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -26,7 +26,6 @@ use parking_lot::Mutex;
 
 use crate::runtime::{
     factory::RuntimeFactory,
-    ort::OrtFactory,
     session::RuntimeSession,
     tensor::{Shape, Tensor, TensorData},
 };
@@ -101,16 +100,17 @@ impl SileroVad {
     /// Returns an error if the file is missing or `ort` fails to build the
     /// session. The caller treats an error as "VAD unavailable" and proceeds
     /// without it — VAD is strictly optional.
-    pub fn load(model_path: &Path) -> Result<Self> {
-        let factory = OrtFactory::cpu();
+    pub fn load(model_path: &Path, factory: &dyn RuntimeFactory) -> Result<Self> {
+        tracing::debug!("Loading VAD model from {}", model_path.display());
         let runtime = factory
+            .cpu_fallback()
             .create(1)
             .map_err(|e| anyhow::anyhow!(e))
-            .with_context(|| format!("Failed to create runtime for {}", model_path.display()))?;
+            .context("Failed to create runtime for VAD model")?;
         let session = runtime
-            .load_session(model_path)
+            .load_session(model_path, false)
             .map_err(|e| anyhow::anyhow!(e))
-            .with_context(|| format!("Failed to load VAD model {}", model_path.display()))?;
+            .context("Failed to load VAD model")?;
         tracing::info!("VAD model loaded from {}", model_path.display());
         Ok(Self {
             session: Mutex::new(session),
@@ -406,6 +406,7 @@ impl Hangover {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::ort::OrtFactory;
 
     fn cfg(
         threshold: f32,
@@ -591,7 +592,7 @@ mod tests {
             eprintln!("skipping {}: Silero VAD model not present", path.display());
             return;
         }
-        let vad = SileroVad::load(&path).expect("load silero");
+        let vad = SileroVad::load(&path, &OrtFactory::cpu()).expect("load silero");
 
         // 1 s of pure silence → several frames, all low probability.
         let silence = vec![0.0f32; 16000];
@@ -645,7 +646,7 @@ mod tests {
             eprintln!("skipping {}: Silero VAD model not present", path.display());
             return;
         }
-        let vad = SileroVad::load(&path).expect("load silero");
+        let vad = SileroVad::load(&path, &OrtFactory::cpu()).expect("load silero");
         let c = VadConfig::default();
         let mut ep = VadEndpointer::new(&c);
 
@@ -674,7 +675,7 @@ mod tests {
             eprintln!("skipping {}: Silero VAD model not present", path.display());
             return;
         }
-        let vad = SileroVad::load(&path).expect("load silero");
+        let vad = SileroVad::load(&path, &OrtFactory::cpu()).expect("load silero");
         let c = VadConfig::default();
         let mut ep = VadEndpointer::new(&c);
 

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -115,15 +115,15 @@ impl SileroVad {
         Ok(Self {
             session: Mutex::new(session),
             input_tensors: Mutex::new(vec![
-                Tensor::new(
+                Tensor::new_checked(
                     Shape::new(vec![1, VAD_FRAME_SAMPLES]),
                     TensorData::F32(vec![0.0; VAD_FRAME_SAMPLES]),
                 ),
-                Tensor::new(
+                Tensor::new_checked(
                     Shape::new(vec![2, 1, 128]),
                     TensorData::F32(vec![0.0; VAD_STATE_LEN]),
                 ),
-                Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![VAD_SAMPLE_RATE])),
+                Tensor::new_checked(Shape::new(vec![1]), TensorData::I64(vec![VAD_SAMPLE_RATE])),
             ]),
         })
     }

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -106,7 +106,7 @@ impl SileroVad {
     }
 
     /// Like [`SileroVad::load`], but loads the ONNX session through a
-    /// caller-supplied [`RuntimeFactory`] (e.g. a non-`ort` backend or a test
+    /// caller-supplied `RuntimeFactory` (e.g. a non-`ort` backend or a test
     /// mock) instead of the default CPU `ort` runtime.
     pub fn load_with_factory(model_path: &Path, factory: &dyn RuntimeFactory) -> Result<Self> {
         tracing::debug!("Loading VAD model from {}", model_path.display());

--- a/crates/gigastt-core/tests/vad_file.rs
+++ b/crates/gigastt-core/tests/vad_file.rs
@@ -57,7 +57,8 @@ fn vad_file_skips_silence_keeps_transcript() {
         );
         return;
     }
-    let vad = SileroVad::load(&vad_path).expect("load silero vad");
+    let factory = gigastt_core::cpu_factory();
+    let vad = SileroVad::load(&vad_path, &*factory).expect("load silero vad");
     let vad_engine = Engine::load(&model_dir)
         .expect("load vad engine")
         .with_vad(Some(vad), VadConfig::default());

--- a/crates/gigastt-core/tests/vad_file.rs
+++ b/crates/gigastt-core/tests/vad_file.rs
@@ -58,7 +58,7 @@ fn vad_file_skips_silence_keeps_transcript() {
         return;
     }
     let factory = gigastt_core::cpu_factory();
-    let vad = SileroVad::load(&vad_path, &*factory).expect("load silero vad");
+    let vad = SileroVad::load_with_factory(&vad_path, &*factory).expect("load silero vad");
     let vad_engine = Engine::load(&model_dir)
         .expect("load vad engine")
         .with_vad(Some(vad), VadConfig::default());

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -675,7 +675,11 @@ fn maybe_load_punctuator(
     if !resolve_punctuation(mode, variant) {
         return None;
     }
-    match gigastt_core::punctuation::Punctuator::load(std::path::Path::new(punct_model_dir)) {
+    let factory = gigastt_core::cpu_factory();
+    match gigastt_core::punctuation::Punctuator::load(
+        std::path::Path::new(punct_model_dir),
+        &*factory,
+    ) {
         Ok(p) => {
             tracing::info!("Punctuation restoration enabled (model dir: {punct_model_dir})");
             Some(p)
@@ -738,7 +742,8 @@ fn maybe_load_vad(enabled: bool, vad_model_dir: &str) -> Option<gigastt_core::va
         return None;
     }
     let path = std::path::Path::new(vad_model_dir).join(gigastt_core::vad::VAD_MODEL_FILE);
-    match gigastt_core::vad::SileroVad::load(&path) {
+    let factory = gigastt_core::cpu_factory();
+    match gigastt_core::vad::SileroVad::load(&path, &*factory) {
         Ok(v) => {
             tracing::info!("VAD enabled (model dir: {vad_model_dir})");
             Some(v)

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -676,7 +676,7 @@ fn maybe_load_punctuator(
         return None;
     }
     let factory = gigastt_core::cpu_factory();
-    match gigastt_core::punctuation::Punctuator::load(
+    match gigastt_core::punctuation::Punctuator::load_with_factory(
         std::path::Path::new(punct_model_dir),
         &*factory,
     ) {
@@ -743,7 +743,7 @@ fn maybe_load_vad(enabled: bool, vad_model_dir: &str) -> Option<gigastt_core::va
     }
     let path = std::path::Path::new(vad_model_dir).join(gigastt_core::vad::VAD_MODEL_FILE);
     let factory = gigastt_core::cpu_factory();
-    match gigastt_core::vad::SileroVad::load(&path, &*factory) {
+    match gigastt_core::vad::SileroVad::load_with_factory(&path, &*factory) {
         Ok(v) => {
             tracing::info!("VAD enabled (model dir: {vad_model_dir})");
             Some(v)


### PR DESCRIPTION
## Summary

Introduces an internal runtime abstraction layer in `gigastt-core` so that `ort` is isolated to a single adapter module (`runtime/ort/`). This reduces vendor lock-in, enables model-free unit tests via a mock runtime, and leaves the door open for future custom backends.

- Adds backend-agnostic `Runtime`, `RuntimeSession`, `RuntimeFactory` traits and `Tensor`/`Shape`/`RuntimeError` value types.
- Implements an `ort` adapter that preserves existing behavior, execution providers (CPU/CoreML/CUDA/NNAPI), disk caches, and thread configuration.
- Refactors `Engine`, `SessionPool`, `decode.rs`, `vad.rs`, and `punctuation.rs` to use the abstraction.
- Adds `MockRuntime`/`MockFactory` and unit tests that build an `Engine` without ONNX models.
- Adds a CI check that fails on any `use ort::` or `extern crate ort` outside `runtime/ort/`.

## Test Plan

- [x] `cargo test --workspace --lib --bins`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check -p gigastt-core --features coreml`
- [x] `cargo check -p gigastt-core --features cuda`
- [x] `cargo check -p gigastt-core --features nnapi`
- [x] `cargo check -p gigastt-core --features diarization`

## Notes

- `RuntimeSession::run` takes `&[Tensor]` (borrowed inputs) to avoid hot-path clones.