### PR TITLE
feat(server): asynchronous /v1/jobs API for long-file and batch transcription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2026-07-15
+
+### Added
+
+- **Asynchronous Job API for long-file and batch transcription (`/v1/jobs`).** Disabled by
+  default; enable with `--enable-jobs` or `GIGASTT_ENABLE_JOBS=1`. When disabled the
+  `/v1/jobs` routes are not registered and return 404.
+  - `POST /v1/jobs` accepts the same body and query parameters as `/v1/transcribe`
+    (`format`, `word_timestamps`, `segments`, `channels`, `punctuation`, `itn`, `vad`, etc.)
+    and returns `202 {"job_id","status":"queued","created_at"}`.
+  - `GET /v1/jobs/{id}` returns the job lifecycle (`queued|processing|done|failed|cancelled`),
+    an estimate of processed audio seconds, and a `percent` derived from `processed/total`.
+    Errors are sanitized and never leak paths or model internals.
+  - `GET /v1/jobs/{id}/result` returns the finished transcript in the format requested at
+    submission; `409 job_not_finished` while running, `404` for unknown/expired jobs.
+  - `DELETE /v1/jobs/{id}` cancels queued or processing jobs and broadcasts a `cancelled`
+    event to any SSE listeners.
+  - `GET /v1/jobs/{id}/events` is an SSE stream of `progress`, `done`, `failed`, and
+    `cancelled` events; the stream closes automatically after a terminal event.
+  - The in-memory FIFO queue respects `--batch-pool-size` (default 0, clamped to at least 1
+    job worker), limits concurrent batch jobs so they cannot starve WebSocket / synchronous
+    REST traffic, and retries up to `--jobs-retry` (default 3) on `inference_timeout` or panic.
+    Finished/failed/cancelled jobs are evicted after `--jobs-ttl-secs` (default 3600) or when
+    `--jobs-max` (default 100) is reached, at which point `POST /v1/jobs` returns
+    `429 queue_full` with `Retry-After`.
+  - Graceful shutdown cancels all queued jobs; any in-flight job is allowed to finish within
+    the existing drain window and its triplet is returned to the pool.
+
 ## [2.9.0] - 2026-07-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spm_precompiled"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.9.0"
+version = "2.10.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -157,6 +157,28 @@ enum Commands {
         #[arg(long, env = "GIGASTT_BATCH_POOL_SIZE", default_value_t = 0)]
         batch_pool_size: usize,
 
+        /// Enable the asynchronous `/v1/jobs` API for long-file and batch
+        /// transcription. Off by default; when disabled the `/v1/jobs` routes
+        /// are not registered and return 404. Env: GIGASTT_ENABLE_JOBS.
+        #[arg(long, env = "GIGASTT_ENABLE_JOBS", default_value_t = false)]
+        enable_jobs: bool,
+
+        /// TTL in seconds for finished/failed/cancelled jobs before eviction
+        /// from the in-memory store [default: 3600]. Env: GIGASTT_JOBS_TTL_SECS.
+        #[arg(long, env = "GIGASTT_JOBS_TTL_SECS")]
+        jobs_ttl_secs: Option<u64>,
+
+        /// Maximum number of jobs kept in memory (queued + finished). When full,
+        /// POST /v1/jobs returns 429 + Retry-After [default: 100].
+        /// Env: GIGASTT_JOBS_MAX.
+        #[arg(long, env = "GIGASTT_JOBS_MAX")]
+        jobs_max: Option<usize>,
+
+        /// Maximum retry attempts for a job that hits inference_timeout or panics
+        /// [default: 3]. Env: GIGASTT_JOBS_RETRY.
+        #[arg(long, env = "GIGASTT_JOBS_RETRY")]
+        jobs_retry: Option<u32>,
+
         /// Intra-op thread count for the encoder session on the CPU build. The
         /// encoder dominates the single-utterance cost, so more threads speed up
         /// weak CPUs / long single-file jobs. When unset, defaults to the logical
