### PR TITLE
release: 2.4.0 — optional Candle/Metal backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-06-23
+
 ### Added
 
+- **Optional Candle / Metal inference backend (`--features candle`, experimental).**
+  A pure-Rust alternative to the default ONNX Runtime path that runs the GigaAM v3
+  `rnnt` encoder, decoder (LSTM prediction network), and joiner on the Apple Silicon
+  **Metal GPU** (Candle's CPU backend elsewhere). Strictly opt-in and additive — the
+  default `ort` build is unchanged and remains the default. Transcription is
+  **byte-for-byte identical to the `ort` backend** on the benchmark fixtures
+  (per-stage numeric parity ~1e-6; whole-file and streaming transcripts identical).
+  Weights convert from the local ONNX models via `scripts/convert_gigaam_candle.py`
+  (no PyTorch or extra download). Mutually exclusive with `coreml`/`cuda`/`nnapi`;
+  `rnnt` head only (e2e_rnnt falls back to `ort`). See
+  [`docs/candle-backend.md`](docs/candle-backend.md).
 - **Prebuilt Docker images on GitHub Container Registry.** Each tagged release
   now publishes `ghcr.io/ekhodzitsky/gigastt:{X.Y.Z,latest}` (CPU, multi-arch
   linux/amd64 + linux/arm64) and `:{X.Y.Z-cuda,cuda}` (CUDA, linux/amd64), so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/gigastt-ffi/Cargo.toml
+++ b/crates/gigastt-ffi/Cargo.toml
@@ -22,7 +22,7 @@ cuda = ["gigastt-core/cuda"]
 diarization = ["gigastt-core/diarization"]
 
 [dependencies]
-gigastt-core = { version = "2.3.0", path = "../gigastt-core", default-features = false, features = ["file-decode"] }
+gigastt-core = { version = "2.4.0", path = "../gigastt-core", default-features = false, features = ["file-decode"] }
 serde_json = "1"
 tracing = "0.1"
 

--- a/crates/gigastt-node/Cargo.toml
+++ b/crates/gigastt-node/Cargo.toml
@@ -27,7 +27,7 @@ nnapi = ["gigastt-core/nnapi"]
 # Lean core: file decoding only — no HTTP download, no async runtime (the binding
 # side-loads models and uses the synchronous checkout_blocking path on a libuv
 # worker thread). onnxruntime is statically linked via ort's default download-binaries.
-gigastt-core = { version = "2.3.0", path = "../gigastt-core", default-features = false, features = ["file-decode"] }
+gigastt-core = { version = "2.4.0", path = "../gigastt-core", default-features = false, features = ["file-decode"] }
 napi = { version = "3", default-features = false, features = ["napi4"] }
 napi-derive = "3"
 

--- a/crates/gigastt-uniffi/Cargo.toml
+++ b/crates/gigastt-uniffi/Cargo.toml
@@ -28,7 +28,7 @@ nnapi = ["gigastt-core/nnapi"]
 [dependencies]
 # Lean core: file decoding only — no HTTP download, no async runtime (the
 # bindings side-load models and use the synchronous checkout_blocking path).
-gigastt-core = { version = "2.3.0", path = "../gigastt-core", default-features = false, features = ["file-decode"] }
+gigastt-core = { version = "2.4.0", path = "../gigastt-core", default-features = false, features = ["file-decode"] }
 uniffi = { version = "0.28", features = ["cli"] }
 thiserror = "2"
 

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -26,7 +26,7 @@ diarization = ["gigastt-core/diarization"]
 quantize = ["gigastt-core/quantize"]
 
 [dependencies]
-gigastt-core = { version = "2.3.0", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
+gigastt-core = { version = "2.4.0", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
 
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }


### PR DESCRIPTION
Cuts **2.4.0** (minor; additive `--features candle` backend). Bumps workspace + inter-crate versions 2.3.0 → 2.4.0 and adds the CHANGELOG 2.4.0 section.

Headline: optional pure-Rust **Candle/Metal** GigaAM v3 backend (Metal on Apple Silicon), byte-for-byte identical to the default ONNX Runtime path; `ort` remains the default. Audited + hardened (#119).

After merge: tag `v2.4.0` (→ release.yml GitHub Release: tarballs/FFI/SBOM/minisign) and `cargo publish` gigastt-core / gigastt-ffi / gigastt to crates.io. npm/PyPI bindings are not bumped (functionally unchanged — candle is a Rust-crate feature).