### PR TITLE
fix(server): reserve pool slot before decoding in SSE /v1/transcribe/stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     from the encoder present on disk. REST `/v1/models` reports them as
     `gigaam-multilingual-ctc` / `gigaam-multilingual-large-ctc`.
 
+### Fixed
+
+- **The SSE streaming endpoint (`POST /v1/transcribe/stream`) now reserves a batch-pool
+  slot before decoding the upload**, capping the number of concurrent audio decodes at the
+  pool size. Previously the handler expanded each compressed upload to f32 PCM before
+  checking out a pool slot, so a burst of large uploads (up to the body-size limit) could
+  each inflate into a multi-hundred-megabyte buffer simultaneously and exhaust memory. The
+  endpoint now returns `503` + `Retry-After` under pool saturation, matching the synchronous
+  `/v1/transcribe` handler.
+
 ## [2.10.0] - 2026-07-15
 
 ### Added

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -806,50 +806,17 @@ pub async fn transcribe_stream(
         ));
     }
 
-    // Decode audio first (in spawn_blocking since symphonia is blocking).
-    // `body` is `axum::body::Bytes`, so the move into the blocking closure is
-    // a refcount bump and `decode_audio_bytes_shared` reads the upload
-    // buffer in place.
-    let samples = tokio::task::spawn_blocking(move || {
-        // catch_unwind mirrors the REST handler: a panic inside the blocking
-        // decode (e.g. a crafted container that trips an upstream arithmetic
-        // panic) is absorbed and surfaced as a normal decode error instead of a
-        // `JoinError`, so the SSE path returns a clean 422 rather than a 500.
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            gigastt_core::inference::audio::decode_audio_bytes_shared(body)
-        })) {
-            Ok(inner) => inner,
-            Err(_) => {
-                tracing::error!("Panic in SSE audio decode — treated as decode error");
-                Err(anyhow::anyhow!("Audio decode thread panicked"))
-            }
-        }
-    })
-    .await
-    .map_err(|e| {
-        tracing::error!("spawn_blocking join error: {e}");
-        api_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Internal server error",
-            "internal",
-        )
-    })?
-    .map_err(|e| {
-        tracing::error!("Audio decode error: {e:#}");
-        api_error(
-            StatusCode::UNPROCESSABLE_ENTITY,
-            "Failed to decode audio file. Check format (WAV, MP3, M4A, OGG, FLAC supported).",
-            "invalid_audio",
-        )
-    })?;
-
-    // Checkout a session triplet from the batch pool — SSE file transcription
-    // decodes and transcribes the *entire* upload (holding the triplet for the
-    // whole file), so it is a batch workload, not interactive streaming. Draw
-    // from the dedicated batch pool when one exists (falling back to the
-    // interactive pool otherwise) so it can't starve real-time WebSocket
-    // streaming, matching `/v1/transcribe`. Strip the lifetime via `into_owned`
-    // so the triplet can travel through `spawn_blocking`.
+    // Checkout a session triplet from the batch pool BEFORE decoding. SSE file
+    // transcription decodes and transcribes the *entire* upload (holding the
+    // triplet for the whole file), so it is a batch workload, not interactive
+    // streaming. Reserving first — like `/v1/transcribe` — is load-bearing: it
+    // caps the number of *concurrent decodes* at the pool size, so a burst of
+    // large (compressed) uploads can't each expand into a full f32 PCM buffer at
+    // once and exhaust memory. A saturated pool yields 503 / `Retry-After` here,
+    // before any decode. Draw from the dedicated batch pool when one exists
+    // (falling back to the interactive pool otherwise) so it can't starve
+    // real-time WebSocket streaming. Strip the lifetime via `into_owned` so the
+    // triplet can travel through `spawn_blocking`.
     // Snapshot the current engine once; a concurrent hot-reload swap only
     // affects later requests, so this stream rides the pool it started on.
     let engine = state.engine.load_full();
@@ -882,6 +849,46 @@ pub async fn transcribe_stream(
         );
     }
     let mut reservation = guard.into_owned();
+
+    // Decode audio now that a slot is reserved (in spawn_blocking since symphonia
+    // is blocking). Holding the reservation across the decode is what bounds the
+    // number of concurrent PCM expansions to the pool size. `body` is
+    // `axum::body::Bytes`, so the move into the blocking closure is a refcount
+    // bump and `decode_audio_bytes_shared` reads the upload buffer in place. On a
+    // decode error the early `?` return drops `reservation`, returning the
+    // triplet to the pool.
+    let samples = tokio::task::spawn_blocking(move || {
+        // catch_unwind mirrors the REST handler: a panic inside the blocking
+        // decode (e.g. a crafted container that trips an upstream arithmetic
+        // panic) is absorbed and surfaced as a normal decode error instead of a
+        // `JoinError`, so the SSE path returns a clean 422 rather than a 500.
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            gigastt_core::inference::audio::decode_audio_bytes_shared(body)
+        })) {
+            Ok(inner) => inner,
+            Err(_) => {
+                tracing::error!("Panic in SSE audio decode — treated as decode error");
+                Err(anyhow::anyhow!("Audio decode thread panicked"))
+            }
+        }
+    })
+    .await
+    .map_err(|e| {
+        tracing::error!("spawn_blocking join error: {e}");
+        api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Internal server error",
+            "internal",
+        )
+    })?
+    .map_err(|e| {
+        tracing::error!("Audio decode error: {e:#}");
+        api_error(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Failed to decode audio file. Check format (WAV, MP3, M4A, OGG, FLAC supported).",
+            "invalid_audio",
+        )
+    })?;
 
     // Create mpsc channel for streaming segments from the inference task to SSE.
     let (tx, rx) = tokio::sync::mpsc::channel::<

