### PR TITLE
ci: nightly Miri + TSAN memory-safety job over the pure-Rust core + pool

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,122 @@
+# Nightly memory-safety / data-race pass over the pure-Rust core.
+#
+# This job is deliberately narrow. What it DOES cover:
+#   * Miri (undefined-behaviour / aliasing / provenance / integer-overflow
+#     interpreter) over the ~320 synchronous unit tests in `gigastt-core` that
+#     exercise pure-Rust logic: the INT8 quantizer, the RNN-T greedy decode
+#     loop, the tokenizer, the audio-byte / PCM16-framing decode surface, the
+#     tensor / protocol / export / error / itn / punctuation / vad / lexicon /
+#     bias modules, and the mock runtime.
+#   * ThreadSanitizer over the `Pool` checkout / checkin / OwnedReservation
+#     concurrency primitive (blocking + async slow paths, FIFO-under-contention,
+#     panic-unwind return-to-pool). Items are plain `u32` / `String`, so the
+#     signal is about the pool's own synchronization, not model code.
+#
+# What it does NOT cover (left to the existing e2e / soak / CoreML-smoke jobs
+# plus code review — do not read this as a broad "memory-safety CI"):
+#   * The onnxruntime inference path (Miri interprets Rust MIR and cannot call
+#     the onnxruntime C API; the ort-FFI roundtrip tests are `#[cfg_attr(miri,
+#     ignore)]`).
+#   * The objc2 / Core ML ANE bridge (Objective-C runtime, macOS-only; compiled
+#     out here via `--no-default-features`).
+#   * The `gigastt-ffi` C-ABI cdylib.
+#   * `ArcSwap<Engine>` hot-reload (integration-tested, not unit-tested).
+#   * The mel-spectrogram FFT and rubato resampler numeric paths — excluded from
+#     the Miri subset because a single sinc-resample / 1 s mel transform runs for
+#     minutes under the interpreter (see the `#[cfg_attr(miri, ignore)]` /
+#     `#[cfg(all(test, not(miri)))]` markers). These are numeric-correctness
+#     tests with little UB signal; they run natively on every `cargo test`. This
+#     is a documented Miri coverage gap, not a disabled test.
+#
+# NOTE: the Miri skip set was locked empirically on a macOS/aarch64 host (Miri
+# interprets host-agnostic MIR, so the eligible/ineligible split is the same),
+# while this workflow runs the interpretation on ubuntu-latest / x86_64.
+
+name: Nightly Miri + TSAN
+
+on:
+  schedule:
+    # 03:42 UTC daily — skewed off soak.yml's 03:17 so the two nightly jobs
+    # don't contend for runners.
+    - cron: '42 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: miri-tsan-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  miri:
+    runs-on: ubuntu-latest
+    name: Miri (pure-Rust core)
+    timeout-minutes: 40
+    env:
+      # Override rust-toolchain.toml's stable pin: Miri only ships on nightly.
+      RUSTUP_TOOLCHAIN: nightly
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: miri
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # `--no-default-features` drops diarization (polyvoice) and the coreml/ane
+      # bridges; `__internals` exposes the synthetic constructors the tests use;
+      # `net` keeps the download-helper unit tests compiling (their `#[cfg(net)]`
+      # helpers are referenced by non-gated tests); `async-pool` compiles the
+      # async pool path. `--lib` restricts to unit tests (integration tests need
+      # the 850 MB model). The ineligible tests (ort FFI, tokio runtime, heavy
+      # FFT/resample) carry `#[cfg_attr(miri, ignore)]` / `#[cfg(not(miri))]`
+      # markers in-source, so no `--skip` list is needed here.
+      - name: cargo miri test (core, sync subset)
+        env:
+          # -Zmiri-disable-isolation: a handful of tests touch tempfiles. No
+          #   network / no real ort is reached.
+          # -Zmiri-strict-provenance: the pointer-heavy quantizer / tensor code
+          #   is provenance-clean, so run the stricter check for free.
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance
+        run: >
+          cargo miri test
+          -p gigastt-core --lib
+          --no-default-features
+          --features "__internals file-decode net async-pool"
+
+  tsan:
+    runs-on: ubuntu-latest
+    name: TSAN (Pool concurrency)
+    timeout-minutes: 40
+    env:
+      RUSTUP_TOOLCHAIN: nightly
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          # -Zbuild-std recompiles the standard library with the sanitizer.
+          components: rust-src
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: tsan
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # ThreadSanitizer over the pool tests only (filter `pool`). `-Zbuild-std`
+      # + an explicit target are required for a sanitized std. The host lock was
+      # done on aarch64-apple-darwin; CI uses the Linux gnu target.
+      - name: cargo test -Zsanitizer=thread (pool)
+        env:
+          RUSTFLAGS: -Zsanitizer=thread
+          RUSTDOCFLAGS: -Zsanitizer=thread
+        run: >
+          cargo test
+          -p gigastt-core --lib
+          --no-default-features
+          --features "__internals file-decode net async-pool"
+          -Zbuild-std
+          --target x86_64-unknown-linux-gnu
+          pool -- --test-threads=1

