### PR TITLE
feat(rest): ?segments=true JSON + segment-grouped markdown on /v1/transcribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Segment-level output on `POST /v1/transcribe` (`?segments=true`).** The default JSON
+  response gains an additive `segments` array — `[{start, end, text, words:[…]}]` — that
+  groups words into cue-sized segments, sharing the exact boundaries used by the `srt` /
+  `vtt` exports (one grouping source), while the top-level `text` / `words` / `duration`
+  stay unchanged. Combined with `format=md`, `segments=true` switches Markdown to
+  `### [mm:ss]` (widening to `[hh:mm:ss]` past an hour) section headers per segment instead
+  of the flat `# Transcript` blob. Fully opt-in: the default response and plain `format=md`
+  are byte-unchanged, and `txt` / `srt` / `vtt` ignore the flag (already flat / cue-based).
 - **Model hot-reload without a restart.** A new loopback-only `POST /v1/admin/reload`
   rebuilds the inference engine from the exact boot recipe (model dir, pool sizes,
   encoder threads, and the punctuation / ITN / VAD / hotword chain) and atomically

--- a/crates/gigastt-core/src/export.rs
+++ b/crates/gigastt-core/src/export.rs
@@ -5,6 +5,7 @@
 
 use crate::error::GigasttError;
 use crate::inference::{TranscribeResult, WordInfo};
+use serde::Serialize;
 use std::str::FromStr;
 
 /// Supported export formats for transcription results.
@@ -217,11 +218,32 @@ pub fn to_md(result: &TranscribeResult, include_word_timestamps: bool) -> String
 }
 
 /// Internal cue used for SRT/VTT line grouping.
+///
+/// Carries the words that fall within the cue's span so higher-level exports
+/// (segment JSON, segment-grouped Markdown) can reuse the exact same grouping
+/// boundaries as SRT/VTT instead of re-deriving them.
 #[derive(Clone, Debug)]
 struct Cue {
     start: f64,
     end: f64,
     text: String,
+    words: Vec<WordInfo>,
+}
+
+/// A grouped transcript segment: a cue-sized span of words with an aggregate
+/// start/end and text. Segments share their boundaries with the SRT/VTT cues
+/// (both come from [`build_cues`]), so `?segments=true` JSON, SRT, VTT, and the
+/// segment-grouped Markdown mode all agree on where segments begin and end.
+#[derive(Clone, Debug, Serialize)]
+pub struct Segment {
+    /// Segment start time in seconds (start of its first word).
+    pub start: f64,
+    /// Segment end time in seconds (end of its last word).
+    pub end: f64,
+    /// Rendered segment text (speaker label prefix included when diarized).
+    pub text: String,
+    /// The words that fall within this segment's span.
+    pub words: Vec<WordInfo>,
 }
 
 /// Group words into caption cues with speaker-aware line breaking.
@@ -235,6 +257,7 @@ fn build_cues(words: &[WordInfo], max_chars: usize, max_words: usize) -> Vec<Cue
         start: words[0].start,
         end: words[0].end,
         text: String::new(),
+        words: Vec::new(),
     };
     let mut current_speaker: Option<u32> = None;
     let mut word_count = 0;
@@ -245,6 +268,7 @@ fn build_cues(words: &[WordInfo], max_chars: usize, max_words: usize) -> Vec<Cue
             cue.text = cue.text.trim_end().to_string();
             cues.push(cue.clone());
             cue.text.clear();
+            cue.words.clear();
         }
     };
 
@@ -286,11 +310,81 @@ fn build_cues(words: &[WordInfo], max_chars: usize, max_words: usize) -> Vec<Cue
         }
         current.text.push_str(&word.word);
         current.end = word.end;
+        current.words.push(word.clone());
         word_count += 1;
     }
 
     flush(&mut current, &mut cues);
     cues