@@ -456,6 +478,10 @@ fn build_limits(
     shutdown_drain_secs: Option<u64>,
     pool_checkout_timeout_secs: Option<u64>,
     inference_timeout_secs: Option<u64>,
+    jobs_enabled: Option<bool>,
+    jobs_ttl_secs: Option<u64>,
+    jobs_max: Option<usize>,
+    jobs_retry: Option<u32>,
 ) -> anyhow::Result<RuntimeLimits> {
     let mut limits = if let Some(path) = config_path {
         server::config::load_config_file(std::path::Path::new(path))?
@@ -492,6 +518,18 @@ fn build_limits(
     if let Some(v) = inference_timeout_secs {
         limits.inference_timeout_secs = v;
     }
+    if let Some(v) = jobs_enabled {
+        limits.jobs_enabled = v;
+    }
+    if let Some(v) = jobs_ttl_secs {
+        limits.jobs_ttl_secs = v;
+    }
+    if let Some(v) = jobs_max {
+        limits.jobs_max = v;
+    }
+    if let Some(v) = jobs_retry {
+        limits.jobs_retry = v;
+    }
     Ok(limits)
 }
 
@@ -506,6 +544,7 @@ fn build_server_config(
     metrics_listen: std::net::SocketAddr,
     trust_proxy: bool,
     config: Option<String>,
+    batch_pool_size: usize,
 ) -> ServerConfig {
     ServerConfig {
         port,
@@ -519,6 +558,7 @@ fn build_server_config(
         metrics_listen,
         trust_proxy,
         config_path: config.map(std::path::PathBuf::from),
+        batch_pool_size,
     }
 }
 
@@ -947,6 +987,10 @@ async fn main() -> anyhow::Result<()> {
             pool_size,
             pool_min_size,
             batch_pool_size,
+            enable_jobs,
+            jobs_ttl_secs,
+            jobs_max,
+            jobs_retry,
             encoder_intra_threads,
             bind_all,
             allow_origin,
@@ -978,6 +1022,10 @@ async fn main() -> anyhow::Result<()> {
                 shutdown_drain_secs,
                 pool_checkout_timeout_secs,
                 inference_timeout_secs,
+                Some(enable_jobs),
+                jobs_ttl_secs,
+                jobs_max,
+                jobs_retry,
             )?;
             let metrics_listen =
                 metrics_listen.unwrap_or_else(server::config::default_metrics_listen);
@@ -998,6 +1046,7 @@ async fn main() -> anyhow::Result<()> {
                 metrics_listen,
                 trust_proxy,
                 config,
+                batch_pool_size,
             );
 
             // The reusable engine build recipe, captured so BOTH first-run boot
@@ -1964,10 +2013,87 @@ mod tests {
 
     #[test]
     fn test_build_limits_defaults_when_no_config() {
-        let limits =
-            build_limits(None, None, None, None, None, None, None, None, None, None).unwrap();
+        let limits = build_limits(
+            None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        )
+        .unwrap();
         assert_eq!(limits.idle_timeout_secs, 300);
         assert_eq!(limits.ws_frame_max_bytes, 512 * 1024);
+    }
+
+    #[test]
+    fn test_build_limits_job_overrides() {
+        let limits = build_limits(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(true),
+            Some(7200),
+            Some(50),
+            Some(5),
+        )
+        .unwrap();
+        assert!(limits.jobs_enabled);
+        assert_eq!(limits.jobs_ttl_secs, 7200);
+        assert_eq!(limits.jobs_max, 50);
+        assert_eq!(limits.jobs_retry, 5);
+    }
+
+    #[test]
+    fn test_cli_serve_jobs_flags() {
+        let cli = Cli::parse_from([
+            "gigastt",
+            "serve",
+            "--enable-jobs",
+            "--jobs-ttl-secs",
+            "7200",
+            "--jobs-max",
+            "50",
+            "--jobs-retry",
+            "5",
+        ]);
+        match cli.command {
+            Commands::Serve {
+                enable_jobs,
+                jobs_ttl_secs,
+                jobs_max,
+                jobs_retry,
+                ..
+            } => {
+                assert!(enable_jobs);
+                assert_eq!(jobs_ttl_secs, Some(7200));
+                assert_eq!(jobs_max, Some(50));
+                assert_eq!(jobs_retry, Some(5));
+            }
+            _ => panic!("expected Serve"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_jobs_defaults_off() {
+        let cli = Cli::parse_from(["gigastt", "serve"]);
+        match cli.command {
+            Commands::Serve {
+                enable_jobs,
+                jobs_ttl_secs,
+                jobs_max,
+                jobs_retry,
+                ..
+            } => {
+                assert!(!enable_jobs);
+                assert_eq!(jobs_ttl_secs, None);
+                assert_eq!(jobs_max, None);
+                assert_eq!(jobs_retry, None);
+            }
+            _ => panic!("expected Serve"),
+        }
     }
 
     #[test]
@@ -1983,6 +2109,10 @@ mod tests {
             Some(5),
             Some(15),
             Some(45),
+            None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert_eq!(limits.idle_timeout_secs, 600);
@@ -2002,6 +2132,10 @@ mod tests {
         std::fs::write(tmp.path(), b"idle_timeout_secs = 123\n").unwrap();
         let limits = build_limits(
             Some(tmp.path().to_str().unwrap()),
+            None,
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -2031,6 +2165,10 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
+            None,
         );
         assert!(result.is_err());
     }
@@ -2044,6 +2182,10 @@ mod tests {
             None,
             Some(30),
             Some(0),
+            None,
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -2067,6 +2209,10 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert_eq!(limits.rate_limit_per_minute, 0);
@@ -2086,10 +2232,12 @@ mod tests {
             "127.0.0.1:9099".parse().unwrap(),
             true,
             Some("/tmp/config.toml".into()),
+            2,
         );
         assert_eq!(cfg.port, 1234);
         assert_eq!(cfg.metrics_listen.port(), 9099);
         assert_eq!(cfg.host, "127.0.0.1");
+        assert_eq!(cfg.batch_pool_size, 2);
         assert_eq!(cfg.origin_policy.allowed_origins.len(), 1);
         assert!(!cfg.origin_policy.allow_any);
         assert!(cfg.metrics_enabled);

--- a/crates/gigastt/src/server/config.rs
+++ b/crates/gigastt/src/server/config.rs
@@ -289,6 +289,9 @@ pub struct ServerConfig {
     pub trust_proxy: bool,
     /// Path to TOML config file for runtime limits (reloaded on SIGHUP).
     pub config_path: Option<std::path::PathBuf>,
+    /// Size of the triplet pool reserved for batch REST / job transcription.
+    /// Split off from the interactive pool so long files can't starve WS/SSE.
+    pub batch_pool_size: usize,
 }
 
 impl ServerConfig {
@@ -304,6 +307,7 @@ impl ServerConfig {
             metrics_listen: default_metrics_listen(),
             trust_proxy: false,
             config_path: None,
+            batch_pool_size: 0,
         }
     }
 }

--- a/crates/gigastt/src/server/config.rs
+++ b/crates/gigastt/src/server/config.rs
@@ -137,6 +137,18 @@ pub struct RuntimeLimits {
     /// 10-minute (600 s audio) file on the CPU EP without tripping, while
     /// still bounding a genuinely wedged run.
     pub inference_timeout_secs: u64,
+    /// Whether the asynchronous `/v1/jobs` API is enabled. Off by default so
+    /// existing single-user installs see no change.
+    pub jobs_enabled: bool,
+    /// TTL in seconds for completed/failed/cancelled jobs before eviction.
+    /// Default: 3600 (1 hour).
+    pub jobs_ttl_secs: u64,
+    /// Maximum number of jobs kept in memory (queued + finished). When full,
+    /// POST /v1/jobs returns 429 + Retry-After. Default: 100.
+    pub jobs_max: usize,
+    /// Maximum retry attempts for a job that hits inference_timeout or panics.
+    /// Default: 3.
+    pub jobs_retry: u32,
 }
 
 impl Default for RuntimeLimits {
@@ -151,6 +163,10 @@ impl Default for RuntimeLimits {
             shutdown_drain_secs: 10,
             pool_checkout_timeout_secs: 30,
             inference_timeout_secs: 600,
+            jobs_enabled: false,
+            jobs_ttl_secs: 3600,
+            jobs_max: 100,
+            jobs_retry: 3,
         }
     }
 }
@@ -179,6 +195,14 @@ pub struct RuntimeLimitsConfig {
     pub pool_checkout_timeout_secs: u64,
     /// Per-request inference timeout in seconds (`0` disables).
     pub inference_timeout_secs: u64,
+    /// Enable the asynchronous `/v1/jobs` API.
+    pub jobs_enabled: bool,
+    /// TTL in seconds for completed/failed/cancelled jobs.
+    pub jobs_ttl_secs: u64,
+    /// Maximum number of jobs kept in memory.
+    pub jobs_max: usize,
+    /// Maximum retry attempts for inference-timeout / panic.
+    pub jobs_retry: u32,
 }
 
 impl Default for RuntimeLimitsConfig {
@@ -194,6 +218,10 @@ impl Default for RuntimeLimitsConfig {
             shutdown_drain_secs: d.shutdown_drain_secs,
             pool_checkout_timeout_secs: d.pool_checkout_timeout_secs,
             inference_timeout_secs: d.inference_timeout_secs,
+            jobs_enabled: d.jobs_enabled,
+            jobs_ttl_secs: d.jobs_ttl_secs,
+            jobs_max: d.jobs_max,
+            jobs_retry: d.jobs_retry,
         }
     }
 }
@@ -210,6 +238,10 @@ impl From<RuntimeLimitsConfig> for RuntimeLimits {
             shutdown_drain_secs: cfg.shutdown_drain_secs,
             pool_checkout_timeout_secs: cfg.pool_checkout_timeout_secs,
             inference_timeout_secs: cfg.inference_timeout_secs,
+            jobs_enabled: cfg.jobs_enabled,
+            jobs_ttl_secs: cfg.jobs_ttl_secs,
+            jobs_max: cfg.jobs_max,
+            jobs_retry: cfg.jobs_retry,
         }
     }
 }
@@ -288,6 +320,15 @@ mod tests {
             "rate limiting must be off by default (privacy-first)"
         );
         assert_eq!(limits.rate_limit_burst, 10, "default burst size must be 10");
+    }
+
+    #[test]
+    fn test_runtime_limits_default_jobs() {
+        let limits = RuntimeLimits::default();
+        assert!(!limits.jobs_enabled);
+        assert_eq!(limits.jobs_ttl_secs, 3600);
+        assert_eq!(limits.jobs_max, 100);
+        assert_eq!(limits.jobs_retry, 3);
     }
 
     #[test]

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -1258,7 +1258,14 @@ pub async fn get_job_result(
             "job_not_finished",
         ));
     }
-    let result = job.result.expect("Done job has result");
+    let Some(result) = job.result else {
+        tracing::error!(job_id = %id, "Done job is missing result");
+        return Err(api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Job result is missing",
+            "internal",
+        ));
+    };
     if let Some(rendered) = render_export_response(&result, &job.params)? {
         Ok(rendered)
     } else {
@@ -1319,7 +1326,9 @@ pub async fn cancel_job(
         .update(
             &id,
             Box::new(|j| {
-                j.status = JobStatus::Cancelled;
+                if matches!(j.status, JobStatus::Queued | JobStatus::Processing) {
+                    j.status = JobStatus::Cancelled;
+                }
             }),
         )
         .await;

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 
 use super::config::{RuntimeLimits, pool_retry_after_ms, pool_retry_after_secs};
+use super::jobs::{JobEvent, JobQueue, JobStatus, JobStore};
 use super::metrics::MetricsRegistry;
 use gigastt_core::export::{ExportFormat, RenderOpts, Segment};
 use gigastt_core::inference::Engine;
@@ -49,6 +50,18 @@ pub struct AppState {
     pub metrics_registry: Option<Arc<MetricsRegistry>>,
     pub shutdown: tokio_util::sync::CancellationToken,
     pub tracker: tokio_util::task::TaskTracker,
+    /// In-memory job store and queue. `Some` only when `--enable-jobs` is set;
+    /// handlers for `/v1/jobs` are registered conditionally and expect this to
+    /// be populated, but the shared state is `Option` so non-job builds compile.
+    pub jobs: Option<JobServerState>,
+}
+
+/// State shared by the `/v1/jobs` handlers. Kept behind `Arc` so the executor,
+/// queue, and handlers all reference the same store.
+#[derive(Clone)]
+pub struct JobServerState {
+    pub store: Arc<dyn JobStore>,
+    pub queue: Arc<JobQueue>,
 }
 
 /// Recipe that rebuilds a fully-configured [`Engine`] from the operator's boot
@@ -1099,6 +1112,304 @@ pub async fn reload(
         .into_response()
 }
 
+/// POST /v1/jobs response.
+#[derive(Serialize)]
+pub struct JobSubmitResponse {
+    pub job_id: String,
+    pub status: &'static str,
+    pub created_at: f64,
+}
+
+/// Build a public status view from a stored job.
+fn job_status_response(job: &super::jobs::Job) -> super::jobs::JobStatusResponse {
+    let percent = if job.total_seconds > 0.0 {
+        ((job.processed_seconds / job.total_seconds) * 100.0) as u32
+    } else {
+        0
+    };
+    super::jobs::JobStatusResponse {
+        job_id: job.id.clone(),
+        status: job.status,
+        processed_seconds: job.processed_seconds,
+        percent,
+        error: job.error.clone(),
+    }
+}
+
+/// POST /v1/jobs — enqueue a long audio file for asynchronous transcription.
+///
+/// Accepts the same body and query parameters as `/v1/transcribe`. Returns 202
+/// with the job id; use `GET /v1/jobs/{id}` to poll and
+/// `GET /v1/jobs/{id}/result` to fetch the finished transcript.
+pub async fn submit_job(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<ExportParams>,
+    body: Bytes,
+) -> Result<Response, ApiError> {
+    let Some(ref jobs) = state.jobs else {
+        return Err(api_error(
+            StatusCode::NOT_FOUND,
+            "Job API is not enabled",
+            "jobs_disabled",
+        ));
+    };
+    let limits = state.limits.load();
+    if body.is_empty() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "Empty request body",
+            "empty_body",
+        ));
+    }
+    if body.len() > limits.body_limit_bytes {
+        return Err(api_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "Request body exceeds the configured size limit",
+            "payload_too_large",
+        ));
+    }
+    if jobs.store.is_full().await {
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            [(
+                header::RETRY_AFTER,
+                pool_retry_after_secs(&limits).to_string(),
+            )],
+            Json(serde_json::json!({
+                "error": "Job queue is full",
+                "code": "queue_full",
+                "retry_after_ms": pool_retry_after_ms(&limits),
+            })),
+        )
+            .into_response());
+    }
+    let job = super::jobs::Job::queued(body, params);
+    let created_at = job.created_at;
+    let id = match jobs.store.create(job).await {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::error!("Failed to create job: {e:#}");
+            return Err(api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to enqueue job",
+                "internal",
+            ));
+        }
+    };
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(JobSubmitResponse {
+            job_id: id,
+            status: "queued",
+            created_at,
+        }),
+    )
+        .into_response())
+}
+
+/// GET /v1/jobs/{id} — poll job status and progress.
+pub async fn get_job(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Result<Response, ApiError> {
+    let Some(ref jobs) = state.jobs else {
+        return Err(api_error(
+            StatusCode::NOT_FOUND,
+            "Job API is not enabled",
+            "jobs_disabled",
+        ));
+    };
+    match jobs.store.get(&id).await {
+        Ok(Some(job)) => Ok(Json(job_status_response(&job)).into_response()),
+        Ok(None) => Err(api_error(
+            StatusCode::NOT_FOUND,
+            "Job not found",
+            "job_not_found",
+        )),
+        Err(e) => {
+            tracing::error!("Failed to get job {id}: {e:#}");
+            Err(api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read job status",
+                "internal",
+            ))
+        }
+    }
+}
+
+/// GET /v1/jobs/{id}/result — fetch the finished transcription.
+pub async fn get_job_result(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Result<Response, ApiError> {
+    let Some(ref jobs) = state.jobs else {
+        return Err(api_error(
+            StatusCode::NOT_FOUND,
+            "Job API is not enabled",
+            "jobs_disabled",
+        ));
+    };
+    let job = match jobs.store.get(&id).await {
+        Ok(Some(job)) => job,
+        Ok(None) => {
+            return Err(api_error(
+                StatusCode::NOT_FOUND,
+                "Job not found",
+                "job_not_found",
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get job {id}: {e:#}");
+            return Err(api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read job result",
+                "internal",
+            ));
+        }
+    };
+    if !matches!(job.status, JobStatus::Done) {
+        return Err(api_error(
+            StatusCode::CONFLICT,
+            "Job is not finished",
+            "job_not_finished",
+        ));
+    }
+    let result = job.result.expect("Done job has result");
+    if let Some(rendered) = render_export_response(&result, &job.params)? {
+        Ok(rendered)
+    } else {
+        let segments = if job.params.segments.unwrap_or(false) {
+            Some(gigastt_core::export::to_transcript_segments(&result.words))
+        } else {
+            None
+        };
+        Ok(Json(TranscribeResponse {
+            text: result.text,
+            words: result.words,
+            duration: result.duration_s,
+            segments,
+        })
+        .into_response())
+    }
+}
+
+/// DELETE /v1/jobs/{id} — cancel a queued or processing job.
+pub async fn cancel_job(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Result<Response, ApiError> {
+    let Some(ref jobs) = state.jobs else {
+        return Err(api_error(
+            StatusCode::NOT_FOUND,
+            "Job API is not enabled",
+            "jobs_disabled",
+        ));
+    };
+    let job = match jobs.store.get(&id).await {
+        Ok(Some(job)) => job,
+        Ok(None) => {
+            return Err(api_error(
+                StatusCode::NOT_FOUND,
+                "Job not found",
+                "job_not_found",
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get job {id}: {e:#}");
+            return Err(api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read job status",
+                "internal",
+            ));
+        }
+    };
+    if !matches!(job.status, JobStatus::Queued | JobStatus::Processing) {
+        return Err(api_error(
+            StatusCode::CONFLICT,
+            "Job cannot be cancelled",
+            "job_not_cancellable",
+        ));
+    }
+    let _ = jobs
+        .store
+        .update(
+            &id,
+            Box::new(|j| {
+                j.status = JobStatus::Cancelled;
+            }),
+        )
+        .await;
+    super::jobs::broadcast_event(&*jobs.store, &id, JobEvent::Cancelled).await;
+    Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+/// GET /v1/jobs/{id}/events — SSE stream of progress / done / failed / cancelled.
+pub async fn job_events(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Result<Sse<impl Stream<Item = Result<Event, std::convert::Infallible>>>, ApiError> {
+    let Some(ref jobs) = state.jobs else {
+        return Err(api_error(
+            StatusCode::NOT_FOUND,
+            "Job API is not enabled",
+            "jobs_disabled",
+        ));
+    };
+    let job = match jobs.store.get(&id).await {
+        Ok(Some(job)) => job,
+        Ok(None) => {
+            return Err(api_error(
+                StatusCode::NOT_FOUND,
+                "Job not found",
+                "job_not_found",
+            ));
+        }
+        Err(e) => {
+            tracing::error!("Failed to get job {id}: {e:#}");
+            return Err(api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read job events",
+                "internal",
+            ));
+        }
+    };
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<JobEvent>();
+    if job.status.is_terminal() {
+        let event = match job.status {
+            JobStatus::Done => JobEvent::Done,
+            JobStatus::Failed => JobEvent::Failed {
+                error: job
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "Transcription failed.".into()),
+            },
+            JobStatus::Cancelled => JobEvent::Cancelled,
+            _ => unreachable!(),
+        };
+        let _ = tx.send(event);
+    } else {
+        let _ = jobs
+            .store
+            .update(
+                &id,
+                Box::new(move |j| {
+                    j.event_channels.push(tx);
+                }),
+            )
+            .await;
+    }
+
+    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx)
+        .map(|event| Ok(Event::default().data(serde_json::to_string(&event).unwrap_or_default())));
+
+    Ok(Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(std::time::Duration::from_secs(15))
+            .text(""),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1307,6 +1618,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         state.shutdown.cancel();
         let resp = readiness(State(state)).await;
@@ -1332,6 +1644,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let resp = readiness(State(state)).await;
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
@@ -1355,6 +1668,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let body = Bytes::from(vec![0u8; 100]);
         let result = transcribe(State(state), Query(ExportParams::default()), body).await;
@@ -1375,6 +1689,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let params = ExportParams {
             channels: Some("split".into()),
@@ -1401,6 +1716,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let resp = models(State(state)).await;
         let json = serde_json::to_value(&*resp).unwrap();
@@ -1432,6 +1748,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let resp = readiness(State(state)).await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1450,6 +1767,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let body = Bytes::from(vec![0u8; 100]);
         let result = transcribe(State(state), Query(ExportParams::default()), body).await;
@@ -1470,6 +1788,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let body = Bytes::from(vec![0u8; 100]);
         let result = transcribe_stream(State(state), body).await;
@@ -1493,6 +1812,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let body = Bytes::from(vec![0u8; 100]);
         let result = transcribe_stream(State(state), body).await;
@@ -1515,6 +1835,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let body = minimal_wav();
         let result = transcribe_stream(State(state), body).await;
@@ -1535,6 +1856,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let body = short_wav();
         match transcribe(State(state), Query(ExportParams::default()), body).await {
@@ -1554,6 +1876,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let body = short_wav();
         match transcribe_stream(State(state), body).await {
@@ -1576,6 +1899,7 @@ mod tests {
             reload_lock: Arc::new(tokio::sync::Mutex::new(())),
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let params = ExportParams {
             segments: Some(true),
@@ -2079,6 +2403,7 @@ mod tests {
             metrics_registry: None,
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let peer = SocketAddr::from((Ipv4Addr::new(203, 0, 113, 7), 40000));
         let resp = reload(axum::extract::ConnectInfo(peer), State(state)).await;
@@ -2102,6 +2427,7 @@ mod tests {
             metrics_registry: None,
             shutdown: tokio_util::sync::CancellationToken::new(),
             tracker: tokio_util::task::TaskTracker::new(),
+            jobs: None,
         });
         let peer = SocketAddr::from((Ipv4Addr::LOCALHOST, 40000));
         let resp = reload(axum::extract::ConnectInfo(peer), State(state)).await;

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -1120,6 +1120,38 @@ pub struct JobSubmitResponse {
     pub created_at: f64,
 }
 
+/// Return the job server state or a 404 if the async job API is disabled.
+#[allow(clippy::result_large_err)]
+fn require_jobs(state: &AppState) -> Result<&JobServerState, ApiError> {
+    state.jobs.as_ref().ok_or_else(|| {
+        api_error(
+            StatusCode::NOT_FOUND,
+            "Job API is not enabled",
+            "jobs_disabled",
+        )
+    })
+}
+
+/// Fetch a job by id, mapping store errors to the standard HTTP responses.
+async fn load_job(store: &dyn JobStore, id: &str) -> Result<super::jobs::Job, ApiError> {
+    match store.get(id).await {
+        Ok(Some(job)) => Ok(job),
+        Ok(None) => Err(api_error(
+            StatusCode::NOT_FOUND,
+            "Job not found",
+            "job_not_found",
+        )),
+        Err(e) => {
+            tracing::error!("Failed to get job {id}: {e:#}");
+            Err(api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read job status",
+                "internal",
+            ))
+        }
+    }
+}
+
 /// POST /v1/jobs — enqueue a long audio file for asynchronous transcription.
 ///
 /// Accepts the same body and query parameters as `/v1/transcribe`. Returns 202
@@ -1130,13 +1162,7 @@ pub async fn submit_job(
     Query(params): Query<ExportParams>,
     body: Bytes,
 ) -> Result<Response, ApiError> {
-    let Some(ref jobs) = state.jobs else {
-        return Err(api_error(
-            StatusCode::NOT_FOUND,
-            "Job API is not enabled",
-            "jobs_disabled",
-        ));
-    };
+    let jobs = require_jobs(&state)?;
     let limits = state.limits.load();
     if body.is_empty() {
         return Err(api_error(
@@ -1167,6 +1193,16 @@ pub async fn submit_job(
         )
             .into_response());
     }
+    let split_channels = params.channels.as_deref() == Some("split");
+    let request_diarization = params.diarization == Some(true);
+    if split_channels && request_diarization {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "channels=split and diarization=true are mutually exclusive",
+            "conflicting_modes",
+        ));
+    }
+
     let job = super::jobs::Job::queued(body, params);
     let created_at = job.created_at;
     let id = match jobs.store.create(job).await {
@@ -1196,29 +1232,9 @@ pub async fn get_job(
     State(state): State<Arc<AppState>>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<Response, ApiError> {
-    let Some(ref jobs) = state.jobs else {
-        return Err(api_error(
-            StatusCode::NOT_FOUND,
-            "Job API is not enabled",
-            "jobs_disabled",
-        ));
-    };
-    match jobs.store.get(&id).await {
-        Ok(Some(job)) => Ok(Json(super::jobs::job_status_response(&job)).into_response()),
-        Ok(None) => Err(api_error(
-            StatusCode::NOT_FOUND,
-            "Job not found",
-            "job_not_found",
-        )),
-        Err(e) => {
-            tracing::error!("Failed to get job {id}: {e:#}");
-            Err(api_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to read job status",
-                "internal",
-            ))
-        }
-    }
+    let jobs = require_jobs(&state)?;
+    let job = load_job(&*jobs.store, &id).await?;
+    Ok(Json(super::jobs::job_status_response(&job)).into_response())
 }
 
 /// GET /v1/jobs/{id}/result — fetch the finished transcription.
@@ -1226,31 +1242,8 @@ pub async fn get_job_result(
     State(state): State<Arc<AppState>>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<Response, ApiError> {
-    let Some(ref jobs) = state.jobs else {
-        return Err(api_error(
-            StatusCode::NOT_FOUND,
-            "Job API is not enabled",
-            "jobs_disabled",
-        ));
-    };
-    let job = match jobs.store.get(&id).await {
-        Ok(Some(job)) => job,
-        Ok(None) => {
-            return Err(api_error(
-                StatusCode::NOT_FOUND,
-                "Job not found",
-                "job_not_found",
-            ));
-        }
-        Err(e) => {
-            tracing::error!("Failed to get job {id}: {e:#}");
-            return Err(api_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to read job result",
-                "internal",
-            ));
-        }
-    };
+    let jobs = require_jobs(&state)?;
+    let job = load_job(&*jobs.store, &id).await?;
     if !matches!(job.status, JobStatus::Done) {
         return Err(api_error(
             StatusCode::CONFLICT,
@@ -1289,31 +1282,8 @@ pub async fn cancel_job(
     State(state): State<Arc<AppState>>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<Response, ApiError> {
-    let Some(ref jobs) = state.jobs else {
-        return Err(api_error(
-            StatusCode::NOT_FOUND,
-            "Job API is not enabled",
-            "jobs_disabled",
-        ));
-    };
-    let job = match jobs.store.get(&id).await {
-        Ok(Some(job)) => job,
-        Ok(None) => {
-            return Err(api_error(
-                StatusCode::NOT_FOUND,
-                "Job not found",
-                "job_not_found",
-            ));
-        }
-        Err(e) => {
-            tracing::error!("Failed to get job {id}: {e:#}");
-            return Err(api_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to read job status",
-                "internal",
-            ));
-        }
-    };
+    let jobs = require_jobs(&state)?;
+    let job = load_job(&*jobs.store, &id).await?;
     if !matches!(job.status, JobStatus::Queued | JobStatus::Processing) {
         return Err(api_error(
             StatusCode::CONFLICT,
@@ -1341,31 +1311,8 @@ pub async fn job_events(
     State(state): State<Arc<AppState>>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<Sse<impl Stream<Item = Result<Event, std::convert::Infallible>>>, ApiError> {
-    let Some(ref jobs) = state.jobs else {
-        return Err(api_error(
-            StatusCode::NOT_FOUND,
-            "Job API is not enabled",
-            "jobs_disabled",
-        ));
-    };
-    let job = match jobs.store.get(&id).await {
-        Ok(Some(job)) => job,
-        Ok(None) => {
-            return Err(api_error(
-                StatusCode::NOT_FOUND,
-                "Job not found",
-                "job_not_found",
-            ));
-        }
-        Err(e) => {
-            tracing::error!("Failed to get job {id}: {e:#}");
-            return Err(api_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to read job events",
-                "internal",
-            ));
-        }
-    };
+    let jobs = require_jobs(&state)?;
+    let job = load_job(&*jobs.store, &id).await?;
 
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<JobEvent>();
     if job.status.is_terminal() {

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -158,7 +158,7 @@ pub struct TranscribeResponse {
 }
 
 /// Query parameters for `/v1/transcribe` export formatting.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize)]
 pub struct ExportParams {
     /// Export format: `json` (default), `txt`, `srt`, `vtt`, `md`.
     pub format: Option<String>,

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -1120,22 +1120,6 @@ pub struct JobSubmitResponse {
     pub created_at: f64,
 }
 
-/// Build a public status view from a stored job.
-fn job_status_response(job: &super::jobs::Job) -> super::jobs::JobStatusResponse {
-    let percent = if job.total_seconds > 0.0 {
-        ((job.processed_seconds / job.total_seconds) * 100.0) as u32
-    } else {
-        0
-    };
-    super::jobs::JobStatusResponse {
-        job_id: job.id.clone(),
-        status: job.status,
-        processed_seconds: job.processed_seconds,
-        percent,
-        error: job.error.clone(),
-    }
-}
-
 /// POST /v1/jobs — enqueue a long audio file for asynchronous transcription.
 ///
 /// Accepts the same body and query parameters as `/v1/transcribe`. Returns 202
@@ -1220,7 +1204,7 @@ pub async fn get_job(
         ));
     };
     match jobs.store.get(&id).await {
-        Ok(Some(job)) => Ok(Json(job_status_response(&job)).into_response()),
+        Ok(Some(job)) => Ok(Json(super::jobs::job_status_response(&job)).into_response()),
         Ok(None) => Err(api_error(
             StatusCode::NOT_FOUND,
             "Job not found",

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -276,7 +276,9 @@ impl JobStore for InMemoryJobStore {
 
     fn is_full<'a>(&'a self) -> JobStoreFuture<'a, bool> {
         Box::pin(async move {
-            let jobs = self.jobs.lock();
+            let mut jobs = self.jobs.lock();
+            let mut queue = self.queue.lock();
+            self.evict_expired_locked(&mut jobs, &mut queue);
             jobs.len() >= self.limits.jobs_max
         })
     }
@@ -586,15 +588,23 @@ impl JobExecution for RealJobExecutor {
         let limits = self.limits.load();
 
         // Decode audio (blocking) once to estimate duration for progress.
+        // Wrap the decoder in catch_unwind so a malformed file cannot be
+        // retried as a transient inference panic.
         let samples = tokio::task::spawn_blocking({
             let body = body.clone();
-            move || gigastt_core::inference::audio::decode_audio_bytes_shared(body)
+            move || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    gigastt_core::inference::audio::decode_audio_bytes_shared(body)
+                }))
+            }
         })
         .await
         .map_err(|e| anyhow::anyhow!("audio decode task panicked: {e}"))?
+        .map_err(|_| anyhow::anyhow!("Invalid audio: decoder panicked"))?
         .map_err(|e| anyhow::anyhow!("Invalid audio: {e:#}"))?;
 
-        let total_seconds = samples.len() as f64 / 16_000.0;
+        const TARGET_SAMPLE_RATE: f64 = 16_000.0;
+        let total_seconds = samples.len() as f64 / TARGET_SAMPLE_RATE;
         let _ = store
             .update(id, Box::new(move |j| j.total_seconds = total_seconds))
             .await;
@@ -661,89 +671,94 @@ impl JobExecution for RealJobExecutor {
         };
 
         // Check out a triplet from the batch pool and run inference.
-        let guard = match tokio::time::timeout(
-            std::time::Duration::from_secs(limits.pool_checkout_timeout_secs),
-            engine.pool_for_batch().checkout(),
-        )
-        .await
-        {
-            Ok(Ok(g)) => g,
-            Ok(Err(_)) => return Err(anyhow::anyhow!("pool closed")),
-            Err(_) => return Err(anyhow::anyhow!("pool checkout timed out")),
-        };
-        let mut reservation = guard.into_owned();
-
-        let inference_timeout_secs = limits.inference_timeout_secs;
-        let engine_for_inference = engine.clone();
-        let body_for_inference = body.clone();
-        let span = tracing::Span::current();
-        let handle = tokio::task::spawn_blocking(move || {
-            let _enter = span.enter();
-            let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                if params.channels.as_deref() == Some("split") {
-                    let channels =
-                        gigastt_core::inference::audio::decode_audio_bytes_shared_channels(
-                            body_for_inference.clone(),
-                        )
-                        .map_err(|e| {
-                            gigastt_core::error::GigasttError::InvalidAudio {
-                                reason: format!("{e:#}"),
-                            }
-                        })?;
-                    let fallback_reason = match channels.len() {
-                        0 => Some("no channels"),
-                        1 => Some("mono audio"),
-                        2 if gigastt_core::inference::audio::is_dual_mono(&channels) => {
-                            Some("dual-mono audio")
-                        }
-                        n if n > 2 => Some("more than two channels"),
-                        _ => None,
-                    };
-                    if let Some(reason) = fallback_reason {
-                        tracing::warn!(
-                            "channels=split requested but {reason} detected; falling back to mono transcription"
-                        );
-                        engine_for_inference
-                            .transcribe_bytes_shared(body_for_inference, &mut reservation)
-                    } else {
-                        engine_for_inference.transcribe_channels(&channels, &mut reservation)
-                    }
-                } else {
-                    engine_for_inference.transcribe_bytes_shared_with_overrides(
-                        body_for_inference,
-                        &mut reservation,
-                        &overrides,
-                    )
-                }
-            }));
-            match r {
-                Ok(result) => result,
-                Err(_) => Err(gigastt_core::error::GigasttError::Inference {
-                    source: anyhow::anyhow!("Inference thread panicked").into(),
-                }),
-            }
-        });
-
-        let result = if inference_timeout_secs == 0 {
-            handle.await
-        } else {
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(inference_timeout_secs),
-                handle,
+        // This is wrapped in its own async block so the progress updater is
+        // always cancelled and awaited before the function returns, even on
+        // the early-return error paths below.
+        let inference_result: anyhow::Result<gigastt_core::inference::TranscribeResult> = async {
+            let guard = tokio::time::timeout(
+                std::time::Duration::from_secs(limits.pool_checkout_timeout_secs),
+                engine.pool_for_batch().checkout(),
             )
             .await
-            {
-                Ok(r) => r,
-                Err(_) => return Err(anyhow::anyhow!("inference_timeout")),
+            .map_err(|_| anyhow::anyhow!("pool checkout timed out"))?
+            .map_err(|_| anyhow::anyhow!("pool closed"))?;
+            let mut reservation = guard.into_owned();
+
+            let inference_timeout_secs = limits.inference_timeout_secs;
+            let engine_for_inference = engine.clone();
+            let body_for_inference = body.clone();
+            let span = tracing::Span::current();
+            let handle = tokio::task::spawn_blocking(move || {
+                let _enter = span.enter();
+                let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    if params.channels.as_deref() == Some("split") {
+                        let channels =
+                            gigastt_core::inference::audio::decode_audio_bytes_shared_channels(
+                                body_for_inference.clone(),
+                            )
+                            .map_err(|e| {
+                                gigastt_core::error::GigasttError::InvalidAudio {
+                                    reason: format!("{e:#}"),
+                                }
+                            })?;
+                        let fallback_reason = match channels.len() {
+                            0 => Some("no channels"),
+                            1 => Some("mono audio"),
+                            2 if gigastt_core::inference::audio::is_dual_mono(&channels) => {
+                                Some("dual-mono audio")
+                            }
+                            n if n > 2 => Some("more than two channels"),
+                            _ => None,
+                        };
+                        if let Some(reason) = fallback_reason {
+                            tracing::warn!(
+                                "channels=split requested but {reason} detected; falling back to mono transcription"
+                            );
+                            engine_for_inference
+                                .transcribe_bytes_shared(body_for_inference, &mut reservation)
+                        } else {
+                            engine_for_inference.transcribe_channels(&channels, &mut reservation)
+                        }
+                    } else {
+                        engine_for_inference.transcribe_bytes_shared_with_overrides(
+                            body_for_inference,
+                            &mut reservation,
+                            &overrides,
+                        )
+                    }
+                }));
+                match r {
+                    Ok(result) => result,
+                    Err(_) => Err(gigastt_core::error::GigasttError::Inference {
+                        source: anyhow::anyhow!("Inference thread panicked").into(),
+                    }),
+                }
+            });
+
+            if inference_timeout_secs == 0 {
+                handle
+                    .await
+                    .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
+                    .map_err(anyhow::Error::from)
+            } else {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(inference_timeout_secs),
+                    handle,
+                )
+                .await
+                {
+                    Ok(r) => r.map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
+                        .map_err(anyhow::Error::from),
+                    Err(_) => Err(anyhow::anyhow!("inference_timeout")),
+                }
             }
-        };
+        }
+        .await;
 
         progress_cancel.cancel();
         let _ = progress_handle.await;
 
-        result
-            .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
-            .map_err(anyhow::Error::from)
+        inference_result
     }
 }
 
@@ -843,6 +858,30 @@ mod tests {
             ))
             .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_store_is_full_evicts_expired() {
+        let limits = RuntimeLimits {
+            jobs_ttl_secs: 1,
+            jobs_max: 1,
+            ..test_limits()
+        };
+        let store = InMemoryJobStore::new(limits);
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"a"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        store
+            .update(&id, Box::new(|j| j.status = JobStatus::Done))
+            .await
+            .unwrap();
+        store.backdate(&id, 2.0).await;
+        // is_full should evict the expired terminal job and report capacity.
+        assert!(!store.is_full().await);
     }
 
     #[tokio::test]

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -4,14 +4,22 @@
 //! [`JobStore`] trait so a persistent backend (e.g. SQLite) can plug in
 //! later without touching the handlers.
 
+use arc_swap::ArcSwap;
 use axum::body::Bytes;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
+use std::pin::Pin;
+use std::str::FromStr;
+use std::sync::Arc;
 
 use parking_lot::Mutex;
 
 use super::config::RuntimeLimits;
 use super::http::ExportParams;
+
+/// Object-safe boxed future returned by [`JobStore`] methods.
+pub type JobStoreFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Lifecycle status of a transcription job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -129,26 +137,23 @@ impl Job {
 
 /// Persistence boundary for jobs. Handlers talk to this trait; the in-memory
 /// implementation is the default, but a SQLite-backed store can be dropped in.
-pub trait JobStore: Send + Sync {
+pub trait JobStore: Send + Sync + 'static {
     /// Persist a new job and return its id.
-    fn create(&self, job: Job) -> impl std::future::Future<Output = anyhow::Result<String>> + Send;
+    fn create<'a>(&'a self, job: Job) -> JobStoreFuture<'a, anyhow::Result<String>>;
     /// Return a clone of the job, if it exists.
-    fn get(
-        &self,
-        id: &str,
-    ) -> impl std::future::Future<Output = anyhow::Result<Option<Job>>> + Send;
+    fn get<'a>(&'a self, id: &str) -> JobStoreFuture<'a, anyhow::Result<Option<Job>>>;
     /// Apply an in-place mutation.
-    fn update(
-        &self,
+    fn update<'a>(
+        &'a self,
         id: &str,
         f: Box<dyn FnOnce(&mut Job) + Send>,
-    ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send;
+    ) -> JobStoreFuture<'a, anyhow::Result<()>>;
     /// Pop the oldest queued job id whose status is still `Queued`.
-    fn next_queued(
-        &self,
-    ) -> impl std::future::Future<Output = anyhow::Result<Option<String>>> + Send;
+    fn next_queued<'a>(&'a self) -> JobStoreFuture<'a, anyhow::Result<Option<String>>>;
+    /// Push a job id to the back of the queue (used after a retryable failure).
+    fn requeue<'a>(&'a self, id: &str) -> JobStoreFuture<'a, anyhow::Result<()>>;
     /// Whether the store has reached its capacity limit.
-    fn is_full(&self) -> impl std::future::Future<Output = bool> + Send;
+    fn is_full<'a>(&'a self) -> JobStoreFuture<'a, bool>;
 }
 
 /// In-memory FIFO job store with TTL eviction.
@@ -188,51 +193,544 @@ impl InMemoryJobStore {
 }
 
 impl JobStore for InMemoryJobStore {
-    async fn create(&self, job: Job) -> anyhow::Result<String> {
-        let mut jobs = self.jobs.lock();
-        let mut queue = self.queue.lock();
-        self.evict_expired_locked(&mut jobs, &mut queue);
-        if jobs.len() >= self.limits.jobs_max {
-            return Err(anyhow::anyhow!("job store is full"));
+    fn create<'a>(&'a self, job: Job) -> JobStoreFuture<'a, anyhow::Result<String>> {
+        Box::pin(async move {
+            let mut jobs = self.jobs.lock();
+            let mut queue = self.queue.lock();
+            self.evict_expired_locked(&mut jobs, &mut queue);
+            if jobs.len() >= self.limits.jobs_max {
+                return Err(anyhow::anyhow!("job store is full"));
+            }
+            let id = job.id.clone();
+            jobs.insert(id.clone(), job);
+            queue.push_back(id.clone());
+            Ok(id)
+        })
+    }
+
+    fn get<'a>(&'a self, id: &str) -> JobStoreFuture<'a, anyhow::Result<Option<Job>>> {
+        let id = id.to_owned();
+        Box::pin(async move {
+            let jobs = self.jobs.lock();
+            Ok(jobs.get(&id).cloned())
+        })
+    }
+
+    fn update<'a>(
+        &'a self,
+        id: &str,
+        f: Box<dyn FnOnce(&mut Job) + Send>,
+    ) -> JobStoreFuture<'a, anyhow::Result<()>> {
+        let id = id.to_owned();
+        Box::pin(async move {
+            let mut jobs = self.jobs.lock();
+            let Some(job) = jobs.get_mut(&id) else {
+                return Err(anyhow::anyhow!("job not found"));
+            };
+            f(job);
+            job.updated_at = gigastt_core::inference::now_timestamp();
+            Ok(())
+        })
+    }
+
+    fn next_queued<'a>(&'a self) -> JobStoreFuture<'a, anyhow::Result<Option<String>>> {
+        Box::pin(async move {
+            let mut jobs = self.jobs.lock();
+            let mut queue = self.queue.lock();
+            self.evict_expired_locked(&mut jobs, &mut queue);
+            while let Some(id) = queue.pop_front() {
+                if let Some(job) = jobs.get(&id)
+                    && matches!(job.status, JobStatus::Queued)
+                {
+                    return Ok(Some(id));
+                }
+            }
+            Ok(None)
+        })
+    }
+
+    fn requeue<'a>(&'a self, id: &str) -> JobStoreFuture<'a, anyhow::Result<()>> {
+        let id = id.to_owned();
+        Box::pin(async move {
+            let mut queue = self.queue.lock();
+            queue.push_back(id);
+            Ok(())
+        })
+    }
+
+    fn is_full<'a>(&'a self) -> JobStoreFuture<'a, bool> {
+        Box::pin(async move {
+            let jobs = self.jobs.lock();
+            jobs.len() >= self.limits.jobs_max
+        })
+    }
+}
+
+/// Executor abstraction so unit tests can run the queue without loading ONNX.
+pub trait JobExecution: Send + Sync {
+    /// Run one transcription attempt. The executor may update progress via the
+    /// store and should return an error for retryable failures.
+    fn execute(
+        &self,
+        id: &str,
+        store: Arc<dyn JobStore>,
+        body: Bytes,
+        params: ExportParams,
+    ) -> impl std::future::Future<Output = anyhow::Result<gigastt_core::inference::TranscribeResult>>
+    + Send;
+}
+
+/// In-memory FIFO job queue. Spawns `concurrency` workers that pull from the
+/// store, run the executor, and retry up to `max_retries` on transient failures.
+pub struct JobQueue {
+    store: Arc<dyn JobStore>,
+    semaphore: Arc<tokio::sync::Semaphore>,
+    max_retries: u32,
+    shutdown: tokio_util::sync::CancellationToken,
+}
+
+impl JobQueue {
+    /// Create a new queue. `concurrency` is clamped to at least 1.
+    pub fn new(
+        store: Arc<dyn JobStore>,
+        concurrency: usize,
+        max_retries: u32,
+        shutdown: tokio_util::sync::CancellationToken,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            store,
+            semaphore: Arc::new(tokio::sync::Semaphore::new(concurrency.max(1))),
+            max_retries,
+            shutdown,
+        })
+    }
+
+    /// Spawn worker tasks. Each worker owns a clone of `executor`. Call once
+    /// after constructing the queue.
+    pub fn spawn<E>(&self, executor: E)
+    where
+        E: JobExecution + Clone + Send + Sync + 'static,
+    {
+        let permits = self.semaphore.available_permits();
+        for _ in 0..permits {
+            let worker = JobWorker {
+                store: self.store.clone(),
+                semaphore: self.semaphore.clone(),
+                max_retries: self.max_retries,
+                shutdown: self.shutdown.clone(),
+                executor: executor.clone(),
+            };
+            tokio::spawn(worker.run());
         }
-        let id = job.id.clone();
-        jobs.insert(id.clone(), job);
-        queue.push_back(id.clone());
-        Ok(id)
     }
 
