### PR TITLE
feat(server): loopback-only POST /v1/admin/reload for model hot-reload without restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Model hot-reload without a restart.** A new loopback-only `POST /v1/admin/reload`
+  rebuilds the inference engine from the exact boot recipe (model dir, pool sizes,
+  encoder threads, and the punctuation / ITN / VAD / hotword chain) and atomically
+  swaps it in. The new engine is warmed before the swap so the first request after a
+  reload pays no cold-start cost, and a build failure leaves the currently-serving
+  engine untouched (the server is never left without a model). In-flight requests keep
+  the engine they started on and finish against its pool. The endpoint is restricted to
+  loopback callers by an explicit peer-IP check that holds even under `--bind-all` /
+  `--cors-allow-any`; a second concurrent reload is rejected with `409`. Returns
+  `200 {"reloaded":true,"variant":…,"encoder":"int8"|"fp32"}` on success.
+
 ## [2.6.0] - 2026-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   engine untouched (the server is never left without a model). In-flight requests keep
   the engine they started on and finish against its pool. The endpoint is restricted to
   loopback callers by an explicit peer-IP check that holds even under `--bind-all` /
-  `--cors-allow-any`; a second concurrent reload is rejected with `409`. Returns
+  `--cors-allow-any`; a second concurrent reload is rejected with `409`. The endpoint
+  is also exempt from the per-IP rate limiter — an operator triggering a reload is
+  gated by the 409/403 logic, not the token bucket. Returns
   `200 {"reloaded":true,"variant":…,"encoder":"int8"|"fp32"}` on success.
 
 ## [2.6.0] - 2026-07-09

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,4 +223,4 @@ Engine auto-detects and prefers INT8 if available; falls back to FP32.
 ## Known limitations (v0.9)
 - CPU EP runs on any platform; CoreML EP requires macOS ARM64; CUDA EP requires Linux x86_64 with CUDA 12+
 - `protoc` must be on `PATH` at build time (in-tree ONNX quantization pipeline regenerates types via `prost-build`)
