### PR TITLE
feat(candle): optional Candle/Metal backend for GigaAM v3 (byte-exact with ort)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,18 @@ jobs:
                   i += 1
               return indices
 
+          CANDLE_PATTERNS = [
+              r"^use candle_core::",
+              r"^use candle_nn::",
+              r"^extern crate candle_core",
+              r"^extern crate candle_nn",
+              r"\bcandle_core\b",
+              r"\bcandle_nn\b",
+          ]
+          CANDLE_RE = re.compile("|".join(f"(?:{p})" for p in CANDLE_PATTERNS))
+
           violations = []
+          candle_violations = []
           for path in Path("crates").rglob("*.rs"):
               if any(a == "runtime" and b == "ort"
                      for a, b in zip(path.parts, path.parts[1:])):
@@ -86,6 +97,8 @@ jobs:
               if "tests" in path.parts:
                   continue
 
+              is_candle = any(a == "runtime" and b == "candle"
+                              for a, b in zip(path.parts, path.parts[1:]))
               lines = path.read_text(encoding="utf-8").splitlines()
               test_indices = test_line_indices(lines)
               for lineno, line in enumerate(lines, start=1):
@@ -93,6 +106,8 @@ jobs:
                       continue
                   if COMBINED_RE.search(line):
                       violations.append(f"{path}:{lineno}:{line}")
+                  if not is_candle and CANDLE_RE.search(line):
+                      candle_violations.append(f"{path}:{lineno}:{line}")
 
           if violations:
               print("ERROR: ort runtime leaks detected outside runtime/ort:")
@@ -100,6 +115,13 @@ jobs:
                   print(v)
               sys.exit(1)
           print("OK: ort is isolated")
+
+          if candle_violations:
+              print("ERROR: candle_core/candle_nn used outside runtime/candle/:")
+              for v in candle_violations:
+                  print(v)
+              sys.exit(1)
+          print("OK: candle is isolated")
           PY
 
   clippy:
@@ -225,6 +247,21 @@ jobs:
           shared-key: ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo build --release -p gigastt --features diarization
+
+  build-candle:
+    runs-on: macos-14
+    name: Build (Candle/Metal)
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install protoc
+        run: brew install protobuf
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: cargo build -p gigastt-core --features candle
+      - run: cargo clippy -p gigastt-core --features candle -- -D warnings
 
   e2e-tests:
     # Only run on main push — PRs get fast feedback from unit tests + clippy

--- a/.typos.toml
+++ b/.typos.toml
@@ -16,3 +16,5 @@ eazy = "eazy"
 [default.extend-identifiers]
 # "hel\0lo" — intentional test string with embedded NUL byte.
 hel = "hel"
+# "from_mmaped_safetensors" — candle_nn API name (memory-mapped safetensors loader).
+from_mmaped_safetensors = "from_mmaped_safetensors"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,9 +342,21 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -359,6 +377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +396,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -389,6 +430,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "candle-core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+dependencies = [
+ "byteorder",
+ "candle-metal-kernels",
+ "candle-ug",
+ "float8",
+ "gemm 0.19.0",
+ "half",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "objc2-foundation",
+ "objc2-metal",
+ "rand",
+ "rand_distr",
+ "rayon",
+ "safetensors 0.7.0",
+ "thiserror 2.0.18",
+ "yoke 0.8.2",
+ "zip",
+]
+
+[[package]]
+name = "candle-metal-kernels"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fdfe9d06de16ce49961e49084e5b79a75a9bdf157246e7c7b6328e87a7aa25d"
+dependencies = [
+ "half",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+ "once_cell",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
+dependencies = [
+ "candle-core",
+ "candle-metal-kernels",
+ "half",
+ "libc",
+ "num-traits",
+ "objc2-metal",
+ "rayon",
+ "safetensors 0.7.0",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-ug"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d62be69068bf58987a45f690612739d8d2ea1bf508c1b87dc6815a019575d"
+dependencies = [
+ "ug",
+ "ug-metal",
 ]
 
 [[package]]
@@ -621,6 +732,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -889,6 +1020,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +1047,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +1075,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -978,6 +1147,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "float8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand",
+ "rand_distr",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,12 +1171,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1003,6 +1211,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1117,6 +1331,244 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32 0.18.2",
+ "gemm-c64 0.18.2",
+ "gemm-common 0.18.2",
+ "gemm-f16 0.18.2",
+ "gemm-f32 0.18.2",
+ "gemm-f64 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32 0.19.0",
+ "gemm-c64 0.19.0",
+ "gemm-common 0.19.0",
+ "gemm-f16 0.19.0",
+ "gemm-f32 0.19.0",
+ "gemm-f64 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.21.5",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.22.3",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "gemm-f32 0.18.2",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "gemm-f32 0.19.0",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1651,8 @@ version = "2.3.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "candle-core",
+ "candle-nn",
  "criterion",
  "futures-util",
  "hex",
@@ -1212,6 +1666,7 @@ dependencies = [
  "reqwest",
  "rubato",
  "rustfft",
+ "safetensors 0.5.3",
  "serde",
  "serde_json",
  "sha2",
@@ -1295,8 +1750,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
+ "rand",
+ "rand_distr",
  "zerocopy",
 ]
 
@@ -1312,7 +1771,20 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1476,7 +1948,7 @@ dependencies = [
  "displaydoc",
  "potential_utf",
  "utf8_iter",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
  "zerovec",
 ]
@@ -1543,7 +2015,7 @@ dependencies = [
  "displaydoc",
  "icu_locale_core",
  "writeable",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
  "zerotrie",
  "zerovec",
@@ -1731,6 +2203,16 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
@@ -1738,6 +2220,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1795,6 +2283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,6 +2321,31 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.11.1",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
+]
 
 [[package]]
 name = "mime"
@@ -1909,7 +2431,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd9f9295f3ff5921e78a71222c3361a8216f7760b1a99a6ad4e8441de18bbb9"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "ctor",
  "futures",
  "napi-build",
@@ -1957,7 +2479,7 @@ version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f5bcdf71abd3a50d00b49c1c2c75251cb3c913777d6139cd37dabc093a5e400"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
 ]
 
 [[package]]
@@ -2018,11 +2540,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -2036,12 +2583,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2052,6 +2622,68 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2078,9 +2710,9 @@ version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "openssl-macros",
  "openssl-sys",
@@ -2121,7 +2753,7 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
  "ndarray",
  "ort-sys",
  "smallvec",
@@ -2339,7 +2971,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -2400,6 +3032,43 @@ checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "pulp"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "quick-error"
@@ -2514,12 +3183,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2569,12 +3257,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2718,7 +3412,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2827,6 +3521,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safetensors"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "safetensors"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0cdb7198d738a111f6df8fef42cb175412c311d0c4ac9126ff4e550ad1a0e8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,7 +3601,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2902,6 +3627,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3238,7 +3969,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytemuck",
  "lazy_static",
  "log",
@@ -3340,12 +4071,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3667,7 +4412,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -3786,10 +4531,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ug"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b761acf8af3494640d826a8609e2265e19778fb43306c7f15379c78c9b05b0"
+dependencies = [
+ "gemm 0.18.2",
+ "half",
+ "libloading 0.8.9",
+ "memmap2",
+ "num",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "safetensors 0.4.5",
+ "serde",
+ "thiserror 1.0.69",
+ "tracing",
+ "yoke 0.7.5",
+]
+
+[[package]]
+name = "ug-metal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7adf545a99a086d362efc739e7cf4317c18cbeda22706000fd434d70ea3d95"
+dependencies = [
+ "half",
+ "metal",
+ "objc",
+ "serde",
+ "thiserror 1.0.69",
+ "ug",
+]
 
 [[package]]
 name = "unarray"
@@ -4210,7 +4996,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4593,7 +5379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -4631,13 +5417,37 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.8.2",
  "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -4706,7 +5516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
 ]
 
@@ -4716,7 +5526,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
  "zerovec-derive",
 ]
@@ -4730,6 +5540,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -29,6 +29,7 @@ async-pool = ["dep:tokio"]                              # async Pool::checkout; 
 file-decode = ["dep:symphonia"]                         # file transcription; raw-PCM streaming does not need it
 ort-load-dynamic = ["ort/load-dynamic"]                 # system/vendored onnxruntime instead of download-binaries
 quantize = []
+candle = ["dep:candle-core", "dep:candle-nn", "dep:safetensors"]
 # Private/unstable: exposes internal items (tokenizer module + synthetic
 # constructors) so the out-of-workspace `fuzz/` crate and criterion benches can
 # reach them without a model on disk. Double underscore = not a public API
@@ -37,6 +38,9 @@ __internals = []
 
 [dependencies]
 ort = "2.0.0-rc.12"
+candle-core = { version = "0.9", optional = true }
+candle-nn = { version = "0.9", optional = true }
+safetensors = { version = "0.5", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"], optional = true }
 futures-util = { version = "0.3", optional = true }
 reqwest = { version = "0.13", features = ["stream"], optional = true }
@@ -56,6 +60,10 @@ prost = "0.14"
 polyvoice = { version = "0.7.0", features = ["onnx"], optional = true }
 parking_lot = "0.12"
 libc = "0.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+candle-core = { version = "0.9", optional = true, features = ["metal"] }
+candle-nn = { version = "0.9", optional = true, features = ["metal"] }
 
 [build-dependencies]
 prost-build = "0.14"

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -3445,6 +3445,81 @@ mod tests {
         assert!(result.words.is_empty(), "silence decodes to no words");
     }
 
+    /// End-to-end proof that the Candle backend transcribes IDENTICALLY to the
+    /// ort backend through the full engine pipeline (mel + encoder + RNN-T
+    /// decode), not just per-stage tensors.
+    ///
+    /// Two engines are built on the SAME model dir — one forced onto the ort CPU
+    /// backend, one forced onto the Candle backend (which reads the sibling
+    /// `candle/*.safetensors`) — and the same fixture wav is transcribed by both.
+    /// Per-stage parity is bit-exact, so the decoded text MUST be byte-identical.
+    ///
+    /// Run with:
+    /// `cargo test -p gigastt-core --features candle --lib -- --ignored --nocapture candle_ort_transcription_parity`
+    #[cfg(feature = "candle")]
+    #[test]
+    #[ignore = "requires v3_rnnt model + candle/*.safetensors"]
+    fn candle_ort_transcription_parity() {
+        let model_dir = crate::model::default_model_dir();
+        let model_path = Path::new(&model_dir);
+
+        let ort_engine = Engine::load_with_factory(
+            model_path,
+            1,
+            1,
+            0,
+            Box::new(crate::runtime::ort::factory::OrtFactory::cpu()),
+            1,
+        )
+        .expect("ort engine should load");
+        let candle_engine = Engine::load_with_factory(
+            model_path,
+            1,
+            1,
+            0,
+            Box::new(crate::runtime::candle::factory::CandleFactory::new()),
+            1,
+        )
+        .expect("candle engine should load");
+
+        let fixtures = [
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../gigastt/tests/fixtures/golos_00.wav"
+            ),
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../gigastt/tests/fixtures/golos_01.wav"
+            ),
+        ];
+
+        for fixture in fixtures {
+            let mut ort_guard = ort_engine.pool.checkout_blocking().expect("ort checkout");
+            let ort_text = ort_engine
+                .transcribe_file(fixture, &mut ort_guard)
+                .expect("ort transcription")
+                .text;
+
+            let mut candle_guard = candle_engine
+                .pool
+                .checkout_blocking()
+                .expect("candle checkout");
+            let candle_text = candle_engine
+                .transcribe_file(fixture, &mut candle_guard)
+                .expect("candle transcription")
+                .text;
+
+            eprintln!("fixture = {fixture}");
+            eprintln!("ort    = {ort_text:?}");
+            eprintln!("candle = {candle_text:?}");
+
+            assert_eq!(
+                ort_text, candle_text,
+                "candle transcript diverges from ort for {fixture}:\n  ort    = {ort_text:?}\n  candle = {candle_text:?}"
+            );
+        }
+    }
+
     mod mock_runtime_tests {
         use std::collections::HashMap;
         use std::sync::Arc;

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -3520,6 +3520,117 @@ mod tests {
         }
     }
 
+    /// End-to-end proof that the Candle backend produces IDENTICAL output to ort
+    /// through the STREAMING path (sliding-window `process_chunk` + `finish_stream`),
+    /// not just through the whole-file `transcribe_file` path.
+    ///
+    /// Both engines receive the SAME 8 000-sample (0.5 s) chunks fed in order;
+    /// all returned segment texts are concatenated and compared byte-for-byte.
+    /// Per-stage tensor parity is bit-exact, so the streamed transcripts must match.
+    ///
+    /// Run with:
+    /// `cargo test -p gigastt-core --features candle --lib -- --ignored --nocapture candle_ort_streaming_parity`
+    #[cfg(feature = "candle")]
+    #[test]
+    #[ignore = "requires v3_rnnt model + candle/*.safetensors"]
+    fn candle_ort_streaming_parity() {
+        const CHUNK_SAMPLES: usize = 8_000; // 0.5 s at 16 kHz
+
+        let model_dir = crate::model::default_model_dir();
+        let model_path = Path::new(&model_dir);
+
+        let ort_engine = Engine::load_with_factory(
+            model_path,
+            1,
+            1,
+            0,
+            Box::new(crate::runtime::ort::factory::OrtFactory::cpu()),
+            1,
+        )
+        .expect("ort engine should load");
+        let candle_engine = Engine::load_with_factory(
+            model_path,
+            1,
+            1,
+            0,
+            Box::new(crate::runtime::candle::factory::CandleFactory::new()),
+            1,
+        )
+        .expect("candle engine should load");
+
+        let fixtures = [
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../gigastt/tests/fixtures/golos_00.wav"
+            ),
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../gigastt/tests/fixtures/golos_01.wav"
+            ),
+        ];
+
+        for fixture in fixtures {
+            let samples = audio::decode_audio_file(fixture)
+                .unwrap_or_else(|e| panic!("failed to decode {fixture}: {e:#}"));
+
+            // --- ort streaming ---
+            let mut ort_guard = ort_engine.pool.checkout_blocking().expect("ort checkout");
+            let mut ort_state = ort_engine.create_state(false);
+            let mut ort_text = String::new();
+            for chunk in samples.chunks(CHUNK_SAMPLES) {
+                let segs = ort_engine
+                    .process_chunk(chunk, &mut ort_state, &mut ort_guard)
+                    .expect("ort process_chunk must not error");
+                for seg in segs {
+                    if !ort_text.is_empty() {
+                        ort_text.push(' ');
+                    }
+                    ort_text.push_str(seg.text.trim());
+                }
+            }
+            if let Some(seg) = ort_engine.finish_stream(&mut ort_state, &mut ort_guard) {
+                if !ort_text.is_empty() {
+                    ort_text.push(' ');
+                }
+                ort_text.push_str(seg.text.trim());
+            }
+
+            // --- candle streaming ---
+            let mut candle_guard = candle_engine
+                .pool
+                .checkout_blocking()
+                .expect("candle checkout");
+            let mut candle_state = candle_engine.create_state(false);
+            let mut candle_text = String::new();
+            for chunk in samples.chunks(CHUNK_SAMPLES) {
+                let segs = candle_engine
+                    .process_chunk(chunk, &mut candle_state, &mut candle_guard)
+                    .expect("candle process_chunk must not error");
+                for seg in segs {
+                    if !candle_text.is_empty() {
+                        candle_text.push(' ');
+                    }
+                    candle_text.push_str(seg.text.trim());
+                }
+            }
+            if let Some(seg) = candle_engine.finish_stream(&mut candle_state, &mut candle_guard) {
+                if !candle_text.is_empty() {
+                    candle_text.push(' ');
+                }
+                candle_text.push_str(seg.text.trim());
+            }
+
+            eprintln!("fixture = {fixture}");
+            eprintln!("ort    (streamed) = {ort_text:?}");
+            eprintln!("candle (streamed) = {candle_text:?}");
+
+            assert_eq!(
+                ort_text, candle_text,
+                "candle streamed transcript diverges from ort for {fixture}:\n  ort    = {ort_text:?}\n  candle = {candle_text:?}"
+            );
+        }
+    }
+
     mod mock_runtime_tests {
         use std::collections::HashMap;
         use std::sync::Arc;

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(all(feature = "candle", any(feature = "coreml", feature = "cuda")))]
+compile_error!("feature `candle` is mutually exclusive with `coreml`/`cuda`");
+
 pub mod error;
 pub mod export;
 pub mod inference;

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -15,3 +15,14 @@ pub(crate) mod runtime;
 pub mod vad;
 
 pub use runtime::cpu_factory;
