### PR TITLE
fix(candle): harden backend per audit (variant routing, guards, errors, converter, CI tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo build -p gigastt-core --features candle
       - run: cargo clippy -p gigastt-core --features candle -- -D warnings
+      - run: cargo test -p gigastt-core --features candle --lib
 
   e2e-tests:
     # Only run on main push — PRs get fast feedback from unit tests + clippy

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1098,21 +1098,33 @@ impl Engine {
         };
 
         tracing::info!("Detected model variant: {variant:?}");
-        let is_int8 = model_dir.join(variant.encoder_int8_file()).exists();
-        if is_int8 {
-            tracing::info!("Using INT8 quantized encoder");
+        // The candle backend loads FP32 `candle/*.safetensors` and ignores the
+        // INT8 ONNX encoder, so report no INT8 there and gate out the INT8 / ONNX
+        // / CPU-EP logs below (which are wrong for candle), emitting an accurate
+        // candle line instead. The default (ort) logging is unchanged.
+        let is_int8 =
+            !cfg!(feature = "candle") && model_dir.join(variant.encoder_int8_file()).exists();
+        if !cfg!(feature = "candle") {
+            if is_int8 {
+                tracing::info!("Using INT8 quantized encoder");
+            }
+
+            tracing::info!(
+                "Loading ONNX models from {} (pool_size={pool_size})...",
+                model_dir.display()
+            );
         }
 
+        #[cfg(feature = "candle")]
         tracing::info!(
-            "Loading ONNX models from {} (pool_size={pool_size})...",
+            "Loading Candle models from {} (pool_size={pool_size})...",
             model_dir.display()
         );
-
         #[cfg(feature = "coreml")]
         tracing::info!("Using CoreML execution provider (Neural Engine + CPU)");
         #[cfg(feature = "cuda")]
         tracing::info!("Using CUDA execution provider (falls back to CPU if unavailable)");
-        #[cfg(not(any(feature = "coreml", feature = "cuda")))]
+        #[cfg(not(any(feature = "coreml", feature = "cuda", feature = "candle")))]
         tracing::info!("Using CPU execution provider");
 
         // CoreML can reject a model at load time; fall back to CPU if that happens.

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -1,5 +1,8 @@
-#[cfg(all(feature = "candle", any(feature = "coreml", feature = "cuda")))]
-compile_error!("feature `candle` is mutually exclusive with `coreml`/`cuda`");
+#[cfg(all(
+    feature = "candle",
+    any(feature = "coreml", feature = "cuda", feature = "nnapi")
+))]
+compile_error!("feature `candle` is mutually exclusive with `coreml`/`cuda`/`nnapi`");
 
 pub mod error;
 pub mod export;