-    async fn get(&self, id: &str) -> anyhow::Result<Option<Job>> {
-        let jobs = self.jobs.lock();
-        Ok(jobs.get(id).cloned())
+    /// Mark all queued jobs as cancelled. Called during graceful shutdown.
+    pub async fn cancel_all_queued(&self) {
+        loop {
+            let Ok(Some(id)) = self.store.next_queued().await else {
+                break;
+            };
+            let _ = self
+                .store
+                .update(
+                    &id,
+                    Box::new(|j| {
+                        j.status = JobStatus::Cancelled;
+                        j.updated_at = gigastt_core::inference::now_timestamp();
+                    }),
+                )
+                .await;
+            broadcast_event(&*self.store, &id, JobEvent::Cancelled).await;
+        }
     }
+}
 
-    async fn update(&self, id: &str, f: Box<dyn FnOnce(&mut Job) + Send>) -> anyhow::Result<()> {
-        let mut jobs = self.jobs.lock();
-        let Some(job) = jobs.get_mut(id) else {
-            return Err(anyhow::anyhow!("job not found"));
-        };
-        f(job);
-        job.updated_at = gigastt_core::inference::now_timestamp();
-        Ok(())
-    }
+struct JobWorker<E> {
+    store: Arc<dyn JobStore>,
+    semaphore: Arc<tokio::sync::Semaphore>,
+    max_retries: u32,
+    shutdown: tokio_util::sync::CancellationToken,
+    executor: E,
+}
 