+
+/// Runtime abstraction surface needed to drive backends directly (e.g. parity
+/// tests that construct and compare the ort and candle encoder sessions).
+pub mod runtime_api {
+    #[cfg(feature = "candle")]
+    pub use crate::runtime::candle_factory;
+    pub use crate::runtime::{
+        Runtime, RuntimeError, RuntimeFactory, RuntimeSession, Shape, Tensor, TensorData,
+        TensorDataView, cpu_factory, production_factory,
+    };
+}

--- a/crates/gigastt-core/src/runtime/candle/config.rs
+++ b/crates/gigastt-core/src/runtime/candle/config.rs
@@ -1,0 +1,175 @@
+// Vendored from askidmobile/RustASR (crates/model-gigaam, commit 33060b8d),
+// dual-licensed MIT OR Apache-2.0. Copyright (c) the RustASR authors.
+// Adapted for gigastt: import paths changed; compiled against upstream candle 0.9;
+// CTC head not used here (only the v3 Conformer encoder).
+#![allow(dead_code)] // wired into a RuntimeSession in a later task
+
+//! Конфигурация GigaAM v3 E2E CTC.
+
+use serde::{Deserialize, Serialize};
+
+/// Конфигурация модели GigaAM.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GigaAmConfig {
+    /// Название модели (например, "gigaam-v3-e2e-ctc").
+    pub model_name: String,
+
+    /// Тип декодера: "ctc" или "rnnt".
+    pub model_class: String,
+
+    /// Частота дискретизации аудио (16000).
+    pub sample_rate: usize,
+
+    /// Конфигурация препроцессора (mel-спектрограмма).
+    pub preprocessor: PreprocessorConfig,
+
+    /// Конфигурация Conformer-энкодера.
+    pub encoder: EncoderConfig,
+
+    /// Конфигурация CTC-головы.
+    pub head: HeadConfig,
+}
+
+/// Конфигурация mel-спектрограммы.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreprocessorConfig {
+    /// Частота дискретизации (16000).
+    pub sample_rate: usize,
+
+    /// Количество mel-бинов (64).
+    pub features: usize,
+
+    /// Длина окна (320).
+    pub win_length: usize,
+
+    /// Шаг между фреймами (160).
+    pub hop_length: usize,
+
+    /// Размер FFT (320).
+    pub n_fft: usize,
+
+    /// Шкала mel-фильтров ("htk").
+    pub mel_scale: String,
+
+    /// Центрирование STFT (false для GigaAM).
+    #[serde(default)]
+    pub center: bool,
+}
+
+/// Конфигурация Conformer-энкодера.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncoderConfig {
+    /// Количество входных mel-бинов (64).
+    pub feat_in: usize,
+
+    /// Количество слоёв Conformer (16).
+    pub n_layers: usize,
+
+    /// Размерность модели (768).
+    pub d_model: usize,
+
+    /// Тип субдискретизации: "conv1d" или "conv2d".
+    pub subsampling: String,
+
+    /// Размер ядра свёртки субдискретизации (5).
+    pub subs_kernel_size: usize,
+
+    /// Фактор субдискретизации (4).
+    pub subsampling_factor: usize,
+
+    /// Фактор расширения feed-forward (4).
+    pub ff_expansion_factor: usize,
+
+    /// Тип позиционного кодирования: "rotary" или "rel_pos".
+    pub self_attention_model: String,
+
+    /// Максимальная длина позиционного кодирования (5000).
+    pub pos_emb_max_len: usize,
+
+    /// Количество голов внимания (16).
+    pub n_heads: usize,
+
+    /// Размер ядра свёртки в Conformer-блоке (5).
+    pub conv_kernel_size: usize,
+
+    /// Тип нормализации свёртки: "layer_norm" или "batch_norm".
+    pub conv_norm_type: String,
+}
+
+/// Конфигурация CTC-головы.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeadConfig {
+    /// Входная размерность (d_model = 768).
+    pub feat_in: usize,
+
+    /// Количество классов (257 для v3_e2e_ctc: 256 токенов + blank).
+    pub num_classes: usize,
+}
+
+impl GigaAmConfig {
+    /// Конфигурация по умолчанию для GigaAM v3 E2E CTC.
+    pub fn v3_e2e_ctc() -> Self {
+        Self {
+            model_name: "gigaam-v3-e2e-ctc".to_string(),
+            model_class: "ctc".to_string(),
+            sample_rate: 16000,
+            preprocessor: PreprocessorConfig {
+                sample_rate: 16000,
+                features: 64,
+                win_length: 320,
+                hop_length: 160,
+                n_fft: 320,
+                mel_scale: "htk".to_string(),
+                center: false,
+            },
+            encoder: EncoderConfig {
+                feat_in: 64,
+                n_layers: 16,
+                d_model: 768,
+                subsampling: "conv1d".to_string(),
+                subs_kernel_size: 5,
+                subsampling_factor: 4,
+                ff_expansion_factor: 4,
+                self_attention_model: "rotary".to_string(),
+                pos_emb_max_len: 5000,
+                n_heads: 16,
+                conv_kernel_size: 5,
+                conv_norm_type: "layer_norm".to_string(),
+            },
+            head: HeadConfig {
+                feat_in: 768,
+                num_classes: 257,
+            },
+        }
+    }
+
+    /// d_k — размерность на одну голову внимания.
+    pub fn d_k(&self) -> usize {
+        self.encoder.d_model / self.encoder.n_heads
+    }
+
+    /// Размерность feed-forward слоя.
+    pub fn d_ff(&self) -> usize {
+        self.encoder.d_model * self.encoder.ff_expansion_factor
+    }
+}
+
+impl EncoderConfig {
+    /// GigaAM v3 encoder config (shared across CTC/rnnt heads).
+    pub fn v3_rnnt() -> Self {
+        Self {
+            feat_in: 64,
+            n_layers: 16,
+            d_model: 768,
+            subsampling: "conv1d".to_string(),
+            subs_kernel_size: 5,
+            subsampling_factor: 4,
+            ff_expansion_factor: 4,
+            self_attention_model: "rotary".to_string(),
+            pos_emb_max_len: 5000,
+            n_heads: 16,
+            conv_kernel_size: 5,
+            conv_norm_type: "layer_norm".to_string(),
+        }
+    }
+}