--- a/crates/gigastt-core/src/inference/audio.rs
+++ b/crates/gigastt-core/src/inference/audio.rs
@@ -594,6 +594,7 @@ mod tests {
     // --- resample tests ---
 
     #[test]
+    #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
     fn test_resample_downsample_length() {
         let input: Vec<f32> = (0..4800).map(|i| (i as f32).sin()).collect();
         let output = resample(&input, SampleRate(48000), SampleRate(16000)).unwrap();
@@ -608,6 +609,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
     fn test_resample_upsample_length() {
         let input: Vec<f32> = (0..800).map(|i| (i as f32).sin()).collect();
         let output = resample(&input, SampleRate(8000), SampleRate(16000)).unwrap();
@@ -621,6 +623,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
     fn test_resample_preserves_dc() {
         // Constant signal should remain approximately constant after resampling.
         // Rubato FIR filter may cause transients at edges; check the middle 80%.
@@ -752,6 +755,7 @@ mod tests {
     // --- stress tests: robustness edge cases ---
 
     #[test]
+    #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
     fn test_resample_nan_input() {
         let input = vec![f32::NAN; 1000];
         let output = resample(&input, SampleRate(48000), SampleRate(16000)).unwrap();
@@ -763,6 +767,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
     fn test_resample_infinity_input() {
         let input = vec![f32::INFINITY; 500];
         let output = resample(&input, SampleRate(48000), SampleRate(16000)).unwrap();
@@ -776,6 +781,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
     fn test_resample_mixed_nan_normal() {
         let mut input = vec![0.5_f32; 480];
         input[100] = f32::NAN;
@@ -1110,6 +1116,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
     fn test_decode_wav_resamples_to_16k() {
         // 48kHz mono WAV exercises the n_frames_hint capacity reservation and
         // the post-decode resample-to-16kHz branch.
@@ -1189,6 +1196,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
     fn test_resample_with_cache_sanitizes_non_finite() {
         let mut cache: Option<rubato::Async<f32>> = None;
         let mut input = vec![0.5_f32; 480];
@@ -1218,6 +1226,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
     fn test_resample_with_cache_reuses_then_recreates() {
         let mut cache: Option<rubato::Async<f32>> = None;
         let mut out = Vec::new();
@@ -1283,7 +1292,12 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+// Excluded under Miri: proptest runs hundreds of cases per property, each
+// driving the resampler / WAV decoder — orders of magnitude too slow under
+// the Miri interpreter to finish in the nightly job's budget. The same
+// properties run natively on every `cargo test`; this only trims the Miri
+// coverage, not the stable-toolchain coverage.
+#[cfg(all(test, not(miri)))]
 mod proptests {
     use super::tests::make_wav_bytes;
     use super::*;

--- a/crates/gigastt-core/src/inference/features.rs
+++ b/crates/gigastt-core/src/inference/features.rs
@@ -186,7 +186,14 @@ impl MelSpectrogram {
     }
 }
 
-#[cfg(test)]
+// Excluded under Miri: every test drives a real `rustfft` forward transform
+// over 1 s / 200 ms buffers (dozens of FFTs per test). The FFT inner loops are
+// orders of magnitude too slow under the Miri interpreter to finish in the
+// nightly job's budget. These are numeric-correctness tests, not pointer /
+// aliasing tests — they add nothing to Miri's UB signal and run natively on
+// every `cargo test`. Documented coverage gap: the mel FFT path is not
+// Miri-checked.
+#[cfg(all(test, not(miri)))]
 mod tests {
     use super::*;
 

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -2854,6 +2854,7 @@ mod tests {
     // pool.
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_pool_guard_returns_triplet_on_normal_drop() {
         let pool = Pool::new(vec![1u32, 2, 3]);
         assert_eq!(pool.available(), 3);
@@ -2866,6 +2867,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_pool_guard_returns_triplet_on_panic_unwind() {
         // The guard's Drop impl runs during unwind, so a panic between
         // checkout and the natural end of scope still restores capacity.
@@ -2886,6 +2888,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_pool_close_wakes_waiters_with_closed() {
         // A waiter blocked in `checkout` after the inventory is exhausted
         // must resolve to PoolError::Closed when `close()` fires. Map the
@@ -2906,6 +2909,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_pool_fifo_under_contention() {
         // With a single-slot pool and three queued waiters, the order of
         // wake-ups must match the order in which `checkout` was called.
@@ -2942,6 +2946,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_into_owned_for_spawn_blocking() {
         // `into_owned` strips the lifetime so the item can be moved into a
         // blocking thread, then `OwnedReservation::checkin` returns it.
@@ -2964,6 +2969,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_owned_reservation_returns_on_spawn_blocking_panic() {
         // If the blocking task panics, the reservation's Drop must still
         // return the item so the pool does not leak capacity.
@@ -2986,6 +2992,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_owned_reservation_drop_returns_item() {
         // Dropping an unchecked-in reservation still returns the item.
         let pool = std::sync::Arc::new(Pool::new(vec![String::from("triplet")]));
@@ -3003,6 +3010,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_pool_close_is_idempotent() {
         // `pool.close()` is wired into the shutdown hook; calling it twice
         // (e.g. shutdown signal + Drop) must not panic.
@@ -3012,6 +3020,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_pool_waiters_count() {
         let pool = std::sync::Arc::new(Pool::<u32>::new(vec![]));
         let w1 = tokio::spawn({
@@ -3030,6 +3039,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_owned_reservation_round_trip_through_option() {
         // Mirrors the pattern used by `handle_binary_frame` in ws.rs:
         // the reservation is temporarily moved out of an Option into
@@ -3054,6 +3064,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_pool_slot_not_leaked_on_cancelled_checkout() {
         // If a checkout future is cancelled after registering a waiter but
         // before receiving an item, the oneshot receiver is dropped while the
@@ -3084,6 +3095,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_pool_slot_not_leaked_on_timeout_checkout() {
         // Same scenario as above, but using tokio::time::timeout instead of
         // abort — this is the exact path hit by the REST and WS handlers.
@@ -3107,6 +3119,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_pool_multiple_dead_waiters_are_skipped() {
         // Several cancelled waiters in a row should all be skipped in one
         // checkin pass.
@@ -3456,6 +3469,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "mel FFT over 1s of audio is too slow under Miri")]
     fn test_feature_extractor_compute_mel_reuses_buffers() {
         // `compute_mel` writes into caller-owned scratch buffers and returns the
         // frame count. One second of 16 kHz audio → ~100 frames; the output

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -1398,6 +1398,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_stream_to_partial_then_finalize_success() {
         let server = wiremock::MockServer::start().await;
         let payload = b"fake model bytes";
@@ -1424,6 +1425,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_stream_to_partial_then_finalize_http_error() {
         let server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -1444,6 +1446,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_stream_to_partial_then_finalize_checksum_mismatch() {
         let server = wiremock::MockServer::start().await;
         let payload = b"wrong bytes";
@@ -1491,6 +1494,7 @@ mod tests {
     /// `ensure_punct_model` short-circuits (no network, no `.partial`) when all
     /// three files are already present.
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_ensure_punct_model_present_no_download() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let dir = tmp.path();
@@ -1749,6 +1753,7 @@ mod tests {
     /// Verify that `ensure_model(None, dir)` with a complete E2eRnnt install
     /// does NOT create any `.partial` files (no download triggered).
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_ensure_model_none_respects_existing_e2e_install() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let dir = tmp.path();
@@ -1794,6 +1799,7 @@ mod tests {
     /// `ensure_model_variant(None, dir)`: with a complete install already on
     /// disk it must succeed without touching the network (no `.partial` files).
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_ensure_model_wrapper_uses_existing_install() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let dir = tmp.path();
@@ -1821,6 +1827,7 @@ mod tests {
     /// `ensure_model_variant(Some(Rnnt), dir)` against a matching install is the
     /// `VariantAction::Use` branch: returns Rnnt with no download.
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_ensure_model_variant_explicit_match_uses_existing() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let dir = tmp.path();
@@ -1844,6 +1851,7 @@ mod tests {
     /// `ensure_vad_model` short-circuits (no network, no `.partial`) when the
     /// Silero ONNX file is already present in the VAD directory.
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_ensure_vad_model_present_no_download() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let dir = tmp.path();
@@ -1903,6 +1911,7 @@ mod tests {
     /// a complete Rnnt set pre-staged under a nested path is detected and used
     /// as-is (early `Use(...)` return) without any network access.
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_ensure_model_variant_uses_complete_set_in_nested_path() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let nested = tmp.path().join("a").join("b").join("models");
@@ -1990,6 +1999,7 @@ mod tests {
     /// `ensure_prequantized_model_variant` short-circuits (no network, no
     /// `.partial`) when the pre-quantized set is already present.
     #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
     async fn test_ensure_prequantized_present_no_download() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let dir = tmp.path();

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -490,7 +490,11 @@ mod tests {
     /// config + tokenizer both load, but the ONNX model file is absent: `load`
     /// must fail at `Session::commit_from_file` (the `ort_err` + context branch),
     /// never panic. This is the last gate the caller turns into "punct disabled".
+    // Skipped under Miri: this is the one punctuation-load test that drives
+    // past the config + tokenizer gates into `OrtRuntime::load_session`, which
+    // calls the onnxruntime C API — a foreign function Miri cannot interpret.
     #[test]
+    #[cfg_attr(miri, ignore = "reaches onnxruntime FFI via Punctuator::load")]
     fn test_load_valid_config_and_tokenizer_missing_model_errors() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::write(tmp.path().join(PUNCT_CONFIG_FILE), MINIMAL_CONFIG_JSON).unwrap();

--- a/crates/gigastt-core/src/runtime/ort/tensor.rs
+++ b/crates/gigastt-core/src/runtime/ort/tensor.rs
@@ -92,7 +92,10 @@ pub fn value_to_tensor(value: Value) -> Result<Tensor, RuntimeError> {
 mod tests {
     use super::*;
 
+    // Skipped under Miri: constructs a real `ort::value::Tensor`, which calls
+    // into the onnxruntime C API — a foreign function Miri cannot interpret.
     #[test]
+    #[cfg_attr(miri, ignore = "calls into onnxruntime FFI")]
     fn test_tensor_ort_roundtrip_f32() {
         let tensor = Tensor::new(
             Shape::new(vec![2, 3]),
@@ -105,6 +108,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "calls into onnxruntime FFI")]
     fn test_tensor_ort_roundtrip_i32() {
         let tensor = Tensor::new(Shape::new(vec![3]), TensorData::I32(vec![1, 2, 3])).unwrap();
         let value = tensor.clone().into_ort_value().unwrap();
@@ -113,6 +117,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore = "calls into onnxruntime FFI")]
     fn test_tensor_ort_roundtrip_i64() {
         let tensor =
             Tensor::new(Shape::new(vec![2, 2]), TensorData::I64(vec![1, 2, 3, 4])).unwrap();


### PR DESCRIPTION
Adds `.github/workflows/miri.yml` — two nightly (`cron '42 3 * * *'`, skewed off soak's `17 3`) + `workflow_dispatch` jobs on `ubuntu-latest`, `timeout-minutes: 40`. Not on `pull_request` / `push` (too slow). Implements the achievable subset of roadmap item SUS-07.

## Jobs

**`miri`** — interprets the synchronous `gigastt-core` unit tests for UB / aliasing / provenance / integer overflow. Locked invocation:

```
RUSTUP_TOOLCHAIN=nightly
MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-strict-provenance"
cargo miri test -p gigastt-core --lib --no-default-features \
  --features "__internals file-decode net async-pool"
```

**`tsan`** — ThreadSanitizer over the `Pool` checkout / checkin / `OwnedReservation` concurrency primitive:

```
RUSTFLAGS="-Zsanitizer=thread"
cargo test -p gigastt-core --lib --no-default-features \
  --features "__internals file-decode net async-pool" \
  -Zbuild-std --target x86_64-unknown-linux-gnu pool -- --test-threads=1
```

## Local verification (macOS M1 Pro / aarch64)

- **Miri: GREEN — 322 passed, 0 failed, 54 ignored, ~235 s** (~4 min, well inside the 40-min budget). `-Zmiri-strict-provenance` also stays green (322 passed, ~228 s), so it's enabled in the workflow.
- **TSAN: ran locally and clean** on `aarch64-apple-darwin` — 26 pool tests passed, 0 failed, no `ThreadSanitizer` warning / data race (includes the real-thread `test_pool_checkout_blocking_slow_path`, `test_pool_fifo_under_contention`, `test_pool_close_wakes_waiters_with_closed`, and the `spawn_blocking` reservation tests). The workflow uses the Linux `x86_64-unknown-linux-gnu` target; the skip set / eligibility split was locked on macOS (Miri interprets host-agnostic MIR, so the split is the same).
- **No real bug found.** Neither Miri nor TSAN surfaced UB, an aliasing violation, a provenance error, or a data race in our code. The only two Miri aborts during bring-up were `unsupported operation: can't call foreign function` on tests that build a real onnxruntime session — CI-config issues, resolved by skip attributes, not bugs.
- Normal `cargo test -p gigastt-core --lib` (stable, default features) unchanged: **370 passed / 17 ignored** — the 17 are the pre-existing `#[ignore = "requires model"]` tests, none of mine (`cfg(miri)` is false off-Miri, so the new attributes are inert). Full pre-commit gate (`fmt` / `clippy --workspace -D warnings` / `typos` / `cargo test --workspace --lib --bins`) passes. `actionlint` clean on the workflow.

## How ineligible tests are excluded (in-source, so the invocation needs no `--skip`)

`#[cfg_attr(miri, ignore)]`:
- 3 ort-FFI roundtrip tests in `runtime/ort/tensor.rs`
- 1 `punctuation::test_load_valid_config_and_tokenizer_missing_model_errors` (the one load test that drives past config+tokenizer into `OrtRuntime::load_session` → onnxruntime C API)
- 23 `#[tokio::test]` tests in `inference/mod.rs` (13) + `model/mod.rs` (10) — tokio's runtime is unsupported under Miri
- 9 rubato sinc-resample tests + 1 mel-FFT test in `inference/{audio,mod}.rs`

`#[cfg(all(test, not(miri)))]` on whole modules:
- `inference::audio::proptests` (proptest × hundreds of cases × resampler)
- `inference::features::tests` (every test drives a real `rustfft` transform)

**Coverage gap (documented, not a disabled test):** a single sinc-resample / 1 s mel FFT runs for *minutes* under the interpreter, so the DSP numeric paths are excluded from the Miri subset. They are numeric-correctness tests with little UB signal and still run natively on every `cargo test`.

## Honest coverage statement (also at the top of the workflow file)

**Covered:** memory-safety / UB (Miri) over pure-Rust core logic — INT8 quantizer, RNN-T decode loop, mel *setup*, tokenizer, audio-byte / PCM16-framing decode, tensor / protocol / export / error / itn / punctuation / vad / lexicon / bias, mock runtime — plus data-race (TSAN) over the `Pool` checkout / checkin / `OwnedReservation` primitive.

**NOT covered** (stays on the existing e2e / soak / CoreML-smoke jobs + review): the objc2 ANE bridge, the onnxruntime inference path, the `gigastt-ffi` C-ABI cdylib, `ArcSwap<Engine>` hot-reload, and the mel-FFT / resampler numeric paths. This is deliberately **not** a broad "memory-safety CI".

No version bump; `specs/` and `CHANGELOG.md` untouched (SUS-07 is CI tooling, not user-facing).