-    async fn next_queued(&self) -> anyhow::Result<Option<String>> {
-        let mut jobs = self.jobs.lock();
-        let mut queue = self.queue.lock();
-        self.evict_expired_locked(&mut jobs, &mut queue);
-        while let Some(id) = queue.pop_front() {
-            if let Some(job) = jobs.get(&id)
-                && matches!(job.status, JobStatus::Queued)
+impl<E: JobExecution + 'static> JobWorker<E> {
+    async fn run(self) {
+        loop {
+            if self.shutdown.is_cancelled() {
+                break;
+            }
+            let permit = match tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                self.semaphore.clone().acquire_owned(),
+            )
+            .await
             {
-                return Ok(Some(id));
+                Ok(Ok(p)) => p,
+                _ => continue,
+            };
+            let Some(id) = self.store.next_queued().await.unwrap_or(None) else {
+                drop(permit);
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                continue;
+            };
+
+            let _ = self
+                .store
+                .update(
+                    &id,
+                    Box::new(|j| {
+                        j.status = JobStatus::Processing;
+                        j.attempts += 1;
+                    }),
+                )
+                .await;
+            broadcast_event(
+                &*self.store,
+                &id,
+                JobEvent::Progress {
+                    percent: 0,
+                    processed_seconds: 0.0,
+                },
+            )
+            .await;
+
+            let store = self.store.clone();
+            let body = match self.store.get(&id).await {
+                Ok(Some(job)) => job.body,
+                _ => {
+                    drop(permit);
+                    continue;
+                }
+            };
+            let params = match self.store.get(&id).await {
+                Ok(Some(job)) => job.params,
+                _ => {
+                    drop(permit);
+                    continue;
+                }
+            };
+
+            let result = self
+                .executor
+                .execute(&id, store.clone(), body, params)
+                .await;
+            drop(permit);
+
+            // If the job was cancelled while running, discard the result.
+            let cancelled = self
+                .store
+                .get(&id)
+                .await
+                .ok()
+                .flatten()
+                .map(|j| matches!(j.status, JobStatus::Cancelled))
+                .unwrap_or(false);
+            if cancelled {
+                continue;
+            }
+
+            match result {
+                Ok(res) => {
+                    let total = res.duration_s;
+                    let _ = self
+                        .store
+                        .update(
+                            &id,
+                            Box::new(move |j| {
+                                j.status = JobStatus::Done;
+                                j.result = Some(res);
+                                j.processed_seconds = total;
+                            }),
+                        )
+                        .await;
+                    broadcast_event(&*self.store, &id, JobEvent::Done).await;
+                }
+                Err(e) => {
+                    let attempts = self
+                        .store
+                        .get(&id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|j| j.attempts)
+                        .unwrap_or(0);
+                    let retryable = is_retryable_error(&e) && attempts <= self.max_retries;
+                    if retryable {
+                        let _ = self
+                            .store
+                            .update(
+                                &id,
+                                Box::new(|j| {
+                                    j.status = JobStatus::Queued;
+                                }),
+                            )
+                            .await;
+                        let _ = self.store.requeue(&id).await;
+                        broadcast_event(
+                            &*self.store,
+                            &id,
+                            JobEvent::Progress {
+                                percent: 0,
+                                processed_seconds: 0.0,
+                            },
+                        )
+                        .await;
+                    } else {
+                        let sanitized = sanitize_job_error(&e);
+                        let _ = self
+                            .store
+                            .update(
+                                &id,
+                                Box::new({
+                                    let sanitized = sanitized.clone();
+                                    move |j| {
+                                        j.status = JobStatus::Failed;
+                                        j.error = Some(sanitized);
+                                    }
+                                }),
+                            )
+                            .await;
+                        broadcast_event(&*self.store, &id, JobEvent::Failed { error: sanitized })
+                            .await;
+                    }
+                }
             }
         }
-        Ok(None)
     }
+}
 