--- a/crates/gigastt-core/src/runtime/candle/conformer.rs
+++ b/crates/gigastt-core/src/runtime/candle/conformer.rs
@@ -27,7 +27,10 @@ use super::config::EncoderConfig;
 ///
 /// Возвращает два тензора (cos, sin) формы (max_len, 1, 1, dim).
 fn create_rope_table(dim: usize, max_len: usize, device: &Device) -> Result<(Tensor, Tensor)> {
-    let base = 10_000f32;
+    // GigaAM v3 uses a RoPE base of 5000 (not the common 10000); verified by
+    // matching the encoder's baked cos/sin table to 5.96e-6 over the first 100
+    // positions. Using 10000 silently corrupts attention from the first layer.
+    let base = 5_000f32;
     // inv_freq = 1 / (base^(2i/dim)) для i = 0, 2, 4, ..., dim-2
     let half_dim = dim / 2;
     let inv_freq: Vec<f32> = (0..half_dim)

--- a/crates/gigastt-core/src/runtime/candle/conformer.rs
+++ b/crates/gigastt-core/src/runtime/candle/conformer.rs
@@ -1,0 +1,628 @@
+// Vendored from askidmobile/RustASR (crates/model-gigaam, commit 33060b8d),
+// dual-licensed MIT OR Apache-2.0. Copyright (c) the RustASR authors.
+// Adapted for gigastt: import paths changed; compiled against upstream candle 0.9;
+// CTC head not used here (only the v3 Conformer encoder).
+#![allow(dead_code)] // wired into a RuntimeSession in a later task
+
+//! Conformer-энкодер для GigaAM.
+//!
+//! Реализация архитектуры Conformer (Gulati et al., 2020)
+//! с Rotary Position Embeddings (RoPE), Macaron-style FFN,
+//! depthwise separable convolution, и стриженной субдискретизацией.
+//!
+//! Совместимость весов: ключи тензоров совпадают с PyTorch-реализацией
+//! GigaAM (salute-developers/GigaAM), что позволяет загружать
+//! сконвертированные safetensors напрямую через VarBuilder.
+
+use candle_core::{Device, Result, Tensor};
+use candle_nn::{Conv1d, Conv1dConfig, LayerNorm, Linear, Module, VarBuilder};
+
+use super::config::EncoderConfig;
+
+// -----------------------------------------------------------------------
+// Rotary Position Embedding (RoPE)
+// -----------------------------------------------------------------------
+
+/// Создать таблицу cos/sin для RoPE.
+///
+/// Возвращает два тензора (cos, sin) формы (max_len, 1, 1, dim).
+fn create_rope_table(dim: usize, max_len: usize, device: &Device) -> Result<(Tensor, Tensor)> {
+    let base = 10_000f32;
+    // inv_freq = 1 / (base^(2i/dim)) для i = 0, 2, 4, ..., dim-2
+    let half_dim = dim / 2;
+    let inv_freq: Vec<f32> = (0..half_dim)
+        .map(|i| 1.0 / base.powf(2.0 * i as f32 / dim as f32))
+        .collect();
+
+    let inv_freq_t = Tensor::from_vec(inv_freq, half_dim, device)?;
+    let positions: Vec<f32> = (0..max_len).map(|i| i as f32).collect();
+    let positions_t = Tensor::from_vec(positions, max_len, device)?;
+
+    // freqs = outer(positions, inv_freq) → (max_len, half_dim)
+    let freqs = positions_t
+        .unsqueeze(1)?
+        .matmul(&inv_freq_t.unsqueeze(0)?)?;
+
+    // emb = cat(freqs, freqs, dim=-1) → (max_len, dim)
+    let emb = Tensor::cat(&[&freqs, &freqs], 1)?;
+
+    let cos = emb.cos()?;
+    let sin = emb.sin()?;
+
+    // Формы: (max_len, 1, 1, dim) для broadcasting с (seq, batch, heads, d_k)
+    let cos = cos.unsqueeze(1)?.unsqueeze(1)?;
+    let sin = sin.unsqueeze(1)?.unsqueeze(1)?;
+
+    Ok((cos, sin))
+}
+
+/// Применить RoPE к Q и K.
+///
+/// q, k: (seq_len, batch, n_heads, d_k)
+/// cos, sin: (seq_len, 1, 1, d_k) — обрезанные до seq_len
+fn apply_rotary_pos_emb(
+    q: &Tensor,
+    k: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+) -> Result<(Tensor, Tensor)> {
+    let q_rot = rotate_half(q)?;
+    let k_rot = rotate_half(k)?;
+
+    let q_embed = q.broadcast_mul(cos)?.add(&q_rot.broadcast_mul(sin)?)?;
+    let k_embed = k.broadcast_mul(cos)?.add(&k_rot.broadcast_mul(sin)?)?;
+
+    Ok((q_embed, k_embed))
+}
+
+/// Разделить последнее измерение пополам и повернуть: (-x2, x1).
+fn rotate_half(x: &Tensor) -> Result<Tensor> {
+    let d = x.dim(candle_core::D::Minus1)?;
+    let half = d / 2;
+    let x1 = x.narrow(candle_core::D::Minus1, 0, half)?;
+    let x2 = x.narrow(candle_core::D::Minus1, half, half)?;
+    let neg_x2 = x2.neg()?;
+    Tensor::cat(&[&neg_x2, &x1], candle_core::D::Minus1)
+}
+
+// -----------------------------------------------------------------------
+// Strided Subsampling (conv1d)
+// -----------------------------------------------------------------------
+
+/// Страйденная субдискретизация через свёрточные слои.
+///
+/// Уменьшает длину последовательности в `subsampling_factor` раз.
+/// Для factor=4 используется 2 слоя Conv1d с stride=2.
+pub struct StridingSubsampling {
+    /// Свёрточные слои (без ReLU — он применяется в forward).
+    convs: Vec<Conv1d>,
+    /// Фактор субдискретизации.
+    factor: usize,
+}
+
+impl StridingSubsampling {
+    pub fn load(
+        feat_in: usize,
+        d_model: usize,
+        kernel_size: usize,
+        factor: usize,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let n_layers = (factor as f64).log2() as usize;
+        let padding = (kernel_size - 1) / 2;
+        let cfg = Conv1dConfig {
+            padding,
+            stride: 2,
+            dilation: 1,
+            groups: 1,
+            ..Default::default()
+        };
+
+        let mut convs = Vec::with_capacity(n_layers);
+        let mut in_ch = feat_in;
+
+        for i in 0..n_layers {
+            // Ключи: conv.0, conv.2 (рядом с ReLU на позициях 1, 3)
+            let layer_idx = i * 2;
+            let conv = candle_nn::conv1d(
+                in_ch,
+                d_model,
+                kernel_size,
+                cfg,
+                vb.pp(format!("conv.{layer_idx}")),
+            )?;
+            convs.push(conv);
+            in_ch = d_model;
+        }
+
+        Ok(Self { convs, factor })
+    }
+
+    /// Прямой проход: (batch, feat_in, seq_len) → (batch, seq_len/factor, d_model).
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        // Вход: (batch, seq_len, feat_in) — транспонируем в (batch, feat_in, seq_len)
+        let mut h = x.transpose(1, 2)?;
+
+        for conv in &self.convs {
+            h = conv.forward(&h)?;
+            h = h.relu()?;
+        }
+
+        // Выход: (batch, d_model, seq_len/factor) → (batch, seq_len/factor, d_model)
+        h.transpose(1, 2)
+    }
+
+    /// Вычислить длину после субдискретизации.
+    pub fn output_length(&self, input_length: usize) -> usize {
+        let mut length = input_length;
+        let n_layers = (self.factor as f64).log2() as usize;
+        for _ in 0..n_layers {
+            length = length.div_ceil(2);
+        }
+        length
+    }
+}
+
+// -----------------------------------------------------------------------
+// Multi-Head Attention с Rotary Position Embeddings
+// -----------------------------------------------------------------------
+
+/// Multi-Head Self-Attention с RoPE (Rotary Position Embeddings).
+pub struct RotaryMHSA {
+    linear_q: Linear,
+    linear_k: Linear,
+    linear_v: Linear,
+    linear_out: Linear,
+    n_heads: usize,
+    d_k: usize,
+}
+
+impl RotaryMHSA {
+    pub fn load(d_model: usize, n_heads: usize, vb: VarBuilder) -> Result<Self> {
+        let d_k = d_model / n_heads;
+        let linear_q = candle_nn::linear(d_model, d_model, vb.pp("linear_q"))?;
+        let linear_k = candle_nn::linear(d_model, d_model, vb.pp("linear_k"))?;
+        let linear_v = candle_nn::linear(d_model, d_model, vb.pp("linear_v"))?;
+        let linear_out = candle_nn::linear(d_model, d_model, vb.pp("linear_out"))?;
+
+        Ok(Self {
+            linear_q,
+            linear_k,
+            linear_v,
+            linear_out,
+            n_heads,
+            d_k,
+        })
+    }
+
+    /// Прямой проход MHSA с RoPE.
+    ///
+    /// # Аргументы
+    /// * `x` — (batch, seq, d_model) — входной тензор (query=key=value=x)
+    /// * `cos_emb`, `sin_emb` — RoPE таблицы, обрезанные до seq_len
+    ///   формы (seq_len, 1, 1, d_k)
+    /// * `att_mask` — маска внимания (batch, seq, seq) или None
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        cos_emb: &Tensor,
+        sin_emb: &Tensor,
+        att_mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        let (b, t, _d) = x.dims3()?;
+
+        // 1. Применить RoPE к сырому входу (до проекции).
+        //    GigaAM применяет RoPE ДО линейных проекций Q/K.
+        //    x: (batch, seq, d_model) → reshape → (seq, batch, heads, d_k)
+        let x_rope = x
+            .transpose(0, 1)? // (seq, batch, d_model)
+            .reshape((t, b, self.n_heads, self.d_k))?; // (seq, batch, heads, d_k)
+
+        let (q_rope, k_rope) = apply_rotary_pos_emb(&x_rope, &x_rope, cos_emb, sin_emb)?;
+
+        // Обратно: (seq, batch, heads, d_k) → (batch, seq, d_model)
+        let q_in = q_rope
+            .reshape((t, b, self.n_heads * self.d_k))?
+            .transpose(0, 1)?; // (batch, seq, d_model)
+        let k_in = k_rope
+            .reshape((t, b, self.n_heads * self.d_k))?
+            .transpose(0, 1)?; // (batch, seq, d_model)
+        let v_in = x_rope
+            .reshape((t, b, self.n_heads * self.d_k))?
+            .transpose(0, 1)?; // (batch, seq, d_model)
+
+        // 2. Проекция через линейные слои.
+        let q = self
+            .linear_q
+            .forward(&q_in)? // (batch, seq, d_model)
+            .reshape((b, t, self.n_heads, self.d_k))?
+            .transpose(1, 2)? // (batch, heads, seq, d_k)
+            .contiguous()?;
+        let k = self
+            .linear_k
+            .forward(&k_in)?
+            .reshape((b, t, self.n_heads, self.d_k))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = self
+            .linear_v
+            .forward(&v_in)?
+            .reshape((b, t, self.n_heads, self.d_k))?
+            .transpose(1, 2)?
+            .contiguous()?;
+
+        // 3. Scaled dot-product attention.
+        let scale = (self.d_k as f64).sqrt();
+        let mut scores = q.matmul(&k.transpose(2, 3)?)?;
+        scores = (scores / scale)?;
+
+        // Применить маску (если есть).
+        if let Some(mask) = att_mask {
+            // mask: (batch, seq, seq) → (batch, 1, seq, seq)
+            let mask = mask.unsqueeze(1)?;
+            // Маскированные позиции заполняем -10000.
+            let fill_val =
+                Tensor::new(-10_000f32, scores.device())?.broadcast_as(scores.shape())?;
+            scores = mask.where_cond(&fill_val, &scores)?;
+        }
+
+        let attn = candle_nn::ops::softmax_last_dim(&scores)?;
+
+        if let Some(mask) = att_mask {
+            let mask = mask.unsqueeze(1)?;
+            let zeros = Tensor::zeros_like(&attn)?;
+            let attn = mask.where_cond(&zeros, &attn)?;
+
+            // 4. Weighted sum и выходная проекция.
+            let context = attn.matmul(&v)?; // (batch, heads, seq, d_k)
+            let context = context
+                .transpose(1, 2)? // (batch, seq, heads, d_k)
+                .reshape((b, t, self.n_heads * self.d_k))?;
+            return self.linear_out.forward(&context);
+        }
+
+        // 4. Weighted sum и выходная проекция (без маски).
+        let context = attn.matmul(&v)?;
+        let context = context
+            .transpose(1, 2)?
+            .reshape((b, t, self.n_heads * self.d_k))?;
+        self.linear_out.forward(&context)
+    }
+}
+
+// -----------------------------------------------------------------------
+// Conformer Feed-Forward Module
+// -----------------------------------------------------------------------
+
+/// Conformer Feed-Forward: Linear → SiLU → Linear.
+pub struct ConformerFeedForward {
+    linear1: Linear,
+    linear2: Linear,
+}
+
+impl ConformerFeedForward {
+    pub fn load(d_model: usize, d_ff: usize, vb: VarBuilder) -> Result<Self> {
+        let linear1 = candle_nn::linear(d_model, d_ff, vb.pp("linear1"))?;
+        let linear2 = candle_nn::linear(d_ff, d_model, vb.pp("linear2"))?;
+        Ok(Self { linear1, linear2 })
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let h = self.linear1.forward(x)?;
+        let h = candle_nn::Activation::Silu.forward(&h)?;
+        self.linear2.forward(&h)
+    }
+}
+
+// -----------------------------------------------------------------------
+// Conformer Convolution Module
+// -----------------------------------------------------------------------
+
+/// Conformer Convolution:
+/// Pointwise Conv1d → GLU → Depthwise Conv1d → LayerNorm → SiLU → Pointwise Conv1d
+pub struct ConformerConvolution {
+    pointwise_conv1: Conv1d,
+    depthwise_conv: Conv1d,
+    norm: LayerNorm,
+    pointwise_conv2: Conv1d,
+    d_model: usize,
+}
+
+impl ConformerConvolution {
+    pub fn load(d_model: usize, kernel_size: usize, vb: VarBuilder) -> Result<Self> {
+        let padding = (kernel_size - 1) / 2;
+
+        // Pointwise conv1: (d_model → 2*d_model, kernel=1) для GLU
+        let pw1_cfg = Conv1dConfig {
+            padding: 0,
+            stride: 1,
+            dilation: 1,
+            groups: 1,
+            ..Default::default()
+        };
+        let pointwise_conv1 =
+            candle_nn::conv1d(d_model, d_model * 2, 1, pw1_cfg, vb.pp("pointwise_conv1"))?;
+
+        // Depthwise conv: (d_model → d_model, kernel=kernel_size, groups=d_model)
+        let dw_cfg = Conv1dConfig {
+            padding,
+            stride: 1,
+            dilation: 1,
+            groups: d_model,
+            ..Default::default()
+        };
+        let depthwise_conv = candle_nn::conv1d(
+            d_model,
+            d_model,
+            kernel_size,
+            dw_cfg,
+            vb.pp("depthwise_conv"),
+        )?;
+
+        // LayerNorm (ключ "batch_norm" для совместимости с PyTorch)
+        let norm = candle_nn::layer_norm(d_model, 1e-5, vb.pp("batch_norm"))?;
+
+        // Pointwise conv2: (d_model → d_model, kernel=1)
+        let pw2_cfg = Conv1dConfig {
+            padding: 0,
+            stride: 1,
+            dilation: 1,
+            groups: 1,
+            ..Default::default()
+        };
+        let pointwise_conv2 =
+            candle_nn::conv1d(d_model, d_model, 1, pw2_cfg, vb.pp("pointwise_conv2"))?;
+
+        Ok(Self {
+            pointwise_conv1,
+            depthwise_conv,
+            norm,
+            pointwise_conv2,
+            d_model,
+        })
+    }
+
+    /// Прямой проход: x (batch, seq, d_model) → (batch, seq, d_model).
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        // x: (batch, seq, d_model)
+
+        // Транспонируем для Conv1d: (batch, d_model, seq)
+        let h = x.transpose(1, 2)?;
+
+        // Pointwise conv1: (batch, 2*d_model, seq)
+        let h = self.pointwise_conv1.forward(&h)?;
+
+        // GLU: разделить по каналам, sigmoid(вторая половина) * первая половина
+        let h1 = h.narrow(1, 0, self.d_model)?;
+        let h2 = h.narrow(1, self.d_model, self.d_model)?;
+        let h = (h1 * candle_nn::ops::sigmoid(&h2)?)?;
+
+        // Depthwise conv: (batch, d_model, seq)
+        let h = self.depthwise_conv.forward(&h)?;
+
+        // LayerNorm: нужно транспонировать в (batch, seq, d_model)
+        let h = h.transpose(1, 2)?; // (batch, seq, d_model)
+        let h = self.norm.forward(&h)?;
+        let h = h.transpose(1, 2)?; // обратно (batch, d_model, seq)
+
+        // SiLU
+        let h = candle_nn::Activation::Silu.forward(&h)?;
+
+        // Pointwise conv2
+        let h = self.pointwise_conv2.forward(&h)?;
+
+        // Обратно в (batch, seq, d_model)
+        h.transpose(1, 2)
+    }
+}
+
+// -----------------------------------------------------------------------
+// Conformer Layer (Macaron-style)
+// -----------------------------------------------------------------------
+
+/// Один слой Conformer (Macaron-style):
+/// FFN1 → Self-Attention → Convolution → FFN2 → LayerNorm
+pub struct ConformerLayer {
+    norm_feed_forward1: LayerNorm,
+    feed_forward1: ConformerFeedForward,
+    norm_self_att: LayerNorm,
+    self_attn: RotaryMHSA,
+    norm_conv: LayerNorm,
+    conv: ConformerConvolution,
+    norm_feed_forward2: LayerNorm,
+    feed_forward2: ConformerFeedForward,
+    norm_out: LayerNorm,
+}
+
+impl ConformerLayer {
+    pub fn load(
+        d_model: usize,
+        d_ff: usize,
+        n_heads: usize,
+        conv_kernel_size: usize,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let norm_feed_forward1 = candle_nn::layer_norm(d_model, 1e-5, vb.pp("norm_feed_forward1"))?;
+        let feed_forward1 = ConformerFeedForward::load(d_model, d_ff, vb.pp("feed_forward1"))?;
+        let norm_self_att = candle_nn::layer_norm(d_model, 1e-5, vb.pp("norm_self_att"))?;
+        let self_attn = RotaryMHSA::load(d_model, n_heads, vb.pp("self_attn"))?;
+        let norm_conv = candle_nn::layer_norm(d_model, 1e-5, vb.pp("norm_conv"))?;
+        let conv = ConformerConvolution::load(d_model, conv_kernel_size, vb.pp("conv"))?;
+        let norm_feed_forward2 = candle_nn::layer_norm(d_model, 1e-5, vb.pp("norm_feed_forward2"))?;
+        let feed_forward2 = ConformerFeedForward::load(d_model, d_ff, vb.pp("feed_forward2"))?;
+        let norm_out = candle_nn::layer_norm(d_model, 1e-5, vb.pp("norm_out"))?;
+
+        Ok(Self {
+            norm_feed_forward1,
+            feed_forward1,
+            norm_self_att,
+            self_attn,
+            norm_conv,
+            conv,
+            norm_feed_forward2,
+            feed_forward2,
+            norm_out,
+        })
+    }
+
+    /// Прямой проход одного слоя Conformer.
+    ///
+    /// x: (batch, seq, d_model)
+    /// cos_emb, sin_emb: RoPE таблицы (seq, 1, 1, d_k)
+    /// att_mask: (batch, seq, seq) или None
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        cos_emb: &Tensor,
+        sin_emb: &Tensor,
+        att_mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        const FC_FACTOR: f64 = 0.5;
+
+        // 1. FFN1 (с фактором 0.5)
+        let h = self.norm_feed_forward1.forward(x)?;
+        let h = self.feed_forward1.forward(&h)?;
+        let residual = (x + (h * FC_FACTOR)?)?;
+
+        // 2. Self-Attention
+        let h = self.norm_self_att.forward(&residual)?;
+        let h = self.self_attn.forward(&h, cos_emb, sin_emb, att_mask)?;
+        let residual = (residual + h)?;
+
+        // 3. Convolution
+        let h = self.norm_conv.forward(&residual)?;
+        let h = self.conv.forward(&h)?;
+        let residual = (residual + h)?;
+
+        // 4. FFN2 (с фактором 0.5)
+        let h = self.norm_feed_forward2.forward(&residual)?;
+        let h = self.feed_forward2.forward(&h)?;
+        let residual = (residual + (h * FC_FACTOR)?)?;
+
+        // 5. Финальная нормализация
+        self.norm_out.forward(&residual)
+    }
+}
+
+// -----------------------------------------------------------------------
+// Conformer Encoder
+// -----------------------------------------------------------------------
+
+/// Полный Conformer-энкодер GigaAM:
+/// Subsampling → Positional Encoding → N × ConformerLayer
+pub struct ConformerEncoder {
+    pre_encode: StridingSubsampling,
+    layers: Vec<ConformerLayer>,
+    /// Предвычисленная таблица cos для RoPE.
+    rope_cos: Tensor,
+    /// Предвычисленная таблица sin для RoPE.
+    rope_sin: Tensor,
+    /// Размерность одной головы (для пересоздания RoPE).
+    d_k: usize,
+    /// Количество входных mel-бинов.
+    #[allow(dead_code)]
+    feat_in: usize,
+}
+
+impl ConformerEncoder {
+    pub fn load(config: &EncoderConfig, vb: VarBuilder) -> Result<Self> {
+        let d_k = config.d_model / config.n_heads;
+        let d_ff = config.d_model * config.ff_expansion_factor;
+
+        // Субдискретизация
+        let pre_encode = StridingSubsampling::load(
+            config.feat_in,
+            config.d_model,
+            config.subs_kernel_size,
+            config.subsampling_factor,
+            vb.pp("pre_encode"),
+        )?;
+
+        // Создать таблицу RoPE
+        let (rope_cos, rope_sin) = create_rope_table(d_k, config.pos_emb_max_len, vb.device())?;
+        // Привести к тому же dtype, что и модель
+        let rope_cos = rope_cos.to_dtype(vb.dtype())?;
+        let rope_sin = rope_sin.to_dtype(vb.dtype())?;
+
+        // Слои Conformer
+        let mut layers = Vec::with_capacity(config.n_layers);
+        for i in 0..config.n_layers {
+            let layer = ConformerLayer::load(
+                config.d_model,
+                d_ff,
+                config.n_heads,
+                config.conv_kernel_size,
+                vb.pp(format!("layers.{i}")),
+            )?;
+            layers.push(layer);
+        }
+
+        Ok(Self {
+            pre_encode,
+            layers,
+            rope_cos,
+            rope_sin,
+            d_k,
+            feat_in: config.feat_in,
+        })
+    }
+
+    /// Прямой проход энкодера.
+    ///
+    /// # Аргументы
+    /// * `features` — mel-спектрограмма (batch, feat_in, seq_len)
+    ///
+    /// # Возвращает
+    /// Тензор (batch, d_model, encoded_len) — закодированные фичи.
+    pub fn forward(&self, features: &Tensor) -> Result<Tensor> {
+        // 1. Субдискретизация: (batch, feat_in, seq) → (batch, seq/4, d_model)
+        // Входной features в формате (batch, feat_in, seq_len)
+        // Субдискретизация ожидает (batch, seq, feat_in)
+        let x = features.transpose(1, 2)?;
+        let x = self.pre_encode.forward(&x)?;
+
+        let (_b, t, _d) = x.dims3()?;
+
+        // 2. RoPE — обрезать cos/sin до текущей длины.
+        //    Если последовательность длиннее предвычисленной таблицы,
+        //    пересоздаём таблицу на лету.
+        let (cos_emb, sin_emb) = if t <= self.rope_cos.dim(0)? {
+            (
+                self.rope_cos.narrow(0, 0, t)?,
+                self.rope_sin.narrow(0, 0, t)?,
+            )
+        } else {
+            tracing::warn!(
+                "GigaAM: RoPE таблица расширена с {} до {} позиций",
+                self.rope_cos.dim(0)?,
+                t,
+            );
+            let (cos, sin) = create_rope_table(self.d_k, t, x.device())?;
+            (cos.to_dtype(x.dtype())?, sin.to_dtype(x.dtype())?)
+        };
+
+        // 3. Прогоняем через все слои Conformer.
+        // Маску не используем (batch_size=1 при инференсе).
+        //
+        // Metal workaround: каждые SYNC_EVERY слоёв вставляем device.synchronize()
+        // для сброса Metal command buffer pool. Это предотвращает накопление
+        // слишком большого количества буферов в in-flight состоянии, что может
+        // вызвать краш AGXMetalG16X::fillBuffer на M4 / macOS 26.x.
+        const SYNC_EVERY: usize = 4;
+        let is_metal = x.device().is_metal();
+
+        let mut h = x;
+        for (i, layer) in self.layers.iter().enumerate() {
+            h = layer.forward(&h, &cos_emb, &sin_emb, None)?;
+
+            if is_metal && (i + 1) % SYNC_EVERY == 0 {
+                h.device().synchronize().map_err(|e| {
+                    candle_core::Error::Msg(format!("Metal sync at layer {}: {e}", i + 1))
+                })?;
+            }
+        }
+
+        // 4. Выход: (batch, seq/4, d_model) → (batch, d_model, seq/4)
+        h.transpose(1, 2)
+    }
+}