--- a/crates/gigastt-core/src/runtime/candle/runtime.rs
+++ b/crates/gigastt-core/src/runtime/candle/runtime.rs
@@ -55,12 +55,26 @@ impl Runtime for CandleRuntime {
             .to_ascii_lowercase();
 
         if name.contains("decoder") {
-            let vb = self.var_builder(&dir.join("candle/decoder.safetensors"))?;
-            return Ok(Box::new(DecoderSession::load(vb, self.device.clone())?));
+            let st_path = dir.join("candle/decoder.safetensors");
+            let vb = self.var_builder(&st_path)?;
+            let session = DecoderSession::load(vb, self.device.clone()).map_err(|e| {
+                RuntimeError::LoadFailed {
+                    path: st_path,
+                    message: e.to_string(),
+                }
+            })?;
+            return Ok(Box::new(session));
         }
         if name.contains("joint") || name.contains("joiner") {
-            let vb = self.var_builder(&dir.join("candle/joiner.safetensors"))?;
-            return Ok(Box::new(JoinerSession::load(vb, self.device.clone())?));
+            let st_path = dir.join("candle/joiner.safetensors");
+            let vb = self.var_builder(&st_path)?;
+            let session = JoinerSession::load(vb, self.device.clone()).map_err(|e| {
+                RuntimeError::LoadFailed {
+                    path: st_path,
+                    message: e.to_string(),
+                }
+            })?;
+            return Ok(Box::new(session));
         }
 
         Err(RuntimeError::InferenceFailed(format!(
@@ -85,6 +99,12 @@ impl CandleRuntime {
                 ),
             });
         }
+        // SAFETY: `from_mmaped_safetensors` memory-maps `st` and requires the
+        // file to stay valid and unchanged for the VarBuilder's lifetime. `st`
+        // lives under `~/.gigastt/models/candle/`, is produced by gigastt's own
+        // converter, and is not mutated or truncated by gigastt while loaded. The
+        // preceding `exists()` check is advisory only; the mmap call itself is the
+        // authoritative error path (a missing/corrupt file returns `Err` here).
         unsafe {
             candle_nn::VarBuilder::from_mmaped_safetensors(
                 std::slice::from_ref(&st.to_path_buf()),
@@ -95,6 +115,51 @@ impl CandleRuntime {
                 path: st.to_path_buf(),
                 message: e.to_string(),
             })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::factory::Runtime;
+
+    fn cpu_runtime() -> CandleRuntime {
+        CandleRuntime::new(CandleDevice::Cpu).expect("CPU device always available")
+    }
+
+    #[test]
+    fn test_load_session_missing_candle_dir_is_load_failed() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No `candle/` subdir exists; the encoder weights resolution must fail
+        // with LoadFailed (not InferenceFailed) so it's classified consistently
+        // with the ort encoder load path. (`Box<dyn RuntimeSession>` is not Debug,
+        // so match on the Result rather than using expect_err.)
+        let model_path = tmp.path().join("v3_rnnt_encoder.onnx");
+        match cpu_runtime().load_session(&model_path, true) {
+            Ok(_) => panic!("missing weights must fail"),
+            Err(RuntimeError::LoadFailed { .. }) => {}
+            Err(other) => panic!("expected LoadFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_load_session_bogus_filename_is_classification_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A non-encoder file whose name is neither decoder nor joint/joiner must
+        // hit the classification error branch.
+        let model_path = tmp.path().join("something_else.onnx");
+        match cpu_runtime().load_session(&model_path, false) {
+            Ok(_) => panic!("unclassifiable file must fail"),
+            Err(RuntimeError::InferenceFailed(msg)) => {
+                assert!(
+                    msg.contains("cannot classify"),
+                    "expected classification error, got: {msg}"
+                );
+            }
+            Err(other) => {
+                panic!("expected InferenceFailed classification error, got {other:?}")
+            }
         }
     }
 }

--- a/crates/gigastt-core/src/runtime/candle/tensor.rs
+++ b/crates/gigastt-core/src/runtime/candle/tensor.rs
@@ -38,18 +38,27 @@ pub(crate) fn to_candle(t: &Tensor, dev: &Device) -> Result<CandleTensor, Runtim
 
 /// Convert a `candle_core::Tensor` back into a runtime [`Tensor`].
 ///
-/// The candle tensor is cast to F32 (the encoder output is f32) and flattened
-/// to a contiguous `Vec<f32>`; its dims become the runtime [`Shape`].
+/// Branches on the candle dtype to preserve element type (mirrors `to_candle`'s
+/// dtype switch): F32 -> [`TensorData::F32`], I64 -> [`TensorData::I64`]. I32 is
+/// not produced here because `to_candle` widens I32 inputs to I64, so they
+/// round-trip as I64. Any other candle dtype (U8/U32/F16/BF16/F64) is never
+/// produced by this backend and returns an error rather than silently casting.
 pub(crate) fn from_candle(c: &CandleTensor) -> Result<Tensor, RuntimeError> {
     let dims = c.dims().to_vec();
-    let data = c
-        .to_dtype(DType::F32)
-        .map_err(backend_err)?
-        .flatten_all()
-        .map_err(backend_err)?
-        .to_vec1::<f32>()
-        .map_err(backend_err)?;
-    Tensor::new(Shape::new(dims), TensorData::F32(data))
+    let flat = c.flatten_all().map_err(backend_err)?;
+    match c.dtype() {
+        DType::F32 => {
+            let data = flat.to_vec1::<f32>().map_err(backend_err)?;
+            Tensor::new(Shape::new(dims), TensorData::F32(data))
+        }
+        DType::I64 => {
+            let data = flat.to_vec1::<i64>().map_err(backend_err)?;
+            Tensor::new(Shape::new(dims), TensorData::I64(data))
+        }
+        other => Err(RuntimeError::InferenceFailed(format!(
+            "from_candle: unsupported candle dtype {other:?}"
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -85,5 +94,17 @@ mod tests {
             c.flatten_all().unwrap().to_vec1::<i64>().unwrap(),
             vec![123]
         );
+    }
+
+    #[test]
+    fn test_i64_roundtrip_preserves_dtype_and_data() {
+        let original = Tensor::new(Shape::new(vec![1, 3]), TensorData::I64(vec![1, 2, 3])).unwrap();
+
+        let c = to_candle(&original, &Device::Cpu).unwrap();
+        assert_eq!(c.dtype(), DType::I64);
+
+        let recovered = from_candle(&c).unwrap();
+        assert_eq!(recovered.shape().dims(), &[1, 3]);
+        assert_eq!(recovered.view().data().as_i64(), Some(&[1, 2, 3][..]));
     }
 }

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -144,6 +144,13 @@ impl RuntimeFactory for OrtFactory {
 /// When `feature = "candle"` is enabled, returns a `CandleFactory` (Metal on
 /// Apple Silicon, CPU otherwise). Otherwise returns an `OrtFactory` selected
 /// by the active execution-provider feature.
+///
+/// NOTE: the Candle backend is rnnt-only (34-token char vocab,
+/// `EncoderConfig::v3_rnnt()`); it cannot serve an `e2e_rnnt` model. This entry
+/// point has no model directory to detect the variant from, so it always returns
+/// `CandleFactory` under the feature — callers that know the directory should use
+/// [`production_factory`], which falls back to the ort factory for non-rnnt
+/// models.
 pub fn default_factory() -> Box<dyn RuntimeFactory> {
     #[cfg(feature = "candle")]
     {
@@ -171,20 +178,26 @@ pub fn cpu_factory() -> Box<dyn RuntimeFactory> {
 /// Returns a production `ort` factory that preserves the provider selection and
 /// disk-cache layout used by the engine before the runtime abstraction.
 pub fn production_factory(model_dir: &Path) -> Box<dyn RuntimeFactory> {
+    // The Candle backend is rnnt-only (34-token char vocab,
+    // `EncoderConfig::v3_rnnt()`); for an `e2e_rnnt` model it would produce wrong
+    // output / fail to load. Use it only when the detected variant is `Rnnt`,
+    // otherwise fall back to the ort factory below.
     #[cfg(feature = "candle")]
     {
-        let _ = model_dir;
-        Box::new(crate::runtime::candle::factory::CandleFactory::new())
+        if matches!(
+            crate::model::ModelVariant::detect_in_dir(model_dir),
+            Some(crate::model::ModelVariant::Rnnt)
+        ) {
+            return Box::new(crate::runtime::candle::factory::CandleFactory::new());
+        }
     }
-    #[cfg(not(feature = "candle"))]
-    {
-        let factory = if cfg!(feature = "coreml") {
-            OrtFactory::coreml()
-        } else if cfg!(feature = "cuda") {
-            OrtFactory::cuda()
-        } else {
-            OrtFactory::cpu().with_optimized_cache_dir(model_dir.join("optimized_cache"))
-        };
-        Box::new(factory)
-    }
+
+    let factory = if cfg!(feature = "coreml") {
+        OrtFactory::coreml()
+    } else if cfg!(feature = "cuda") {
+        OrtFactory::cuda()
+    } else {
+        OrtFactory::cpu().with_optimized_cache_dir(model_dir.join("optimized_cache"))
+    };
+    Box::new(factory)
 }

--- a/scripts/convert_gigaam_candle.py
+++ b/scripts/convert_gigaam_candle.py
@@ -59,6 +59,30 @@ VOCAB = 34  # rnnt char vocab (incl. blank)
 ENC_DIM = 768  # encoder output dim
 
 
+def _assert_onnx_float(init: onnx.TensorProto, name: str) -> None:
+    """Fail loudly if an initializer is not ONNX FLOAT (fp32).
+
+    A quantized (INT8) or FP16 source would be silently corrupted by the
+    subsequent ``.astype(np.float32)`` cast, so reject it up front.
+    """
+    if init.data_type != onnx.TensorProto.FLOAT:
+        dtype_name = onnx.TensorProto.DataType.Name(init.data_type)
+        raise SystemExit(
+            f"FAIL: initializer {name!r} has dtype {dtype_name}, expected FLOAT "
+            f"(fp32); a non-FLOAT source cannot be cast to float32 without "
+            f"corruption"
+        )
+
+
+def _float_initializers(graph: onnx.GraphProto) -> dict[str, np.ndarray]:
+    """Load every initializer as float32, asserting each source is ONNX FLOAT."""
+    out: dict[str, np.ndarray] = {}
+    for i in graph.initializer:
+        _assert_onnx_float(i, i.name)
+        out[i.name] = numpy_helper.to_array(i).astype(np.float32)
+    return out
+
+
 def build_expected_shapes() -> dict[str, tuple[int, ...]]:
     """The full set of keys + shapes the candle encoder VarBuilder expects."""
     exp: dict[str, tuple[int, ...]] = {
@@ -140,21 +164,25 @@ def convert_encoder() -> int:
     tensors: dict[str, np.ndarray] = {}
 
     # 1. Recover Linear weights via Add -> MatMul -> onnx::MatMul tracing.
-    #    Track which biases got paired so the rest can be copied directly.
-    paired_bias: set[str] = set()
+    #    Track which anon weights got consumed so we can assert none are orphaned.
+    consumed_anon: set[str] = set()
     n_linear = 0
     for node in graph.node:
         if node.op_type != "Add":
             continue
-        bias_in = None
-        other_in = None
-        for inp in node.input:
-            if inp in bias_names:
-                bias_in = inp
-            else:
-                other_in = inp
-        if bias_in is None or other_in is None:
+        bias_inputs = [inp for inp in node.input if inp in bias_names]
+        other_inputs = [inp for inp in node.input if inp not in bias_names]
+        # Only consider Adds that pair exactly one bias with exactly one other
+        # input (the MatMul output). Anything else is not a Linear bias add.
+        if len(bias_inputs) != 1 or len(other_inputs) != 1:
             continue
+        bias_in = bias_inputs[0]
+        other_in = other_inputs[0]
+        if len(node.input) != 2:
+            raise SystemExit(
+                f"FAIL: Linear-bias Add {node.name!r} must have exactly 2 inputs, "
+                f"got {len(node.input)}: {list(node.input)}"
+            )
         prod = producer.get(other_in)
         if prod is None or prod.op_type != "MatMul":
             continue
@@ -162,13 +190,34 @@ def convert_encoder() -> int:
         if weight_init is None:
             continue
 
-        w = numpy_helper.to_array(inits[weight_init]).astype(np.float32)
+        src = inits[weight_init]
+        _assert_onnx_float(src, weight_init)
+        w = numpy_helper.to_array(src).astype(np.float32)
         # ONNX MatMul weight is [in, out] (x @ W); candle_nn::linear wants [out, in].
         w_t = np.ascontiguousarray(w.T)
         key = bias_in[: -len(".bias")] + ".weight"
+        if key in tensors:
+            raise SystemExit(
+                f"FAIL: duplicate Linear weight key {key!r} (two Add->bias "
+                f"resolutions wrote the same output)"
+            )
         tensors[key] = w_t
-        paired_bias.add(bias_in)
+        consumed_anon.add(weight_init)
         n_linear += 1
+
+    # Every anonymous onnx::MatMul initializer must be consumed exactly once; an
+    # orphan means the Add->MatMul tracing missed a Linear weight.
+    orphan_anon = sorted(anon_names - consumed_anon)
+    if orphan_anon:
+        raise SystemExit(
+            f"FAIL: {len(orphan_anon)} unconsumed onnx::MatMul initializer(s): "
+            f"{orphan_anon}"
+        )
+    if len(consumed_anon) != n_linear:
+        raise SystemExit(
+            f"FAIL: recovered {n_linear} Linear weights but consumed "
+            f"{len(consumed_anon)} anon initializers (must be equal)"
+        )
 
     print(f"  recovered {n_linear} Linear weights (transposed [in,out]->[out,in])")
 
@@ -180,7 +229,10 @@ def convert_encoder() -> int:
     for name, init in inits.items():
         if name in anon_names:
             continue
+        _assert_onnx_float(init, name)
         arr = numpy_helper.to_array(init).astype(np.float32)
+        if name in tensors:
+            raise SystemExit(f"FAIL: duplicate output key {name!r} (already written)")
         tensors[name] = np.ascontiguousarray(arr)
         n_copied += 1
     print(f"  copied {n_copied} named conv/LayerNorm/bias initializers verbatim")
@@ -249,7 +301,7 @@ def convert_decoder() -> int:
 
     print(f"Loading ONNX: {DECODER_ONNX_PATH}")
     model = onnx.load(str(DECODER_ONNX_PATH))
-    inits = {i.name: numpy_helper.to_array(i).astype(np.float32) for i in model.graph.initializer}
+    inits = _float_initializers(model.graph)
 
     def need(name: str) -> np.ndarray:
         if name not in inits:
@@ -320,7 +372,7 @@ def convert_joiner() -> int:
 
     print(f"Loading ONNX: {JOINER_ONNX_PATH}")
     model = onnx.load(str(JOINER_ONNX_PATH))
-    inits = {i.name: numpy_helper.to_array(i).astype(np.float32) for i in model.graph.initializer}
+    inits = _float_initializers(model.graph)
 
     def need(name: str) -> np.ndarray:
         if name not in inits:


### PR DESCRIPTION
Adversarial audit of the merged Candle backend (#118) found 23 issues (0 false positives on verified high findings; no critical, no default-ort-path regressions). This fixes the real defects. **Parity unchanged: encoder 4.05e-6, decoder/joiner 0.0, transcription byte-identical** (rnnt numeric path untouched).

## Fixes
1. **Variant-gate routing** — `production_factory` now uses Candle only for `ModelVariant::Rnnt`; e2e_rnnt falls back to ort (candle is rnnt-only; previously all variants routed to candle → wrong output/load failure for e2e).
2. **nnapi in the mutual-exclusion guard** (`candle`⊕`coreml`/`cuda`/`nnapi`) — previously `candle+nnapi` compiled and silently routed to candle.
3. **decoder/joiner load failures → `LoadFailed`** (consistent with encoder; was `InferenceFailed`).
4. **`// SAFETY:` comment** on the `from_mmaped_safetensors` unsafe block.
5. **Gate misleading INT8/CPU-EP load logs** under the candle path (candle loads FP32 on Metal).
6. **`from_candle` branches on dtype** (F32/I64) instead of blind F32 cast.
7. **Converter hardening** (`scripts/convert_gigaam_candle.py`): assert no orphan/duplicate Linear-weight pairings, assert ONNX FLOAT dtype before cast, removed dead var.
8. **CI runs candle tests** (`cargo test -p gigastt-core --features candle --lib`) + new model-free error-path unit tests (missing safetensors → LoadFailed; bogus filename → classification error).

## Deferred (low value / vendored code)
RoPE table caching (vendored conformer.rs), broader model-gated parity fixtures, ffi/uniffi/node candle passthrough (bindings ship ort), honoring encoder length-input.