-- Hot-reload of the INT8 encoder after `serve` boot still requires a restart (tracked as open item `19` in `specs/todo.md`).
+- The model can be hot-reloaded after `serve` boot without a restart via the loopback-only `POST /v1/admin/reload` endpoint (rebuilds the engine from the boot recipe, warms it, then atomically swaps; keeps the old engine on failure). Replacing the model *files* on disk still requires that endpoint (or a restart) for the change to take effect.

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -1007,12 +1007,16 @@ async fn main() -> anyhow::Result<()> {
                 let vad_model_dir = vad_model_dir.clone();
                 let hotwords_file = hotwords_file.clone();
                 std::sync::Arc::new(move || -> anyhow::Result<inference::Engine> {
-                    // Detect the head present on disk; fall back to the requested
-                    // variant, else the default, when the dir has no encoder yet.
-                    let resolved =
-                        model::ModelVariant::detect_in_dir(std::path::Path::new(&model_dir))
-                            .or(model_variant)
-                            .unwrap_or_default();
+                    // Honor the explicit --model-variant when set; otherwise
+                    // detect what is present on disk. Reload never downloads, so
+                    // if the requested variant's files are absent the engine load
+                    // will fail with a clear error — the operator asked for a
+                    // variant that isn't there.
+                    let resolved = model_variant
+                        .or_else(|| {
+                            model::ModelVariant::detect_in_dir(std::path::Path::new(&model_dir))
+                        })
+                        .unwrap_or_default();
                     ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
                     let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
                     let hotwords = resolve_hotwords(hotwords_file.as_deref(), hotwords_default);

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -994,17 +994,25 @@ async fn main() -> anyhow::Result<()> {
                 config,
             );
 
-            // Build the engine in the background while a minimal bootstrap
-            // responder serves /health (200) and /ready (503 initializing) on the
-            // port, so probes / Docker HEALTHCHECK don't see connection-refused
-            // during the first-run model download + INT8 quantization. The heavy
-            // synchronous work (quantize, ONNX session load, post-processor loads)
-            // runs on a blocking thread so the bootstrap responder stays snappy.
-            let load = async move {
-                let resolved = model::ensure_model_variant(model_variant, &model_dir).await?;
-                maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
-                maybe_download_vad_model(vad, &vad_model_dir).await;
-                tokio::task::spawn_blocking(move || -> anyhow::Result<inference::Engine> {
+            // The reusable engine build recipe, captured so BOTH first-run boot
+            // and `POST /v1/admin/reload` produce a byte-for-byte identical
+            // engine — including the punctuation / ITN / VAD / hotword chain a
+            // fresh `Engine::load_*` starts without. Synchronous (ONNX session
+            // load, quantization) so it can run on a blocking thread on either
+            // path; it re-detects the on-disk variant so a reload picks up a
+            // model swapped on disk between boot and reload.
+            let build_engine: server::EngineBuilder = {
+                let model_dir = model_dir.clone();
+                let punct_model_dir = punct_model_dir.clone();
+                let vad_model_dir = vad_model_dir.clone();
+                let hotwords_file = hotwords_file.clone();
+                std::sync::Arc::new(move || -> anyhow::Result<inference::Engine> {
+                    // Detect the head present on disk; fall back to the requested
+                    // variant, else the default, when the dir has no encoder yet.
+                    let resolved =
+                        model::ModelVariant::detect_in_dir(std::path::Path::new(&model_dir))
+                            .or(model_variant)
+                            .unwrap_or_default();
                     ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
                     let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
                     let hotwords = resolve_hotwords(hotwords_file.as_deref(), hotwords_default);
@@ -1043,10 +1051,30 @@ async fn main() -> anyhow::Result<()> {
                     log_rss();
                     Ok(engine)
                 })
-                .await
-                .context("engine load task panicked")?
             };
-            server::run_with_config_loading(server_config, None, load).await?;
+
+            // Build the engine in the background while a minimal bootstrap
+            // responder serves /health (200) and /ready (503 initializing) on the
+            // port, so probes / Docker HEALTHCHECK don't see connection-refused
+            // during the first-run model download + INT8 quantization. The heavy
+            // synchronous work (quantize, ONNX session load, post-processor loads)
+            // runs on a blocking thread so the bootstrap responder stays snappy.
+            let boot_builder = build_engine.clone();
+            let load = async move {
+                let resolved = model::ensure_model_variant(model_variant, &model_dir).await?;
+                maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
+                maybe_download_vad_model(vad, &vad_model_dir).await;
+                tokio::task::spawn_blocking(move || boot_builder())
+                    .await
+                    .context("engine load task panicked")?
+            };
+            server::run_with_config_loading_reloadable(
+                server_config,
+                None,
+                load,
+                Some(build_engine),
+            )
+            .await?;
         }
         Commands::Download {
             model_dir,

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -52,9 +52,9 @@ pub struct AppState {
 }
 
 /// Recipe that rebuilds a fully-configured [`Engine`] from the operator's boot
-/// options. Stored in [`AppState`] so the reload endpoint (and SIGHUP) can
-/// produce a fresh engine that re-applies the punctuation / ITN / VAD / hotword
-/// chain — a bare `Engine::load_*` starts with all of those set to `None`.
+/// options. Stored in [`AppState`] so `POST /v1/admin/reload` can produce a
+/// fresh engine that re-applies the punctuation / ITN / VAD / hotword chain —
+/// a bare `Engine::load_*` starts with all of those set to `None`.
 pub type EngineBuilder = Arc<dyn Fn() -> anyhow::Result<Engine> + Send + Sync>;
 
 /// GET /metrics — Prometheus text-format exposition. Returns 404 when the

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -30,12 +30,32 @@ use gigastt_core::inference::Engine;
 /// WebSocket handlers and `spawn_blocking` SSE tasks fall outside that lane
 /// and must be drained explicitly.
 pub struct AppState {
-    pub engine: Arc<Engine>,
+    /// The live inference engine, held behind an [`ArcSwap`] so it can be
+    /// atomically replaced by the model hot-reload endpoint without a restart.
+    /// Handlers `load_full()` the current `Arc<Engine>` at request start and
+    /// use it for the whole request; a concurrent swap only affects requests
+    /// that start after it, so in-flight work always finishes against the
+    /// engine (and pool) it began with.
+    pub engine: Arc<ArcSwap<Engine>>,
+    /// Rebuilds the engine from the exact boot recipe (model dir, pool sizes,
+    /// threads, punctuation / ITN / VAD / hotwords). `Some` on the real server
+    /// path; `None` for the thin `run`/`run_with_shutdown` test entry points
+    /// and unit tests, where the reload endpoint reports `reload_unsupported`.
+    pub engine_builder: Option<EngineBuilder>,
+    /// Serializes model reloads so two concurrent `POST /v1/admin/reload`
+    /// calls can't both rebuild + swap; the loser gets `409 reload_in_progress`.
+    pub reload_lock: Arc<tokio::sync::Mutex<()>>,
     pub limits: Arc<ArcSwap<RuntimeLimits>>,
     pub metrics_registry: Option<Arc<MetricsRegistry>>,
     pub shutdown: tokio_util::sync::CancellationToken,
     pub tracker: tokio_util::task::TaskTracker,
 }
+
+/// Recipe that rebuilds a fully-configured [`Engine`] from the operator's boot
+/// options. Stored in [`AppState`] so the reload endpoint (and SIGHUP) can
+/// produce a fresh engine that re-applies the punctuation / ITN / VAD / hotword
+/// chain — a bare `Engine::load_*` starts with all of those set to `None`.
+pub type EngineBuilder = Arc<dyn Fn() -> anyhow::Result<Engine> + Send + Sync>;
 
 /// GET /metrics — Prometheus text-format exposition. Returns 404 when the
 /// server was started without `--metrics`.
@@ -335,7 +355,7 @@ pub struct ReadinessResponse {
 /// minimal bootstrap responder (see [`super::run_with_config_loading`]) that
 /// reports `model: "loading"`; this handler only runs once the engine is ready.
 pub async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
-    let engine = &state.engine;
+    let engine = state.engine.load_full();
     let variant = engine.variant();
     Json(HealthResponse {
         status: "ok".into(),
@@ -365,27 +385,24 @@ pub(crate) fn sample_batch_pool_gauges(reg: &MetricsRegistry, engine: &Engine) {
 
 /// GET /ready — readiness probe for k8s and orchestrators.
 pub async fn readiness(State(state): State<Arc<AppState>>) -> Response {
+    let engine = state.engine.load_full();
     if state.shutdown.is_cancelled() {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ReadinessResponse {
                 status: "not_ready".into(),
                 pool_available: 0,
-                pool_total: state.engine.pool.total(),
+                pool_total: engine.pool.total(),
                 reason: Some("shutting_down".into()),
             }),
         )
             .into_response();
     }
-    let available = state.engine.pool.available();
+    let available = engine.pool.available();
     if let Some(ref reg) = state.metrics_registry {
         reg.gauge_set("gigastt_pool_available", &[], available as i64);
-        reg.gauge_set(
-            "gigastt_pool_waiters",
-            &[],
-            state.engine.pool.waiters() as i64,
-        );
-        sample_batch_pool_gauges(reg, &state.engine);
+        reg.gauge_set("gigastt_pool_waiters", &[], engine.pool.waiters() as i64);
+        sample_batch_pool_gauges(reg, &engine);
     }
     if available == 0 {
         return (
@@ -393,7 +410,7 @@ pub async fn readiness(State(state): State<Arc<AppState>>) -> Response {
             Json(ReadinessResponse {
                 status: "not_ready".into(),
                 pool_available: 0,
-                pool_total: state.engine.pool.total(),
+                pool_total: engine.pool.total(),
                 reason: Some("pool_exhausted".into()),
             }),
         )
@@ -402,7 +419,7 @@ pub async fn readiness(State(state): State<Arc<AppState>>) -> Response {
     Json(ReadinessResponse {
         status: "ready".into(),
         pool_available: available,
-        pool_total: state.engine.pool.total(),
+        pool_total: engine.pool.total(),
         reason: None,
     })
     .into_response()
@@ -410,7 +427,7 @@ pub async fn readiness(State(state): State<Arc<AppState>>) -> Response {
 
 /// GET /v1/models — list loaded models and capabilities.
 pub async fn models(State(state): State<Arc<AppState>>) -> Json<ModelInfo> {
-    let engine = &state.engine;
+    let engine = state.engine.load_full();
     #[cfg(feature = "diarization")]
     let diarization = engine.has_speaker_encoder();
     #[cfg(not(feature = "diarization"))]
@@ -422,7 +439,7 @@ pub async fn models(State(state): State<Arc<AppState>>) -> Json<ModelInfo> {
             engine.pool.available() as i64,
         );
         reg.gauge_set("gigastt_pool_waiters", &[], engine.pool.waiters() as i64);
-        sample_batch_pool_gauges(reg, engine);
+        sample_batch_pool_gauges(reg, &engine);
     }
     let variant = engine.variant();
     Json(ModelInfo {
@@ -486,6 +503,11 @@ pub async fn transcribe(
         ));
     }
 
+    // Snapshot the current engine once at request start; a concurrent hot-reload
+    // swaps the `ArcSwap`, but this request keeps the engine (and its pool) it
+    // began with for its whole lifetime.
+    let engine = state.engine.load_full();
+
     // Checkout a session triplet from the batch pool (blocks if none
     // available) — this is a long file-transcription job, so it draws from the
     // dedicated batch pool when one exists (falling back to the interactive
@@ -495,7 +517,7 @@ pub async fn transcribe(
     let checkout_start = std::time::Instant::now();
     let guard = match tokio::time::timeout(
         std::time::Duration::from_secs(limits.pool_checkout_timeout_secs),
-        state.engine.pool_for_batch().checkout(),
+        engine.pool_for_batch().checkout(),
     )
     .await
     {
@@ -521,8 +543,6 @@ pub async fn transcribe(
         );
     }
     let mut reservation = guard.into_owned();
-
-    let engine = state.engine.clone();
 
     let inference_start = std::time::Instant::now();
     let span = tracing::Span::current();
@@ -685,10 +705,13 @@ pub async fn transcribe_stream(
     // interactive pool otherwise) so it can't starve real-time WebSocket
     // streaming, matching `/v1/transcribe`. Strip the lifetime via `into_owned`
     // so the triplet can travel through `spawn_blocking`.
+    // Snapshot the current engine once; a concurrent hot-reload swap only
+    // affects later requests, so this stream rides the pool it started on.
+    let engine = state.engine.load_full();
     let checkout_start = std::time::Instant::now();
     let guard = match tokio::time::timeout(
         std::time::Duration::from_secs(limits.pool_checkout_timeout_secs),
-        state.engine.pool_for_batch().checkout(),
+        engine.pool_for_batch().checkout(),
     )
     .await
     {
@@ -720,7 +743,6 @@ pub async fn transcribe_stream(
         Result<gigastt_core::inference::TranscriptSegment, StreamError>,
     >(16);
 
-    let engine = state.engine.clone();
     // The axum handler future has already returned by the time the SSE stream
     // starts flowing, so `with_graceful_shutdown` can't observe this task. Clone
     // the shutdown token and check it before every chunk so SIGTERM during a
@@ -795,6 +817,154 @@ pub async fn transcribe_stream(
             .interval(std::time::Duration::from_secs(15))
             .text(""),
     ))
+}
+
+/// Whether the reload endpoint should accept a request from `peer`.
+///
+/// Model reload is an administrative, machine-local action: it must stay
+/// reachable only from the loopback interface even under `--bind-all` /
+/// `--cors-allow-any`, which would otherwise widen `origin_middleware` (the only
+/// other gate). Pure so the loopback decision can be unit-tested without a model
+/// or a live socket.
+fn peer_is_loopback(peer: &std::net::SocketAddr) -> bool {
+    peer.ip().is_loopback()
+}
+
+/// POST /v1/admin/reload — rebuild the inference engine from the boot recipe and
+/// atomically swap it in without a restart.
+///
+/// Strictly loopback-only (checked here, not just via the origin middleware),
+/// serialized by a mutex so two reloads can't race, and fail-safe: a build error
+/// leaves the currently-serving engine untouched. The new engine is warmed
+/// before the swap so the first post-swap request doesn't pay the cold cost.
+/// In-flight requests keep the engine they started on and finish against its
+/// pool; the old engine drops when its last reference goes.
+pub async fn reload(
+    axum::extract::ConnectInfo(peer): axum::extract::ConnectInfo<std::net::SocketAddr>,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    // Gotcha #2: enforce loopback here so reload stays local even when
+    // `origin_middleware` has been widened by `--bind-all` / `--cors-allow-any`
+    // or a caller omits the Origin header.
+    if !peer_is_loopback(&peer) {
+        tracing::warn!(peer = %peer, "Rejecting non-loopback model reload request");
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "Model reload is only available from loopback",
+                "code": "loopback_only",
+            })),
+        )
+            .into_response();
+    }
+
+    let Some(builder) = state.engine_builder.clone() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "Model reload is not available on this server",
+                "code": "reload_unsupported",
+            })),
+        )
+            .into_response();
+    };
+
+    // Serialize reloads: the loser of the race gets 409 rather than queueing, so
+    // an operator hammering the endpoint can't stack up concurrent rebuilds.
+    let _reload_guard = match state.reload_lock.try_lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": "A model reload is already in progress",
+                    "code": "reload_in_progress",
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    tracing::info!(peer = %peer, "Model reload requested — rebuilding engine");
+
+    // Build the new engine off the request path (ONNX session load is blocking).
+    let build = tokio::task::spawn_blocking(move || builder()).await;
+
+    let new_engine = match build {
+        Ok(Ok(engine)) => engine,
+        Ok(Err(e)) => {
+            // Keep the old engine untouched. Log the detail, return a sanitized
+            // message (no path / model leakage) matching the internal-error policy.
+            tracing::error!("Model reload build failed: {e:#}");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "Model reload failed; the previous model is still serving",
+                    "code": "reload_failed",
+                })),
+            )
+                .into_response();
+        }
+        Err(join_err) => {
+            tracing::error!("Model reload build task panicked: {join_err}");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "Model reload failed; the previous model is still serving",
+                    "code": "reload_failed",
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // Warm the fresh engine BEFORE swapping so the first post-swap request
+    // doesn't pay the EP-compile / first-allocation cost. A warmup failure is
+    // non-fatal (mirrors boot): the engine already fell back to CPU internally.
+    let new_engine = match tokio::task::spawn_blocking(move || {
+        if let Err(e) = new_engine.warmup() {
+            tracing::warn!("Reloaded engine warmup failed (swapping anyway): {e:#}");
+        }
+        new_engine
+    })
+    .await
+    {
+        Ok(engine) => engine,
+        Err(join_err) => {
+            tracing::error!("Model reload warmup task panicked: {join_err}");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "Model reload failed; the previous model is still serving",
+                    "code": "reload_failed",
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let variant = new_engine.variant();
+    let encoder = if new_engine.is_int8() { "int8" } else { "fp32" };
+
+    // Atomic swap. In-flight requests holding the old `Arc<Engine>` finish
+    // against the old pool; it drops when its last reference goes. We do NOT
+    // close the old pool — that would strand in-flight work.
+    state.engine.store(Arc::new(new_engine));
+    tracing::info!(
+        variant = variant.as_str(),
+        encoder,
+        "Model reloaded and swapped"
+    );
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "reloaded": true,
+            "variant": variant.as_str(),
+            "encoder": encoder,
+        })),
+    )
+        .into_response()
 }
 
 #[cfg(test)]
@@ -958,9 +1128,11 @@ mod tests {
     #[ignore = "requires model"]
     async fn test_readiness_when_shutdown_cancelled() {
         let state = Arc::new(AppState {
-            engine: test_engine(),
+            engine: engine_swap(test_engine()),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
             metrics_registry: None,
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -981,9 +1153,11 @@ mod tests {
             .map(|_| engine.pool.checkout_blocking().unwrap())
             .collect();
         let state = Arc::new(AppState {
-            engine,
+            engine: engine_swap(engine),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
             metrics_registry: None,
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -999,12 +1173,14 @@ mod tests {
     #[ignore = "requires model"]
     async fn test_transcribe_payload_too_large() {
         let state = Arc::new(AppState {
-            engine: test_engine(),
+            engine: engine_swap(test_engine()),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits {
                 body_limit_bytes: 10,
                 ..RuntimeLimits::default()
             })),
             metrics_registry: None,
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -1020,9 +1196,11 @@ mod tests {
     #[ignore = "requires model"]
     async fn test_models_with_metrics() {
         let state = Arc::new(AppState {
-            engine: test_engine(),
+            engine: engine_swap(test_engine()),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
             metrics_registry: Some(Arc::new(MetricsRegistry::new())),
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -1049,9 +1227,11 @@ mod tests {
     #[ignore = "requires model"]
     async fn test_readiness_with_metrics() {
         let state = Arc::new(AppState {
-            engine: fresh_engine(),
+            engine: engine_swap(fresh_engine()),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
             metrics_registry: Some(Arc::new(MetricsRegistry::new())),
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -1065,9 +1245,11 @@ mod tests {
         let engine = fresh_engine();
         engine.pool.close();
         let state = Arc::new(AppState {
-            engine,
+            engine: engine_swap(engine),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
             metrics_registry: None,
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -1083,9 +1265,11 @@ mod tests {
     #[ignore = "requires model"]
     async fn test_transcribe_stream_invalid_audio() {
         let state = Arc::new(AppState {
-            engine: test_engine(),
+            engine: engine_swap(test_engine()),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
             metrics_registry: None,
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -1101,12 +1285,14 @@ mod tests {
     #[ignore = "requires model"]
     async fn test_transcribe_stream_payload_too_large() {
         let state = Arc::new(AppState {
-            engine: test_engine(),
+            engine: engine_swap(test_engine()),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits {
                 body_limit_bytes: 10,
                 ..RuntimeLimits::default()
             })),
             metrics_registry: None,
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -1124,9 +1310,11 @@ mod tests {
         let engine = fresh_engine();
         engine.pool.close();
         let state = Arc::new(AppState {
-            engine,
+            engine: engine_swap(engine),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
             metrics_registry: None,
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -1142,9 +1330,11 @@ mod tests {
     #[ignore = "requires model"]
     async fn test_transcribe_with_metrics() {
         let state = Arc::new(AppState {
-            engine: test_engine(),
+            engine: engine_swap(test_engine()),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
             metrics_registry: Some(Arc::new(MetricsRegistry::new())),
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -1159,9 +1349,11 @@ mod tests {
     #[ignore = "requires model"]
     async fn test_transcribe_stream_with_metrics() {
         let state = Arc::new(AppState {
-            engine: test_engine(),
+            engine: engine_swap(test_engine()),
             limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
             metrics_registry: Some(Arc::new(MetricsRegistry::new())),
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
         });
@@ -1467,6 +1659,84 @@ mod tests {
     }
 
     #[test]
+    fn test_peer_is_loopback_guard() {
+        use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+        // IPv4 + IPv6 loopback are accepted regardless of source port.
+        assert!(peer_is_loopback(&SocketAddr::from((
+            Ipv4Addr::LOCALHOST,
+            5000
+        ))));
+        assert!(peer_is_loopback(&SocketAddr::from((
+            Ipv6Addr::LOCALHOST,
+            5000
+        ))));
+        // A non-loopback peer (LAN / public) is rejected — reload must stay local
+        // even under --bind-all / --cors-allow-any.
+        assert!(!peer_is_loopback(&SocketAddr::from((
+            Ipv4Addr::new(192, 168, 1, 10),
+            9876
+        ))));
+        assert!(!peer_is_loopback(&SocketAddr::from((
+            Ipv4Addr::new(10, 0, 0, 1),
+            9876
+        ))));
+        assert!(!peer_is_loopback(&SocketAddr::from((
+            Ipv4Addr::new(8, 8, 8, 8),
+            443
+        ))));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires model"]
+    async fn test_reload_rejects_non_loopback_peer() {
+        // The loopback guard fires before any engine work: a non-loopback
+        // ConnectInfo yields 403 `loopback_only` even with a builder present.
+        // Model-gated only because `AppState` needs a concrete `Engine`; the
+        // pure guard logic is covered model-free by `test_peer_is_loopback_guard`.
+        use std::net::{Ipv4Addr, SocketAddr};
+        let state = Arc::new(AppState {
+            engine: engine_swap(test_engine()),
+            engine_builder: Some(Arc::new(|| {
+                anyhow::bail!("builder must not run for a rejected peer")
+            })),
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
+            limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
+            metrics_registry: None,
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            tracker: tokio_util::task::TaskTracker::new(),
+        });
+        let peer = SocketAddr::from((Ipv4Addr::new(203, 0, 113, 7), 40000));
+        let resp = reload(axum::extract::ConnectInfo(peer), State(state)).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["code"], "loopback_only");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires model"]
+    async fn test_reload_unsupported_when_no_builder() {
+        // A loopback peer with no stored builder (the thin `run_with_shutdown` /
+        // test path) gets `reload_unsupported`, not a swap.
+        use std::net::{Ipv4Addr, SocketAddr};
+        let state = Arc::new(AppState {
+            engine: engine_swap(test_engine()),
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
+            limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
+            metrics_registry: None,
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            tracker: tokio_util::task::TaskTracker::new(),
+        });
+        let peer = SocketAddr::from((Ipv4Addr::LOCALHOST, 40000));
+        let resp = reload(axum::extract::ConnectInfo(peer), State(state)).await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["code"], "reload_unsupported");
+    }
+
+    #[test]
     fn test_sse_data_payload_includes_words_and_timestamp() {
         // A successful segment carries text, timestamp and words through
         // unchanged so SSE clients can render word-level UI.
@@ -1498,6 +1768,12 @@ mod tests {
 
     fn fresh_engine() -> Arc<Engine> {
         Arc::new(Engine::load_with_pool_size(&gigastt_core::model::default_model_dir(), 1).unwrap())
+    }
+
+    /// Wrap an engine handle in the `ArcSwap` the `AppState` now holds. Keeps
+    /// the model-gated test constructors terse after the hot-reload swap change.
+    fn engine_swap(engine: Arc<Engine>) -> Arc<ArcSwap<Engine>> {
+        Arc::new(ArcSwap::new(engine))
     }
 
     fn minimal_wav() -> Bytes {

--- a/crates/gigastt/src/server/middleware.rs
+++ b/crates/gigastt/src/server/middleware.rs
@@ -17,6 +17,7 @@ fn metric_path_label(path: &str) -> &'static str {
         "/v1/transcribe" => "/v1/transcribe",
         "/v1/transcribe/stream" => "/v1/transcribe/stream",
         "/v1/ws" => "/v1/ws",
+        "/v1/admin/reload" => "/v1/admin/reload",
         "/metrics" => "/metrics",
         _ => "other",
     }
@@ -38,15 +39,17 @@ pub(crate) async fn http_metrics_middleware(
     let method = req.method().clone();
     let path = metric_path_label(req.uri().path());
     let start = std::time::Instant::now();
-    // Sample pool availability on every request.
+    // Sample pool availability on every request against the currently-live
+    // engine (a hot-reload may have swapped it).
+    let engine = state.engine.load_full();
     registry.gauge_set(
         "gigastt_pool_available",
         &[],
-        state.engine.pool.available() as i64,
+        engine.pool.available() as i64,
     );
     // Plus the dedicated batch pool, when one was split off, so its saturation
     // is visible separately from the interactive pool.
-    http::sample_batch_pool_gauges(&registry, &state.engine);
+    http::sample_batch_pool_gauges(&registry, &engine);
     let response = next.run(req).await;
     let elapsed = start.elapsed().as_secs_f64();
     let status = response.status().as_u16().to_string();

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -11,6 +11,7 @@ pub mod rate_limit;
 mod ws;
 
 pub use config::{OriginPolicy, RuntimeLimits, ServerConfig};
+pub use http::EngineBuilder;
 
 use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
@@ -136,6 +137,22 @@ pub async fn run_with_config_loading<Fut>(
 where
     Fut: std::future::Future<Output = Result<gigastt_core::inference::Engine>> + Send + 'static,
 {
+    run_with_config_loading_reloadable(config, shutdown, load, None).await
+}
+
+/// Like [`run_with_config_loading`], but also carries the [`EngineBuilder`]
+/// recipe so the server that starts after the model loads exposes a working
+/// `POST /v1/admin/reload`. The `load` future typically calls the *same*
+/// builder once to produce the boot engine, so boot and reload share one recipe.
+pub async fn run_with_config_loading_reloadable<Fut>(
+    config: ServerConfig,
+    shutdown: Option<tokio::sync::oneshot::Receiver<()>>,
+    load: Fut,
+    engine_builder: Option<http::EngineBuilder>,
+) -> Result<()>
+where
+    Fut: std::future::Future<Output = Result<gigastt_core::inference::Engine>> + Send + 'static,
+{
     let addr: SocketAddr = format!("{}:{}", config.host, config.port)
         .parse()
         .context("Invalid host:port")?;
@@ -215,7 +232,14 @@ where
         Outcome::Loaded(res) => {
             let engine = (*res).context("engine load task panicked")??;
             tracing::info!("Model ready — starting full server");
-            run_with_config_listener(engine, config, Some(real_rx), listener).await
+            run_with_config_listener_reloadable(
+                engine,
+                config,
+                Some(real_rx),
+                listener,
+                engine_builder,
+            )
+            .await
         }
     }
 }
@@ -225,9 +249,23 @@ where
 /// race between `free_port()` and server startup.
 pub async fn run_with_config_listener(
     engine: gigastt_core::inference::Engine,
+    config: ServerConfig,
+    shutdown: Option<tokio::sync::oneshot::Receiver<()>>,
+    listener: tokio::net::TcpListener,
+) -> Result<()> {
+    run_with_config_listener_reloadable(engine, config, shutdown, listener, None).await
+}
+
+/// Like [`run_with_config_listener`], but also accepts the [`EngineBuilder`]
+/// recipe that `POST /v1/admin/reload` (and SIGHUP) use to rebuild the engine
+/// in place. `None` disables the reload endpoint (`reload_unsupported`) — the
+/// thin `run` / `run_with_shutdown` and test entry points take that path.
+pub async fn run_with_config_listener_reloadable(
+    engine: gigastt_core::inference::Engine,
     mut config: ServerConfig,
     shutdown: Option<tokio::sync::oneshot::Receiver<()>>,
     listener: tokio::net::TcpListener,
+    engine_builder: Option<http::EngineBuilder>,
 ) -> Result<()> {
     if config.limits.pool_checkout_timeout_secs == 0 {
         tracing::warn!("pool_checkout_timeout_secs=0 would make the pool unusable; clamping to 1");
@@ -345,7 +383,9 @@ pub async fn run_with_config_listener(
     let tracker = tokio_util::task::TaskTracker::new();
 
     let state = Arc::new(http::AppState {
-        engine: Arc::new(engine),
+        engine: Arc::new(ArcSwap::from_pointee(engine)),
+        engine_builder: engine_builder.clone(),
+        reload_lock: Arc::new(tokio::sync::Mutex::new(())),
         limits: Arc::new(ArcSwap::from_pointee(config.limits.clone())),
         metrics_registry: metrics_registry.clone(),
         shutdown: shutdown_root.clone(),
@@ -457,6 +497,15 @@ pub async fn run_with_config_listener(
         // /v1/ws is the canonical WebSocket path (versioned, aligned with REST).
         .route("/v1/ws", get(ws::ws_handler))
         .route("/v1/ws", options(|| async { StatusCode::NO_CONTENT }))
+        // Admin: hot-reload the model without a restart. Registered inside the
+        // protected router so it inherits `origin_middleware`, but the handler
+        // additionally enforces a strict loopback peer check (see `http::reload`)
+        // so it stays local even under `--bind-all` / `--cors-allow-any`.
+        .route("/v1/admin/reload", post(http::reload))
+        .route(
+            "/v1/admin/reload",
+            options(|| async { StatusCode::NO_CONTENT }),
+        )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             middleware::http_metrics_middleware,
@@ -504,9 +553,11 @@ pub async fn run_with_config_listener(
         protected
     };
 
-    // Clone the engine handle before `state` is consumed by `with_state` so
-    // the shutdown closure can call `pool.close()` after the listener task
-    // begins draining.
+    // Clone the *swap handle* (not a snapshot) before `state` is consumed by
+    // `with_state` so the shutdown closure can close the pools of whichever
+    // engine is live at shutdown time. Capturing a pre-swap snapshot here would
+    // close the boot engine's pools even after a hot-reload swapped in a new
+    // one, stranding the new pool's waiters (they'd never get `PoolError::Closed`).
     let shutdown_engine = state.engine.clone();
 
     // Clone the state for the separate metrics listener before `state` is moved
@@ -617,8 +668,10 @@ pub async fn run_with_config_listener(
             // Wake every waiter still blocked on `pool.checkout()` with
             // PoolError::Closed so they fall through to a 503 / `pool_closed`
             // response instead of being stranded for the full checkout timeout.
+            // Load the engine that is live *now* (a hot-reload may have swapped
+            // it since boot) so we close the pool waiters are actually parked on.
             // Idempotent — safe even if the pool was already closed.
-            shutdown_engine.close_pools();
+            shutdown_engine.load_full().close_pools();
         }
     };
 

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -257,9 +257,9 @@ pub async fn run_with_config_listener(
 }
 
 /// Like [`run_with_config_listener`], but also accepts the [`EngineBuilder`]
-/// recipe that `POST /v1/admin/reload` (and SIGHUP) use to rebuild the engine
-/// in place. `None` disables the reload endpoint (`reload_unsupported`) — the
-/// thin `run` / `run_with_shutdown` and test entry points take that path.
+/// recipe that `POST /v1/admin/reload` uses to rebuild the engine in place.
+/// `None` disables the reload endpoint (`reload_unsupported`) — the thin
+/// `run` / `run_with_shutdown` and test entry points take that path.
 pub async fn run_with_config_listener_reloadable(
     engine: gigastt_core::inference::Engine,
     mut config: ServerConfig,

--- a/crates/gigastt/src/server/rate_limit.rs
+++ b/crates/gigastt/src/server/rate_limit.rs
@@ -364,6 +364,13 @@ fn is_rfc1918(ip: IpAddr) -> bool {
 /// async fn rate_limit_middleware(limiter: Arc<RateLimiter>, trust_proxy: bool, req: Request, next: Next) -> Response
 /// { ret.status() == 429 || ret.status() == next.run(req).await.status() }
 /// ```
+/// Paths exempt from per-IP rate limiting. These are either handled by a
+/// separate mechanism (loopback-only enforcement in the handler itself) or
+/// are already outside the main request budget.
+fn is_rate_limit_exempt(path: &str) -> bool {
+    path == "/v1/admin/reload"
+}
+
 pub async fn rate_limit_middleware(
     limiter: Arc<RateLimiter>,
     trust_proxy: bool,
@@ -371,6 +378,9 @@ pub async fn rate_limit_middleware(
     req: Request,
     next: Next,
 ) -> Response {
+    if is_rate_limit_exempt(req.uri().path()) {
+        return next.run(req).await;
+    }
     let Some(ip) = extract_client_ip(&req, trust_proxy) else {
         tracing::debug!("rate limit: could not determine client IP");
         return next.run(req).await;
@@ -620,6 +630,22 @@ mod tests {
             "len={} must not exceed cap={}",
             limiter.len(),
             limiter.max_entries
+        );
+    }
+
+    #[test]
+    fn test_admin_reload_is_rate_limit_exempt() {
+        assert!(
+            is_rate_limit_exempt("/v1/admin/reload"),
+            "/v1/admin/reload must be exempt from rate limiting"
+        );
+        assert!(
+            !is_rate_limit_exempt("/v1/transcribe"),
+            "/v1/transcribe must NOT be exempt"
+        );
+        assert!(
+            !is_rate_limit_exempt("/health"),
+            "/health must NOT be exempt (it is outside the rate-limit layer entirely)"
         );
     }
 

--- a/crates/gigastt/src/server/ws.rs
+++ b/crates/gigastt/src/server/ws.rs
@@ -108,6 +108,10 @@ async fn handle_ws(socket: WebSocket, peer: SocketAddr, state: Arc<http::AppStat
         }
     }
     let _ws_guard = WsMetricsGuard(state.clone());
+    // Snapshot the live engine once for the whole session; a concurrent
+    // hot-reload swaps the `ArcSwap`, but this session keeps the engine (and
+    // pool) it checked out from until it ends.
+    let engine = state.engine.load_full();
     let checkout_start = std::time::Instant::now();
     // `select!` the pool checkout against the shutdown token so SIGTERM
     // during pool saturation returns immediately instead of waiting the full
@@ -127,7 +131,7 @@ async fn handle_ws(socket: WebSocket, peer: SocketAddr, state: Arc<http::AppStat
         }
         res = tokio::time::timeout(
             std::time::Duration::from_secs(state.limits.load().pool_checkout_timeout_secs),
-            state.engine.pool.checkout(),
+            engine.pool.checkout(),
         ) => match res {
             Ok(Ok(guard)) => guard,
             Ok(Err(_pool_closed)) => {
@@ -173,7 +177,7 @@ async fn handle_ws(socket: WebSocket, peer: SocketAddr, state: Arc<http::AppStat
     let result = handle_ws_inner(
         socket,
         peer,
-        &state.engine,
+        &engine,
         &limits,
         reservation,
         state.shutdown.clone(),

--- a/crates/gigastt/tests/common/mod.rs
+++ b/crates/gigastt/tests/common/mod.rs
@@ -78,6 +78,37 @@ pub async fn start_server(model_dir: &str) -> (u16, oneshot::Sender<()>) {
     (port, shutdown_tx)
 }
 
+/// Start a server whose `POST /v1/admin/reload` endpoint is wired to an engine
+/// builder that loads from `builder_model_dir`. The initially-served engine is
+/// always built from the real `model_dir`; `builder_model_dir` is what a reload
+/// rebuilds from — point it at a garbage dir to exercise the fail-safe
+/// keep-old-engine path. Returns `(port, shutdown_sender)`.
+pub async fn start_server_reloadable(
+    model_dir: &str,
+    builder_model_dir: &str,
+) -> (u16, oneshot::Sender<()>) {
+    let (port, listener) = free_port().await;
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let engine = gigastt::inference::Engine::load(model_dir).unwrap();
+    let config = gigastt::server::ServerConfig::local(port);
+
+    let builder_dir = builder_model_dir.to_string();
+    let builder: gigastt::server::EngineBuilder =
+        std::sync::Arc::new(move || Ok(gigastt::inference::Engine::load(&builder_dir)?));
+
+    tokio::spawn(gigastt::server::run_with_config_listener_reloadable(
+        engine,
+        config,
+        Some(shutdown_rx),
+        listener,
+        Some(builder),
+    ));
+
+    wait_for_ready(port, Duration::from_secs(30)).await;
+    (port, shutdown_tx)
+}
+
 /// Start the server with an explicit session-pool size. Used by the pool
 /// saturation tests so they don't depend on `DEFAULT_POOL_SIZE` (which changed
 /// to 2 in v2.3) or the RAM-aware cap — a small fixed pool is deterministic.

--- a/crates/gigastt/tests/e2e_admin_reload.rs
+++ b/crates/gigastt/tests/e2e_admin_reload.rs
@@ -1,0 +1,243 @@
+//! E2E tests for the loopback-only model hot-reload endpoint
+//! (`POST /v1/admin/reload`). Require the model on disk; run with:
+//!
+//! ```sh
+//! cargo test -p gigastt --test e2e_admin_reload -- --ignored --test-threads=1
+//! ```
+
+mod common;
+
+use common::{generate_wav, model_dir, start_server_reloadable, ws_connect};
+use futures_util::{SinkExt, StreamExt};
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+
+/// Decode a response body as JSON without depending on reqwest's `json` feature
+/// (the crate enables only `stream`), matching the other e2e suites.
+async fn json_body(resp: reqwest::Response) -> serde_json::Value {
+    let text = resp.text().await.expect("Expected text body");
+    serde_json::from_str(&text).expect("Expected JSON body")
+}
+
+/// Happy path: a reload swaps in a fresh engine and the server keeps serving.
+#[tokio::test]
+#[ignore = "requires model"]
+async fn test_reload_happy_swap() {
+    let dir = model_dir();
+    let (port, _shutdown) = start_server_reloadable(&dir, &dir).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Baseline: /v1/models serves a working model.
+    let before = json_body(
+        client
+            .get(format!("{base}/v1/models"))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+    let before_variant = before["variant"].as_str().unwrap().to_string();
+
+    // Reload → 200 { reloaded: true, variant, encoder }.
+    let resp = client
+        .post(format!("{base}/v1/admin/reload"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "reload should succeed");
+    let body = json_body(resp).await;
+    assert_eq!(body["reloaded"], true);
+    assert_eq!(body["variant"], before_variant);
+    assert!(
+        body["encoder"] == "int8" || body["encoder"] == "fp32",
+        "encoder must be reported: {body:?}"
+    );
+
+    // /v1/models still serves the same model after the swap.
+    let after = json_body(
+        client
+            .get(format!("{base}/v1/models"))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(after["variant"], before_variant);
+
+    // A fresh transcription succeeds against the swapped-in engine.
+    let wav = generate_wav(1, 16000);
+    let resp = client
+        .post(format!("{base}/v1/transcribe"))
+        .body(wav)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "transcribe must work after the model swap"
+    );
+    let v = json_body(resp).await;
+    assert!(v.get("text").is_some(), "response must carry a text field");
+}
+
+/// Two simultaneous reloads: exactly one wins (200), the other is rejected with
+/// 409 `reload_in_progress`.
+#[tokio::test]
+#[ignore = "requires model"]
+async fn test_reload_concurrency_returns_409() {
+    let dir = model_dir();
+    let (port, _shutdown) = start_server_reloadable(&dir, &dir).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    let a = client.post(format!("{base}/v1/admin/reload")).send();
+    let b = client.post(format!("{base}/v1/admin/reload")).send();
+    let (ra, rb) = tokio::join!(a, b);
+    let (ra, rb) = (ra.unwrap(), rb.unwrap());
+
+    let mut statuses = [ra.status().as_u16(), rb.status().as_u16()];
+    statuses.sort_unstable();
+    assert_eq!(
+        statuses,
+        [200, 409],
+        "one reload must win (200) and the other must get 409, got {statuses:?}"
+    );
+
+    // The 409 body carries the machine-readable code.
+    for r in [ra, rb] {
+        if r.status() == 409 {
+            let v = json_body(r).await;
+            assert_eq!(v["code"], "reload_in_progress");
+        }
+    }
+}
+
+/// A build failure (garbage model dir) must keep the ORIGINAL engine serving —
+/// the server is never left engineless.
+#[tokio::test]
+#[ignore = "requires model"]
+async fn test_reload_bad_dir_keeps_old_engine() {
+    let good = model_dir();
+    let bad = tempfile::tempdir().unwrap();
+    let bad_dir = bad.path().to_string_lossy().into_owned();
+
+    let (port, _shutdown) = start_server_reloadable(&good, &bad_dir).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Reload from the empty dir → 503 reload_failed.
+    let resp = client
+        .post(format!("{base}/v1/admin/reload"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        503,
+        "reload from a bad model dir must fail with 503"
+    );
+    let body = json_body(resp).await;
+    assert_eq!(body["code"], "reload_failed");
+    // Sanitized message — must not leak the bad path.
+    let msg = body["error"].as_str().unwrap();
+    assert!(
+        !msg.contains(bad.path().to_string_lossy().as_ref()),
+        "error message must not leak the model path: {msg}"
+    );
+
+    // The original engine still serves both /v1/models and /v1/transcribe.
+    let resp = client
+        .get(format!("{base}/v1/models"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "old engine must still serve /v1/models");
+
+    let wav = generate_wav(1, 16000);
+    let resp = client
+        .post(format!("{base}/v1/transcribe"))
+        .body(wav)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "old engine must still transcribe after a failed reload"
+    );
+}
+
+/// A WebSocket session started before the reload rides the old pool to a clean
+/// `Final`, AND a fresh REST transcription after the swap succeeds. Proves the
+/// swap drops no in-flight work.
+#[tokio::test]
+#[ignore = "requires model"]
+async fn test_reload_does_not_drop_inflight_ws() {
+    let dir = model_dir();
+    let (port, _shutdown) = start_server_reloadable(&dir, &dir).await;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::new();
+
+    // Open a WS stream and feed some audio (48 kHz default sample rate).
+    let (mut sink, mut stream, _ready) = ws_connect(port).await;
+    let pcm = common::generate_pcm16_tone(0.5, 48000, 440.0);
+    sink.send(Message::Binary(pcm.clone().into()))
+        .await
+        .unwrap();
+
+    // Fire the reload mid-session.
+    let reload_resp = client
+        .post(format!("{base}/v1/admin/reload"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        reload_resp.status(),
+        200,
+        "mid-session reload should succeed"
+    );
+
+    // Feed a little more, then Stop — the session must complete with a Final,
+    // proving it kept its (old) pool across the swap.
+    sink.send(Message::Binary(pcm.into())).await.unwrap();
+    sink.send(Message::Text(r#"{"type":"stop"}"#.to_string().into()))
+        .await
+        .unwrap();
+
+    let mut saw_final = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_secs(5), stream.next()).await {
+            Ok(Some(Ok(msg))) => {
+                if let Ok(text) = msg.into_text()
+                    && let Ok(v) = serde_json::from_str::<serde_json::Value>(&text)
+                    && v["type"] == "final"
+                {
+                    saw_final = true;
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+    assert!(
+        saw_final,
+        "in-flight WS session must still complete with a Final after a mid-session reload"
+    );
+
+    // A fresh REST transcription after the swap succeeds on the new engine.
+    let wav = generate_wav(1, 16000);
+    let resp = client
+        .post(format!("{base}/v1/transcribe"))
+        .body(wav)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "a new request after the swap must hit a working engine"
+    );
+}

--- a/crates/gigastt/tests/e2e_shutdown.rs
+++ b/crates/gigastt/tests/e2e_shutdown.rs
@@ -441,3 +441,75 @@ async fn test_clean_shutdown_releases_listener() {
         "clean shutdown must release the listener (drain path must complete)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 8. shutdown closes the RELOADED engine's pools, not the boot engine's
+// ---------------------------------------------------------------------------
+
+/// Guards the hot-reload shutdown invariant: after a model reload swaps in a new
+/// engine, a subsequent shutdown must close the *live* engine's pools so waiters
+/// parked on the new pool wake with `PoolError::Closed` (503 `pool_closed`). If
+/// shutdown closed a pre-swap snapshot instead, this waiter would hang and the
+/// 10 s timeout below would fire.
+#[ignore]
+#[tokio::test]
+async fn test_shutdown_after_reload_closes_new_engine_pool() {
+    let model_dir = common::model_dir();
+    let (port, shutdown) = common::start_server_reloadable(&model_dir, &model_dir).await;
+    let client = reqwest::Client::new();
+
+    // Swap the engine BEFORE saturating, so the pool the waiter parks on belongs
+    // to the reloaded engine — not the one captured at boot.
+    let reload = client
+        .post(format!("http://127.0.0.1:{port}/v1/admin/reload"))
+        .send()
+        .await
+        .expect("reload request failed");
+    assert_eq!(reload.status(), 200, "reload should succeed");
+
+    // Saturate the (new) default pool with long-running REST jobs.
+    let long_wav = common::generate_wav(60, 16000);
+    let mut occupiers = Vec::new();
+    for _ in 0..4 {
+        let url = format!("http://127.0.0.1:{port}/v1/transcribe");
+        let body = long_wav.clone();
+        let c = client.clone();
+        occupiers.push(tokio::spawn(async move {
+            let _ = c.post(&url).body(body).send().await;
+        }));
+    }
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // A waiter blocked inside the new pool's `checkout()`.
+    let waiter_url = format!("http://127.0.0.1:{port}/v1/transcribe");
+    let waiter_body = long_wav.clone();
+    let waiter = tokio::spawn(async move {
+        reqwest::Client::new()
+            .post(&waiter_url)
+            .body(waiter_body)
+            .send()
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Shutdown must close the reloaded engine's pools.
+    let _ = shutdown.send(());
+
+    let resp = tokio::time::timeout(Duration::from_secs(10), waiter)
+        .await
+        .expect("waiter did not resolve within 10s — shutdown closed the wrong engine's pool")
+        .expect("waiter task panicked");
+    let resp = resp.expect("waiter request failed before reaching the server");
+    assert_eq!(
+        resp.status().as_u16(),
+        503,
+        "waiter on the reloaded engine's pool must get 503 on shutdown"
+    );
+    let body_text = resp.text().await.expect("read body");
+    let body: serde_json::Value = serde_json::from_str(&body_text).expect("invalid JSON body");
+    assert_eq!(body["code"], "pool_closed");
+
+    for h in occupiers {
+        let _ = h.await;
+    }
+}


### PR DESCRIPTION
## Summary

Adds model hot-reload without a full server restart via a loopback-only `POST /v1/admin/reload` that atomically swaps the inference `Engine`.

### Design

- **`AppState.engine` is now `Arc<ArcSwap<Engine>>`** (mirrors the existing `limits: Arc<ArcSwap<RuntimeLimits>>` pattern). Every reader `load_full()`s the current `Arc<Engine>` at request start and uses it for the whole request, so a concurrent swap only affects requests that begin after it. In-flight requests keep the engine (and pool) they started on and finish against it; the old engine drops when its last reference goes. The old pool is never closed on swap.
- **Reusable engine builder stored in `AppState`** (`EngineBuilder = Arc<dyn Fn() -> anyhow::Result<Engine> + Send + Sync>`). The build recipe (model dir, pool sizes, encoder threads, and the punctuation / ITN / VAD / hotword chain) is factored out of the `Serve` match arm so **both boot and reload** call the identical recipe. A fresh `Engine` starts with all post-processors `None`, so re-applying the chain is the whole point of storing the recipe. The recipe re-detects the on-disk variant so a reload picks up a model swapped on disk.
- **Handler flow:** `try_lock` the reload mutex (409 `reload_in_progress` on contention) → build off the request path in `spawn_blocking` → **warm the new engine before swapping** (so the first post-swap request pays no cold cost) → `store()` the new `Arc<Engine>`. On build/warmup failure the old engine is left untouched and the handler returns 503 `reload_failed` with a sanitized message (no path leakage). Success returns `200 {"reloaded":true,"variant":…,"encoder":"int8"|"fp32"}`.

### Two mandatory gotchas — both addressed

- **Gotcha #1 (shutdown must close the LIVE engine):** the shutdown path now does `shutdown_engine.load_full().close_pools()` (`crates/gigastt/src/server/mod.rs`), loading whichever engine is live at shutdown time. A pre-captured snapshot would close the boot engine's pools even after a reload, stranding waiters on the new pool. Guarded by an e2e test (`test_shutdown_after_reload_closes_new_engine_pool`).
- **Gotcha #2 (strict loopback):** the handler adds an explicit `ConnectInfo<SocketAddr>` peer-IP loopback check (`peer_is_loopback`) that returns 403 `loopback_only` for any non-loopback peer, so reload stays local even under `--bind-all` / `--cors-allow-any` (which would widen `origin_middleware`, the only other gate). Covered by a model-free unit test.

### Loopback enforcement

Registered inside the `protected` router (inherits `origin_middleware`) **plus** the in-handler peer-IP check above — defence in depth. The reload route is also added to `metric_path_label` so it stays observable.

### SIGHUP

The optional SIGHUP engine-reload was **deferred**: adding it would change existing `kill -HUP` semantics (which today only reloads limits/rate-limiter from the config file) into a several-second blocking engine rebuild, a behavior change beyond the deliverable. The HTTP endpoint is the deliverable and is complete.

## Tests

New `crates/gigastt/tests/e2e_admin_reload.rs` (model-gated, `--ignored`):

- `test_reload_happy_swap` — reload → 200; `/v1/models` + `/v1/transcribe` work after swap. **PASS**
- `test_reload_does_not_drop_inflight_ws` — WS stream fed mid-session, reload fired, session still completes with `Final` (rides old pool) AND a fresh `/v1/transcribe` after the swap succeeds. **PASS**
- `test_reload_bad_dir_keeps_old_engine` — reload from a garbage dir → 503 `reload_failed`; original engine still serves. **PASS**
- `test_reload_concurrency_returns_409` — two simultaneous reloads → one 200, one 409. **PASS**

Plus: model-free unit test for the loopback guard (`test_peer_is_loopback_guard`, runs in CI), model-gated `test_reload_rejects_non_loopback_peer` / `test_reload_unsupported_when_no_builder`, and an e2e_shutdown extension guarding gotcha #1.

## Verify

- `cargo build` + `cargo build --release`: clean
- `cargo clippy --workspace --all-targets` + `cargo fmt --check`: clean
- `cargo test -p gigastt --lib` (89 pass) + `cargo test -p gigastt-core --lib` (358 pass)
- e2e reload suite (`--ignored`, model present): 4/4 pass; gotcha-#1 shutdown guard: pass; e2e_rest (19) + e2e_ws (25) regression suites: pass

Docs: `CHANGELOG.md` `## [Unreleased]` → `### Added`; `CLAUDE.md` "Known limitations" line updated. No version bump; `specs/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)