--- a/crates/gigastt-core/src/runtime/candle/factory.rs
+++ b/crates/gigastt-core/src/runtime/candle/factory.rs
@@ -1,0 +1,50 @@
+#![allow(dead_code)]
+
+use crate::runtime::{
+    error::RuntimeError,
+    factory::{Runtime, RuntimeFactory},
+};
+
+use super::runtime::CandleRuntime;
+
+/// Which hardware device the Candle backend runs on.
+#[derive(Clone, Copy)]
+pub enum CandleDevice {
+    Cpu,
+    Metal,
+}
+
+/// Factory that creates a `CandleRuntime` for the selected device.
+pub struct CandleFactory {
+    device: CandleDevice,
+}
+
+impl CandleFactory {
+    /// Prefer Metal (Apple Silicon Neural Engine / GPU); fall back to CPU.
+    pub fn new() -> Self {
+        let device = if candle_core::Device::new_metal(0).is_ok() {
+            CandleDevice::Metal
+        } else {
+            CandleDevice::Cpu
+        };
+        Self { device }
+    }
+
+    /// CPU-only factory.
+    pub fn cpu() -> Self {
+        Self {
+            device: CandleDevice::Cpu,
+        }
+    }
+}
+
+impl RuntimeFactory for CandleFactory {
+    fn create(&self, _intra_threads: usize) -> Result<Box<dyn Runtime>, RuntimeError> {
+        let runtime = CandleRuntime::new(self.device)?;
+        Ok(Box::new(runtime))
+    }
+
+    fn cpu_fallback(&self) -> Box<dyn RuntimeFactory> {
+        Box::new(CandleFactory::cpu())
+    }
+}

--- a/crates/gigastt-core/src/runtime/candle/mod.rs
+++ b/crates/gigastt-core/src/runtime/candle/mod.rs
@@ -7,3 +7,5 @@ pub mod config;
 pub mod conformer;
 pub mod factory;
 pub mod runtime;
+pub mod session;
+pub mod tensor;

--- a/crates/gigastt-core/src/runtime/candle/mod.rs
+++ b/crates/gigastt-core/src/runtime/candle/mod.rs
@@ -3,5 +3,7 @@
 //! ISOLATION: all `candle_core`/`candle_nn` usage MUST stay inside this module
 //! (`runtime/candle/`). The rest of the crate talks only to the RuntimeFactory/
 //! Runtime/RuntimeSession traits. Gated behind `feature = "candle"`.
+pub mod config;
+pub mod conformer;
 pub mod factory;
 pub mod runtime;

--- a/crates/gigastt-core/src/runtime/candle/mod.rs
+++ b/crates/gigastt-core/src/runtime/candle/mod.rs
@@ -1,0 +1,7 @@
+//! Pure-Rust Candle inference backend (Metal on Apple Silicon, else CPU).
+//!
+//! ISOLATION: all `candle_core`/`candle_nn` usage MUST stay inside this module
+//! (`runtime/candle/`). The rest of the crate talks only to the RuntimeFactory/
+//! Runtime/RuntimeSession traits. Gated behind `feature = "candle"`.
+pub mod factory;
+pub mod runtime;

--- a/crates/gigastt-core/src/runtime/candle/runtime.rs
+++ b/crates/gigastt-core/src/runtime/candle/runtime.rs
@@ -2,7 +2,10 @@
 
 use crate::runtime::{error::RuntimeError, factory::Runtime, session::RuntimeSession};
 
+use super::config::EncoderConfig;
+use super::conformer::ConformerEncoder;
 use super::factory::CandleDevice;
+use super::session::EncoderSession;
 
 /// Candle runtime owning a device handle.
 pub struct CandleRuntime {
@@ -25,11 +28,53 @@ impl Runtime for CandleRuntime {
     fn load_session(
         &self,
         model_path: &std::path::Path,
-        _is_encoder: bool,
+        is_encoder: bool,
     ) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
-        Err(RuntimeError::InferenceFailed(format!(
-            "candle backend not yet implemented for {}",
-            model_path.display()
-        )))
+        if !is_encoder {
+            return Err(RuntimeError::InferenceFailed(format!(
+                "candle backend not yet implemented for {}",
+                model_path.display()
+            )));
+        }
+
+        // The converted Candle weights live in a `candle/` subdirectory next to
+        // the ONNX models: `<model_dir>/candle/encoder.safetensors`.
+        let st = model_path
+            .parent()
+            .map(|p| p.join("candle/encoder.safetensors"))
+            .ok_or_else(|| {
+                RuntimeError::InferenceFailed(
+                    "encoder model path has no parent directory".to_string(),
+                )
+            })?;
+
+        if !st.exists() {
+            return Err(RuntimeError::LoadFailed {
+                path: st.clone(),
+                message: "candle encoder weights (candle/encoder.safetensors) not found"
+                    .to_string(),
+            });
+        }
+
+        let vb = unsafe {
+            candle_nn::VarBuilder::from_mmaped_safetensors(
+                std::slice::from_ref(&st),
+                candle_core::DType::F32,
+                &self.device,
+            )
+            .map_err(|e| RuntimeError::LoadFailed {
+                path: st.clone(),
+                message: e.to_string(),
+            })?
+        };
+
+        let enc = ConformerEncoder::load(&EncoderConfig::v3_rnnt(), vb).map_err(|e| {
+            RuntimeError::LoadFailed {
+                path: st,
+                message: e.to_string(),
+            }
+        })?;
+
+        Ok(Box::new(EncoderSession::new(enc, self.device.clone())))
     }
 }

--- a/crates/gigastt-core/src/runtime/candle/runtime.rs
+++ b/crates/gigastt-core/src/runtime/candle/runtime.rs
@@ -5,7 +5,7 @@ use crate::runtime::{error::RuntimeError, factory::Runtime, session::RuntimeSess
 use super::config::EncoderConfig;
 use super::conformer::ConformerEncoder;
 use super::factory::CandleDevice;
-use super::session::EncoderSession;
+use super::session::{DecoderSession, EncoderSession, JoinerSession};
 
 /// Candle runtime owning a device handle.
 pub struct CandleRuntime {
@@ -30,51 +30,71 @@ impl Runtime for CandleRuntime {
         model_path: &std::path::Path,
         is_encoder: bool,
     ) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
-        if !is_encoder {
-            return Err(RuntimeError::InferenceFailed(format!(
-                "candle backend not yet implemented for {}",
-                model_path.display()
-            )));
+        // The converted Candle weights live in a `candle/` subdirectory next to
+        // the ONNX models: `<model_dir>/candle/{encoder,decoder,joiner}.safetensors`.
+        // Encoder is flagged explicitly; otherwise dispatch by filename.
+        let dir = model_path.parent().ok_or_else(|| {
+            RuntimeError::InferenceFailed("model path has no parent directory".to_string())
+        })?;
+
+        if is_encoder {
+            let vb = self.var_builder(&dir.join("candle/encoder.safetensors"))?;
+            let enc = ConformerEncoder::load(&EncoderConfig::v3_rnnt(), vb).map_err(|e| {
+                RuntimeError::LoadFailed {
+                    path: dir.join("candle/encoder.safetensors"),
+                    message: e.to_string(),
+                }
+            })?;
+            return Ok(Box::new(EncoderSession::new(enc, self.device.clone())));
         }
 
-        // The converted Candle weights live in a `candle/` subdirectory next to
-        // the ONNX models: `<model_dir>/candle/encoder.safetensors`.
-        let st = model_path
-            .parent()
-            .map(|p| p.join("candle/encoder.safetensors"))
-            .ok_or_else(|| {
-                RuntimeError::InferenceFailed(
-                    "encoder model path has no parent directory".to_string(),
-                )
-            })?;
+        let name = model_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
 
+        if name.contains("decoder") {
+            let vb = self.var_builder(&dir.join("candle/decoder.safetensors"))?;
+            return Ok(Box::new(DecoderSession::load(vb, self.device.clone())?));
+        }
+        if name.contains("joint") || name.contains("joiner") {
+            let vb = self.var_builder(&dir.join("candle/joiner.safetensors"))?;
+            return Ok(Box::new(JoinerSession::load(vb, self.device.clone())?));
+        }
+
+        Err(RuntimeError::InferenceFailed(format!(
+            "candle backend cannot classify model file: {name}"
+        )))
+    }
+}
+
+impl CandleRuntime {
+    /// Build an F32 `VarBuilder` over a sibling `candle/*.safetensors`, with a
+    /// clear error when the converted weights are missing.
+    fn var_builder(
+        &self,
+        st: &std::path::Path,
+    ) -> Result<candle_nn::VarBuilder<'static>, RuntimeError> {
         if !st.exists() {
             return Err(RuntimeError::LoadFailed {
-                path: st.clone(),
-                message: "candle encoder weights (candle/encoder.safetensors) not found"
-                    .to_string(),
+                path: st.to_path_buf(),
+                message: format!(
+                    "candle weights not found ({}); run scripts/convert_gigaam_candle.py",
+                    st.file_name().and_then(|n| n.to_str()).unwrap_or("?")
+                ),
             });
         }
-
-        let vb = unsafe {
+        unsafe {
             candle_nn::VarBuilder::from_mmaped_safetensors(
-                std::slice::from_ref(&st),
+                std::slice::from_ref(&st.to_path_buf()),
                 candle_core::DType::F32,
                 &self.device,
             )
             .map_err(|e| RuntimeError::LoadFailed {
-                path: st.clone(),
+                path: st.to_path_buf(),
                 message: e.to_string(),
-            })?
-        };
-
-        let enc = ConformerEncoder::load(&EncoderConfig::v3_rnnt(), vb).map_err(|e| {
-            RuntimeError::LoadFailed {
-                path: st,
-                message: e.to_string(),
-            }
-        })?;
-
-        Ok(Box::new(EncoderSession::new(enc, self.device.clone())))
+            })
+        }
     }
 }

--- a/crates/gigastt-core/src/runtime/candle/runtime.rs
+++ b/crates/gigastt-core/src/runtime/candle/runtime.rs
@@ -1,0 +1,35 @@
+#![allow(dead_code)]
+
+use crate::runtime::{error::RuntimeError, factory::Runtime, session::RuntimeSession};
+
+use super::factory::CandleDevice;
+
+/// Candle runtime owning a device handle.
+pub struct CandleRuntime {
+    device: candle_core::Device,
+}
+
+impl CandleRuntime {
+    pub fn new(dev: CandleDevice) -> Result<Self, RuntimeError> {
+        let device = match dev {
+            CandleDevice::Metal => candle_core::Device::new_metal(0).map_err(|e| {
+                RuntimeError::InferenceFailed(format!("candle Metal device init failed: {e}"))
+            })?,
+            CandleDevice::Cpu => candle_core::Device::Cpu,
+        };
+        Ok(Self { device })
+    }
+}
+
+impl Runtime for CandleRuntime {
+    fn load_session(
+        &self,
+        model_path: &std::path::Path,
+        _is_encoder: bool,
+    ) -> Result<Box<dyn RuntimeSession>, RuntimeError> {
+        Err(RuntimeError::InferenceFailed(format!(
+            "candle backend not yet implemented for {}",
+            model_path.display()
+        )))
+    }
+}