+}
+
+/// Group a word list into cue-sized segments, reusing the SRT/VTT cue
+/// boundaries so every export format agrees on segment spans.
+///
+/// Each returned [`Segment`] carries the words that fall within its span, so a
+/// consumer can render segment-level UI (e.g. `### [mm:ss]` sections) without
+/// re-deriving offsets from the flat per-word list.
+pub fn to_segments(words: &[WordInfo], max_chars: usize, max_words: usize) -> Vec<Segment> {
+    build_cues(words, max_chars, max_words)
+        .into_iter()
+        .map(|cue| Segment {
+            start: cue.start,
+            end: cue.end,
+            text: cue.text,
+            words: cue.words,
+        })
+        .collect()
+}
+
+/// Segment-grouped Markdown: `### [mm:ss]` (or `[hh:mm:ss]` past one hour)
+/// section headers per cue-sized segment, followed by that segment's text.
+///
+/// Shares its boundaries with SRT/VTT and `?segments=true` (all via
+/// [`build_cues`]). Motivated by downstream consumers that otherwise fabricate
+/// `### mm:ss` offsets because only flat per-word timings were exposed.
+pub fn to_md_segments(result: &TranscribeResult, max_chars: usize, max_words: usize) -> String {
+    let segments = to_segments(&result.words, max_chars, max_words);
+
+    let speaker_count = result
+        .words
+        .iter()
+        .filter_map(|w| w.speaker)
+        .max()
+        .map(|m| m + 1)
+        .unwrap_or(0);
+
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str(&format!("duration: {}\n", result.duration_s));
+    out.push_str("language: ru\n");
+    out.push_str(&format!("speakers: {speaker_count}\n"));
+    out.push_str("---\n\n");
+
+    for segment in &segments {
+        out.push_str(&format!(
+            "### [{}]\n\n",
+            format_timestamp_hms(segment.start)
+        ));
+        out.push_str(&segment.text);
+        out.push_str("\n\n");
+    }
+
+    out
+}
+
+/// Format a timestamp as `mm:ss`, widening to `hh:mm:ss` once it reaches one
+/// hour. Used for the `### [mm:ss]` segment-Markdown headers.
+fn format_timestamp_hms(seconds: f64) -> String {
+    let total_s = seconds.max(0.0).round() as u64;
+    let s = total_s % 60;
+    let total_m = total_s / 60;
+    let m = total_m % 60;
+    let h = total_m / 60;
+    if h > 0 {
+        format!("{h:02}:{m:02}:{s:02}")
+    } else {
+        format!("{m:02}:{s:02}")
+    }
 }
 
 fn format_srt_time(seconds: f64) -> String {
@@ -596,5 +690,129 @@ mod tests {
         let cue_count = srt.trim().split("\n\n").count();
         // 20 words / 5 per line = 4 cues, but exact count depends on chars.
         assert!(cue_count >= 2);
+    }
+
+    #[test]
+    fn test_to_segments_shares_cue_boundaries() {
+        // Two speakers force a cue break, so segments mirror the SRT cues:
+        // one per speaker, with matching spans and per-segment word membership.
+        let words = sample_words();
+        let segments = to_segments(&words, 80, 14);
+        assert_eq!(segments.len(), 2);
+
+        assert_eq!(segments[0].start, 0.0);
+        assert_eq!(segments[0].end, 0.9);
+        assert!(segments[0].text.starts_with("[SPEAKER_0] привет"));
+        assert_eq!(segments[0].words.len(), 2);
+        assert_eq!(segments[0].words[0].word, "привет");
+        assert_eq!(segments[0].words[1].word, "как");
+
+        assert_eq!(segments[1].start, 1.0);
+        assert_eq!(segments[1].end, 1.4);
+        assert!(segments[1].text.contains("дела"));
+        assert_eq!(segments[1].words.len(), 1);
+        assert_eq!(segments[1].words[0].word, "дела");
+    }
+
+    #[test]
+    fn test_to_segments_word_cap_splits() {
+        // A tight per-line cap groups the 20 words into multiple segments whose
+        // spans and word membership line up with the flat list order.
+        let words: Vec<WordInfo> = (0..20)
+            .map(|i| WordInfo {
+                word: format!("word{i}"),
+                start: i as f64,
+                end: i as f64 + 0.4,
+                confidence: 0.9,
+                speaker: None,
+            })
+            .collect();
+        let segments = to_segments(&words, 0, 5);
+        assert_eq!(segments.len(), 4);
+        // Every word is accounted for exactly once, in order.
+        let total: usize = segments.iter().map(|s| s.words.len()).sum();
+        assert_eq!(total, 20);
+        assert_eq!(segments[0].words[0].word, "word0");
+        assert_eq!(segments[0].start, 0.0);
+        assert_eq!(segments[0].end, 4.4);
+        assert_eq!(segments[3].words.last().unwrap().word, "word19");
+    }
+
+    #[test]
+    fn test_to_segments_empty() {
+        let words: Vec<WordInfo> = Vec::new();
+        assert!(to_segments(&words, 80, 14).is_empty());
+    }
+
+    #[test]
+    fn test_to_segments_serializes_with_words() {
+        let words = sample_words();
+        let segments = to_segments(&words, 80, 14);
+        let json = serde_json::to_value(&segments).unwrap();
+        assert_eq!(json[0]["start"], 0.0);
+        assert_eq!(json[0]["end"], 0.9);
+        assert_eq!(json[0]["words"][0]["word"], "привет");
+        // Speaker is carried through (skip_serializing_if only drops None).
+        assert_eq!(json[0]["words"][0]["speaker"], 0);
+    }
+
+    #[test]
+    fn test_to_md_segments_emits_headers() {
+        let result = sample_result();
+        let md = to_md_segments(&result, 80, 14);
+        // Frontmatter is preserved; the flat "# Transcript" blob is replaced by
+        // per-segment "### [mm:ss]" headers.
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("duration: 1.4"));
+        assert!(md.contains("speakers: 2"));
+        assert!(md.contains("### [00:00]\n"));
+        assert!(md.contains("### [00:01]\n"));
+        assert!(md.contains("[SPEAKER_0] привет как"));
+        assert!(md.contains("дела"));
+        assert!(!md.contains("# Transcript"));
+    }
+
+    #[test]
+    fn test_to_md_segments_empty_words() {
+        let result = TranscribeResult {
+            text: String::new(),
+            words: Vec::new(),
+            duration_s: 0.0,
+        };
+        let md = to_md_segments(&result, 80, 14);
+        // No words means no section headers, but the frontmatter still renders.
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("speakers: 0"));
+        assert!(!md.contains("### ["));
+    }
+
+    #[test]
+    fn test_format_timestamp_hms() {
+        // Under a minute, exactly a minute-plus, and past an hour widen as needed.
+        assert_eq!(format_timestamp_hms(0.0), "00:00");
+        assert_eq!(format_timestamp_hms(65.0), "01:05");
+        assert_eq!(format_timestamp_hms(3661.0), "01:01:01");
+        // Rounds to the nearest second; negatives clamp to zero.
+        assert_eq!(format_timestamp_hms(59.6), "01:00");
+        assert_eq!(format_timestamp_hms(-5.0), "00:00");
+    }
+
+    #[test]
+    fn test_md_segments_and_srt_agree_on_boundaries() {
+        // The whole point of routing both through build_cues: the segment count
+        // matches the SRT cue count for the same caps.
+        let words: Vec<WordInfo> = (0..20)
+            .map(|i| WordInfo {
+                word: format!("word{i}"),
+                start: i as f64,
+                end: i as f64 + 0.4,
+                confidence: 0.9,
+                speaker: None,
+            })
+            .collect();
+        let segments = to_segments(&words, 0, 5);
+        let srt = to_srt(&words, 0, 5);
+        let srt_cues = srt.matches("-->").count();
+        assert_eq!(segments.len(), srt_cues);
     }
 }