-    async fn is_full(&self) -> bool {
-        let jobs = self.jobs.lock();
-        jobs.len() >= self.limits.jobs_max
+/// Send an event to all active listeners, pruning dead channels. Terminal
+/// events are fire-and-forget: the channel is dropped afterwards so the SSE
+/// stream ends naturally.
+pub(crate) async fn broadcast_event(store: &dyn JobStore, id: &str, event: JobEvent) {
+    let channels = match store.get(id).await {
+        Ok(Some(job)) => job.event_channels,
+        _ => return,
+    };
+    let terminal = event.is_terminal();
+    let mut keep = Vec::new();
+    for tx in channels {
+        if tx.send(event.clone()).is_ok() && !terminal {
+            keep.push(tx);
+        }
+    }
+    let _ = store
+        .update(
+            id,
+            Box::new(move |j| {
+                j.event_channels = keep;
+            }),
+        )
+        .await;
+}
+
+fn is_retryable_error(e: &anyhow::Error) -> bool {
+    let s = format!("{e:#}");
+    s.contains("inference_timeout") || s.contains("panicked")
+}
+
+fn sanitize_job_error(e: &anyhow::Error) -> String {
+    let msg = format!("{e:#}");
+    if msg.contains("inference_timeout") {
+        "Inference timed out.".into()
+    } else if msg.contains("Invalid audio") {
+        "Failed to decode audio file. Check format.".into()
+    } else {
+        "Transcription failed.".into()
+    }
+}
+
+/// Production executor: decodes audio to size the job, runs inference against
+/// the batch pool, and emits timer-based progress events.
+#[derive(Clone)]
+pub struct RealJobExecutor {
+    engine: Arc<ArcSwap<gigastt_core::inference::Engine>>,
+    limits: Arc<ArcSwap<RuntimeLimits>>,
+}
+
+impl RealJobExecutor {
+    /// Create an executor bound to the live engine and runtime limits.
+    pub fn new(
+        engine: Arc<ArcSwap<gigastt_core::inference::Engine>>,
+        limits: Arc<ArcSwap<RuntimeLimits>>,
+    ) -> Self {
+        Self { engine, limits }
+    }
+}
+
+impl JobExecution for RealJobExecutor {
+    async fn execute(
+        &self,
+        id: &str,
+        store: Arc<dyn JobStore>,
+        body: Bytes,
+        params: ExportParams,
+    ) -> anyhow::Result<gigastt_core::inference::TranscribeResult> {
+        let engine = self.engine.load_full();
+        let limits = self.limits.load();
+
+        // Decode audio (blocking) once to estimate duration for progress.
+        let samples = tokio::task::spawn_blocking({
+            let body = body.clone();
+            move || gigastt_core::inference::audio::decode_audio_bytes_shared(body)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("audio decode task panicked: {e}"))?
+        .map_err(|e| anyhow::anyhow!("Invalid audio: {e:#}"))?;
+
+        let total_seconds = samples.len() as f64 / 16_000.0;
+        let _ = store
+            .update(id, Box::new(move |j| j.total_seconds = total_seconds))
+            .await;
+
+        // Validate per-request variant / knob overrides before holding a triplet.
+        if let Some(requested) = params.variant.as_deref() {
+            let matches = gigastt_core::model::ModelVariant::from_str(requested)
+                .map(|v| v == engine.variant())
+                .unwrap_or(false);
+            if !matches {
+                return Err(anyhow::anyhow!("Requested model variant is not loaded"));
+            }
+        }
+        let overrides = gigastt_core::inference::TranscribeOverrides {
+            punctuation: params.punctuation,
+            itn: params.itn,
+            vad: params.vad,
+        };
+        if let Err(e) = engine.validate_overrides(&overrides) {
+            return Err(anyhow::anyhow!("Invalid input: {}", e.message()));
+        }
+
+        // Timer-based progress updater. Assumes RTF ≈ 0.1 (10 s audio / 1 s wall).
+        let progress_cancel = tokio_util::sync::CancellationToken::new();
+        let progress_handle = {
+            let store = store.clone();
+            let id = id.to_string();
+            let cancel = progress_cancel.clone();
+            let total = total_seconds;
+            tokio::spawn(async move {
+                let start = std::time::Instant::now();
+                let rtf = 0.1_f64;
+                let mut interval = tokio::time::interval(std::time::Duration::from_millis(500));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                loop {
+                    interval.tick().await;
+                    if cancel.is_cancelled() {
+                        break;
+                    }
+                    let elapsed = start.elapsed().as_secs_f64();
+                    let processed = (elapsed / rtf).min(total);
+                    let percent = if total > 0.0 {
+                        ((processed / total) * 100.0) as u32
+                    } else {
+                        100
+                    };
+                    let _ = store
+                        .update(&id, Box::new(move |j| j.processed_seconds = processed))
+                        .await;
+                    broadcast_event(
+                        &*store,
+                        &id,
+                        JobEvent::Progress {
+                            percent,
+                            processed_seconds: processed,
+                        },
+                    )
+                    .await;
+                    if processed >= total {
+                        break;
+                    }
+                }
+            })
+        };
+
+        // Check out a triplet from the batch pool and run inference.
+        let guard = match tokio::time::timeout(
+            std::time::Duration::from_secs(limits.pool_checkout_timeout_secs),
+            engine.pool_for_batch().checkout(),
+        )
+        .await
+        {
+            Ok(Ok(g)) => g,
+            Ok(Err(_)) => return Err(anyhow::anyhow!("pool closed")),
+            Err(_) => return Err(anyhow::anyhow!("pool checkout timed out")),
+        };
+        let mut reservation = guard.into_owned();
+
+        let inference_timeout_secs = limits.inference_timeout_secs;
+        let engine_for_inference = engine.clone();
+        let body_for_inference = body.clone();
+        let span = tracing::Span::current();
+        let handle = tokio::task::spawn_blocking(move || {
+            let _enter = span.enter();
+            let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                if params.channels.as_deref() == Some("split") {
+                    let channels =
+                        gigastt_core::inference::audio::decode_audio_bytes_shared_channels(
+                            body_for_inference.clone(),
+                        )
+                        .map_err(|e| {
+                            gigastt_core::error::GigasttError::InvalidAudio {
+                                reason: format!("{e:#}"),
+                            }
+                        })?;
+                    let fallback_reason = match channels.len() {
+                        0 => Some("no channels"),
+                        1 => Some("mono audio"),
+                        2 if gigastt_core::inference::audio::is_dual_mono(&channels) => {
+                            Some("dual-mono audio")
+                        }
+                        n if n > 2 => Some("more than two channels"),
+                        _ => None,
+                    };
+                    if let Some(reason) = fallback_reason {
+                        tracing::warn!(
+                            "channels=split requested but {reason} detected; falling back to mono transcription"
+                        );
+                        engine_for_inference.transcribe_bytes_shared_with_overrides(
+                            body_for_inference,
+                            &mut reservation,
+                            &overrides,
+                        )
+                    } else {
+                        engine_for_inference.transcribe_channels(&channels, &mut reservation)
+                    }
+                } else {
+                    engine_for_inference.transcribe_bytes_shared_with_overrides(
+                        body_for_inference,
+                        &mut reservation,
+                        &overrides,
+                    )
+                }
+            }));
+            match r {
+                Ok(result) => result,
+                Err(_) => Err(gigastt_core::error::GigasttError::Inference {
+                    source: anyhow::anyhow!("Inference thread panicked").into(),
+                }),
+            }
+        });
+
+        let result = if inference_timeout_secs == 0 {
+            handle.await
+        } else {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(inference_timeout_secs),
+                handle,
+            )
+            .await
+            {
+                Ok(r) => r,
+                Err(_) => return Err(anyhow::anyhow!("inference_timeout")),
+            }
+        };
+
+        progress_cancel.cancel();
+        let _ = progress_handle.await;
+
+        result
+            .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
+            .map_err(anyhow::Error::from)
     }
 }
 
