### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What

Lockfile-only bump of `quinn-proto` 0.11.14 → 0.11.15.

## Why

`cargo audit` flags **RUSTSEC-2026-0185** (high, CVSS 7.5): *remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly*. This fails the Security Audit job repo-wide (it is a transitive dependency, so it also blocks the open dependabot PRs #96/#98/#99). `quinn-proto` is not called directly, so the patched 0.11.15 needs no source changes.

Verified locally: `cargo audit` now reports only the two pre-existing *allowed* warnings (bincode/paste unmaintained); RUSTSEC-2026-0185 is gone.