### PR TITLE
feat(engine): per-request RTF log + loud warning on FP32 encoder fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Per-request RTF `info!` log on every completed file transcription (audio seconds, wall seconds, RTF, encoder label `int8/cpu` etc.); covers CLI `transcribe`, REST `/v1/transcribe`, and SSE — not the streaming WebSocket path.
+- `warn!` when the INT8 quantized encoder is missing and the engine falls back to the FP32 encoder on the default ORT path; names the one-line fix (`gigastt download` or `gigastt quantize`). Suppressed for candle and ANE builds, which have their own model formats.
+
 ## [2.5.0] - 2026-06-24
 
 ### Added

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1107,6 +1107,14 @@ impl Engine {
         if !cfg!(feature = "candle") {
             if is_int8 {
                 tracing::info!("Using INT8 quantized encoder");
+            } else if !cfg!(feature = "ane") {
+                // On the default ORT path the INT8 encoder is expected. Warn so
+                // the operator knows inference will be slower and larger than
+                // intended. Fix: run `gigastt quantize` or re-run `gigastt download`.
+                tracing::warn!(
+                    "INT8 encoder not found — loading FP32 encoder (4× larger, slower). \
+                     Run `gigastt download` or `gigastt quantize` to generate it."
+                );
             }
 
             tracing::info!(
@@ -1831,6 +1839,7 @@ impl Engine {
         float_samples: &[f32],
         triplet: &mut SessionTriplet,
     ) -> Result<TranscribeResult, GigasttError> {
+        let wall_start = std::time::Instant::now();
         let duration_s = float_samples.len() as f64 / 16000.0;
 
         // When a VAD is attached, decode only the detected speech regions
@@ -1899,6 +1908,32 @@ impl Engine {
             Some(p) => p.restore(&text),
             None => text,
         };
+
+        let wall_s = wall_start.elapsed().as_secs_f64();
+        let rtf = if duration_s > 0.0 {
+            wall_s / duration_s
+        } else {
+            0.0
+        };
+        let encoder_label = if self.int8 { "int8" } else { "fp32" };
+        let backend_label = if cfg!(feature = "candle") {
+            "candle"
+        } else if cfg!(feature = "ane") {
+            "ane"
+        } else if cfg!(feature = "coreml") {
+            "coreml"
+        } else if cfg!(feature = "cuda") {
+            "cuda"
+        } else {
+            "cpu"
+        };
+        tracing::info!(
+            audio_s = format_args!("{duration_s:.2}"),
+            wall_s = format_args!("{wall_s:.2}"),
+            rtf = format_args!("{rtf:.3}"),
+            encoder = format_args!("{encoder_label}/{backend_label}"),
+            "transcribe complete"
+        );
 
         Ok(TranscribeResult {
             text,


### PR DESCRIPTION
## Summary

- Adds a `tracing::info!` at the end of every completed file transcription (CLI `transcribe`, REST `/v1/transcribe`, SSE) with audio duration, wall time, RTF, and encoder label. Not emitted on the streaming WebSocket path (different semantics).
- Adds a `tracing::warn!` in the engine loader when the INT8 quantized encoder file is missing and the ORT path silently falls back to FP32, naming the one-line fix.

## Example log lines

INT8 present (normal operation):
```
INFO gigastt_core::inference: transcribe complete audio_s=4.00 wall_s=0.37 rtf=0.092 encoder=int8/cpu
```

INT8 missing (FP32 fallback):
```
WARN gigastt_core::inference: INT8 encoder not found — loading FP32 encoder (4× larger, slower). Run `gigastt download` or `gigastt quantize` to generate it.
INFO gigastt_core::inference: transcribe complete audio_s=4.00 wall_s=1.29 rtf=0.324 encoder=fp32/cpu
```

## Scoping decisions

- RTF log: single `wall_start` timer in `transcribe_samples` (the shared tail of `transcribe_file`, `transcribe_bytes`, `transcribe_bytes_shared`). Long-form chunked files log once with totals, not per-chunk, because `transcribe_samples_chunked` is called from `decode_words` which is called from within `transcribe_samples` — the outer timer covers the full wall time.
- FP32 warn: guarded by `!cfg!(feature = "candle")` (already gates the INT8 block) and additionally `!cfg!(feature = "ane")`. The `candle` backend uses safetensors; the `ane` backend uses CoreML `.mlpackage`s — neither has an INT8 ONNX encoder, so the warn would be misleading. The `coreml` and `cuda` ORT EP builds do use the INT8 ONNX encoder and correctly get the warn.
- `GIGASTT_SKIP_QUANTIZE`: this flag is a CLI / `main.rs` concern; the engine itself has no skip-quantize signal. When the user explicitly skipped quantization, the INT8 file won't exist, so the warn fires. This is intentional: the operator is reminded that performance is degraded. The `info!` log at startup already prints "Skipping INT8 quantization" from `main.rs` before the engine loads, providing context.

## Test plan

- [x] `cargo build -p gigastt-core` — clean
- [x] `cargo test -p gigastt-core --lib` — 357 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `RUST_LOG=info cargo run --release -- transcribe golos_00.wav` with INT8 present → `transcribe complete ... encoder=int8/cpu`
- [x] Same with INT8 renamed away → `WARN INT8 encoder not found` + `encoder=fp32/cpu`; INT8 file restored, warn gone
- [x] Main checkout (`/Users/ekhodzitsky/Documents/personal/gigastt`) untouched