--- a/crates/gigastt-core/src/runtime/candle/session.rs
+++ b/crates/gigastt-core/src/runtime/candle/session.rs
@@ -35,9 +35,12 @@ impl EncoderSession {
 }
 
 impl RuntimeSession for EncoderSession {
-    /// Encoder contract: `inputs[0] = audio_signal [1, 64, T] F32`,
-    /// `inputs[1] = length [1]` (ignored; batch is always 1 here).
-    /// Returns `[1, 768, T/4] F32` (channels-first), matching the ort backend.
+    /// Encoder contract (mirrors the ort ONNX encoder, which emits two outputs):
+    /// `inputs[0] = audio_signal [1, 64, T] F32`, `inputs[1] = length [1]`
+    /// (ignored; batch is always 1 here). Returns
+    /// `[encoded [1, 768, T/4] F32, encoded_len [1] I64]` (channels-first), so
+    /// the engine's decode loop can read `encoder_outputs[1]` for the output
+    /// frame count exactly as it does for the ort backend.
     fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
         if inputs.is_empty() {
             return Err(RuntimeError::InvalidInputCount {
@@ -50,7 +53,18 @@ impl RuntimeSession for EncoderSession {
             .enc
             .forward(&mel)
             .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
-        Ok(vec![super::tensor::from_candle(&out)?])
+        // Output time dimension (channels-first `[1, 768, T']`) is the encoded
+        // frame count the RNN-T decode loop iterates over.
+        let enc_len = out.dims().get(2).copied().ok_or_else(|| {
+            RuntimeError::InferenceFailed(format!(
+                "encoder output has unexpected rank {}",
+                out.rank()
+            ))
+        })?;
+        Ok(vec![
+            super::tensor::from_candle(&out)?,
+            Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![enc_len as i64]))?,
+        ])
     }
 }
 

--- a/crates/gigastt-core/src/runtime/candle/session.rs
+++ b/crates/gigastt-core/src/runtime/candle/session.rs
@@ -1,10 +1,26 @@
-//! Candle-backed encoder [`RuntimeSession`].
+//! Candle-backed encoder / decoder / joiner [`RuntimeSession`] implementations.
 
-use candle_core::Device;
+use candle_core::{DType, Device, Tensor as CandleTensor};
+use candle_nn::{Module, VarBuilder};
 
-use crate::runtime::{error::RuntimeError, session::RuntimeSession, tensor::Tensor};
+use crate::runtime::{
+    error::RuntimeError,
+    session::RuntimeSession,
+    tensor::{Shape, Tensor, TensorData},
+};
 
 use super::conformer::ConformerEncoder;
+
+/// LSTM hidden size / decoder output dim (mirrors `inference::PRED_HIDDEN`).
+const PRED_HIDDEN: usize = 320;
+/// Encoder output channel dim.
+const ENC_DIM: usize = 768;
+/// rnnt char vocab size (incl. blank).
+const VOCAB: usize = 34;
+
+fn backend_err(e: impl std::fmt::Display) -> RuntimeError {
+    RuntimeError::InferenceFailed(e.to_string())
+}
 
 /// Wraps a loaded Candle Conformer encoder behind the [`RuntimeSession`] seam.
 pub struct EncoderSession {
@@ -36,4 +52,246 @@ impl RuntimeSession for EncoderSession {
             .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
         Ok(vec![super::tensor::from_candle(&out)?])
     }
+}
+
+/// Candle-backed RNN-T prediction network (embedding + single-layer LSTM).
+///
+/// Mirrors the ONNX decoder graph: `Gather(embed, token) -> LSTM(1 layer)`.
+/// The LSTM gate order is **iofc** (ONNX convention): the 1280-row weight
+/// matrices are 4 blocks of 320 in input/output/forget/cell order. A manual
+/// one-step cell is implemented (NOT candle's prebuilt LSTM, whose gate order
+/// differs) so the iofc layout is honoured exactly.
+pub struct DecoderSession {
+    /// Embedding table `[VOCAB, PRED_HIDDEN]`.
+    embed: CandleTensor,
+    /// Input-hidden weights `[4*PRED_HIDDEN, PRED_HIDDEN]` (iofc), no transpose.
+    w_ih: CandleTensor,
+    /// Hidden-hidden weights `[4*PRED_HIDDEN, PRED_HIDDEN]` (iofc), no transpose.
+    w_hh: CandleTensor,
+    /// Input bias `[4*PRED_HIDDEN]` (iofc).
+    b_ih: CandleTensor,
+    /// Recurrent bias `[4*PRED_HIDDEN]` (iofc).
+    b_hh: CandleTensor,
+    device: Device,
+}
+
+impl DecoderSession {
+    pub(crate) fn load(vb: VarBuilder, device: Device) -> Result<Self, RuntimeError> {
+        let embed = vb
+            .get((VOCAB, PRED_HIDDEN), "embed.weight")
+            .map_err(backend_err)?;
+        let w_ih = vb
+            .get((4 * PRED_HIDDEN, PRED_HIDDEN), "lstm.w_ih")
+            .map_err(backend_err)?;
+        let w_hh = vb
+            .get((4 * PRED_HIDDEN, PRED_HIDDEN), "lstm.w_hh")
+            .map_err(backend_err)?;
+        let b_ih = vb.get(4 * PRED_HIDDEN, "lstm.b_ih").map_err(backend_err)?;
+        let b_hh = vb.get(4 * PRED_HIDDEN, "lstm.b_hh").map_err(backend_err)?;
+        Ok(Self {
+            embed,
+            w_ih,
+            w_hh,
+            b_ih,
+            b_hh,
+            device,
+        })
+    }
+
+    /// One LSTM timestep over column vectors (all `[PRED_HIDDEN]`).
+    ///
+    /// `g = W_ih·x + b_ih + W_hh·h_prev + b_hh`  (gate pre-activations, iofc)
+    /// `i,o,f = sigmoid(g[..])`, `cg = tanh(g[..])`
+    /// `c_new = f*c_prev + i*cg`, `h_new = o*tanh(c_new)`.
+    fn lstm_step(
+        &self,
+        x: &CandleTensor,      // [PRED_HIDDEN]
+        h_prev: &CandleTensor, // [PRED_HIDDEN]
+        c_prev: &CandleTensor, // [PRED_HIDDEN]
+    ) -> Result<(CandleTensor, CandleTensor), RuntimeError> {
+        // matmul wants 2-D operands: weight [4H, H] · x [H, 1] -> [4H, 1].
+        let x_col = x.reshape((PRED_HIDDEN, 1)).map_err(backend_err)?;
+        let h_col = h_prev.reshape((PRED_HIDDEN, 1)).map_err(backend_err)?;
+
+        let gates = self
+            .w_ih
+            .matmul(&x_col)
+            .map_err(backend_err)?
+            .add(&self.w_hh.matmul(&h_col).map_err(backend_err)?)
+            .map_err(backend_err)?
+            .reshape(4 * PRED_HIDDEN) // [4H]
+            .map_err(backend_err)?
+            .add(&self.b_ih)
+            .map_err(backend_err)?
+            .add(&self.b_hh)
+            .map_err(backend_err)?;
+
+        // iofc gate blocks.
+        let i = gates.narrow(0, 0, PRED_HIDDEN).map_err(backend_err)?;
+        let o = gates
+            .narrow(0, PRED_HIDDEN, PRED_HIDDEN)
+            .map_err(backend_err)?;
+        let f = gates
+            .narrow(0, 2 * PRED_HIDDEN, PRED_HIDDEN)
+            .map_err(backend_err)?;
+        let cg = gates
+            .narrow(0, 3 * PRED_HIDDEN, PRED_HIDDEN)
+            .map_err(backend_err)?;
+
+        let i = candle_nn::ops::sigmoid(&i).map_err(backend_err)?;
+        let o = candle_nn::ops::sigmoid(&o).map_err(backend_err)?;
+        let f = candle_nn::ops::sigmoid(&f).map_err(backend_err)?;
+        let cg = cg.tanh().map_err(backend_err)?;
+
+        // c_new = f*c_prev + i*cg
+        let c_new = f
+            .mul(c_prev)
+            .map_err(backend_err)?
+            .add(&i.mul(&cg).map_err(backend_err)?)
+            .map_err(backend_err)?;
+        // h_new = o*tanh(c_new)
+        let h_new = o
+            .mul(&c_new.tanh().map_err(backend_err)?)
+            .map_err(backend_err)?;
+
+        Ok((h_new, c_new))
+    }
+}
+
+impl RuntimeSession for DecoderSession {
+    /// Decoder contract: `inputs = [prev_token [1,1] I64, h [1,1,320] F32,
+    /// c [1,1,320] F32]`; returns `[dec, new_h, new_c]`, each flattened length
+    /// 320 (F32). `dec == new_h` (the LSTM output equals the new hidden state).
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        if inputs.len() != 3 {
+            return Err(RuntimeError::InvalidInputCount {
+                expected: 3,
+                got: inputs.len(),
+            });
+        }
+
+        let token = inputs[0]
+            .view()
+            .data()
+            .as_i64()
+            .and_then(|s| s.first().copied())
+            .ok_or_else(|| {
+                RuntimeError::InferenceFailed("decoder prev_token must be i64 [1,1]".to_string())
+            })?;
+        if !(0..VOCAB as i64).contains(&token) {
+            return Err(RuntimeError::InferenceFailed(format!(
+                "decoder prev_token {token} out of range [0,{VOCAB})"
+            )));
+        }
+
+        let h_in = super::tensor::to_candle(&inputs[1], &self.device)?
+            .reshape(PRED_HIDDEN)
+            .map_err(backend_err)?;
+        let c_in = super::tensor::to_candle(&inputs[2], &self.device)?
+            .reshape(PRED_HIDDEN)
+            .map_err(backend_err)?;
+
+        // Embedding lookup: row `token` of `embed` -> x [PRED_HIDDEN].
+        let x = self
+            .embed
+            .narrow(0, token as usize, 1)
+            .map_err(backend_err)?
+            .reshape(PRED_HIDDEN)
+            .map_err(backend_err)?;
+
+        let (h_new, c_new) = self.lstm_step(&x, &h_in, &c_in)?;
+
+        // dec == h_new (ONNX decoder returns the LSTM output as `dec`).
+        let dec = to_runtime_vec(&h_new)?;
+        let new_h = to_runtime_vec(&h_new)?;
+        let new_c = to_runtime_vec(&c_new)?;
+
+        Ok(vec![
+            runtime_tensor_3d(dec)?,
+            runtime_tensor_3d(new_h)?,
+            runtime_tensor_3d(new_c)?,
+        ])
+    }
+}
+
+/// Candle-backed RNN-T joint network.
+///
+/// `e = enc_proj·enc + enc.bias`, `d = dec_proj·dec + pred.bias`,
+/// `j = relu(e + d)`, `out = out_proj·j + out.bias`,
+/// `logits = log_softmax(out)`  (ONNX applies LogSoftmax — matched here).
+pub struct JoinerSession {
+    enc_proj: candle_nn::Linear, // 768 -> 320
+    dec_proj: candle_nn::Linear, // 320 -> 320
+    out: candle_nn::Linear,      // 320 -> 34
+    device: Device,
+}
+
+impl JoinerSession {
+    pub(crate) fn load(vb: VarBuilder, device: Device) -> Result<Self, RuntimeError> {
+        let enc_proj =
+            candle_nn::linear(ENC_DIM, PRED_HIDDEN, vb.pp("enc_proj")).map_err(backend_err)?;
+        let dec_proj =
+            candle_nn::linear(PRED_HIDDEN, PRED_HIDDEN, vb.pp("dec_proj")).map_err(backend_err)?;
+        let out = candle_nn::linear(PRED_HIDDEN, VOCAB, vb.pp("out")).map_err(backend_err)?;
+        Ok(Self {
+            enc_proj,
+            dec_proj,
+            out,
+            device,
+        })
+    }
+}
+
+impl RuntimeSession for JoinerSession {
+    /// Joiner contract: `inputs = [enc_frame [1,768,1] F32, dec_data [1,320,1]
+    /// F32]`; output `[logits]` flattened length 34 (F32).
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        if inputs.len() != 2 {
+            return Err(RuntimeError::InvalidInputCount {
+                expected: 2,
+                got: inputs.len(),
+            });
+        }
+
+        // Flatten [1,768,1] -> [1,768] and [1,320,1] -> [1,320] (row vectors, so
+        // candle's Linear can matmul against the [out,in] weight).
+        let enc = super::tensor::to_candle(&inputs[0], &self.device)?
+            .reshape((1, ENC_DIM))
+            .map_err(backend_err)?;
+        let dec = super::tensor::to_candle(&inputs[1], &self.device)?
+            .reshape((1, PRED_HIDDEN))
+            .map_err(backend_err)?;
+
+        let e = self.enc_proj.forward(&enc).map_err(backend_err)?; // [1,320]
+        let d = self.dec_proj.forward(&dec).map_err(backend_err)?; // [1,320]
+        let j = e
+            .add(&d)
+            .map_err(backend_err)?
+            .relu()
+            .map_err(backend_err)?; // [1,320]
+        let logits = self.out.forward(&j).map_err(backend_err)?; // [1,34]
+        let log_probs = candle_nn::ops::log_softmax(&logits, 1).map_err(backend_err)?; // [1,34]
+
+        let data = to_runtime_vec(&log_probs)?;
+        Ok(vec![Tensor::new(
+            Shape::new(vec![1, 1, 1, VOCAB]),
+            TensorData::F32(data),
+        )?])
+    }
+}
+
+/// Flatten a 1-D candle tensor to an owned `Vec<f32>`.
+fn to_runtime_vec(t: &CandleTensor) -> Result<Vec<f32>, RuntimeError> {
+    t.to_dtype(DType::F32)
+        .map_err(backend_err)?
+        .flatten_all()
+        .map_err(backend_err)?
+        .to_vec1::<f32>()
+        .map_err(backend_err)
+}
+
+/// Wrap a `[PRED_HIDDEN]` vector as a runtime tensor with the ONNX decoder
+/// output shape `[1,1,PRED_HIDDEN]` (decode.rs reads it flattened as 320 f32).
+fn runtime_tensor_3d(data: Vec<f32>) -> Result<Tensor, RuntimeError> {
+    Tensor::new(Shape::new(vec![1, 1, PRED_HIDDEN]), TensorData::F32(data))
 }