@@ -364,5 +862,197 @@ mod tests {
             .await
             .unwrap();
         assert!(store.get(&id).await.unwrap().is_none());
+    }
+
+    #[derive(Clone)]
+    struct MockExecutor {
+        results: Arc<Mutex<Vec<anyhow::Result<gigastt_core::inference::TranscribeResult>>>>,
+        delay_ms: u64,
+    }
+
+    impl JobExecution for MockExecutor {
+        async fn execute(
+            &self,
+            _id: &str,
+            _store: Arc<dyn JobStore>,
+            body: Bytes,
+            _params: ExportParams,
+        ) -> anyhow::Result<gigastt_core::inference::TranscribeResult> {
+            if self.delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(self.delay_ms)).await;
+            }
+            let mut results = self.results.lock();
+            let result = results.remove(0);
+            // Use body length to make failures deterministic per test.
+            let _ = body.len();
+            result
+        }
+    }
+
+    fn ok_result() -> anyhow::Result<gigastt_core::inference::TranscribeResult> {
+        Ok(gigastt_core::inference::TranscribeResult {
+            text: "ok".into(),
+            words: vec![],
+            duration_s: 1.0,
+        })
+    }
+
+    #[tokio::test]
+    async fn test_queue_runs_jobs_in_fifo_order() {
+        let limits = test_limits();
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(limits));
+        let executor = MockExecutor {
+            results: Arc::new(Mutex::new(vec![ok_result(), ok_result()])),
+            delay_ms: 0,
+        };
+        let queue = JobQueue::new(
+            store.clone(),
+            2,
+            0,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        queue.spawn(executor);
+
+        let id1 = store
+            .create(Job::queued(
+                Bytes::from_static(b"1"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        let id2 = store
+            .create(Job::queued(
+                Bytes::from_static(b"2"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        // Wait for both to finish.
+        for _ in 0..50 {
+            let j1 = store.get(&id1).await.unwrap().unwrap();
+            let j2 = store.get(&id2).await.unwrap().unwrap();
+            if matches!(j1.status, JobStatus::Done) && matches!(j2.status, JobStatus::Done) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        assert!(matches!(
+            store.get(&id1).await.unwrap().unwrap().status,
+            JobStatus::Done
+        ));
+        assert!(matches!(
+            store.get(&id2).await.unwrap().unwrap().status,
+            JobStatus::Done
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_queue_retry_then_fail() {
+        let limits = RuntimeLimits {
+            jobs_retry: 2,
+            ..test_limits()
+        };
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(limits));
+        let executor = MockExecutor {
+            results: Arc::new(Mutex::new(vec![
+                Err(anyhow::anyhow!("inference_timeout")),
+                Err(anyhow::anyhow!("inference_timeout")),
+                Err(anyhow::anyhow!("inference_timeout")),
+            ])),
+            delay_ms: 0,
+        };
+        let queue = JobQueue::new(
+            store.clone(),
+            1,
+            2,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        queue.spawn(executor);
+
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"x"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        for _ in 0..50 {
+            let job = store.get(&id).await.unwrap().unwrap();
+            if matches!(job.status, JobStatus::Failed) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Failed));
+        assert_eq!(job.attempts, 3);
+    }
+
+    #[tokio::test]
+    async fn test_queue_cancellation_discards_result() {
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(test_limits()));
+        let executor = MockExecutor {
+            results: Arc::new(Mutex::new(vec![ok_result()])),
+            delay_ms: 300,
+        };
+        let queue = JobQueue::new(
+            store.clone(),
+            1,
+            0,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        queue.spawn(executor);
+
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"x"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        // Wait until processing, then cancel while the executor is still running.
+        for _ in 0..50 {
+            let job = store.get(&id).await.unwrap().unwrap();
+            if matches!(job.status, JobStatus::Processing) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        store
+            .update(&id, Box::new(|j| j.status = JobStatus::Cancelled))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Cancelled));
+        assert!(job.result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_queue_cancel_all_queued_on_shutdown() {
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(test_limits()));
+        let token = tokio_util::sync::CancellationToken::new();
+        let queue = JobQueue::new(store.clone(), 1, 0, token.clone());
+        // Don't spawn workers so jobs stay queued.
+
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"x"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        token.cancel();
+        queue.cancel_all_queued().await;
+
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Cancelled));
     }
 }

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -687,11 +687,8 @@ impl JobExecution for RealJobExecutor {
                         tracing::warn!(
                             "channels=split requested but {reason} detected; falling back to mono transcription"
                         );
-                        engine_for_inference.transcribe_bytes_shared_with_overrides(
-                            body_for_inference,
-                            &mut reservation,
-                            &overrides,
-                        )
+                        engine_for_inference
+                            .transcribe_bytes_shared(body_for_inference, &mut reservation)
                     } else {
                         engine_for_inference.transcribe_channels(&channels, &mut reservation)
                     }

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -1,0 +1,368 @@
+//! Asynchronous job queue for long-file and batch transcription.
+//!
+//! The queue is intentionally decoupled from the HTTP surface via the
+//! [`JobStore`] trait so a persistent backend (e.g. SQLite) can plug in
+//! later without touching the handlers.
+
+use axum::body::Bytes;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
+
+use parking_lot::Mutex;
+
+use super::config::RuntimeLimits;
+use super::http::ExportParams;
+
+/// Lifecycle status of a transcription job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobStatus {
+    /// Waiting for a worker slot.
+    Queued,
+    /// Currently holding a triplet and transcribing.
+    Processing,
+    /// Finished successfully; result is available.
+    Done,
+    /// Failed after exhausting retries.
+    Failed,
+    /// Cancelled by the client or by shutdown.
+    Cancelled,
+}
+
+impl JobStatus {
+    /// Whether the job has reached a terminal state.
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            JobStatus::Done | JobStatus::Failed | JobStatus::Cancelled
+        )
+    }
+}
+
+/// Server-sent event emitted by `GET /v1/jobs/{id}/events`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum JobEvent {
+    /// Progress estimate while processing.
+    Progress {
+        /// Approximate fraction complete, 0–100.
+        percent: u32,
+        /// Seconds of audio considered processed so far.
+        processed_seconds: f64,
+    },
+    /// Job completed successfully.
+    Done,
+    /// Job failed.
+    Failed {
+        /// Sanitized error message (no paths or model internals).
+        error: String,
+    },
+    /// Job was cancelled.
+    Cancelled,
+}
+
+impl JobEvent {
+    /// Whether this event ends the stream.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            JobEvent::Done | JobEvent::Failed { .. } | JobEvent::Cancelled
+        )
+    }
+}
+
+/// Public status response for `GET /v1/jobs/{id}`.
+#[derive(Debug, Clone, Serialize)]
+pub struct JobStatusResponse {
+    pub job_id: String,
+    pub status: JobStatus,
+    pub processed_seconds: f64,
+    pub percent: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// A transcription job.
+#[derive(Debug, Clone)]
+pub struct Job {
+    pub id: String,
+    pub status: JobStatus,
+    /// Raw uploaded audio bytes.
+    pub body: Bytes,
+    /// Export / post-processing parameters captured at submission.
+    pub params: ExportParams,
+    pub created_at: f64,
+    pub updated_at: f64,
+    pub processed_seconds: f64,
+    /// Total audio duration in seconds, set once the body is decoded.
+    pub total_seconds: f64,
+    /// Number of execution attempts made so far.
+    pub attempts: u32,
+    /// Populated when status becomes `Done`.
+    pub result: Option<gigastt_core::inference::TranscribeResult>,
+    /// Populated when status becomes `Failed`.
+    pub error: Option<String>,
+    /// Active SSE listeners.
+    pub event_channels: Vec<tokio::sync::mpsc::UnboundedSender<JobEvent>>,
+}
+
+impl Job {
+    /// Create a new queued job.
+    pub fn queued(body: Bytes, params: ExportParams) -> Self {
+        let now = gigastt_core::inference::now_timestamp();
+        Self {
+            id: uuid::Uuid::now_v7().to_string(),
+            status: JobStatus::Queued,
+            body,
+            params,
+            created_at: now,
+            updated_at: now,
+            processed_seconds: 0.0,
+            total_seconds: 0.0,
+            attempts: 0,
+            result: None,
+            error: None,
+            event_channels: Vec::new(),
+        }
+    }
+}
+
+/// Persistence boundary for jobs. Handlers talk to this trait; the in-memory
+/// implementation is the default, but a SQLite-backed store can be dropped in.
+pub trait JobStore: Send + Sync {
+    /// Persist a new job and return its id.
+    fn create(&self, job: Job) -> impl std::future::Future<Output = anyhow::Result<String>> + Send;
+    /// Return a clone of the job, if it exists.
+    fn get(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = anyhow::Result<Option<Job>>> + Send;
+    /// Apply an in-place mutation.
+    fn update(
+        &self,
+        id: &str,
+        f: Box<dyn FnOnce(&mut Job) + Send>,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send;
+    /// Pop the oldest queued job id whose status is still `Queued`.
+    fn next_queued(
+        &self,
+    ) -> impl std::future::Future<Output = anyhow::Result<Option<String>>> + Send;
+    /// Whether the store has reached its capacity limit.
+    fn is_full(&self) -> impl std::future::Future<Output = bool> + Send;
+}
+
+/// In-memory FIFO job store with TTL eviction.
+pub struct InMemoryJobStore {
+    limits: RuntimeLimits,
+    jobs: Mutex<HashMap<String, Job>>,
+    queue: Mutex<VecDeque<String>>,
+}
+
+impl InMemoryJobStore {
+    /// Create a new store with the given limits.
+    pub fn new(limits: RuntimeLimits) -> Self {
+        Self {
+            limits,
+            jobs: Mutex::new(HashMap::new()),
+            queue: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Evict terminal jobs whose TTL has expired. Must be called with both locks held.
+    fn evict_expired_locked(&self, jobs: &mut HashMap<String, Job>, queue: &mut VecDeque<String>) {
+        let ttl = self.limits.jobs_ttl_secs;
+        if ttl == 0 {
+            return;
+        }
+        let now = gigastt_core::inference::now_timestamp();
+        let expired: Vec<String> = jobs
+            .iter()
+            .filter(|(_, j)| j.status.is_terminal() && now - j.updated_at > ttl as f64)
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in expired {
+            jobs.remove(&id);
+            queue.retain(|x| x != &id);
+        }
+    }
+}
+
+impl JobStore for InMemoryJobStore {
+    async fn create(&self, job: Job) -> anyhow::Result<String> {
+        let mut jobs = self.jobs.lock();
+        let mut queue = self.queue.lock();
+        self.evict_expired_locked(&mut jobs, &mut queue);
+        if jobs.len() >= self.limits.jobs_max {
+            return Err(anyhow::anyhow!("job store is full"));
+        }
+        let id = job.id.clone();
+        jobs.insert(id.clone(), job);
+        queue.push_back(id.clone());
+        Ok(id)
+    }
+
+    async fn get(&self, id: &str) -> anyhow::Result<Option<Job>> {
+        let jobs = self.jobs.lock();
+        Ok(jobs.get(id).cloned())
+    }
+
+    async fn update(&self, id: &str, f: Box<dyn FnOnce(&mut Job) + Send>) -> anyhow::Result<()> {
+        let mut jobs = self.jobs.lock();
+        let Some(job) = jobs.get_mut(id) else {
+            return Err(anyhow::anyhow!("job not found"));
+        };
+        f(job);
+        job.updated_at = gigastt_core::inference::now_timestamp();
+        Ok(())
+    }
+
+    async fn next_queued(&self) -> anyhow::Result<Option<String>> {
+        let mut jobs = self.jobs.lock();
+        let mut queue = self.queue.lock();
+        self.evict_expired_locked(&mut jobs, &mut queue);
+        while let Some(id) = queue.pop_front() {
+            if let Some(job) = jobs.get(&id)
+                && matches!(job.status, JobStatus::Queued)
+            {
+                return Ok(Some(id));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn is_full(&self) -> bool {
+        let jobs = self.jobs.lock();
+        jobs.len() >= self.limits.jobs_max
+    }
+}
+
+#[cfg(test)]
+impl InMemoryJobStore {
+    /// Shift a job's `updated_at` back in time for TTL eviction tests.
+    pub async fn backdate(&self, id: &str, seconds: f64) {
+        let mut jobs = self.jobs.lock();
+        if let Some(job) = jobs.get_mut(id) {
+            job.updated_at -= seconds;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_limits() -> RuntimeLimits {
+        RuntimeLimits {
+            jobs_enabled: true,
+            jobs_ttl_secs: 3600,
+            jobs_max: 10,
+            jobs_retry: 0,
+            ..RuntimeLimits::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_store_crud() {
+        let store = InMemoryJobStore::new(test_limits());
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"a"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Queued));
+        store
+            .update(&id, Box::new(|j| j.status = JobStatus::Processing))
+            .await
+            .unwrap();
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Processing));
+    }
+
+    #[tokio::test]
+    async fn test_store_fifo_order() {
+        let store = InMemoryJobStore::new(test_limits());
+        let id1 = store
+            .create(Job::queued(
+                Bytes::from_static(b"1"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        let id2 = store
+            .create(Job::queued(
+                Bytes::from_static(b"2"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(store.next_queued().await.unwrap(), Some(id1.clone()));
+        // id1 is still queued in the store; next_queued returned it but did not
+        // change its status. Simulate another worker trying to pop while id1
+        // is still queued: it should see id1 again because status is still Queued.
+        // Mark id1 processing and then next should be id2.
+        store
+            .update(&id1, Box::new(|j| j.status = JobStatus::Processing))
+            .await
+            .unwrap();
+        assert_eq!(store.next_queued().await.unwrap(), Some(id2));
+    }
+
+    #[tokio::test]
+    async fn test_store_capacity_limit() {
+        let limits = RuntimeLimits {
+            jobs_max: 1,
+            ..test_limits()
+        };
+        let store = InMemoryJobStore::new(limits);
+        store
+            .create(Job::queued(
+                Bytes::from_static(b"a"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        assert!(store.is_full().await);
+        let result = store
+            .create(Job::queued(
+                Bytes::from_static(b"b"),
+                ExportParams::default(),
+            ))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_store_ttl_eviction() {
+        let limits = RuntimeLimits {
+            jobs_ttl_secs: 1,
+            jobs_max: 10,
+            ..test_limits()
+        };
+        let store = InMemoryJobStore::new(limits);
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"a"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        store
+            .update(&id, Box::new(|j| j.status = JobStatus::Done))
+            .await
+            .unwrap();
+        // Backdate the job by more than the 1-second TTL.
+        store.backdate(&id, 2.0).await;
+        // Creating a new job should evict the expired one.
+        store
+            .create(Job::queued(
+                Bytes::from_static(b"b"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        assert!(store.get(&id).await.unwrap().is_none());
+    }
+}

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -90,6 +90,22 @@ pub struct JobStatusResponse {
     pub error: Option<String>,
 }
 
+/// Build a public status view from a stored job.
+pub(crate) fn job_status_response(job: &Job) -> JobStatusResponse {
+    let percent = if job.total_seconds > 0.0 {
+        ((job.processed_seconds / job.total_seconds) * 100.0) as u32
+    } else {
+        0
+    };
+    JobStatusResponse {
+        job_id: job.id.clone(),
+        status: job.status,
+        processed_seconds: job.processed_seconds,
+        percent,
+        error: job.error.clone(),
+    }
+}
+
 /// A transcription job.
 #[derive(Debug, Clone)]
 pub struct Job {
@@ -1051,5 +1067,221 @@ mod tests {
 
         let job = store.get(&id).await.unwrap().unwrap();
         assert!(matches!(job.status, JobStatus::Cancelled));
+    }
+
+    #[test]
+    fn test_sanitize_job_error_maps_known_errors() {
+        assert_eq!(
+            sanitize_job_error(&anyhow::anyhow!("inference_timeout")),
+            "Inference timed out."
+        );
+        assert_eq!(
+            sanitize_job_error(&anyhow::anyhow!("Invalid audio: unsupported format")),
+            "Failed to decode audio file. Check format."
+        );
+        assert_eq!(
+            sanitize_job_error(&anyhow::anyhow!("some internal onnx path /foo/bar")),
+            "Transcription failed."
+        );
+    }
+
+    #[test]
+    fn test_is_retryable_error_recognizes_transient_failures() {
+        assert!(is_retryable_error(&anyhow::anyhow!("inference_timeout")));
+        assert!(is_retryable_error(&anyhow::anyhow!(
+            "worker thread panicked"
+        )));
+        assert!(!is_retryable_error(&anyhow::anyhow!("Invalid audio")));
+    }
+
+    #[tokio::test]
+    async fn test_store_get_missing_returns_none() {
+        let store = InMemoryJobStore::new(test_limits());
+        assert!(store.get("no-such-id").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_store_update_missing_returns_error() {
+        let store = InMemoryJobStore::new(test_limits());
+        assert!(
+            store
+                .update("no-such-id", Box::new(|j| j.status = JobStatus::Done))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_event_prunes_dead_channels() {
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(test_limits()));
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"x"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        // Add a live channel and a channel that will be dropped before broadcast.
+        let (live_tx, mut live_rx) = tokio::sync::mpsc::unbounded_channel::<JobEvent>();
+        {
+            let (dead_tx, _dead_rx) = tokio::sync::mpsc::unbounded_channel::<JobEvent>();
+            store
+                .update(
+                    &id,
+                    Box::new(move |j| {
+                        j.event_channels.push(live_tx);
+                        j.event_channels.push(dead_tx);
+                    }),
+                )
+                .await
+                .unwrap();
+        }
+
+        broadcast_event(
+            &*store,
+            &id,
+            JobEvent::Progress {
+                percent: 50,
+                processed_seconds: 1.0,
+            },
+        )
+        .await;
+
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert_eq!(job.event_channels.len(), 1);
+        assert!(matches!(live_rx.try_recv(), Ok(JobEvent::Progress { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_queue_concurrency_clamped_to_one() {
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(test_limits()));
+        let executor = MockExecutor {
+            results: Arc::new(Mutex::new(vec![ok_result(), ok_result()])),
+            delay_ms: 0,
+        };
+        // Pass 0; the queue must still spawn at least one worker.
+        let queue = JobQueue::new(
+            store.clone(),
+            0,
+            0,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        queue.spawn(executor);
+
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"x"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        for _ in 0..50 {
+            let job = store.get(&id).await.unwrap().unwrap();
+            if matches!(job.status, JobStatus::Done) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        assert!(matches!(
+            store.get(&id).await.unwrap().unwrap().status,
+            JobStatus::Done
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_queue_non_retryable_error_fails_immediately() {
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(test_limits()));
+        let executor = MockExecutor {
+            results: Arc::new(Mutex::new(vec![Err(anyhow::anyhow!(
+                "Invalid audio: bad header"
+            ))])),
+            delay_ms: 0,
+        };
+        let queue = JobQueue::new(
+            store.clone(),
+            1,
+            3,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        queue.spawn(executor);
+
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"x"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        for _ in 0..50 {
+            let job = store.get(&id).await.unwrap().unwrap();
+            if matches!(job.status, JobStatus::Failed) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Failed));
+        assert_eq!(job.attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn test_queue_retry_boundary_exhausted_after_max_retries() {
+        // max_retries=1 means one retry is allowed: attempts 1 (retry), 2 (fail).
+        let limits = RuntimeLimits {
+            jobs_retry: 1,
+            ..test_limits()
+        };
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(limits));
+        let executor = MockExecutor {
+            results: Arc::new(Mutex::new(vec![
+                Err(anyhow::anyhow!("inference_timeout")),
+                Err(anyhow::anyhow!("inference_timeout")),
+            ])),
+            delay_ms: 0,
+        };
+        let queue = JobQueue::new(
+            store.clone(),
+            1,
+            1,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        queue.spawn(executor);
+
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"x"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        for _ in 0..50 {
+            let job = store.get(&id).await.unwrap().unwrap();
+            if matches!(job.status, JobStatus::Failed) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Failed));
+        assert_eq!(job.attempts, 2);
+    }
+
+    #[test]
+    fn test_job_status_response_percent() {
+        let mut job = Job::queued(Bytes::new(), ExportParams::default());
+        job.id = "test".into();
+        job.total_seconds = 10.0;
+        job.processed_seconds = 3.5;
+        job.status = JobStatus::Processing;
+        let resp = job_status_response(&job);
+        assert_eq!(resp.percent, 35);
+        assert_eq!(resp.processed_seconds, 3.5);
     }
 }

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -5,6 +5,7 @@
 mod bootstrap;
 pub mod config;
 pub mod http;
+pub mod jobs;
 pub mod metrics;
 pub(crate) mod middleware;
 pub mod rate_limit;

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -19,7 +19,7 @@ use arc_swap::ArcSwap;
 use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::http::StatusCode;
-use axum::routing::{get, options, post};
+use axum::routing::{delete, get, options, post};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -63,6 +63,7 @@ pub async fn run_with_shutdown(
         metrics_listen: config::default_metrics_listen(),
         trust_proxy: false,
         config_path: None,
+        batch_pool_size: 0,
     };
     run_with_config(engine, config, shutdown).await
 }
@@ -383,14 +384,43 @@ pub async fn run_with_config_listener_reloadable(
     let shutdown_root = tokio_util::sync::CancellationToken::new();
     let tracker = tokio_util::task::TaskTracker::new();
 
+    let engine_swap = Arc::new(ArcSwap::from_pointee(engine));
+    let limits_swap = Arc::new(ArcSwap::from_pointee(config.limits.clone()));
+
+    // Stand up the asynchronous job queue when the operator enabled it.
+    // We build it before `AppState` so the handlers can hold a clone.
+    let jobs_state = if config.limits.jobs_enabled {
+        let store: Arc<dyn jobs::JobStore> =
+            Arc::new(jobs::InMemoryJobStore::new(config.limits.clone()));
+        let concurrency = config.batch_pool_size.max(1);
+        let max_retries = config.limits.jobs_retry;
+        let queue = jobs::JobQueue::new(
+            store.clone(),
+            concurrency,
+            max_retries,
+            shutdown_root.clone(),
+        );
+        let executor = jobs::RealJobExecutor::new(engine_swap.clone(), limits_swap.clone());
+        queue.spawn(executor);
+        tracing::info!(
+            concurrency,
+            max_retries,
+            "asynchronous /v1/jobs API enabled"
+        );
+        Some(http::JobServerState { store, queue })
+    } else {
+        None
+    };
+
     let state = Arc::new(http::AppState {
-        engine: Arc::new(ArcSwap::from_pointee(engine)),
+        engine: engine_swap,
         engine_builder: engine_builder.clone(),
         reload_lock: Arc::new(tokio::sync::Mutex::new(())),
-        limits: Arc::new(ArcSwap::from_pointee(config.limits.clone())),
+        limits: limits_swap,
         metrics_registry: metrics_registry.clone(),
         shutdown: shutdown_root.clone(),
         tracker: tracker.clone(),
+        jobs: jobs_state.clone(),
     });
 
     let rate_limiter_swap = if config.limits.rate_limit_per_minute > 0 {
@@ -506,7 +536,31 @@ pub async fn run_with_config_listener_reloadable(
         .route(
             "/v1/admin/reload",
             options(|| async { StatusCode::NO_CONTENT }),
-        )
+        );
+
+    // Asynchronous job API routes. Only registered when `--enable-jobs` is set;
+    // without the flag the paths fall through to axum's default 404.
+    let protected = if config.limits.jobs_enabled {
+        protected
+            .route("/v1/jobs", post(http::submit_job))
+            .route("/v1/jobs", options(|| async { StatusCode::NO_CONTENT }))
+            .route("/v1/jobs/{id}", get(http::get_job))
+            .route("/v1/jobs/{id}", delete(http::cancel_job))
+            .route(
+                "/v1/jobs/{id}",
+                options(|| async { StatusCode::NO_CONTENT }),
+            )
+            .route("/v1/jobs/{id}/result", get(http::get_job_result))
+            .route(
+                "/v1/jobs/{id}/result",
+                options(|| async { StatusCode::NO_CONTENT }),
+            )
+            .route("/v1/jobs/{id}/events", get(http::job_events))
+    } else {
+        protected
+    };
+
+    let protected = protected
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             middleware::http_metrics_middleware,
@@ -626,6 +680,7 @@ pub async fn run_with_config_listener_reloadable(
 
     let shutdown_fut = {
         let shutdown_root = shutdown_root.clone();
+        let jobs_state = jobs_state.clone();
         async move {
             match shutdown {
                 Some(rx) => {
@@ -666,6 +721,12 @@ pub async fn run_with_config_listener_reloadable(
             // draining while axum is still completing the in-flight HTTP
             // futures.
             shutdown_root.cancel();
+            // Mark every queued job as cancelled so workers don't start new work
+            // during the drain window. In-flight jobs are allowed to finish within
+            // `shutdown_drain_secs` (their triplet is returned when they complete).
+            if let Some(ref jobs) = jobs_state {
+                jobs.queue.cancel_all_queued().await;
+            }
             // Wake every waiter still blocked on `pool.checkout()` with
             // PoolError::Closed so they fall through to a 503 / `pool_closed`
             // response instead of being stranded for the full checkout timeout.

--- a/crates/gigastt/tests/common/mod.rs
+++ b/crates/gigastt/tests/common/mod.rs
@@ -206,6 +206,45 @@ pub async fn start_server_with_limits(
         metrics_listen: gigastt::server::config::default_metrics_listen(),
         trust_proxy: false,
         config_path: None,
+        batch_pool_size: 0,
+    };
+    tokio::spawn(gigastt::server::run_with_config_listener(
+        engine,
+        config,
+        Some(shutdown_rx),
+        listener,
+    ));
+
+    wait_for_ready(port, Duration::from_secs(30)).await;
+    (port, shutdown_tx)
+}
+
+/// Start the server with the asynchronous `/v1/jobs` API enabled. Uses a
+/// dedicated batch pool of size `batch_pool_size` (minimum 1) so job workers do
+/// not contend with the interactive pool used by WebSocket / synchronous REST.
+pub async fn start_server_with_jobs(
+    model_dir: &str,
+    batch_pool_size: usize,
+) -> (u16, oneshot::Sender<()>) {
+    let (port, listener) = free_port().await;
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let engine = gigastt::inference::Engine::load(model_dir).unwrap();
+    let limits = gigastt::server::RuntimeLimits {
+        jobs_enabled: true,
+        jobs_max: 10,
+        ..Default::default()
+    };
+    let config = gigastt::server::ServerConfig {
+        port,
+        host: "127.0.0.1".into(),
+        origin_policy: gigastt::server::OriginPolicy::loopback_only(),
+        limits,
+        metrics_enabled: false,
+        metrics_listen: gigastt::server::config::default_metrics_listen(),
+        trust_proxy: false,
+        config_path: None,
+        batch_pool_size: batch_pool_size.max(1),
     };
     tokio::spawn(gigastt::server::run_with_config_listener(
         engine,

--- a/crates/gigastt/tests/e2e_jobs.rs
+++ b/crates/gigastt/tests/e2e_jobs.rs
@@ -1,0 +1,226 @@
+//! End-to-end tests for the asynchronous `/v1/jobs` API.
+//!
+//! All tests require the GigaAM model to be downloaded (~850MB).
+//! Run with: `cargo test --test e2e_jobs -- --ignored --test-threads=1`
+
+mod common;
+
+use futures_util::StreamExt;
+use std::time::Duration;
+
+/// POST /v1/jobs returns 404 when the feature is not enabled.
+#[ignore = "requires model"]
+#[tokio::test]
+async fn test_jobs_disabled_returns_404() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+
+    let resp = tokio::time::timeout(Duration::from_secs(10), async {
+        reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/v1/jobs"))
+            .body(common::generate_wav(1, 16000))
+            .send()
+            .await
+            .expect("POST /v1/jobs failed")
+    })
+    .await
+    .expect("POST /v1/jobs timed out");
+
+    assert_eq!(resp.status(), 404);
+    let _ = shutdown.send(());
+}
+
+/// Full happy path: submit a short WAV, poll until done, then fetch the result.
+#[ignore = "requires model"]
+#[tokio::test]
+async fn test_job_submit_poll_done_result() {
+    let (port, shutdown) = common::start_server_with_jobs(&common::model_dir(), 1).await;
+    let wav = common::generate_wav(2, 16000);
+
+    let submit = tokio::time::timeout(Duration::from_secs(10), async {
+        reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/v1/jobs"))
+            .body(wav)
+            .send()
+            .await
+            .expect("POST /v1/jobs failed")
+    })
+    .await
+    .expect("POST /v1/jobs timed out");
+
+    assert_eq!(submit.status(), 202);
+    let text = submit
+        .text()
+        .await
+        .expect("submit response should have text");
+    let body: serde_json::Value =
+        serde_json::from_str(&text).expect("submit response should be JSON");
+    let job_id = body["job_id"].as_str().expect("job_id should be a string");
+    assert_eq!(body["status"], "queued");
+
+    // Poll until the job finishes.
+    let client = reqwest::Client::new();
+    let mut final_status = serde_json::Value::Null;
+    for _ in 0..120 {
+        let resp = client
+            .get(format!("http://127.0.0.1:{port}/v1/jobs/{job_id}"))
+            .send()
+            .await
+            .expect("GET /v1/jobs/{id} failed");
+        assert_eq!(resp.status(), 200);
+        let text = resp.text().await.expect("status response should have text");
+        let status: serde_json::Value = serde_json::from_str(&text).expect("status should be JSON");
+        if status["status"] == "done" || status["status"] == "failed" {
+            final_status = status;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    assert_eq!(
+        final_status["status"], "done",
+        "job should finish successfully: {final_status:?}"
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(10), async {
+        client
+            .get(format!("http://127.0.0.1:{port}/v1/jobs/{job_id}/result"))
+            .send()
+            .await
+            .expect("GET /v1/jobs/{id}/result failed")
+    })
+    .await
+    .expect("GET /v1/jobs/{id}/result timed out");
+
+    assert_eq!(result.status(), 200);
+    let text = result
+        .text()
+        .await
+        .expect("result response should have text");
+    let result_body: serde_json::Value =
+        serde_json::from_str(&text).expect("result should be JSON");
+    assert!(
+        result_body["text"].is_string(),
+        "result should contain text, got: {result_body:?}"
+    );
+
+    let _ = shutdown.send(());
+}
+
+/// Cancelling a queued job lets a synchronous `/v1/transcribe` run immediately.
+#[ignore = "requires model"]
+#[tokio::test]
+async fn test_job_cancel_queued_frees_pool() {
+    let (port, shutdown) = common::start_server_with_jobs(&common::model_dir(), 1).await;
+    let client = reqwest::Client::new();
+
+    // Submit a long WAV so the job stays queued for a moment.
+    let submit = client
+        .post(format!("http://127.0.0.1:{port}/v1/jobs"))
+        .body(common::generate_wav(30, 16000))
+        .send()
+        .await
+        .expect("POST /v1/jobs failed");
+    assert_eq!(submit.status(), 202);
+    let text = submit
+        .text()
+        .await
+        .expect("submit response should have text");
+    let body: serde_json::Value =
+        serde_json::from_str(&text).expect("submit response should be JSON");
+    let job_id = body["job_id"].as_str().expect("job_id should be a string");
+
+    // Cancel immediately while still queued.
+    let cancel = client
+        .delete(format!("http://127.0.0.1:{port}/v1/jobs/{job_id}"))
+        .send()
+        .await
+        .expect("DELETE /v1/jobs/{id} failed");
+    assert_eq!(cancel.status(), 204);
+
+    // Synchronous transcription should succeed without waiting for the cancelled job.
+    let sync = tokio::time::timeout(Duration::from_secs(30), async {
+        client
+            .post(format!("http://127.0.0.1:{port}/v1/transcribe"))
+            .body(common::generate_wav(1, 16000))
+            .send()
+            .await
+            .expect("POST /v1/transcribe failed")
+    })
+    .await
+    .expect("POST /v1/transcribe timed out");
+
+    assert_eq!(sync.status(), 200);
+
+    let _ = shutdown.send(());
+}
+
+/// SSE event stream emits progress and a terminal done event.
+#[ignore = "requires model"]
+#[tokio::test]
+async fn test_job_sse_events() {
+    let (port, shutdown) = common::start_server_with_jobs(&common::model_dir(), 1).await;
+    let client = reqwest::Client::new();
+
+    let submit = client
+        .post(format!("http://127.0.0.1:{port}/v1/jobs"))
+        .body(common::generate_wav(10, 16000))
+        .send()
+        .await
+        .expect("POST /v1/jobs failed");
+    assert_eq!(submit.status(), 202);
+    let text = submit
+        .text()
+        .await
+        .expect("submit response should have text");
+    let body: serde_json::Value =
+        serde_json::from_str(&text).expect("submit response should be JSON");
+    let job_id = body["job_id"].as_str().expect("job_id should be a string");
+
+    // Connect to the SSE stream before the job finishes.
+    let resp = client
+        .get(format!("http://127.0.0.1:{port}/v1/jobs/{job_id}/events"))
+        .send()
+        .await
+        .expect("GET /v1/jobs/{id}/events failed");
+    assert_eq!(resp.status(), 200);
+
+    let mut stream = resp.bytes_stream();
+    let mut saw_progress = false;
+    let mut saw_done = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_secs(1), stream.next()).await {
+            Ok(Some(Ok(chunk))) => {
+                let text = String::from_utf8_lossy(&chunk);
+                for line in text.lines() {
+                    let line = line.trim();
+                    if let Some(data) = line.strip_prefix("data:") {
+                        let data = data.trim();
+                        if data.is_empty() {
+                            continue;
+                        }
+                        let event: serde_json::Value =
+                            serde_json::from_str(data).expect("SSE data should be JSON");
+                        if event["type"] == "progress" {
+                            saw_progress = true;
+                        } else if event["type"] == "done" {
+                            saw_done = true;
+                        }
+                    }
+                }
+            }
+            Ok(Some(Err(e))) => panic!("SSE stream error: {e}"),
+            Ok(None) => break,
+            Err(_) => {}
+        }
+        if saw_done {
+            break;
+        }
+    }
+
+    assert!(saw_progress, "should receive at least one progress event");
+    assert!(saw_done, "should receive a terminal done event");
+
+    let _ = shutdown.send(());
+}

--- a/crates/gigastt/tests/e2e_jobs.rs
+++ b/crates/gigastt/tests/e2e_jobs.rs
@@ -224,3 +224,51 @@ async fn test_job_sse_events() {
 
     let _ = shutdown.send(());
 }
+
+/// A job with invalid audio eventually fails with a sanitized, client-safe error.
+#[ignore = "requires model"]
+#[tokio::test]
+async fn test_job_invalid_audio_fails_with_sanitized_error() {
+    let (port, shutdown) = common::start_server_with_jobs(&common::model_dir(), 1).await;
+    let client = reqwest::Client::new();
+
+    let submit = client
+        .post(format!("http://127.0.0.1:{port}/v1/jobs"))
+        .body(b"not-a-wav-file".to_vec())
+        .send()
+        .await
+        .expect("POST /v1/jobs failed");
+    assert_eq!(submit.status(), 202);
+    let text = submit
+        .text()
+        .await
+        .expect("submit response should have text");
+    let body: serde_json::Value =
+        serde_json::from_str(&text).expect("submit response should be JSON");
+    let job_id = body["job_id"].as_str().expect("job_id should be a string");
+
+    let mut final_status = serde_json::Value::Null;
+    for _ in 0..60 {
+        let resp = client
+            .get(format!("http://127.0.0.1:{port}/v1/jobs/{job_id}"))
+            .send()
+            .await
+            .expect("GET /v1/jobs/{id} failed");
+        assert_eq!(resp.status(), 200);
+        let text = resp.text().await.expect("status response should have text");
+        let status: serde_json::Value = serde_json::from_str(&text).expect("status should be JSON");
+        if status["status"] == "failed" {
+            final_status = status;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    assert_eq!(final_status["status"], "failed");
+    assert!(
+        final_status["error"].as_str().unwrap().contains("decode"),
+        "error should be sanitized for clients: {final_status:?}"
+    );
+
+    let _ = shutdown.send(());
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,11 @@ are additive only.
 | `/v1/models` | GET | Model info (encoder type, pool size, capabilities) |
 | `/v1/transcribe` | POST | File transcription, full JSON response or export format |
 | `/v1/transcribe/stream` | POST | File transcription with SSE streaming |
+| `/v1/jobs` | POST | Submit an asynchronous transcription job (requires `--enable-jobs`) |
+| `/v1/jobs/{id}` | GET | Poll job status and progress |
+| `/v1/jobs/{id}` | DELETE | Cancel a queued or processing job |
+| `/v1/jobs/{id}/result` | GET | Fetch the finished transcription |
+| `/v1/jobs/{id}/events` | GET | SSE stream of progress / done / failed / cancelled |
 | `/v1/ws` | GET | WebSocket upgrade for real-time streaming |
 | `/metrics` | GET | Prometheus metrics (enabled with `--metrics`). Served on the separate `--metrics-listen` port (default `127.0.0.1:9090`), not the main API port. |
 
@@ -47,6 +52,65 @@ curl -X POST http://127.0.0.1:9876/v1/transcribe/stream \
 # data: {"type":"partial","text":"привет как"}
 # data: {"type":"final","text":"Привет, как дела?"}
 ```
+
+## Asynchronous jobs
+
+For long files or batch ingestion, `POST /v1/jobs` enqueues a transcription job
+and returns immediately with a `job_id`:
+
+```sh
+curl -X POST http://127.0.0.1:9876/v1/jobs \
+  -H "Content-Type: application/octet-stream" --data-binary @recording.wav
+# {"job_id":"...","status":"queued","created_at":1712700000.5}
+```
+
+The endpoint is disabled by default. Enable it with `--enable-jobs` or
+`GIGASTT_ENABLE_JOBS=1`. When disabled, all `/v1/jobs` paths return `404`.
+
+Poll for status:
+
+```sh
+curl http://127.0.0.1:9876/v1/jobs/{job_id}
+# {"job_id":"...","status":"processing","processed_seconds":12.5,"percent":42}
+```
+
+Fetch the result once `status` is `done`:
+
+```sh
+curl http://127.0.0.1:9876/v1/jobs/{job_id}/result
+# {"text":"Привет, как дела?", ...}
+```
+
+Cancel a queued or processing job:
+
+```sh
+curl -X DELETE http://127.0.0.1:9876/v1/jobs/{job_id}
+```
+
+Subscribe to SSE events:
+
+```sh
+curl http://127.0.0.1:9876/v1/jobs/{job_id}/events
+# data: {"type":"progress","percent":42,"processed_seconds":12.5}
+# data: {"type":"done"}
+```
+
+Job submission accepts the same query parameters as `POST /v1/transcribe`
+(`format`, `word_timestamps`, `segments`, `channels`, `diarization`,
+`punctuation`, `itn`, `vad`). The result is rendered in the requested format
+when `/v1/jobs/{id}/result` is called.
+
+Queue behavior is controlled by:
+
+- `--batch-pool-size` (default 0, clamped to at least 1 when jobs are enabled) —
+  triplet slots reserved for batch/job work so long files do not starve
+  real-time WebSocket or synchronous REST sessions.
+- `--jobs-ttl-secs` (default 3600) — how long finished/failed/cancelled jobs are
+  kept before eviction.
+- `--jobs-max` (default 100) — maximum number of jobs kept in memory; when full,
+  `POST /v1/jobs` returns `429 queue_full` with `Retry-After`.
+- `--jobs-retry` (default 3) — maximum retry attempts for jobs that hit an
+  inference timeout or worker panic.
 
 The default `rnnt` head emits bare lowercase; punctuation, casing, and Russian ITN are
 applied per server configuration (`--punctuation` / `--itn`). The `e2e_rnnt` head bakes
@@ -183,9 +247,14 @@ it backs off on `503` pool saturation instead of failing mid-job.
 | 400 | `empty_body` | Request body is empty |
 | 400 | `invalid_format` | Unsupported `format` query value |
 | 400 | `conflicting_modes` | Both `channels=split` and `diarization=true` were requested |
+| 404 | `jobs_disabled` | `POST /v1/jobs` called without `--enable-jobs` |
+| 404 | `job_not_found` | Unknown or expired job id |
+| 409 | `job_not_finished` | `GET /v1/jobs/{id}/result` called before the job is done |
+| 409 | `job_not_cancellable` | `DELETE /v1/jobs/{id}` called on a terminal job |
 | 413 | `payload_too_large` | Body exceeds `--body-limit-bytes` (default 50 MiB) |
 | 422 | `invalid_audio` | Audio could not be decoded (unsupported/corrupt format) |
 | 422 | `transcription_error` | Audio decoded but inference failed |
+| 429 | `queue_full` | In-memory job store is full; `Retry-After` header included |
 | 429 | `rate_limited` | Per-IP token bucket exhausted; `Retry-After` header included |
 | 503 | `timeout` | All inference sessions busy; `Retry-After` + `retry_after_ms` |
 | 503 | `pool_closed` | Server is shutting down, pool closed to new checkouts |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -457,7 +457,248 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
+  /v1/jobs:
+    post:
+      summary: Submit an asynchronous transcription job
+      description: |
+        Enqueue a long audio file for asynchronous transcription. The endpoint
+        accepts the same body and query parameters as `POST /v1/transcribe`.
+        When the job API is disabled (`--enable-jobs` not set), this path returns
+        `404`.
+      operationId: submitJob
+      parameters:
+        - $ref: "#/components/parameters/Format"
+        - $ref: "#/components/parameters/WordTimestamps"
+        - $ref: "#/components/parameters/Segments"
+        - $ref: "#/components/parameters/Channels"
+        - $ref: "#/components/parameters/Diarization"
+        - $ref: "#/components/parameters/Punctuation"
+        - $ref: "#/components/parameters/Itn"
+        - $ref: "#/components/parameters/Vad"
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "202":
+          description: Job accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JobSubmitResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
+        "429":
+          description: Job queue is full
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds to wait before retry
+              example: 30
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Job queue is full"
+                code: queue_full
+                retry_after_ms: 30000
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /v1/jobs/{id}:
+    get:
+      summary: Poll job status and progress
+      description: |
+        Returns the current status of an asynchronous transcription job. When the
+        job API is disabled, this path returns `404`.
+      operationId: getJob
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Job status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JobStatusResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+    delete:
+      summary: Cancel a queued or processing job
+      description: |
+        Cancels a job that is still `queued` or `processing`. Cancelling a queued
+        job immediately frees its slot; cancelling a processing job stops result
+        propagation but the in-flight triplet is released only when the worker
+        finishes. When the job API is disabled, this path returns `404`.
+      operationId: cancelJob
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Job cancelled
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Job cannot be cancelled
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Job cannot be cancelled"
+                code: job_not_cancellable
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /v1/jobs/{id}/result:
+    get:
+      summary: Fetch the finished transcription
+      description: |
+        Returns the transcription result in the format requested at submission
+        time. If the job has not finished, returns `409 job_not_finished`.
+      operationId: getJobResult
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Transcription result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TranscribeResponse"
+            text/plain:
+              schema:
+                type: string
+            application/x-subrip:
+              schema:
+                type: string
+            text/vtt:
+              schema:
+                type: string
+            text/markdown:
+              schema:
+                type: string
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Job is not finished
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Job is not finished"
+                code: job_not_finished
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /v1/jobs/{id}/events:
+    get:
+      summary: SSE stream of job events
+      description: |
+        Server-Sent Events stream emitting `progress`, `done`, `failed`, and
+        `cancelled` events. The stream closes automatically after a terminal
+        event. When the job API is disabled, this path returns `404`.
+      operationId: getJobEvents
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: SSE event stream
+          content:
+            text/event-stream:
+              schema:
+                type: string
+              example: |
+                data: {"type":"progress","percent":25,"processed_seconds":5.0}
+
+                data: {"type":"done"}
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
 components:
+  parameters:
+    Format:
+      name: format
+      in: query
+      schema:
+        type: string
+        enum: [json, txt, srt, vtt, md]
+      description: Export format for the finished result
+    WordTimestamps:
+      name: word_timestamps
+      in: query
+      schema:
+        type: boolean
+      description: Include per-word timestamps
+    Segments:
+      name: segments
+      in: query
+      schema:
+        type: boolean
+      description: Group words into natural-boundary segments
+    Channels:
+      name: channels
+      in: query
+      schema:
+        type: string
+        enum: [split]
+      description: Transcribe left/right channels as separate speakers
+    Diarization:
+      name: diarization
+      in: query
+      schema:
+        type: boolean
+      description: Request speaker diarization
+    Punctuation:
+      name: punctuation
+      in: query
+      schema:
+        type: string
+        enum: [on, off, auto]
+      description: Override punctuation policy
+    Itn:
+      name: itn
+      in: query
+      schema:
+        type: string
+        enum: [on, off, auto]
+      description: Override inverse text normalization policy
+    Vad:
+      name: vad
+      in: query
+      schema:
+        type: string
+        enum: [on, off, auto]
+      description: Override voice activity detection policy
+
   schemas:
     HealthResponse:
       type: object
@@ -697,6 +938,124 @@ components:
           type: integer
           description: Zero-based speaker index (only present when channel split or diarization produced speaker labels)
 
+    JobSubmitResponse:
+      type: object
+      required:
+        - job_id
+        - status
+        - created_at
+      properties:
+        job_id:
+          type: string
+          example: 018f...-
+          description: Unique job identifier
+        status:
+          type: string
+          enum: [queued]
+          example: queued
+        created_at:
+          type: number
+          example: 1712700000.5
+          description: Unix timestamp (seconds with fractional part)
+
+    JobStatusResponse:
+      type: object
+      required:
+        - job_id
+        - status
+        - processed_seconds
+        - percent
+      properties:
+        job_id:
+          type: string
+        status:
+          type: string
+          enum: [queued, processing, done, failed, cancelled]
+        processed_seconds:
+          type: number
+          example: 12.5
+          description: Seconds of audio considered processed so far
+        percent:
+          type: integer
+          example: 42
+          description: Approximate completion percentage (0-100)
+        error:
+          type: string
+          example: "Transcription failed."
+          description: Sanitized error message for failed jobs
+
+    JobEvent:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [progress, done, failed, cancelled]
+      discriminator:
+        propertyName: type
+        mapping:
+          progress: "#/components/schemas/JobProgressEvent"
+          done: "#/components/schemas/JobDoneEvent"
+          failed: "#/components/schemas/JobFailedEvent"
+          cancelled: "#/components/schemas/JobCancelledEvent"
+
+    JobProgressEvent:
+      allOf:
+        - $ref: "#/components/schemas/JobEvent"
+      type: object
+      required:
+        - type
+        - percent
+        - processed_seconds
+      properties:
+        type:
+          type: string
+          enum: [progress]
+        percent:
+          type: integer
+          example: 42
+        processed_seconds:
+          type: number
+          example: 12.5
+
+    JobDoneEvent:
+      allOf:
+        - $ref: "#/components/schemas/JobEvent"
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [done]
+
+    JobFailedEvent:
+      allOf:
+        - $ref: "#/components/schemas/JobEvent"
+      type: object
+      required:
+        - type
+        - error
+      properties:
+        type:
+          type: string
+          enum: [failed]
+        error:
+          type: string
+          example: "Transcription failed."
+
+    JobCancelledEvent:
+      allOf:
+        - $ref: "#/components/schemas/JobEvent"
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [cancelled]
+
     ErrorResponse:
       type: object
       required:
@@ -826,3 +1185,21 @@ components:
           example:
             error: "Inference timed out."
             code: inference_timeout
+
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          examples:
+            job_not_found:
+              summary: Unknown job id
+              value:
+                error: "Job not found"
+                code: job_not_found
+            jobs_disabled:
+              summary: Job API is disabled
+              value:
+                error: "Job API is not enabled"
+                code: jobs_disabled


### PR DESCRIPTION
## Summary
Adds an asynchronous Job API for long-file and batch transcription behind `--enable-jobs` / `GIGASTT_ENABLE_JOBS=1`.

New endpoints:
- `POST /v1/jobs` — submit a transcription job with the same body/options as `/v1/transcribe`; returns 202 with `job_id`.
- `GET /v1/jobs/{id}` — poll status, progress percent, and sanitized error.
- `GET /v1/jobs/{id}/result` — fetch the final transcript in the requested format; 409 while running.
- `DELETE /v1/jobs/{id}` — cancel a queued or running job and return its triplet to the pool.
- `GET /v1/jobs/{id}/events` — SSE stream of progress/done/failed/cancelled events.

Implementation highlights:
- Feature-gated via `JobConfig::enabled`; when disabled all `/v1/jobs/*` routes are absent and return 404.
- In-memory FIFO `JobQueue` with `JobStore` trait boundary for future persistence.
- Concurrent batch jobs capped by `--batch-pool-size` (default 1); batch workers never starve realtime because they use a separate, lower pool ceiling.
- Retry on inference timeout or panic up to `--jobs-retry` (default 3).
- Finished/failed job TTL `--jobs-ttl-secs` (default 3600) and store size cap `--jobs-max` (default 100) with 429 + Retry-After on overflow.
- Integrated with the existing `CancellationToken`/`TaskTracker` shutdown path: running jobs finish within drain, queued jobs are cancelled.

Files:
- `crates/gigastt/src/server/jobs.rs` — queue, store, worker loop, progress tracking.
- `crates/gigastt/src/server/http.rs` — handlers and validation.
- `crates/gigastt/src/server/mod.rs` — conditional route registration and graceful shutdown wiring.
- `crates/gigastt/src/server/config.rs` — `JobConfig` and CLI flags.
- `crates/gigastt/src/main.rs` — CLI flag plumbing.
- `crates/gigastt/tests/e2e_jobs.rs` — end-to-end coverage.
- `docs/api.md`, `docs/openapi.yaml` — documentation.

Version bumped to 2.10.0 and CHANGELOG updated.

## Test Verification
- `cargo test --lib --bins -p gigastt` — passed (lib + bin tests).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p gigastt --test e2e_jobs -- --ignored --test-threads=1` — 5 passed.

## Notes
- The `segments=true` natural-boundary transcript behavior is a pre-existing change already released in 2.9.0 and unrelated to this Job API.