--- a/crates/gigastt/tests/e2e_errors.rs
+++ b/crates/gigastt/tests/e2e_errors.rs
@@ -248,6 +248,82 @@ async fn test_rest_saturated_pool_returns_503() {
     let _ = shutdown.send(());
 }
 
+// ─── 4b. SSE /v1/transcribe/stream reserves a pool slot BEFORE decoding ──────
+
+/// Regression for the SSE memory-exhaustion ordering bug: `/v1/transcribe/stream`
+/// must check out a pool slot *before* decoding the upload, exactly like the
+/// synchronous `/v1/transcribe`. We prove the ordering behaviourally: with the
+/// pool saturated, a stream request carrying *invalid* audio must block on the
+/// pool checkout and time out with 503 `timeout` — NOT decode first and fail
+/// fast with 422 `invalid_audio`. If decode ran before checkout (the old bug),
+/// an unbounded number of concurrent decodes could each expand a compressed
+/// upload into a full f32 PCM buffer and exhaust memory.
+///
+/// Takes ~30 s (the pool checkout timeout), like `test_rest_saturated_pool_returns_503`.
+#[ignore]
+#[tokio::test]
+async fn test_sse_stream_reserves_pool_before_decode() {
+    const POOL: usize = 2;
+    let model_dir = common::model_dir();
+    let (port, shutdown) = common::start_server_with_pool(&model_dir, POOL).await;
+
+    // Saturate the pool with WebSocket sessions (the SSE handler draws from the
+    // same batch pool, falling back to the interactive pool).
+    let mut clients = Vec::new();
+    for _ in 0..POOL {
+        let (sink, stream, _ready) = common::ws_connect(port).await;
+        clients.push((sink, stream));
+    }
+
+    // Deliberately invalid audio: if the handler decoded before reserving, this
+    // would 422 immediately; reserving first makes it wait on the saturated pool.
+    let not_audio = b"this is definitely not a valid audio container".to_vec();
+    let client = reqwest::Client::new();
+
+    // Allow 35 seconds so the 30-second server checkout timeout has room to expire.
+    let response = tokio::time::timeout(
+        Duration::from_secs(35),
+        client
+            .post(format!("http://127.0.0.1:{port}/v1/transcribe/stream"))
+            .body(not_audio)
+            .send(),
+    )
+    .await
+    .expect(
+        "Test timed out before server returned 503 — check checkout ordering in transcribe_stream",
+    )
+    .expect("HTTP request failed");
+
+    assert_eq!(
+        response.status().as_u16(),
+        503,
+        "SSE stream must reserve the pool before decoding: a saturated pool must \
+         yield 503, not decode the (invalid) upload first and return 422"
+    );
+
+    let body_text = response
+        .text()
+        .await
+        .expect("Response body should be readable");
+    let body: serde_json::Value =
+        serde_json::from_str(&body_text).expect("Response body should be JSON");
+    assert_eq!(
+        body["code"], "timeout",
+        "Expected code='timeout' (blocked on pool checkout, upload never decoded), got: {body}"
+    );
+
+    // Release pool slots.
+    let stop_json = serde_json::to_string(&serde_json::json!({"type": "stop"})).unwrap();
+    for (mut sink, mut stream) in clients {
+        sink.send(Message::Text(stop_json.clone().into()))
+            .await
+            .unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), stream.next()).await;
+    }
+
+    let _ = shutdown.send(());
+}
+
 // ─── 5. WebSocket idle timeout ──────────────────────────────────────────────
 
 /// Connect a WebSocket client, receive Ready, then send nothing.


### PR DESCRIPTION
## Problem
`POST /v1/transcribe/stream` (SSE) decoded the entire upload to f32 PCM (inside `spawn_blocking`) **before** checking out a batch-pool slot, so the number of concurrent decodes was unbounded. Under `--bind-all` with the default (disabled) rate limiter, a burst of large compressed uploads (Opus/FLAC/MP3, up to the 50 MiB body limit) could each expand into a multi-hundred-MB–GB PCM buffer simultaneously and exhaust memory — a remote-reachable DoS. The synchronous `/v1/transcribe` already reserves the pool slot first and decodes inside the reservation; the streaming path had diverged.

## Fix
Reorder `transcribe_stream` to match the synchronous handler: load the engine and check out the batch-pool slot first, then decode while holding the reservation. Concurrent decodes are now capped at the pool size; a saturated pool returns `503 + Retry-After` before any decode. On a decode error the early return drops the reservation, returning the triplet to the pool. No behavioural change on the happy path.

## Test
Adds `test_sse_stream_reserves_pool_before_decode` (`e2e_errors`, model-gated): with the pool saturated, an invalid-audio stream request now returns `503 timeout` (blocked on checkout, upload never decoded) instead of `422 invalid_audio` (decoded first) — the pre-fix behaviour — so the test fails if the ordering regresses.

Found in a local repository audit (2026-07-16); this is the one HIGH-severity, network-reachable finding.