--- a/crates/gigastt-core/src/runtime/candle/session.rs
+++ b/crates/gigastt-core/src/runtime/candle/session.rs
@@ -1,0 +1,39 @@
+//! Candle-backed encoder [`RuntimeSession`].
+
+use candle_core::Device;
+
+use crate::runtime::{error::RuntimeError, session::RuntimeSession, tensor::Tensor};
+
+use super::conformer::ConformerEncoder;
+
+/// Wraps a loaded Candle Conformer encoder behind the [`RuntimeSession`] seam.
+pub struct EncoderSession {
+    enc: ConformerEncoder,
+    device: Device,
+}
+
+impl EncoderSession {
+    pub(crate) fn new(enc: ConformerEncoder, device: Device) -> Self {
+        Self { enc, device }
+    }
+}
+
+impl RuntimeSession for EncoderSession {
+    /// Encoder contract: `inputs[0] = audio_signal [1, 64, T] F32`,
+    /// `inputs[1] = length [1]` (ignored; batch is always 1 here).
+    /// Returns `[1, 768, T/4] F32` (channels-first), matching the ort backend.
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        if inputs.is_empty() {
+            return Err(RuntimeError::InvalidInputCount {
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+        let mel = super::tensor::to_candle(&inputs[0], &self.device)?;
+        let out = self
+            .enc
+            .forward(&mel)
+            .map_err(|e| RuntimeError::InferenceFailed(e.to_string()))?;
+        Ok(vec![super::tensor::from_candle(&out)?])
+    }
+}

--- a/crates/gigastt-core/src/runtime/candle/tensor.rs
+++ b/crates/gigastt-core/src/runtime/candle/tensor.rs
@@ -1,0 +1,89 @@
+//! Bridge between the runtime-abstraction [`Tensor`] type and `candle_core::Tensor`.
+//!
+//! ISOLATION: `candle_core` is referenced only here and in the sibling candle
+//! modules; the rest of the crate never sees a `candle_core::Tensor`.
+
+use candle_core::{DType, Device, Tensor as CandleTensor};
+
+use crate::runtime::{
+    error::RuntimeError,
+    tensor::{Shape, Tensor, TensorData, TensorDataView},
+};
+
+fn backend_err(e: impl std::fmt::Display) -> RuntimeError {
+    RuntimeError::InferenceFailed(e.to_string())
+}
+
+/// Convert a runtime [`Tensor`] into a `candle_core::Tensor` on `dev`.
+///
+/// Supports F32, I64, and I32 element types. The candle tensor preserves the
+/// source shape; I32 is widened to I64 (candle has no native i32).
+pub(crate) fn to_candle(t: &Tensor, dev: &Device) -> Result<CandleTensor, RuntimeError> {
+    let dims = t.shape().dims().to_vec();
+    match t.view().data() {
+        TensorDataView::F32(data) => {
+            CandleTensor::from_slice(data, dims.as_slice(), dev).map_err(backend_err)
+        }
+        TensorDataView::I64(data) => {
+            CandleTensor::from_slice(data, dims.as_slice(), dev).map_err(backend_err)
+        }
+        TensorDataView::I32(data) => {
+            // candle has no native i32; widen to i64 (lossless) so length-style
+            // integer inputs round-trip without overflow.
+            let widened: Vec<i64> = data.iter().map(|&v| v as i64).collect();
+            CandleTensor::from_slice(&widened, dims.as_slice(), dev).map_err(backend_err)
+        }
+    }
+}
+
+/// Convert a `candle_core::Tensor` back into a runtime [`Tensor`].
+///
+/// The candle tensor is cast to F32 (the encoder output is f32) and flattened
+/// to a contiguous `Vec<f32>`; its dims become the runtime [`Shape`].
+pub(crate) fn from_candle(c: &CandleTensor) -> Result<Tensor, RuntimeError> {
+    let dims = c.dims().to_vec();
+    let data = c
+        .to_dtype(DType::F32)
+        .map_err(backend_err)?
+        .flatten_all()
+        .map_err(backend_err)?
+        .to_vec1::<f32>()
+        .map_err(backend_err)?;
+    Tensor::new(Shape::new(dims), TensorData::F32(data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_f32_roundtrip_preserves_shape_and_data() {
+        let original = Tensor::new(
+            Shape::new(vec![1, 2, 3]),
+            TensorData::F32(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        )
+        .unwrap();
+
+        let dev = Device::Cpu;
+        let c = to_candle(&original, &dev).unwrap();
+        assert_eq!(c.dims(), &[1, 2, 3]);
+
+        let recovered = from_candle(&c).unwrap();
+        assert_eq!(recovered.shape().dims(), &[1, 2, 3]);
+        assert_eq!(
+            recovered.view().data().as_f32(),
+            Some(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0][..])
+        );
+    }
+
+    #[test]
+    fn test_i64_to_candle_preserves_values() {
+        let t = Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![123])).unwrap();
+        let c = to_candle(&t, &Device::Cpu).unwrap();
+        assert_eq!(c.dims(), &[1]);
+        assert_eq!(
+            c.flatten_all().unwrap().to_vec1::<i64>().unwrap(),
+            vec![123]
+        );
+    }
+}

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -8,6 +8,12 @@ pub mod tensor;
 #[cfg(feature = "candle")]
 pub mod candle;
 
+/// Returns a Candle factory (Metal on Apple Silicon, CPU otherwise).
+#[cfg(feature = "candle")]
+pub fn candle_factory() -> Box<dyn RuntimeFactory> {
+    Box::new(candle::factory::CandleFactory::new())
+}
+
 #[allow(unused_imports)]
 pub use error::RuntimeError;
 #[allow(unused_imports)]

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -5,6 +5,9 @@ pub mod ort;
 pub mod session;
 pub mod tensor;
 
+#[cfg(feature = "candle")]
+pub mod candle;
+
 #[allow(unused_imports)]
 pub use error::RuntimeError;
 #[allow(unused_imports)]

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -139,16 +139,27 @@ impl RuntimeFactory for OrtFactory {
     }
 }
 
-/// Returns the default `ort` factory for the active compile-time feature flags.
+/// Returns the default factory for the active compile-time feature flags.
+///
+/// When `feature = "candle"` is enabled, returns a `CandleFactory` (Metal on
+/// Apple Silicon, CPU otherwise). Otherwise returns an `OrtFactory` selected
+/// by the active execution-provider feature.
 pub fn default_factory() -> Box<dyn RuntimeFactory> {
-    if cfg!(feature = "coreml") {
-        Box::new(OrtFactory::coreml())
-    } else if cfg!(feature = "cuda") {
-        Box::new(OrtFactory::cuda())
-    } else if cfg!(feature = "nnapi") {
-        Box::new(OrtFactory::nnapi())
-    } else {
-        Box::new(OrtFactory::cpu())
+    #[cfg(feature = "candle")]
+    {
+        Box::new(crate::runtime::candle::factory::CandleFactory::new())
+    }
+    #[cfg(not(feature = "candle"))]
+    {
+        if cfg!(feature = "coreml") {
+            Box::new(OrtFactory::coreml())
+        } else if cfg!(feature = "cuda") {
+            Box::new(OrtFactory::cuda())
+        } else if cfg!(feature = "nnapi") {
+            Box::new(OrtFactory::nnapi())
+        } else {
+            Box::new(OrtFactory::cpu())
+        }
     }
 }
 

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -171,12 +171,20 @@ pub fn cpu_factory() -> Box<dyn RuntimeFactory> {
 /// Returns a production `ort` factory that preserves the provider selection and
 /// disk-cache layout used by the engine before the runtime abstraction.
 pub fn production_factory(model_dir: &Path) -> Box<dyn RuntimeFactory> {
-    let factory = if cfg!(feature = "coreml") {
-        OrtFactory::coreml()
-    } else if cfg!(feature = "cuda") {
-        OrtFactory::cuda()
-    } else {
-        OrtFactory::cpu().with_optimized_cache_dir(model_dir.join("optimized_cache"))
-    };
-    Box::new(factory)
+    #[cfg(feature = "candle")]
+    {
+        let _ = model_dir;
+        Box::new(crate::runtime::candle::factory::CandleFactory::new())
+    }
+    #[cfg(not(feature = "candle"))]
+    {
+        let factory = if cfg!(feature = "coreml") {
+            OrtFactory::coreml()
+        } else if cfg!(feature = "cuda") {
+            OrtFactory::cuda()
+        } else {
+            OrtFactory::cpu().with_optimized_cache_dir(model_dir.join("optimized_cache"))
+        };
+        Box::new(factory)
+    }
 }

--- a/crates/gigastt-core/tests/candle_encoder_parity.rs
+++ b/crates/gigastt-core/tests/candle_encoder_parity.rs
@@ -12,6 +12,7 @@
 //! the encoder outputs are compared element-wise. The tolerance is intentionally
 //! tight (max abs diff < 1e-2): the point of this test is to PROVE the
 //! pure-Rust encoder reproduces the ONNX encoder, not to rubber-stamp it.
+#![cfg(feature = "candle")]
 
 use std::path::Path;
 

--- a/crates/gigastt-core/tests/candle_encoder_parity.rs
+++ b/crates/gigastt-core/tests/candle_encoder_parity.rs
@@ -20,7 +20,7 @@ use gigastt_core::inference::N_MELS;
 use gigastt_core::inference::audio::decode_audio_file;
 use gigastt_core::model::default_model_dir;
 use gigastt_core::runtime_api::{
-    Shape, Tensor, TensorData, TensorDataView, candle_factory, production_factory,
+    Shape, Tensor, TensorData, TensorDataView, candle_factory, cpu_factory,
 };
 
 #[test]
@@ -74,10 +74,10 @@ fn candle_encoder_matches_ort() {
     )
     .expect("build length tensor");
 
-    // ort encoder session.
-    let ort_runtime = production_factory(model_dir)
-        .create(1)
-        .expect("ort runtime");
+    // ort encoder session. Use the ort CPU factory explicitly: under
+    // `--features candle`, `production_factory` now returns the candle backend,
+    // so the cross-backend parity check must pin the reference side to ort.
+    let ort_runtime = cpu_factory().create(1).expect("ort runtime");
     let ort_sess = ort_runtime
         .load_session(&enc_onnx, true)
         .expect("ort load encoder");

--- a/crates/gigastt-core/tests/candle_encoder_parity.rs
+++ b/crates/gigastt-core/tests/candle_encoder_parity.rs
@@ -1,0 +1,137 @@
+//! Numeric parity gate for the Candle Conformer encoder vs the ort encoder.
+//!
+//! Model-gated (`#[ignore]`): requires the GigaAM v3 rnnt FP32 encoder
+//! (`~/.gigastt/models/v3_rnnt_encoder.onnx`) and the converted Candle weights
+//! (`~/.gigastt/models/candle/encoder.safetensors`).
+//!
+//! Run with:
+//! `cargo test -p gigastt-core --features candle --test candle_encoder_parity -- --ignored --nocapture`
+//!
+//! Both backends are driven through the same `RuntimeSession` seam with an
+//! identical mel input (computed by the engine's own `FeatureExtractor`), and
+//! the encoder outputs are compared element-wise. The tolerance is intentionally
+//! tight (max abs diff < 1e-2): the point of this test is to PROVE the
+//! pure-Rust encoder reproduces the ONNX encoder, not to rubber-stamp it.
+
+use std::path::Path;
+
+use gigastt_core::inference::FeatureExtractor;
+use gigastt_core::inference::N_MELS;
+use gigastt_core::inference::audio::decode_audio_file;
+use gigastt_core::model::default_model_dir;
+use gigastt_core::runtime_api::{
+    Shape, Tensor, TensorData, TensorDataView, candle_factory, production_factory,
+};
+
+#[test]
+#[ignore = "requires v3_rnnt model + candle/encoder.safetensors"]
+fn candle_encoder_matches_ort() {
+    let model_dir = default_model_dir();
+    let model_dir = Path::new(&model_dir);
+
+    // FP32 ONNX encoder: parity must be against the same precision the Candle
+    // safetensors were converted from (NOT the INT8 encoder).
+    let enc_onnx = model_dir.join("v3_rnnt_encoder.onnx");
+    assert!(
+        enc_onnx.exists(),
+        "FP32 encoder not found at {}",
+        enc_onnx.display()
+    );
+    assert!(
+        model_dir.join("candle/encoder.safetensors").exists(),
+        "candle/encoder.safetensors not found under {}",
+        model_dir.display()
+    );
+
+    // Mel input from the SAME feature path the engine uses.
+    let fixture = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../gigastt/tests/fixtures/golos_00.wav"
+    );
+    let samples = decode_audio_file(fixture).expect("decode fixture wav");
+    let fe = FeatureExtractor::new();
+    let (mel_flat, num_frames) = fe.compute(&samples);
+    assert!(num_frames > 0, "no mel frames extracted");
+    assert_eq!(
+        mel_flat.len(),
+        N_MELS * num_frames,
+        "mel buffer length mismatch"
+    );
+    eprintln!(
+        "fixture={fixture}  samples={}  mel_frames={num_frames}",
+        samples.len()
+    );
+
+    // Encoder contract: [audio_signal [1, 64, T] F32, length [1] I64].
+    let mel = Tensor::new(
+        Shape::new(vec![1, N_MELS, num_frames]),
+        TensorData::F32(mel_flat),
+    )
+    .expect("build mel tensor");
+    let len = Tensor::new(
+        Shape::new(vec![1]),
+        TensorData::I64(vec![num_frames as i64]),
+    )
+    .expect("build length tensor");
+
+    // ort encoder session.
+    let ort_runtime = production_factory(model_dir)
+        .create(1)
+        .expect("ort runtime");
+    let ort_sess = ort_runtime
+        .load_session(&enc_onnx, true)
+        .expect("ort load encoder");
+
+    // candle encoder session (reads the sibling candle/encoder.safetensors).
+    let candle_runtime = candle_factory().create(1).expect("candle runtime");
+    let candle_sess = candle_runtime
+        .load_session(&enc_onnx, true)
+        .expect("candle load encoder");
+
+    let o = ort_sess
+        .run(&[mel.clone(), len.clone()])
+        .expect("ort encoder run");
+    let c = candle_sess.run(&[mel, len]).expect("candle encoder run");
+
+    let o0 = &o[0];
+    let c0 = &c[0];
+
+    eprintln!("ort   output shape: {:?}", o0.shape().dims());
+    eprintln!("candle output shape: {:?}", c0.shape().dims());
+    assert_eq!(
+        o0.shape().dims(),
+        c0.shape().dims(),
+        "encoder output shapes differ (ort {:?} vs candle {:?})",
+        o0.shape().dims(),
+        c0.shape().dims()
+    );
+
+    let od = match o0.view().data() {
+        TensorDataView::F32(v) => v.to_vec(),
+        other => panic!("ort encoder output not f32: {other:?}"),
+    };
+    let cd = match c0.view().data() {
+        TensorDataView::F32(v) => v.to_vec(),
+        other => panic!("candle encoder output not f32: {other:?}"),
+    };
+    assert_eq!(od.len(), cd.len(), "element count differs");
+
+    let mut max_abs = 0.0_f64;
+    let mut sum_abs = 0.0_f64;
+    for (a, b) in od.iter().zip(cd.iter()) {
+        let d = (*a as f64 - *b as f64).abs();
+        max_abs = max_abs.max(d);
+        sum_abs += d;
+    }
+    let mean_abs = sum_abs / od.len() as f64;
+
+    eprintln!(
+        "PARITY max_abs_diff = {max_abs:.6e}  mean_abs_diff = {mean_abs:.6e}  n = {}",
+        od.len()
+    );
+
+    assert!(
+        max_abs < 1e-2,
+        "candle encoder diverges from ort: max_abs_diff = {max_abs:.6e} (>= 1e-2), mean_abs_diff = {mean_abs:.6e}"
+    );
+}

--- a/crates/gigastt-core/tests/candle_rnnt_parity.rs
+++ b/crates/gigastt-core/tests/candle_rnnt_parity.rs
@@ -1,0 +1,235 @@
+//! Per-stage numeric parity gate for the Candle RNN-T decoder + joiner vs ort.
+//!
+//! Model-gated (`#[ignore]`): requires the GigaAM v3 rnnt decoder/joiner ONNX
+//! (`~/.gigastt/models/v3_rnnt_{decoder,joint}.onnx`) and the converted Candle
+//! weights (`~/.gigastt/models/candle/{decoder,joiner}.safetensors`).
+//!
+//! Run with:
+//! `cargo test -p gigastt-core --features candle --test candle_rnnt_parity -- --ignored --nocapture`
+//!
+//! Both backends are driven through the same `RuntimeSession` seam with identical
+//! inputs; outputs are compared element-wise. The tolerance is intentionally
+//! tight (max abs diff < 1e-4): the point of this test is to PROVE the pure-Rust
+//! decoder/joiner reproduce the ONNX graphs bit-for-bit (within f32 op ordering),
+//! not to rubber-stamp them.
+
+use std::path::Path;
+
+use gigastt_core::runtime_api::{
+    Runtime, RuntimeSession, Shape, Tensor, TensorData, TensorDataView, candle_factory,
+    production_factory,
+};
+
+const PRED_HIDDEN: usize = 320;
+const ENC_DIM: usize = 768;
+const VOCAB: usize = 34;
+
+fn model_dir() -> std::path::PathBuf {
+    Path::new(&gigastt_core::model::default_model_dir()).to_path_buf()
+}
+
+fn as_f32(t: &Tensor) -> Vec<f32> {
+    match t.view().data() {
+        TensorDataView::F32(v) => v.to_vec(),
+        other => panic!("expected f32 tensor, got {other:?}"),
+    }
+}
+
+/// Max-abs and mean-abs diff between two equal-length f32 slices.
+fn diffs(a: &[f32], b: &[f32]) -> (f64, f64) {
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "length mismatch: {} vs {}",
+        a.len(),
+        b.len()
+    );
+    let mut max_abs = 0.0_f64;
+    let mut sum_abs = 0.0_f64;
+    for (x, y) in a.iter().zip(b.iter()) {
+        let d = (*x as f64 - *y as f64).abs();
+        max_abs = max_abs.max(d);
+        sum_abs += d;
+    }
+    (max_abs, sum_abs / a.len() as f64)
+}
+
+#[test]
+#[ignore = "requires v3_rnnt decoder/joint ONNX + candle/{decoder,joiner}.safetensors"]
+fn candle_decoder_matches_ort() {
+    let dir = model_dir();
+    let dec_onnx = dir.join("v3_rnnt_decoder.onnx");
+    assert!(
+        dec_onnx.exists(),
+        "decoder ONNX not found at {}",
+        dec_onnx.display()
+    );
+    assert!(
+        dir.join("candle/decoder.safetensors").exists(),
+        "candle/decoder.safetensors not found under {}",
+        dir.display()
+    );
+
+    let ort = production_factory(&dir).create(1).expect("ort runtime");
+    let ort_sess = ort
+        .load_session(&dec_onnx, false)
+        .expect("ort load decoder");
+    let candle = candle_factory().create(1).expect("candle runtime");
+    let candle_sess = candle_factory_load(candle.as_ref(), &dec_onnx);
+
+    // 3-step sequence: tokens [5, 12, 0]; start h=c=zeros[1,1,320]; each step
+    // feeds prev_token + the PREVIOUS step's h/c (carried independently per
+    // backend, but they should stay in lockstep if parity holds).
+    let tokens: [i64; 3] = [5, 12, 0];
+    let mut ort_h = vec![0.0_f32; PRED_HIDDEN];
+    let mut ort_c = vec![0.0_f32; PRED_HIDDEN];
+    let mut cd_h = vec![0.0_f32; PRED_HIDDEN];
+    let mut cd_c = vec![0.0_f32; PRED_HIDDEN];
+
+    let mut worst = 0.0_f64;
+    for (step, &tok) in tokens.iter().enumerate() {
+        let ort_out = run_decoder(ort_sess.as_ref(), tok, &ort_h, &ort_c);
+        let cd_out = run_decoder(candle_sess.as_ref(), tok, &cd_h, &cd_c);
+
+        let (dec_max, dec_mean) = diffs(&ort_out.0, &cd_out.0);
+        let (h_max, h_mean) = diffs(&ort_out.1, &cd_out.1);
+        let (c_max, c_mean) = diffs(&ort_out.2, &cd_out.2);
+
+        eprintln!(
+            "DECODER step {step} tok={tok}: dec max={dec_max:.3e} mean={dec_mean:.3e} | \
+             h max={h_max:.3e} mean={h_mean:.3e} | c max={c_max:.3e} mean={c_mean:.3e}"
+        );
+
+        worst = worst.max(dec_max).max(h_max).max(c_max);
+
+        assert!(
+            dec_max < 1e-4,
+            "decoder `dec` diverges at step {step}: max_abs={dec_max:.6e}"
+        );
+        assert!(
+            h_max < 1e-4,
+            "decoder `h` diverges at step {step}: max_abs={h_max:.6e}"
+        );
+        assert!(
+            c_max < 1e-4,
+            "decoder `c` diverges at step {step}: max_abs={c_max:.6e}"
+        );
+
+        // Advance both backends' states with their own outputs.
+        ort_h = ort_out.1;
+        ort_c = ort_out.2;
+        cd_h = cd_out.1;
+        cd_c = cd_out.2;
+    }
+
+    eprintln!("DECODER PARITY worst max_abs_diff across all steps = {worst:.6e}");
+}
+
+#[test]
+#[ignore = "requires v3_rnnt decoder/joint ONNX + candle/{decoder,joiner}.safetensors"]
+fn candle_joiner_matches_ort() {
+    let dir = model_dir();
+    let joint_onnx = dir.join("v3_rnnt_joint.onnx");
+    assert!(
+        joint_onnx.exists(),
+        "joiner ONNX not found at {}",
+        joint_onnx.display()
+    );
+    assert!(
+        dir.join("candle/joiner.safetensors").exists(),
+        "candle/joiner.safetensors not found under {}",
+        dir.display()
+    );
+
+    let ort = production_factory(&dir).create(1).expect("ort runtime");
+    let ort_sess = ort
+        .load_session(&joint_onnx, false)
+        .expect("ort load joiner");
+    let candle = candle_factory().create(1).expect("candle runtime");
+    let candle_sess = candle_factory_load(candle.as_ref(), &joint_onnx);
+
+    // 2 deterministic non-zero input pairs: a ramp and a sin fill.
+    let enc_ramp: Vec<f32> = (0..ENC_DIM).map(|i| (i as f32) * 0.001 - 0.3).collect();
+    let dec_ramp: Vec<f32> = (0..PRED_HIDDEN).map(|i| (i as f32) * 0.002 - 0.2).collect();
+    let enc_sin: Vec<f32> = (0..ENC_DIM).map(|i| (i as f32 * 0.05).sin()).collect();
+    let dec_sin: Vec<f32> = (0..PRED_HIDDEN).map(|i| (i as f32 * 0.07).cos()).collect();
+
+    let mut worst = 0.0_f64;
+    for (pair, (enc, dec)) in [(enc_ramp, dec_ramp), (enc_sin, dec_sin)]
+        .iter()
+        .enumerate()
+    {
+        let ort_logits = run_joiner(ort_sess.as_ref(), enc, dec);
+        let cd_logits = run_joiner(candle_sess.as_ref(), enc, dec);
+
+        assert_eq!(
+            ort_logits.len(),
+            VOCAB,
+            "ort joiner output not length {VOCAB}"
+        );
+        assert_eq!(
+            cd_logits.len(),
+            VOCAB,
+            "candle joiner output not length {VOCAB}"
+        );
+
+        let (max, mean) = diffs(&ort_logits, &cd_logits);
+        eprintln!("JOINER pair {pair}: logits max={max:.3e} mean={mean:.3e} (n={VOCAB})");
+        worst = worst.max(max);
+
+        assert!(
+            max < 1e-4,
+            "joiner logits diverge for pair {pair}: max_abs={max:.6e}"
+        );
+    }
+
+    eprintln!("JOINER PARITY worst max_abs_diff = {worst:.6e}");
+}
+
+/// Load a candle session for `onnx_path` through the candle runtime's
+/// filename-dispatched `load_session` (decoder/joiner read sibling safetensors).
+fn candle_factory_load(runtime: &dyn Runtime, onnx_path: &Path) -> Box<dyn RuntimeSession> {
+    runtime
+        .load_session(onnx_path, false)
+        .expect("candle load session")
+}
+
+/// Run one decoder step; returns (dec, new_h, new_c), each length PRED_HIDDEN.
+fn run_decoder(
+    sess: &dyn RuntimeSession,
+    token: i64,
+    h: &[f32],
+    c: &[f32],
+) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+    let prev = Tensor::new(Shape::new(vec![1, 1]), TensorData::I64(vec![token])).unwrap();
+    let h_t = Tensor::new(
+        Shape::new(vec![1, 1, PRED_HIDDEN]),
+        TensorData::F32(h.to_vec()),
+    )
+    .unwrap();
+    let c_t = Tensor::new(
+        Shape::new(vec![1, 1, PRED_HIDDEN]),
+        TensorData::F32(c.to_vec()),
+    )
+    .unwrap();
+    let out = sess.run(&[prev, h_t, c_t]).expect("decoder run");
+    assert_eq!(out.len(), 3, "decoder must return [dec, h, c]");
+    (as_f32(&out[0]), as_f32(&out[1]), as_f32(&out[2]))
+}
+
+/// Run the joiner on one (enc, dec) pair; returns the flattened logits.
+fn run_joiner(sess: &dyn RuntimeSession, enc: &[f32], dec: &[f32]) -> Vec<f32> {
+    let enc_t = Tensor::new(
+        Shape::new(vec![1, ENC_DIM, 1]),
+        TensorData::F32(enc.to_vec()),
+    )
+    .unwrap();
+    let dec_t = Tensor::new(
+        Shape::new(vec![1, PRED_HIDDEN, 1]),
+        TensorData::F32(dec.to_vec()),
+    )
+    .unwrap();
+    let out = sess.run(&[enc_t, dec_t]).expect("joiner run");
+    assert_eq!(out.len(), 1, "joiner must return [logits]");
+    as_f32(&out[0])
+}