--- a/crates/gigastt-core/src/export.rs
+++ b/crates/gigastt-core/src/export.rs
@@ -232,7 +232,7 @@ struct Cue {
 
 /// A grouped transcript segment: a cue-sized span of words with an aggregate
 /// start/end and text. Segments share their boundaries with the SRT/VTT cues
-/// (both come from [`build_cues`]), so `?segments=true` JSON, SRT, VTT, and the
+/// (both come from `build_cues`), so `?segments=true` JSON, SRT, VTT, and the
 /// segment-grouped Markdown mode all agree on where segments begin and end.
 #[derive(Clone, Debug, Serialize)]
 pub struct Segment {
@@ -340,7 +340,7 @@ pub fn to_segments(words: &[WordInfo], max_chars: usize, max_words: usize) -> Ve
 /// section headers per cue-sized segment, followed by that segment's text.
 ///
 /// Shares its boundaries with SRT/VTT and `?segments=true` (all via
-/// [`build_cues`]). Motivated by downstream consumers that otherwise fabricate
+/// `build_cues`). Motivated by downstream consumers that otherwise fabricate
 /// `### mm:ss` offsets because only flat per-word timings were exposed.
 pub fn to_md_segments(result: &TranscribeResult, max_chars: usize, max_words: usize) -> String {
     let segments = to_segments(&result.words, max_chars, max_words);

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -16,7 +16,7 @@ use arc_swap::ArcSwap;
 
 use super::config::{RuntimeLimits, pool_retry_after_ms, pool_retry_after_secs};
 use super::metrics::MetricsRegistry;
-use gigastt_core::export::{ExportFormat, RenderOpts};
+use gigastt_core::export::{ExportFormat, RenderOpts, Segment};
 use gigastt_core::inference::Engine;
 
 /// Shared application state for all handlers. Carries runtime limits so the
@@ -150,6 +150,11 @@ pub struct TranscribeResponse {
     pub words: Vec<gigastt_core::inference::WordInfo>,
     /// Duration of the submitted audio in seconds.
     pub duration: f64,
+    /// Cue-sized segments, present only when the caller passed `?segments=true`.
+    /// Additive: absent from the default response, so existing clients that read
+    /// `text` / `words` / `duration` are unaffected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segments: Option<Vec<Segment>>,
 }
 
 /// Query parameters for `/v1/transcribe` export formatting.
@@ -169,6 +174,12 @@ pub struct ExportParams {
     /// Include per-word timestamps in Markdown output.
     #[serde(default)]
     pub word_timestamps: Option<bool>,
+    /// Return cue-sized segments. In the default (JSON) response this adds a
+    /// `segments` array; combined with `format=md` it switches Markdown to
+    /// `### [mm:ss]` segment headers. Ignored for `txt`/`srt`/`vtt` (those are
+    /// already flat / cue-based).
+    #[serde(default)]
+    pub segments: Option<bool>,
 }
 
 /// Render a transcription result into the requested export format.
@@ -195,7 +206,20 @@ fn render_export_response(
         include_word_timestamps: params.word_timestamps.unwrap_or(false),
     };
 
-    let body = format.render(result, &opts);
+    // Precedence for `format` × `segments`: only Markdown composes with
+    // `segments=true`, switching to `### [mm:ss]` section headers over the same
+    // cue boundaries as SRT/VTT. `txt`/`srt`/`vtt` ignore `segments` (flat /
+    // already cue-based); plain `format=md` keeps the frontmatter + `# Transcript`
+    // blob unchanged.
+    let body = if format == ExportFormat::Md && params.segments.unwrap_or(false) {
+        gigastt_core::export::to_md_segments(
+            result,
+            opts.max_chars_per_line,
+            opts.max_words_per_line,
+        )
+    } else {
+        format.render(result, &opts)
+    };
     let mut builder = Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, format.content_type());
@@ -604,10 +628,24 @@ pub async fn transcribe(
             if let Some(rendered) = render_export_response(&result, &params)? {
                 Ok(rendered)
             } else {
+                // Default JSON response. `?segments=true` adds a cue-grouped
+                // `segments` array (same boundaries as SRT/VTT) alongside the
+                // unchanged top-level `text` / `words` / `duration`; absent
+                // otherwise so existing clients see the exact same shape.
+                let segments = if params.segments.unwrap_or(false) {
+                    Some(gigastt_core::export::to_segments(
+                        &result.words,
+                        params.max_chars_per_line.unwrap_or(80),
+                        params.max_words_per_line.unwrap_or(14),
+                    ))
+                } else {
+                    None
+                };
                 Ok(Json(TranscribeResponse {
                     text: result.text,
                     words: result.words,
                     duration: result.duration_s,
+                    segments,
                 })
                 .into_response())
             }
@@ -997,6 +1035,7 @@ mod tests {
             words: vec![],
 
             duration: 1.5,
+            segments: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -1364,6 +1403,47 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    #[ignore = "requires model"]
+    async fn test_transcribe_segments_json() {
+        // `?segments=true` on the default JSON response adds a `segments` array
+        // with sane start/end ordering and per-segment words, while keeping the
+        // top-level text/words/duration contract.
+        let state = Arc::new(AppState {
+            engine: engine_swap(test_engine()),
+            limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
+            metrics_registry: None,
+            engine_builder: None,
+            reload_lock: Arc::new(tokio::sync::Mutex::new(())),
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            tracker: tokio_util::task::TaskTracker::new(),
+        });
+        let params = ExportParams {
+            segments: Some(true),
+            ..ExportParams::default()
+        };
+        let resp = transcribe(State(state), Query(params), short_wav())
+            .await
+            .expect("transcribe with segments should succeed");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // Top-level contract is preserved.
+        assert!(v.get("text").is_some());
+        assert!(v.get("words").is_some());
+        assert!(v.get("duration").is_some());
+        // The segments array is present and every segment has monotonic timing.
+        let segments = v["segments"].as_array().expect("segments array present");
+        for seg in segments {
+            let start = seg["start"].as_f64().unwrap();
+            let end = seg["end"].as_f64().unwrap();
+            assert!(end >= start, "segment end {end} < start {start}");
+            assert!(seg["words"].is_array());
+        }
+    }
+
     fn sample_export_result() -> gigastt_core::inference::TranscribeResult {
         use gigastt_core::inference::WordInfo;
         gigastt_core::inference::TranscribeResult {
@@ -1577,11 +1657,114 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_render_export_md_segments_emits_headers() {
+        // `format=md` + `segments=true` switches Markdown to `### [mm:ss]`
+        // section headers over the cue boundaries, dropping the flat
+        // `# Transcript` blob.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("md".into()),
+            segments: Some(true),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/markdown; charset=utf-8"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("### [00:00]"));
+        assert!(text.contains("[SPEAKER_0] привет мир"));
+        // Segment mode replaces the flat transcript blob.
+        assert!(!text.contains("# Transcript"));
+    }
+
+    #[tokio::test]
+    async fn test_render_export_md_without_segments_unchanged() {
+        // Plain `format=md` (no segments) keeps the existing frontmatter +
+        // `# Transcript` layout — segment mode is strictly opt-in.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("md".into()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("# Transcript"));
+        assert!(!text.contains("### ["));
+    }
+
+    #[tokio::test]
+    async fn test_render_export_segments_ignored_for_srt() {
+        // `segments=true` is a JSON/Markdown affordance; SRT is already
+        // cue-based and must render identically with or without the flag.
+        let result = sample_export_result();
+        let plain = ExportParams {
+            format: Some("srt".into()),
+            ..ExportParams::default()
+        };
+        let with_segments = ExportParams {
+            format: Some("srt".into()),
+            segments: Some(true),
+            ..ExportParams::default()
+        };
+        let a = render_export_response(&result, &plain).unwrap().unwrap();
+        let b = render_export_response(&result, &with_segments)
+            .unwrap()
+            .unwrap();
+        let a_body = axum::body::to_bytes(a.into_body(), 4096).await.unwrap();
+        let b_body = axum::body::to_bytes(b.into_body(), 4096).await.unwrap();
+        assert_eq!(a_body, b_body);
+    }
+
+    #[test]
+    fn test_transcribe_response_omits_segments_when_none() {
+        // The default response must be byte-identical to the pre-feature shape:
+        // no `segments` key when the caller didn't ask for it.
+        let resp = TranscribeResponse {
+            text: "hello".into(),
+            words: vec![],
+            duration: 1.5,
+            segments: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v.get("segments").is_none());
+        assert_eq!(v["text"], "hello");
+        assert_eq!(v["duration"], 1.5);
+    }
+
+    #[test]
+    fn test_transcribe_response_includes_segments_when_present() {
+        use gigastt_core::export::to_segments;
+        use gigastt_core::inference::WordInfo;
+        let words = vec![
+            WordInfo::new("привет", 0.0, 0.5, 0.98, None),
+            WordInfo::new("мир", 0.6, 1.0, 0.97, None),
+        ];
+        let resp = TranscribeResponse {
+            text: "привет мир".into(),
+            words: words.clone(),
+            duration: 1.0,
+            segments: Some(to_segments(&words, 80, 14)),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        let segments = v["segments"].as_array().unwrap();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0]["start"], 0.0);
+        assert_eq!(segments[0]["end"], 1.0);
+        assert_eq!(segments[0]["text"], "привет мир");
+        assert_eq!(segments[0]["words"][0]["word"], "привет");
+    }
+
     #[test]
     fn test_export_params_deserialize_from_query() {
         // The query-param shape drives format negotiation; confirm axum's Query
         // extractor maps every field so the handler sees the caller's choices.
-        let uri: axum::http::Uri = "http://x/?format=srt&download=out.srt&max_chars_per_line=20&max_words_per_line=3&word_timestamps=true"
+        let uri: axum::http::Uri = "http://x/?format=srt&download=out.srt&max_chars_per_line=20&max_words_per_line=3&word_timestamps=true&segments=true"
             .parse()
             .unwrap();
         let Query(params): Query<ExportParams> = Query::try_from_uri(&uri).unwrap();
@@ -1590,6 +1773,7 @@ mod tests {
         assert_eq!(params.max_chars_per_line, Some(20));
         assert_eq!(params.max_words_per_line, Some(3));
         assert_eq!(params.word_timestamps, Some(true));
+        assert_eq!(params.segments, Some(true));
     }
 
     #[test]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -179,6 +179,11 @@ paths:
         via the `format` query parameter: `txt`, `srt`, `vtt`, `md`. Use
         `download` to send `Content-Disposition: attachment`.
 
+        Pass `segments=true` to add a cue-grouped `segments` array to the default
+        JSON response (same boundaries as the `srt` / `vtt` exports); combined
+        with `format=md` it switches Markdown to `### [mm:ss]` segment headers.
+        `txt` / `srt` / `vtt` ignore `segments` (already flat / cue-based).
+
         The entire file is processed in a single inference session.
         Max audio duration: 10 minutes.
       operationId: transcribeFile
@@ -220,6 +225,16 @@ paths:
             type: boolean
             default: false
           description: Include per-word timestamps in Markdown output.
+        - name: segments
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: |
+            Add a cue-grouped `segments` array to the default JSON response, or
+            (with `format=md`) emit `### [mm:ss]` segment headers. Ignored for
+            `txt` / `srt` / `vtt`.
       requestBody:
         required: true
         content:
@@ -542,6 +557,42 @@ components:
           format: double
           example: 2.5
           description: Audio duration in seconds
+        segments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Segment"
+          description: |
+            Cue-grouped segments. Present only when the request passed
+            `segments=true`; omitted otherwise so existing clients are
+            unaffected. Segments share their boundaries with the SRT/VTT exports.
+
+    Segment:
+      type: object
+      required:
+        - start
+        - end
+        - text
+        - words
+      properties:
+        start:
+          type: number
+          format: double
+          example: 0.0
+          description: Segment start time in seconds (start of its first word)
+        end:
+          type: number
+          format: double
+          example: 2.5
+          description: Segment end time in seconds (end of its last word)
+        text:
+          type: string
+          example: "привет как дела"
+          description: Rendered segment text (speaker label prefix when diarized)
+        words:
+          type: array
+          items:
+            $ref: "#/components/schemas/WordInfo"
+          description: The words that fall within this segment's span
 
     WordInfo:
       type: object


### PR DESCRIPTION
Implements the remaining half of the segment-level output roadmap item. The export **formats** half (`txt`/`srt`/`vtt`/`md` via `?format=`) shipped in v2.3.0; this adds the segment half.

Motivation: a downstream consumer (`voodoo2serg/recognition`) currently fabricates `### mm:ss` offsets because gigastt only exposed flat per-word timings. Now segments (and segment-grouped Markdown) come straight from the server.

## What's new

1. **`?segments=true` JSON** on `POST /v1/transcribe`: the default JSON response gains an additive `segments` array `[{start, end, text, words:[…]}]`. Top-level `text` / `words` / `duration` are unchanged.
2. **Segment-grouped Markdown**: `format=md` + `segments=true` emits `### [mm:ss]` (widening to `[hh:mm:ss]` past an hour) section headers per segment instead of the flat `# Transcript` blob.

All grouping reuses `export::build_cues` (the SRT/VTT boundary source), so `?segments=true`, `format=srt`, `format=vtt`, and segment-md all agree on where segments begin and end. New public API in `gigastt-core::export`: `Segment`, `to_segments`, `to_md_segments`, and a `format_timestamp_hms` helper.

## `format` × `segments` precedence

| `format` | `segments=true` | Result |
|----------|-----------------|--------|
| _(none)_ / `json` | yes | JSON with additive `segments` array |
| _(none)_ / `json` | no  | Default JSON (byte-unchanged) |
| `md` | yes | `### [mm:ss]` segment-grouped Markdown |
| `md` | no  | Existing frontmatter + `# Transcript` blob (unchanged) |
| `txt` / `srt` / `vtt` | either | Unchanged (flat / already cue-based; flag ignored) |

## Sample: `?segments=true` JSON

```json
{
  "text": "привет как дела хорошо",
  "duration": 63.5,
  "segments": [
    {
      "start": 0.0,
      "end": 0.9,
      "text": "привет как",
      "words": [
        { "word": "привет", "start": 0.0, "end": 0.5, "confidence": 0.98 },
        { "word": "как",    "start": 0.6, "end": 0.9, "confidence": 0.95 }
      ]
    },
    {
      "start": 62.0,
      "end": 63.5,
      "text": "дела хорошо",
      "words": [
        { "word": "дела",   "start": 62.0, "end": 62.4, "confidence": 0.97 },
        { "word": "хорошо", "start": 63.0, "end": 63.5, "confidence": 0.96 }
      ]
    }
  ]
}
```

## Sample: `format=md&segments=true`

```markdown
---
duration: 63.5
language: ru
speakers: 0
---

### [00:00]

привет как

### [01:02]

дела хорошо
```

## Additive / backward-compatible

- The default response and plain `format=md` are **byte-unchanged**; `segments` is `skip_serializing_if=Option::is_none` so existing clients that read `text`/`words`/`duration` are unaffected.
- No version bump. `specs/` untouched.

## Tests

- `gigastt-core::export` unit tests (no model): `to_segments` boundary/word-membership/span, `to_md_segments` headers, `format_timestamp_hms` (0s / 65s / 3661s), and a segment-vs-SRT boundary-agreement test.
- Handler unit tests (`crates/gigastt/src/server/http.rs`, no model): `format=md&segments=true` emits `### [` headers; plain `format=md` unchanged; `segments` ignored for SRT; `segments` absent from default response when not requested; present + correctly shaped when requested; query-param deserialization. Plus one model-gated (`#[ignore]`) end-to-end `?segments=true` handler test.
- `cargo build` + `cargo clippy --workspace -- -D warnings` + `cargo fmt --check` clean; `cargo test -p gigastt-core --lib` (29 export tests) + `cargo test -p gigastt --lib` (95) green.

Docs: CHANGELOG `[Unreleased] → Added` and `docs/openapi.yaml` (`segments` param + `Segment` schema + `TranscribeResponse.segments`) updated, additive.

Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)