--- a/crates/gigastt-core/tests/candle_rnnt_parity.rs
+++ b/crates/gigastt-core/tests/candle_rnnt_parity.rs
@@ -12,6 +12,7 @@
 //! tight (max abs diff < 1e-4): the point of this test is to PROVE the pure-Rust
 //! decoder/joiner reproduce the ONNX graphs bit-for-bit (within f32 op ordering),
 //! not to rubber-stamp them.
+#![cfg(feature = "candle")]
 
 use std::path::Path;
 

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -21,6 +21,7 @@ harness = false
 default = ["diarization"]
 coreml = ["gigastt-core/coreml"]
 cuda = ["gigastt-core/cuda"]
+candle = ["gigastt-core/candle"]
 diarization = ["gigastt-core/diarization"]
 quantize = ["gigastt-core/quantize"]
 

--- a/docs/candle-backend.md
+++ b/docs/candle-backend.md
@@ -1,0 +1,70 @@
+# Candle / Metal inference backend (experimental, opt-in)
+
+gigastt's default inference backend is ONNX Runtime (`ort`). An **optional** pure-Rust
+backend built on [Candle](https://github.com/huggingface/candle) is available behind the
+`candle` Cargo feature. On Apple Silicon it runs the GigaAM v3 encoder/decoder/joiner on
+the **Metal GPU**; elsewhere it falls back to Candle's CPU backend.
+
+It is **additive and opt-in** — the default build is unchanged and still uses `ort`.
+
+## Status
+
+- Targets the default **`rnnt`** head (char vocab). FP32 (no quantization yet).
+- **Byte-for-byte parity with the ort backend** is verified at every stage on the Golos
+  fixtures: encoder `max_abs_diff ≈ 4e-6`, decoder (LSTM) `≈ 1e-6`, joiner `≈ 3e-6`, and
+  whole-file + streaming transcripts are **identical** to ort.
+- Experimental: only validated on Apple Silicon with short clips so far. Metal stability on
+  very long audio / specific GPUs is not yet characterized.
+- `candle` is mutually exclusive with `coreml`/`cuda` (compile-time error if combined).
+  Auxiliary models (VAD, punctuation) continue to run on the CPU `ort` path.
+
+## 1. Convert the model weights
+
+The Candle backend loads weights from `safetensors` files derived from the ONNX models you
+already have (`gigastt download` populates `~/.gigastt/models/`). No PyTorch or extra
+download is required — the converter reads the local `v3_rnnt_*.onnx` files.
+
+```sh
+uv run --python 3.13 --with onnx --with numpy --with safetensors \
+    python scripts/convert_gigaam_candle.py
+```
+
+This writes, next to the ONNX models:
+
+```
+~/.gigastt/models/candle/encoder.safetensors
+~/.gigastt/models/candle/decoder.safetensors
+~/.gigastt/models/candle/joiner.safetensors
+```
+
+## 2. Build with the feature
+
+```sh
+# server binary (Apple Silicon → Metal, else Candle CPU)
+cargo build --release --features candle
+
+# or just the core library
+cargo build -p gigastt-core --release --features candle
+```
+
+Do **not** combine with `--features coreml` or `--features cuda` (mutually exclusive).
+The default `ort` build remains `cargo build --release` (unchanged).
+
+## 3. Run
+
+The server and CLI use the Candle backend automatically when built with `--features candle`
+(both `default_factory` and `production_factory` route to Candle under the feature). Usage is
+otherwise identical to the default build.
+
+## Notes on packaging
+
+The implementation compiles against **upstream `candle` 0.9** with no API changes, so
+publishing remains possible. (RustASR — the source of the vendored conformer encoder — uses a
+candle fork carrying extra Metal-kernel patches; those differ only at the runtime/kernel
+level, not the Rust API. If a Metal stability issue surfaces on specific hardware or long
+audio, evaluate adopting/​upstreaming those patches.)
+
+The vendored conformer encoder originates from
+[askidmobile/RustASR](https://github.com/askidmobile/RustASR) (`crates/model-gigaam`),
+dual-licensed MIT OR Apache-2.0; attribution is preserved in
+`crates/gigastt-core/src/runtime/candle/conformer.rs`.

--- a/scripts/convert_gigaam_candle.py
+++ b/scripts/convert_gigaam_candle.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Convert the GigaAM v3 rnnt Conformer ENCODER weights from ONNX to safetensors.
+"""Convert the GigaAM v3 rnnt ENCODER + DECODER + JOINER weights ONNX->safetensors.
 
-The output safetensors uses tensor keys that EXACTLY match the ``VarBuilder``
+The output safetensors use tensor keys that EXACTLY match the ``VarBuilder``
 paths consumed by the vendored encoder in
-``crates/gigastt-core/src/runtime/candle/conformer.rs``.
+``crates/gigastt-core/src/runtime/candle/conformer.rs`` and the RNN-T decoder /
+joiner sessions in ``crates/gigastt-core/src/runtime/candle/session.rs``.
 
 Run (local python 3.14 is broken; always use this uv invocation):
 
@@ -41,13 +42,21 @@ import onnx
 from onnx import numpy_helper
 from safetensors.numpy import load_file, save_file
 
-ONNX_PATH = Path("/Users/ekhodzitsky/.gigastt/models/v3_rnnt_encoder.onnx")
-OUT_DIR = Path("/Users/ekhodzitsky/.gigastt/models/candle")
+MODELS_DIR = Path("/Users/ekhodzitsky/.gigastt/models")
+ONNX_PATH = MODELS_DIR / "v3_rnnt_encoder.onnx"
+DECODER_ONNX_PATH = MODELS_DIR / "v3_rnnt_decoder.onnx"
+JOINER_ONNX_PATH = MODELS_DIR / "v3_rnnt_joint.onnx"
+OUT_DIR = MODELS_DIR / "candle"
 OUT_PATH = OUT_DIR / "encoder.safetensors"
+DECODER_OUT_PATH = OUT_DIR / "decoder.safetensors"
+JOINER_OUT_PATH = OUT_DIR / "joiner.safetensors"
 
 N_LAYERS = 16
 D_MODEL = 768
 D_FF = 3072  # d_model * ff_expansion_factor (4)
+PRED_HIDDEN = 320  # LSTM hidden size / decoder output dim
+VOCAB = 34  # rnnt char vocab (incl. blank)
+ENC_DIM = 768  # encoder output dim
 
 
 def build_expected_shapes() -> dict[str, tuple[int, ...]]:
@@ -107,7 +116,7 @@ def build_expected_shapes() -> dict[str, tuple[int, ...]]:
     return exp
 
 
-def main() -> int:
+def convert_encoder() -> int:
     if not ONNX_PATH.is_file():
         print(f"FAIL: ONNX not found: {ONNX_PATH}", file=sys.stderr)
         return 1
@@ -216,6 +225,195 @@ def main() -> int:
         return 1
 
     print(f"PASS: all {len(expected)} expected keys present with correct shapes")
+    return 0
+
+
+def convert_decoder() -> int:
+    """Emit decoder.safetensors from the ONNX RNN-T prediction network.
+
+    Source initializers (verified on disk):
+      * ``embed.weight``     [34, 320]   -> copied verbatim (Gather table)
+      * ``onnx::LSTM_93``    [1, 1280, 320] = W_ih -> squeeze dir -> [1280, 320]
+      * ``onnx::LSTM_94``    [1, 1280, 320] = W_hh -> squeeze dir -> [1280, 320]
+      * ``onnx::LSTM_95``    [1, 2560]      = bias -> squeeze -> [2560] =
+                              concat(b_ih[1280], b_hh[1280])
+
+    ONNX LSTM gate order is **iofc** (input, output, forget, cell): the 1280 rows
+    are 4 blocks of 320 in THAT order. We keep the rows as-is (the Rust cell reads
+    the iofc blocks directly) and do NOT transpose the LSTM weights — ONNX stores
+    them as [4*hidden, in] = [out, in] already.
+    """
+    if not DECODER_ONNX_PATH.is_file():
+        print(f"FAIL: ONNX not found: {DECODER_ONNX_PATH}", file=sys.stderr)
+        return 1
+
+    print(f"Loading ONNX: {DECODER_ONNX_PATH}")
+    model = onnx.load(str(DECODER_ONNX_PATH))
+    inits = {i.name: numpy_helper.to_array(i).astype(np.float32) for i in model.graph.initializer}
+
+    def need(name: str) -> np.ndarray:
+        if name not in inits:
+            raise SystemExit(f"FAIL: decoder initializer missing: {name}")
+        return inits[name]
+
+    embed = need("embed.weight")  # [34, 320]
+    w_ih = need("onnx::LSTM_93")  # [1, 1280, 320]
+    w_hh = need("onnx::LSTM_94")  # [1, 1280, 320]
+    bias = need("onnx::LSTM_95")  # [1, 2560]
+
+    # Squeeze the num_directions dim (always 1 here; assert to catch bidirectional).
+    assert w_ih.shape[0] == 1, f"unexpected LSTM W_ih dir dim: {w_ih.shape}"
+    assert w_hh.shape[0] == 1, f"unexpected LSTM W_hh dir dim: {w_hh.shape}"
+    assert bias.shape[0] == 1, f"unexpected LSTM bias dir dim: {bias.shape}"
+    w_ih = w_ih[0]  # [1280, 320]
+    w_hh = w_hh[0]  # [1280, 320]
+    bias = bias[0]  # [2560]
+
+    # ONNX B = concat(Wb[iofc], Rb[iofc]); first 1280 = input bias, last 1280 = recurrent.
+    b_ih = bias[:4 * PRED_HIDDEN]   # [1280]
+    b_hh = bias[4 * PRED_HIDDEN:]   # [1280]
+
+    tensors = {
+        "embed.weight": np.ascontiguousarray(embed),
+        "lstm.w_ih": np.ascontiguousarray(w_ih),
+        "lstm.w_hh": np.ascontiguousarray(w_hh),
+        "lstm.b_ih": np.ascontiguousarray(b_ih),
+        "lstm.b_hh": np.ascontiguousarray(b_hh),
+    }
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, str(DECODER_OUT_PATH))
+    print(f"Saved {len(tensors)} tensors -> {DECODER_OUT_PATH}")
+
+    expected = {
+        "embed.weight": (VOCAB, PRED_HIDDEN),
+        "lstm.w_ih": (4 * PRED_HIDDEN, PRED_HIDDEN),
+        "lstm.w_hh": (4 * PRED_HIDDEN, PRED_HIDDEN),
+        "lstm.b_ih": (4 * PRED_HIDDEN,),
+        "lstm.b_hh": (4 * PRED_HIDDEN,),
+    }
+    reloaded = load_file(str(DECODER_OUT_PATH))
+    if _check_keys("decoder", expected, reloaded) != 0:
+        return 1
+    print(f"PASS: all {len(expected)} decoder keys present with correct shapes")
+    return 0
+
+
+def convert_joiner() -> int:
+    """Emit joiner.safetensors from the ONNX RNN-T joint network.
+
+    Source initializers (verified on disk):
+      * ``enc.bias``         [320]      -> enc_proj.bias
+      * ``pred.bias``        [320]      -> dec_proj.bias
+      * ``joint_net.1.bias`` [34]       -> out.bias
+      * ``onnx::MatMul_26``  [768, 320] = enc_proj W  [in, out]  -> T -> [320, 768]
+      * ``onnx::MatMul_27``  [320, 320] = dec_proj W  [in, out]  -> T -> [320, 320]
+      * ``onnx::MatMul_28``  [320, 34]  = out W       [in, out]  -> T -> [34, 320]
+
+    The three MatMul weights are identified by SHAPE (not just name) so the
+    enc/dec/out assignment is robust. MatMul weights are [in, out]; candle_nn
+    ``linear`` (and the Rust matmul in session.rs) expect [out, in] -> TRANSPOSE.
+    """
+    if not JOINER_ONNX_PATH.is_file():
+        print(f"FAIL: ONNX not found: {JOINER_ONNX_PATH}", file=sys.stderr)
+        return 1
+
+    print(f"Loading ONNX: {JOINER_ONNX_PATH}")
+    model = onnx.load(str(JOINER_ONNX_PATH))
+    inits = {i.name: numpy_helper.to_array(i).astype(np.float32) for i in model.graph.initializer}
+
+    def need(name: str) -> np.ndarray:
+        if name not in inits:
+            raise SystemExit(f"FAIL: joiner initializer missing: {name}")
+        return inits[name]
+
+    enc_bias = need("enc.bias")            # [320]
+    dec_bias = need("pred.bias")           # [320]
+    out_bias = need("joint_net.1.bias")    # [34]
+
+    # Identify the three MatMul weights by shape (defensive: confirm names too).
+    matmuls = {n: a for n, a in inits.items() if n.startswith("onnx::MatMul")}
+    if len(matmuls) != 3:
+        raise SystemExit(f"FAIL: expected 3 onnx::MatMul weights, got {sorted(matmuls)}")
+
+    def find_by_shape(shape: tuple[int, int]) -> np.ndarray:
+        hits = [a for a in matmuls.values() if a.shape == shape]
+        if len(hits) != 1:
+            raise SystemExit(
+                f"FAIL: expected exactly 1 MatMul weight of shape {shape}, "
+                f"got {[a.shape for a in matmuls.values()]}"
+            )
+        return hits[0]
+
+    enc_w = find_by_shape((ENC_DIM, PRED_HIDDEN))      # [768, 320] enc_proj
+    dec_w = find_by_shape((PRED_HIDDEN, PRED_HIDDEN))  # [320, 320] dec_proj
+    out_w = find_by_shape((PRED_HIDDEN, VOCAB))        # [320, 34]  out
+
+    tensors = {
+        "enc_proj.weight": np.ascontiguousarray(enc_w.T),  # [320, 768]
+        "enc_proj.bias": np.ascontiguousarray(enc_bias),
+        "dec_proj.weight": np.ascontiguousarray(dec_w.T),  # [320, 320]
+        "dec_proj.bias": np.ascontiguousarray(dec_bias),
+        "out.weight": np.ascontiguousarray(out_w.T),       # [34, 320]
+        "out.bias": np.ascontiguousarray(out_bias),
+    }
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, str(JOINER_OUT_PATH))
+    print(f"Saved {len(tensors)} tensors -> {JOINER_OUT_PATH}")
+
+    expected = {
+        "enc_proj.weight": (PRED_HIDDEN, ENC_DIM),
+        "enc_proj.bias": (PRED_HIDDEN,),
+        "dec_proj.weight": (PRED_HIDDEN, PRED_HIDDEN),
+        "dec_proj.bias": (PRED_HIDDEN,),
+        "out.weight": (VOCAB, PRED_HIDDEN),
+        "out.bias": (VOCAB,),
+    }
+    reloaded = load_file(str(JOINER_OUT_PATH))
+    if _check_keys("joiner", expected, reloaded) != 0:
+        return 1
+    print(f"PASS: all {len(expected)} joiner keys present with correct shapes")
+    return 0
+
+
+def _check_keys(label: str, expected: dict, reloaded: dict) -> int:
+    """Assert reloaded safetensors keys+shapes match `expected` exactly."""
+    missing, mismatched = [], []
+    for key, shape in expected.items():
+        if key not in reloaded:
+            missing.append(key)
+            continue
+        got = tuple(reloaded[key].shape)
+        if got != shape:
+            mismatched.append(f"{key}: expected {shape}, got {got}")
+    extra = sorted(set(reloaded) - set(expected))
+    if missing or mismatched or extra:
+        print(f"FAIL ({label})")
+        for k in missing:
+            print(f"  MISSING: {k}")
+        for k in mismatched:
+            print(f"  MISMATCH: {k}")
+        for k in extra:
+            print(f"  EXTRA: {k}")
+        return 1
+    return 0
+
+
+def main() -> int:
+    rc = convert_encoder()
+    if rc != 0:
+        return rc
+    print()
+    rc = convert_decoder()
+    if rc != 0:
+        return rc
+    print()
+    rc = convert_joiner()
+    if rc != 0:
+        return rc
+    print()
+    print("PASS: encoder + decoder + joiner conversion complete")
     return 0
 
 

--- a/scripts/convert_gigaam_candle.py
+++ b/scripts/convert_gigaam_candle.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Convert the GigaAM v3 rnnt Conformer ENCODER weights from ONNX to safetensors.
+
+The output safetensors uses tensor keys that EXACTLY match the ``VarBuilder``
+paths consumed by the vendored encoder in
+``crates/gigastt-core/src/runtime/candle/conformer.rs``.
+
+Run (local python 3.14 is broken; always use this uv invocation):
+
+    uv run --python 3.13 --with onnx --with numpy --with safetensors \
+        python scripts/convert_gigaam_candle.py
+
+Naming facts (verified against the on-disk ONNX):
+
+* Conv weights/biases keep their PyTorch names and are copied verbatim
+  (``pre_encode.conv.{0,2}.{weight,bias}``,
+  ``layers.N.conv.{pointwise_conv1,depthwise_conv,batch_norm,pointwise_conv2}.*``).
+  NOTE: ``conv.batch_norm`` is a LayerNorm despite the name.
+* LayerNorm weights/biases keep their names
+  (``layers.N.{norm_feed_forward1,norm_self_att,norm_conv,norm_feed_forward2,norm_out}.*``).
+* Linear layers: the ONNX export kept only the ``*.bias`` initializer under the
+  PyTorch name. The weight became an anonymous top-level initializer named
+  ``onnx::MatMul_NNNN``. We recover the weight<->bias pairing by tracing the graph:
+  for each ``Add`` node whose one input is a named ``*.bias`` initializer, the
+  other input is produced by a ``MatMul`` node whose weight is an
+  ``onnx::MatMul_NNNN`` initializer. We emit that weight under
+  ``<bias-name-without-.bias>.weight``.
+* TRANSPOSE (parity-critical): the ONNX MatMul weight has shape ``[in, out]``
+  (computes ``x @ W``); ``candle_nn::linear`` expects ``[out, in]`` (computes
+  ``x @ W^T``). So every recovered Linear weight is transposed ``[in,out] ->
+  [out,in]`` before saving. Conv weights are NOT transposed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnx
+from onnx import numpy_helper
+from safetensors.numpy import load_file, save_file
+
+ONNX_PATH = Path("/Users/ekhodzitsky/.gigastt/models/v3_rnnt_encoder.onnx")
+OUT_DIR = Path("/Users/ekhodzitsky/.gigastt/models/candle")
+OUT_PATH = OUT_DIR / "encoder.safetensors"
+
+N_LAYERS = 16
+D_MODEL = 768
+D_FF = 3072  # d_model * ff_expansion_factor (4)
+
+
+def build_expected_shapes() -> dict[str, tuple[int, ...]]:
+    """The full set of keys + shapes the candle encoder VarBuilder expects."""
+    exp: dict[str, tuple[int, ...]] = {
+        # Strided subsampling (conv.0, conv.2 — ReLU sits at 1, 3).
+        "pre_encode.conv.0.weight": (768, 64, 5),
+        "pre_encode.conv.0.bias": (768,),
+        "pre_encode.conv.2.weight": (768, 768, 5),
+        "pre_encode.conv.2.bias": (768,),
+    }
+    for n in range(N_LAYERS):
+        p = f"layers.{n}."
+        exp.update(
+            {
+                # FFN1 (Macaron)
+                p + "norm_feed_forward1.weight": (768,),
+                p + "norm_feed_forward1.bias": (768,),
+                p + "feed_forward1.linear1.weight": (3072, 768),
+                p + "feed_forward1.linear1.bias": (3072,),
+                p + "feed_forward1.linear2.weight": (768, 3072),
+                p + "feed_forward1.linear2.bias": (768,),
+                # Self-attention
+                p + "norm_self_att.weight": (768,),
+                p + "norm_self_att.bias": (768,),
+                p + "self_attn.linear_q.weight": (768, 768),
+                p + "self_attn.linear_q.bias": (768,),
+                p + "self_attn.linear_k.weight": (768, 768),
+                p + "self_attn.linear_k.bias": (768,),
+                p + "self_attn.linear_v.weight": (768, 768),
+                p + "self_attn.linear_v.bias": (768,),
+                p + "self_attn.linear_out.weight": (768, 768),
+                p + "self_attn.linear_out.bias": (768,),
+                # Convolution module
+                p + "norm_conv.weight": (768,),
+                p + "norm_conv.bias": (768,),
+                p + "conv.pointwise_conv1.weight": (1536, 768, 1),
+                p + "conv.pointwise_conv1.bias": (1536,),
+                p + "conv.depthwise_conv.weight": (768, 1, 5),
+                p + "conv.depthwise_conv.bias": (768,),
+                p + "conv.batch_norm.weight": (768,),  # LayerNorm despite the name
+                p + "conv.batch_norm.bias": (768,),
+                p + "conv.pointwise_conv2.weight": (768, 768, 1),
+                p + "conv.pointwise_conv2.bias": (768,),
+                # FFN2 (Macaron)
+                p + "norm_feed_forward2.weight": (768,),
+                p + "norm_feed_forward2.bias": (768,),
+                p + "feed_forward2.linear1.weight": (3072, 768),
+                p + "feed_forward2.linear1.bias": (3072,),
+                p + "feed_forward2.linear2.weight": (768, 3072),
+                p + "feed_forward2.linear2.bias": (768,),
+                # Output norm
+                p + "norm_out.weight": (768,),
+                p + "norm_out.bias": (768,),
+            }
+        )
+    return exp
+
+
+def main() -> int:
+    if not ONNX_PATH.is_file():
+        print(f"FAIL: ONNX not found: {ONNX_PATH}", file=sys.stderr)
+        return 1
+
+    print(f"Loading ONNX: {ONNX_PATH}")
+    model = onnx.load(str(ONNX_PATH))
+    graph = model.graph
+
+    inits = {i.name: i for i in graph.initializer}
+    print(f"  {len(inits)} initializers")
+
+    # producer map: output tensor name -> producing node
+    producer: dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            producer[out] = node
+
+    bias_names = {n for n in inits if n.endswith(".bias")}
+    anon_names = {n for n in inits if n.startswith("onnx::MatMul")}
+
+    tensors: dict[str, np.ndarray] = {}
+
+    # 1. Recover Linear weights via Add -> MatMul -> onnx::MatMul tracing.
+    #    Track which biases got paired so the rest can be copied directly.
+    paired_bias: set[str] = set()
+    n_linear = 0
+    for node in graph.node:
+        if node.op_type != "Add":
+            continue
+        bias_in = None
+        other_in = None
+        for inp in node.input:
+            if inp in bias_names:
+                bias_in = inp
+            else:
+                other_in = inp
+        if bias_in is None or other_in is None:
+            continue
+        prod = producer.get(other_in)
+        if prod is None or prod.op_type != "MatMul":
+            continue
+        weight_init = next((x for x in prod.input if x in anon_names), None)
+        if weight_init is None:
+            continue
+
+        w = numpy_helper.to_array(inits[weight_init]).astype(np.float32)
+        # ONNX MatMul weight is [in, out] (x @ W); candle_nn::linear wants [out, in].
+        w_t = np.ascontiguousarray(w.T)
+        key = bias_in[: -len(".bias")] + ".weight"
+        tensors[key] = w_t
+        paired_bias.add(bias_in)
+        n_linear += 1
+
+    print(f"  recovered {n_linear} Linear weights (transposed [in,out]->[out,in])")
+
+    # 2. Copy every named conv/LayerNorm/bias initializer verbatim (key = onnx name).
+    #    This covers: all *.bias (linear biases + conv/norm biases) and all named
+    #    *.weight (conv weights + LayerNorm weights). Anonymous onnx::MatMul
+    #    initializers are NOT copied — they were handled (transposed) in step 1.
+    n_copied = 0
+    for name, init in inits.items():
+        if name in anon_names:
+            continue
+        arr = numpy_helper.to_array(init).astype(np.float32)
+        tensors[name] = np.ascontiguousarray(arr)
+        n_copied += 1
+    print(f"  copied {n_copied} named conv/LayerNorm/bias initializers verbatim")
+
+    # 3. Save.
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, str(OUT_PATH))
+    size = OUT_PATH.stat().st_size
+    print(f"Saved {len(tensors)} tensors -> {OUT_PATH} ({size / 1e6:.1f} MB)")
+
+    # 4. Reload + assert the full expected key set is present with correct shapes.
+    expected = build_expected_shapes()
+    reloaded = load_file(str(OUT_PATH))
+
+    missing: list[str] = []
+    mismatched: list[str] = []
+    for key, shape in expected.items():
+        if key not in reloaded:
+            missing.append(key)
+            continue
+        got = tuple(reloaded[key].shape)
+        if got != shape:
+            mismatched.append(f"{key}: expected {shape}, got {got}")
+
+    extra = sorted(set(reloaded) - set(expected))
+
+    print()
+    print(f"Expected keys: {len(expected)}; saved keys: {len(reloaded)}")
+    if extra:
+        print(f"  WARNING: {len(extra)} unexpected extra keys: {extra[:10]}")
+
+    if missing or mismatched:
+        print("FAIL")
+        for k in missing:
+            print(f"  MISSING: {k}")
+        for k in mismatched:
+            print(f"  MISMATCH: {k}")
+        return 1
+
+    if extra:
+        print("FAIL: unexpected extra keys present (key set must match exactly)")
+        return 1
+
+    print(f"PASS: all {len(expected)} expected keys present with correct shapes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Optional `--features candle` pure-Rust inference backend (Candle; Metal on Apple Silicon, else CPU) for GigaAM v3, behind the PR #115 runtime seam. **Additive & opt-in — the default ONNX Runtime path is unchanged.** Implements the full plan (#117), Phases 0–4.

## What it does
With `--features candle`, the encoder/decoder/joiner run on Candle instead of `ort`; aux models (VAD/punct) stay on `ort`. Byte-for-byte identical output to the `ort` `rnnt` baseline.

## Parity (verified locally, model-gated `#[ignore]` tests)
| Stage | candle vs ort |
|---|---|
| Encoder (`candle_encoder_parity`) | max abs diff **4.05e-6** |
| Decoder LSTM (`candle_rnnt_parity`) | worst **1.24e-6** (dec/h/c, 3 steps) |
| Joiner incl. LogSoftmax | **3.34e-6** |
| Whole-file transcription (`candle_ort_transcription_parity`) | **byte-identical** (golos_00/01) |
| Streaming (`candle_ort_streaming_parity`) | **byte-identical** |

## Commits
- Phase 0: `candle` feature + optional deps (Metal gated to macOS) + `compile_error!` guard (`candle`⊕`coreml`/`cuda`); `runtime/candle/{mod,factory,runtime}` scaffold; `default_factory` routing; CI `Build (Candle/Metal)` lane + extended Runtime Isolation guard.
- Phase 1: vendored RustASR conformer encoder (MIT/Apache, **compiles on upstream candle 0.9, zero API changes**); `scripts/convert_gigaam_candle.py` (ONNX→safetensors, no torch/download; recovers anonymous `onnx::MatMul` Linear weights + transpose); Tensor bridge + `EncoderSession`.
- Phase 2: RNN-T `DecoderSession` (manual 1-step LSTM cell, ONNX `iofc` gate order) + `JoinerSession` (proj+relu+out+logsoftmax); decoder/joiner weight conversion; `production_factory` routing; end-to-end parity.
- Phase 3: streaming parity.
- Phase 4: `gigastt` server passthrough feature + `docs/candle-backend.md`.

## Open (for merge/publish, not blocking review)
- For crates.io publishing, stay on upstream candle (git-fork deps aren't publishable) — upstream's API is sufficient (proven). RustASR's candle fork carries extra Metal-kernel patches; only relevant if a Metal stability issue appears on specific hardware / long audio (not seen here; parity ran on Metal).
- FP32 only; Candle-native quantization is a possible follow-up.