### PR TITLE
feat(core): add GigaAM Multilingual CTC recognition head (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.0] - 2026-07-17
+
+### Added
+
+- **GigaAM Multilingual charwise-CTC recognition heads (`--model-variant ml_ctc` /
+  `ml_ctc_large`).** Two opt-in heads alongside `rnnt` and `e2e_rnnt`, built on Salute's
+  GigaAM Multilingual encoders (220M and 600M, released June 2026; MIT). Trained across 70+
+  languages with best-in-class WER on Russian, Kazakh, Kyrgyz, and Uzbek (moderate on
+  English); the recognition vocabulary is a 71-class multilingual character set (Latin +
+  Cyrillic + Kazakh/Turkic letters). Output is bare lowercase (no punctuation / casing /
+  ITN), so pair it with `--punctuation` / `--itn` for readable Russian text, the same as the
+  `rnnt` head.
+  - `gigastt download --model-variant ml_ctc` (220M, ~225 MB) or `ml_ctc_large` (600M,
+    ~592 MB) fetches the pre-quantized INT8 encoder and vocabulary directly from
+    `istupakov/gigaam-multilingual-ctc-onnx` / `-large-ctc-onnx` on HuggingFace — no FP32
+    download and no on-device quantization (the upstream INT8 encoder is used as-is). Both
+    files are SHA-256-verified. The two heads share a byte-identical vocabulary.
+  - The heads share the existing 64-mel / FFT 320 / hop 160 frontend, so no audio-pipeline
+    changes are needed; they are encoder-only (a single ONNX with a CTC projection, greedy
+    CTC decoding — no prediction network / joiner).
+  - `serve`, `download`, and `transcribe` accept `ml_ctc` / `ml_ctc_large` (with `-` aliases)
+    via `--model-variant` (or `GIGASTT_MODEL_VARIANT`); the engine also auto-detects the head
+    from the encoder present on disk. REST `/v1/models` reports them as
+    `gigaam-multilingual-ctc` / `gigaam-multilingual-large-ctc`.
+
 ## [2.10.0] - 2026-07-15
 
 ### Added
@@ -1516,7 +1541,8 @@ _Release candidate for v0.9.0 — bundles five P0 fixes plus two supporting item
 - Multi-format audio support: WAV, MP3, M4A/AAC, OGG/Vorbis, FLAC (via symphonia).
 - 39 unit tests (tokenizer, features, decode, inference, protocol).
 
-[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.10.0...HEAD
+[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.0...HEAD
+[2.11.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.10.0...v2.11.0
 [2.10.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.8.0...v2.9.0
 [2.8.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.7.0...v2.8.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-**gigastt** — local speech-to-text server powered by GigaAM v3 (default `rnnt` head, optional `e2e_rnnt`). On-device Russian speech recognition via ONNX Runtime. No cloud APIs, no API keys, full privacy.
+**gigastt** — local speech-to-text server powered by GigaAM v3 (default `rnnt` head, optional `e2e_rnnt`), with an optional GigaAM Multilingual `ml_ctc` head (ru/en/kk/ky/uz). On-device speech recognition via ONNX Runtime. No cloud APIs, no API keys, full privacy.
 
 - **Repository**: https://github.com/ekhodzitsky/gigastt
 - **crates.io**: https://crates.io/crates/gigastt
@@ -103,7 +103,7 @@ crates/
 
 ### Key constants (defined in `crates/gigastt-core/src/inference/mod.rs`)
 - `N_MELS = 64`, `N_FFT = 320`, `HOP_LENGTH = 160`, `PRED_HIDDEN = 320`
-- Encoder dim: 768 (shared across heads). Vocab depends on the head: `rnnt` 34 tokens (char, default) / `e2e_rnnt` 1025 tokens (BPE)
+- Encoder dim: 768 (shared across heads). Vocab depends on the head: `rnnt` 34 tokens (char, default) / `e2e_rnnt` 1025 tokens (BPE) / `ml_ctc` 71 tokens (multilingual char, blank id 70)
 
 ### Data flow
 ```
@@ -201,9 +201,10 @@ Three-tier test architecture:
 
 ## Model
 
-GigaAM v3 from `istupakov/gigaam-v3-onnx` on HuggingFace. Two selectable heads (`--model-variant`, auto-detected from the files on disk):
+GigaAM v3 from `istupakov/gigaam-v3-onnx` on HuggingFace. Three selectable heads (`--model-variant`, auto-detected from the files on disk):
 - **`rnnt`** (default since v2.3): `v3_rnnt_{encoder,decoder,joint}.onnx` + `v3_vocab.txt` (34-token char vocab). Much lower WER than e2e (clean read 3.55% on `golos_crowd_1k` via the cross-engine harness vs e2e 8.60%; leads far-field/phone/YouTube — see `docs/benchmarks.md`); bare lowercase output, so pair with `--punctuation` / `--itn` for readable text.
 - **`e2e_rnnt`**: `v3_e2e_rnnt_{encoder,decoder,joint}.onnx` + `v3_e2e_rnnt_vocab.txt` (1025-token BPE). Punctuation/casing/ITN baked in.
+- **`ml_ctc`**: GigaAM Multilingual charwise-CTC head (220M) from `istupakov/gigaam-multilingual-ctc-onnx`. Encoder-only: `multilingual_ctc.int8.onnx` + `multilingual_vocab.txt` (71-class multilingual char vocab; blank id 70). Downloads the upstream pre-quantized INT8 encoder directly (~225MB; no FP32 download, no on-device quantize). Best-in-class WER on ru/kk/ky/uz (moderate on en); bare lowercase output. Shares the 64-mel frontend; file transcription (greedy CTC decode, no prediction network / joiner).
 - Encoder (shared arch): 844MB (FP32) or 215MB (INT8 quantized, 3.9×); decoder/joiner a few MB each.
 - Sample rate: 16kHz, Features: 64 mel bins
 - ONNX tensors: encoder out `[1, 768, T]` (channels-first), decoder state `[1, 1, 320]`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.10.0"
+version = "2.11.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ gigastt serve
 
 | Capability | Support |
 |---|---|
-| Heads | `rnnt` (34-token char, default — lowest WER) · `e2e_rnnt` (1025-token BPE, punctuation / casing / ITN baked in) |
+| Heads | `rnnt` (34-token char, default — lowest WER) · `e2e_rnnt` (1025-token BPE, punctuation / casing / ITN baked in) · `ml_ctc` / `ml_ctc_large` (GigaAM Multilingual charwise CTC, 220M / 600M, 71-token multilingual char — ru/en/kk/ky/uz) |
 | Post-processing | optional punctuation, casing &amp; Russian ITN — native on `e2e_rnnt`, or a bundled RuPunct + ITN pass on `rnnt` (auto-downloaded; `--punctuation` / `--itn`), overridable per request (`?punctuation=` / `?itn=` / `?vad=`) |
 | Delivery | static binary · C-ABI FFI `cdylib` (Android / mobile) · `gigastt-core` crate (no server deps) |
 | Execution providers | CPU (any platform) · CoreML EP (macOS ARM64) · CUDA 12+ (Linux x86_64) · NNAPI (Android) |

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -10,6 +10,13 @@ description = "Core inference engine for gigastt — GigaAM v3 ONNX Runtime, mod
 keywords = ["stt", "speech-recognition", "gigaam", "onnx", "russian"]
 categories = ["multimedia::audio"]
 
+# Recognition heads are an additive, opt-in catalog, and `ModelVariant` is
+# `#[non_exhaustive]` so new heads ship as minor releases (downstream must use a
+# wildcard match arm). Allow the one-time `#[non_exhaustive]` marking, which
+# cargo-semver-checks otherwise flags as a major-only change.
+[package.metadata.cargo-semver-checks.lints]
+enum_marked_non_exhaustive = "allow"
+
 [lib]
 crate-type = ["rlib"]
 # The library's unit-test harness is not a benchmark; without this, plain

--- a/crates/gigastt-core/examples/quantize_file.rs
+++ b/crates/gigastt-core/examples/quantize_file.rs
@@ -1,0 +1,25 @@
+//! Dev helper: quantize an arbitrary ONNX to INT8 with gigastt's native quantizer
+//! (`quantize::quantize_model`) — used to INT8 the GigaAM-Multilingual CTC export
+//! for the WER fp32-vs-int8 comparison (roadmap 130/133). Not part of the shipped
+//! CLI; the `serve`/`download`/`quantize` subcommands wire the same function to the
+//! gigastt model filenames.
+//!
+//! Usage: cargo run -p gigastt-core --example quantize_file -- <input.onnx> <output.onnx>
+use std::path::Path;
+
+fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("usage: quantize_file <input.onnx> <output.onnx>");
+        std::process::exit(2);
+    }
+    let (input, output) = (Path::new(&args[1]), Path::new(&args[2]));
+    let t = std::time::Instant::now();
+    gigastt_core::quantize::quantize_model(input, output)?;
+    eprintln!(
+        "quantized in {:.1}s -> {}",
+        t.elapsed().as_secs_f64(),
+        output.display()
+    );
+    Ok(())
+}

--- a/crates/gigastt-core/src/inference/ctc.rs
+++ b/crates/gigastt-core/src/inference/ctc.rs
@@ -11,6 +11,8 @@
 //! `[1, D, T]` layout (see [`super::decode::extract_encoder_frame`]).
 
 use super::decode::{TokenInfo, argmax_with_confidence};
+use super::tokenizer::{Tokenizer, WORD_BOUNDARY};
+use super::{SECONDS_PER_FRAME, WordInfo};
 
 /// Greedy CTC decode over a flat `log_probs` buffer of shape `[t_total, vocab]`
 /// (row-major). Returns the collapsed, blank-stripped tokens with a per-token
@@ -54,6 +56,81 @@ pub(crate) fn ctc_greedy_decode(
         });
     }
     out
+}
+
+/// Group CTC-decoded tokens into words with timestamps and confidence.
+///
+/// istupakov's CTC vocab encodes the inter-word space as the `▁` word-boundary
+/// marker at `vocab[0]` (mirroring the RNN-T vocab), NOT a literal `' '`. Words
+/// split on that marker; every other token is a single character concatenated
+/// into the current word. The blank token never appears here (it is dropped in
+/// [`ctc_greedy_decode`]).
+pub(crate) fn ctc_tokens_to_words(
+    tokenizer: &Tokenizer,
+    tokens: &[TokenInfo],
+    frame_offset: usize,
+) -> Vec<WordInfo> {
+    let mut words = Vec::new();
+    let mut current_word = String::new();
+    let mut word_start_frame: Option<usize> = None;
+    let mut word_end_frame: usize = 0;
+    let mut word_confidences: Vec<f32> = Vec::new();
+
+    let flush = |word: &mut String,
+                 start: &mut Option<usize>,
+                 end: usize,
+                 confs: &mut Vec<f32>,
+                 out: &mut Vec<WordInfo>| {
+        if word.is_empty() {
+            return;
+        }
+        let avg_conf: f32 = if confs.is_empty() {
+            1.0
+        } else {
+            confs.iter().sum::<f32>() / confs.len() as f32
+        };
+        out.push(WordInfo {
+            word: std::mem::take(word),
+            start: (start.unwrap_or(0) + frame_offset) as f64 * SECONDS_PER_FRAME,
+            end: (end + frame_offset) as f64 * SECONDS_PER_FRAME,
+            confidence: avg_conf,
+            speaker: None,
+        });
+        *start = None;
+        confs.clear();
+    };
+
+    for token in tokens {
+        let ch = tokenizer.token_text(token.token_id);
+        if ch.starts_with(WORD_BOUNDARY) {
+            flush(
+                &mut current_word,
+                &mut word_start_frame,
+                word_end_frame,
+                &mut word_confidences,
+                &mut words,
+            );
+            continue;
+        }
+        if !ch.is_empty() {
+            current_word.push_str(ch);
+            if word_start_frame.is_none() {
+                word_start_frame = Some(token.frame_index);
+            }
+            word_end_frame = token.frame_index;
+            word_confidences.push(token.confidence);
+        }
+    }
+
+    flush(
+        &mut current_word,
+        &mut word_start_frame,
+        word_end_frame,
+        &mut word_confidences,
+        &mut words,
+    );
+
+    words
 }
 
 #[cfg(test)]
@@ -107,5 +184,62 @@ mod tests {
     fn all_blank_is_empty() {
         let lp = logits(&[2, 2, 2], 3);
         assert!(ctc_greedy_decode(&lp, 3, 3, 2).is_empty());
+    }
+
+    /// Build a CTC-style char tokenizer whose vocab[0] is the `▁` word-boundary
+    /// marker (matching istupakov's `multilingual_vocab.txt`), followed by the
+    /// letters used below and a trailing `<blk>`.
+    fn ctc_tokenizer(letters: &[&str]) -> Tokenizer {
+        let mut toks = vec!["\u{2581}".to_string()];
+        toks.extend(letters.iter().map(|s| s.to_string()));
+        toks.push("<blk>".to_string());
+        Tokenizer::from_tokens(toks)
+    }
+
+    fn tok(id: usize, frame: usize) -> TokenInfo {
+        TokenInfo {
+            token_id: id,
+            frame_index: frame,
+            confidence: 1.0,
+        }
+    }
+
+    #[test]
+    fn groups_words_on_boundary_marker() {
+        // vocab: 0=▁, 1..=6 = п р и в е т, 7..=9 = м и р, 10=<blk>
+        let t = ctc_tokenizer(&["п", "р", "и", "в", "е", "т", "м", "и", "р"]);
+        // "привет мир": п р и в е т ▁ м и р
+        let toks = [
+            tok(1, 0),
+            tok(2, 1),
+            tok(3, 2),
+            tok(4, 3),
+            tok(5, 4),
+            tok(6, 5),
+            tok(0, 6), // ▁ separator
+            tok(7, 7),
+            tok(8, 8),
+            tok(9, 9),
+        ];
+        let words = ctc_tokens_to_words(&t, &toks, 0);
+        assert_eq!(
+            words.iter().map(|w| w.word.as_str()).collect::<Vec<_>>(),
+            vec!["привет", "мир"]
+        );
+        // Timestamps come from the first/last frame of each word.
+        assert!((words[0].start - 0.0).abs() < 1e-9);
+        assert!(words[1].start > words[0].end);
+    }
+
+    #[test]
+    fn leading_and_trailing_boundaries_emit_no_empty_words() {
+        let t = ctc_tokenizer(&["а", "б"]);
+        // ▁ а б ▁  → one word "аб", no empty words from the edge separators.
+        let toks = [tok(0, 0), tok(1, 1), tok(2, 2), tok(0, 3)];
+        let words = ctc_tokens_to_words(&t, &toks, 0);
+        assert_eq!(
+            words.iter().map(|w| w.word.as_str()).collect::<Vec<_>>(),
+            vec!["аб"]
+        );
     }
 }

--- a/crates/gigastt-core/src/inference/ctc.rs
+++ b/crates/gigastt-core/src/inference/ctc.rs
@@ -1,0 +1,111 @@
+//! CTC greedy decoding for the GigaAM Multilingual CTC head.
+//!
+//! Unlike the RNN-T path (encoder + prediction network + joiner), the CTC head is
+//! a single encoder that emits per-frame class log-probabilities. Greedy CTC
+//! decode = per-frame argmax over the vocab, collapse consecutive repeats (a blank
+//! between two identical labels breaks the run and keeps both), then drop blanks.
+//!
+//! `log_probs` is the encoder output `[1, T', V]` read row-major, so frame `t`'s
+//! logits are `log_probs[t*V .. (t+1)*V]` — **frame-major**: `T'` is the outer
+//! axis, the vocab the inner. This differs from the RNN-T encoder's channels-first
+//! `[1, D, T]` layout (see [`super::decode::extract_encoder_frame`]).
+
+use super::decode::{TokenInfo, argmax_with_confidence};
+
+/// Greedy CTC decode over a flat `log_probs` buffer of shape `[t_total, vocab]`
+/// (row-major). Returns the collapsed, blank-stripped tokens with a per-token
+/// frame index (relative to this window) and softmax confidence — the same
+/// [`TokenInfo`] the RNN-T path emits, so downstream word formatting is shared.
+///
+/// - `t_len`: number of valid frames (from the encoder's `encoded_lengths[0]`);
+///   frames past it are right-padding and ignored, even if the tensor's outer dim
+///   is larger.
+/// - `vocab`: class count (71 for GigaAM Multilingual).
+/// - `blank_id`: CTC blank (70 = `vocab - 1`).
+pub(crate) fn ctc_greedy_decode(
+    log_probs: &[f32],
+    t_len: usize,
+    vocab: usize,
+    blank_id: usize,
+) -> Vec<TokenInfo> {
+    if vocab == 0 {
+        return Vec::new();
+    }
+    let usable = t_len.min(log_probs.len() / vocab);
+    let mut out = Vec::new();
+    let mut prev: Option<usize> = None;
+    for t in 0..usable {
+        let row = &log_probs[t * vocab..(t + 1) * vocab];
+        let (id, confidence) = argmax_with_confidence(row, blank_id);
+        // Collapse: skip a frame whose argmax equals the previous frame's argmax
+        // (blank or not). Tracking the raw argmax — not the last *emitted* token —
+        // is what makes a blank between two identical labels keep both.
+        if Some(id) == prev {
+            continue;
+        }
+        prev = Some(id);
+        if id == blank_id {
+            continue;
+        }
+        out.push(TokenInfo {
+            token_id: id,
+            frame_index: t,
+            confidence,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `[t, vocab]` row-major log-prob buffer where frame `t` argmaxes to
+    /// `ids[t]`.
+    fn logits(ids: &[usize], vocab: usize) -> Vec<f32> {
+        let mut lp = vec![-10.0f32; ids.len() * vocab];
+        for (t, &id) in ids.iter().enumerate() {
+            lp[t * vocab + id] = 5.0;
+        }
+        lp
+    }
+
+    #[test]
+    fn collapses_repeats_and_drops_blank() {
+        // vocab=3, blank=2. frames: a a <blk> b  ->  [a, b]
+        let lp = logits(&[0, 0, 2, 1], 3);
+        let toks = ctc_greedy_decode(&lp, 4, 3, 2);
+        assert_eq!(
+            toks.iter().map(|t| t.token_id).collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+        assert_eq!(toks[0].frame_index, 0);
+        assert_eq!(toks[1].frame_index, 3);
+    }
+
+    #[test]
+    fn blank_separates_identical_labels() {
+        // a a <blk> a  ->  [a, a]  (blank breaks the run of identical labels)
+        let lp = logits(&[0, 0, 2, 0], 3);
+        let toks = ctc_greedy_decode(&lp, 4, 3, 2);
+        assert_eq!(
+            toks.iter().map(|t| t.token_id).collect::<Vec<_>>(),
+            vec![0, 0]
+        );
+    }
+
+    #[test]
+    fn honours_t_len_truncation() {
+        // 3 frames in the buffer, but only the first 2 are valid.
+        let lp = logits(&[0, 1, 0], 3);
+        let toks = ctc_greedy_decode(&lp, 2, 3, 2);
+        assert_eq!(toks.len(), 2);
+        assert_eq!(toks[1].frame_index, 1);
+    }
+
+    #[test]
+    fn all_blank_is_empty() {
+        let lp = logits(&[2, 2, 2], 3);
+        assert!(ctc_greedy_decode(&lp, 3, 3, 2).is_empty());
+    }
+}

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -216,10 +216,15 @@ const POOL_RAM_FRACTION_DENOM: u64 = 2;
 ///
 /// Moved out of the pool on checkout and returned on checkin.
 /// Each triplet is independent and can run inference concurrently with others.
+///
+/// The RNN-T heads populate all three sessions. The encoder-only CTC heads leave
+/// `decoder` / `joiner` as `None` — the CTC branch in `run_inference` decodes
+/// straight from the encoder output and never touches them, so loading them would
+/// only waste encoder-sized RAM.
 pub struct SessionTriplet {
     pub(crate) encoder: Box<dyn RuntimeSession>,
-    pub(crate) decoder: Box<dyn RuntimeSession>,
-    pub(crate) joiner: Box<dyn RuntimeSession>,
+    pub(crate) decoder: Option<Box<dyn RuntimeSession>>,
+    pub(crate) joiner: Option<Box<dyn RuntimeSession>>,
     /// Reusable encoder input tensors: `[audio_signal [1, N_MELS, num_frames], length [1]]`.
     /// Resized and overwritten in `run_inference` to avoid per-call allocations.
     pub(crate) encoder_inputs: Vec<Tensor>,
@@ -1433,22 +1438,13 @@ impl Engine {
         min_size: usize,
     ) -> anyhow::Result<Vec<SessionTriplet>> {
         let encoder_path = Self::encoder_model_path(dir, variant);
-        // CTC is encoder-only: no decoder/joiner ONNX exists on disk. Keep the
-        // 3-session SessionTriplet shape but load the encoder into all three
-        // slots — for CTC they are never `.run()` (the CTC branch in
-        // `run_inference` returns right after the encoder run).
-        // TODO: make decoder/joiner Option to avoid 3x encoder RAM for CTC.
-        let is_ctc = variant == ModelVariant::MlCtc;
-        let decoder_path = if is_ctc {
-            encoder_path.clone()
-        } else {
-            dir.join(variant.decoder_file())
-        };
-        let joiner_path = if is_ctc {
-            encoder_path.clone()
-        } else {
-            dir.join(variant.joint_file())
-        };
+        // CTC is encoder-only: no decoder/joiner ONNX exists on disk, and the CTC
+        // branch in `run_inference` returns right after the encoder run without
+        // touching them. Load them only for the RNN-T heads (leaving `None` for
+        // CTC avoids holding an unused, never-run session per pool triplet).
+        let is_ctc = variant.is_ctc();
+        let decoder_path = dir.join(variant.decoder_file());
+        let joiner_path = dir.join(variant.joint_file());
 
         let results: Vec<anyhow::Result<SessionTriplet>> = std::thread::scope(|s| {
             let handles: Vec<_> = (0..pool_size)
@@ -1465,12 +1461,17 @@ impl Engine {
                             let encoder = runtime
                                 .load_session(encoder_path, true)
                                 .map_err(|e| anyhow::anyhow!(e))?;
-                            let decoder = runtime
-                                .load_session(decoder_path, false)
-                                .map_err(|e| anyhow::anyhow!(e))?;
-                            let joiner = runtime
-                                .load_session(joiner_path, false)
-                                .map_err(|e| anyhow::anyhow!(e))?;
+                            let (decoder, joiner) = if is_ctc {
+                                (None, None)
+                            } else {
+                                let decoder = runtime
+                                    .load_session(decoder_path, false)
+                                    .map_err(|e| anyhow::anyhow!(e))?;
+                                let joiner = runtime
+                                    .load_session(joiner_path, false)
+                                    .map_err(|e| anyhow::anyhow!(e))?;
+                                (Some(decoder), Some(joiner))
+                            };
                             Ok(SessionTriplet {
                                 encoder,
                                 decoder,
@@ -2258,7 +2259,7 @@ impl Engine {
         // (`[1, T', 71]`, row-major). Greedy-decode them directly — there is no
         // prediction network / joiner, so we return before the RNN-T block
         // borrows `encoder_outputs` for the decode loop.
-        if self.variant == ModelVariant::MlCtc {
+        if self.variant.is_ctc() {
             let log_probs = encoder_outputs[0]
                 .view()
                 .data()
@@ -2270,15 +2271,21 @@ impl Engine {
                 self.tokenizer.vocab_size(),
                 self.tokenizer.blank_id(),
             );
-            let words = self.ctc_tokens_to_words(&tokens, frame_offset);
+            let words = ctc::ctc_tokens_to_words(&self.tokenizer, &tokens, frame_offset);
             return Ok((words, false)); // CTC has no endpoint signal
         }
 
         // RNN-T greedy decode — the encoder output is borrowed for the decode loop.
         let dec_start = std::time::Instant::now();
         let result = decode::greedy_decode(
-            &*triplet.decoder,
-            &*triplet.joiner,
+            triplet
+                .decoder
+                .as_deref()
+                .expect("RNN-T decoder session must be loaded for a non-CTC head"),
+            triplet
+                .joiner
+                .as_deref()
+                .expect("RNN-T joiner session must be loaded for a non-CTC head"),
             &encoder_outputs[0].view(),
             enc_len,
             self.tokenizer.blank_id(),
@@ -2306,80 +2313,6 @@ impl Engine {
     /// Convert decoded tokens into words with timestamps and confidence.
     fn tokens_to_words(&self, tokens: &[decode::TokenInfo], frame_offset: usize) -> Vec<WordInfo> {
         TokenFormatter::tokens_to_words(&self.tokenizer, tokens, frame_offset)
-    }
-
-    /// Group CTC-decoded tokens into words with timestamps and confidence.
-    ///
-    /// Mirrors [`TokenFormatter::tokens_to_words`] but splits on the CTC vocab's
-    /// literal SPACE token (`" "`, `vocab[0]`) instead of the BPE `▁` boundary
-    /// marker — the CTC head emits one char per token with no per-word prefix.
-    /// The blank token never appears here (dropped in [`ctc::ctc_greedy_decode`]).
-    fn ctc_tokens_to_words(
-        &self,
-        tokens: &[decode::TokenInfo],
-        frame_offset: usize,
-    ) -> Vec<WordInfo> {
-        let mut words = Vec::new();
-        let mut current_word = String::new();
-        let mut word_start_frame: Option<usize> = None;
-        let mut word_end_frame: usize = 0;
-        let mut word_confidences: Vec<f32> = Vec::new();
-
-        let flush = |word: &mut String,
-                     start: &mut Option<usize>,
-                     end: usize,
-                     confs: &mut Vec<f32>,
-                     out: &mut Vec<WordInfo>| {
-            if word.is_empty() {
-                return;
-            }
-            let avg_conf: f32 = if confs.is_empty() {
-                1.0
-            } else {
-                confs.iter().sum::<f32>() / confs.len() as f32
-            };
-            out.push(WordInfo {
-                word: std::mem::take(word),
-                start: (start.unwrap_or(0) + frame_offset) as f64 * SECONDS_PER_FRAME,
-                end: (end + frame_offset) as f64 * SECONDS_PER_FRAME,
-                confidence: avg_conf,
-                speaker: None,
-            });
-            *start = None;
-            confs.clear();
-        };
-
-        for token in tokens {
-            let ch = self.tokenizer.token_text(token.token_id);
-            if ch == " " {
-                flush(
-                    &mut current_word,
-                    &mut word_start_frame,
-                    word_end_frame,
-                    &mut word_confidences,
-                    &mut words,
-                );
-                continue;
-            }
-            if !ch.is_empty() {
-                current_word.push_str(ch);
-                if word_start_frame.is_none() {
-                    word_start_frame = Some(token.frame_index);
-                }
-                word_end_frame = token.frame_index;
-                word_confidences.push(token.confidence);
-            }
-        }
-
-        flush(
-            &mut current_word,
-            &mut word_start_frame,
-            word_end_frame,
-            &mut word_confidences,
-            &mut words,
-        );
-
-        words
     }
 }
 

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod audio;
 mod bias;
+mod ctc;
 mod decode;
 mod features;
 #[cfg(not(feature = "__internals"))]
@@ -1432,8 +1433,22 @@ impl Engine {
         min_size: usize,
     ) -> anyhow::Result<Vec<SessionTriplet>> {
         let encoder_path = Self::encoder_model_path(dir, variant);
-        let decoder_path = dir.join(variant.decoder_file());
-        let joiner_path = dir.join(variant.joint_file());
+        // CTC is encoder-only: no decoder/joiner ONNX exists on disk. Keep the
+        // 3-session SessionTriplet shape but load the encoder into all three
+        // slots — for CTC they are never `.run()` (the CTC branch in
+        // `run_inference` returns right after the encoder run).
+        // TODO: make decoder/joiner Option to avoid 3x encoder RAM for CTC.
+        let is_ctc = variant == ModelVariant::MlCtc;
+        let decoder_path = if is_ctc {
+            encoder_path.clone()
+        } else {
+            dir.join(variant.decoder_file())
+        };
+        let joiner_path = if is_ctc {
+            encoder_path.clone()
+        } else {
+            dir.join(variant.joint_file())
+        };
 
         let results: Vec<anyhow::Result<SessionTriplet>> = std::thread::scope(|s| {
             let handles: Vec<_> = (0..pool_size)
@@ -2239,6 +2254,26 @@ impl Engine {
 
         tracing::debug!("Encoder output: {} frames", enc_len);
 
+        // CTC head: the single encoder emits per-frame class log-probs
+        // (`[1, T', 71]`, row-major). Greedy-decode them directly — there is no
+        // prediction network / joiner, so we return before the RNN-T block
+        // borrows `encoder_outputs` for the decode loop.
+        if self.variant == ModelVariant::MlCtc {
+            let log_probs = encoder_outputs[0]
+                .view()
+                .data()
+                .as_f32()
+                .context("CTC log_probs tensor is not f32")?;
+            let tokens = ctc::ctc_greedy_decode(
+                log_probs,
+                enc_len,
+                self.tokenizer.vocab_size(),
+                self.tokenizer.blank_id(),
+            );
+            let words = self.ctc_tokens_to_words(&tokens, frame_offset);
+            return Ok((words, false)); // CTC has no endpoint signal
+        }
+
         // RNN-T greedy decode — the encoder output is borrowed for the decode loop.
         let dec_start = std::time::Instant::now();
         let result = decode::greedy_decode(
@@ -2271,6 +2306,80 @@ impl Engine {
     /// Convert decoded tokens into words with timestamps and confidence.
     fn tokens_to_words(&self, tokens: &[decode::TokenInfo], frame_offset: usize) -> Vec<WordInfo> {
         TokenFormatter::tokens_to_words(&self.tokenizer, tokens, frame_offset)
+    }
+
+    /// Group CTC-decoded tokens into words with timestamps and confidence.
+    ///
+    /// Mirrors [`TokenFormatter::tokens_to_words`] but splits on the CTC vocab's
+    /// literal SPACE token (`" "`, `vocab[0]`) instead of the BPE `▁` boundary
+    /// marker — the CTC head emits one char per token with no per-word prefix.
+    /// The blank token never appears here (dropped in [`ctc::ctc_greedy_decode`]).
+    fn ctc_tokens_to_words(
+        &self,
+        tokens: &[decode::TokenInfo],
+        frame_offset: usize,
+    ) -> Vec<WordInfo> {
+        let mut words = Vec::new();
+        let mut current_word = String::new();
+        let mut word_start_frame: Option<usize> = None;
+        let mut word_end_frame: usize = 0;
+        let mut word_confidences: Vec<f32> = Vec::new();
+
+        let flush = |word: &mut String,
+                     start: &mut Option<usize>,
+                     end: usize,
+                     confs: &mut Vec<f32>,
+                     out: &mut Vec<WordInfo>| {
+            if word.is_empty() {
+                return;
+            }
+            let avg_conf: f32 = if confs.is_empty() {
+                1.0
+            } else {
+                confs.iter().sum::<f32>() / confs.len() as f32
+            };
+            out.push(WordInfo {
+                word: std::mem::take(word),
+                start: (start.unwrap_or(0) + frame_offset) as f64 * SECONDS_PER_FRAME,
+                end: (end + frame_offset) as f64 * SECONDS_PER_FRAME,
+                confidence: avg_conf,
+                speaker: None,
+            });
+            *start = None;
+            confs.clear();
+        };
+
+        for token in tokens {
+            let ch = self.tokenizer.token_text(token.token_id);
+            if ch == " " {
+                flush(
+                    &mut current_word,
+                    &mut word_start_frame,
+                    word_end_frame,
+                    &mut word_confidences,
+                    &mut words,
+                );
+                continue;
+            }
+            if !ch.is_empty() {
+                current_word.push_str(ch);
+                if word_start_frame.is_none() {
+                    word_start_frame = Some(token.frame_index);
+                }
+                word_end_frame = token.frame_index;
+                word_confidences.push(token.confidence);
+            }
+        }
+
+        flush(
+            &mut current_word,
+            &mut word_start_frame,
+            word_end_frame,
+            &mut word_confidences,
+            &mut words,
+        );
+
+        words
     }
 }
 

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -171,6 +171,9 @@ pub enum ModelVariant {
     Rnnt,
     /// End-to-end RNN-T head with punctuation / casing / ITN.
     E2eRnnt,
+    /// GigaAM Multilingual CTC head; single encoder-only ONNX, 71-class char
+    /// vocab, blank id 70.
+    MlCtc,
 }
 
 impl ModelVariant {
@@ -179,6 +182,7 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "v3_rnnt_encoder.onnx",
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_encoder.onnx",
+            ModelVariant::MlCtc => "multilingual_ctc_encoder.onnx",
         }
     }
 
@@ -187,6 +191,7 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "v3_rnnt_encoder_int8.onnx",
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_encoder_int8.onnx",
+            ModelVariant::MlCtc => "multilingual_ctc_encoder_int8.onnx",
         }
     }
 
@@ -195,6 +200,10 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "v3_rnnt_decoder.onnx",
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_decoder.onnx",
+            // CTC is encoder-only: no decoder/joiner ONNX exists. This empty
+            // path is never loaded — the CTC branch in `run_inference` returns
+            // before the decoder/joiner sessions are touched (see task C).
+            ModelVariant::MlCtc => "",
         }
     }
 
@@ -203,6 +212,9 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "v3_rnnt_joint.onnx",
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_joint.onnx",
+            // CTC is encoder-only: no decoder/joiner ONNX exists (see
+            // `decoder_file`). Never loaded.
+            ModelVariant::MlCtc => "",
         }
     }
 
@@ -214,18 +226,24 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "v3_vocab.txt",
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_vocab.txt",
+            ModelVariant::MlCtc => "multilingual_ctc_vocab.txt",
         }
     }
 
-    /// Files downloaded from HuggingFace for this variant (encoder, decoder,
-    /// joiner, vocab). The INT8 encoder is generated locally, not downloaded.
-    pub fn download_files(self) -> [&'static str; 4] {
-        [
-            self.encoder_file(),
-            self.decoder_file(),
-            self.joint_file(),
-            self.vocab_file(),
-        ]
+    /// Files downloaded from HuggingFace for this variant. RNN-T heads ship
+    /// encoder + decoder + joiner + vocab; the CTC head is encoder-only, so it
+    /// downloads only encoder + vocab. The INT8 encoder is generated locally,
+    /// not downloaded.
+    pub fn download_files(self) -> Vec<&'static str> {
+        match self {
+            ModelVariant::Rnnt | ModelVariant::E2eRnnt => vec![
+                self.encoder_file(),
+                self.decoder_file(),
+                self.joint_file(),
+                self.vocab_file(),
+            ],
+            ModelVariant::MlCtc => vec![self.encoder_file(), self.vocab_file()],
+        }
     }
 
     /// Pinned SHA-256 checksum for a downloaded file, or `None` when no checksum
@@ -234,6 +252,7 @@ impl ModelVariant {
         let table = match self {
             ModelVariant::Rnnt => RNNT_CHECKSUMS,
             ModelVariant::E2eRnnt => E2E_RNNT_CHECKSUMS,
+            ModelVariant::MlCtc => ML_CTC_CHECKSUMS,
         };
         table
             .iter()
@@ -253,6 +272,9 @@ impl ModelVariant {
             ModelVariant::E2eRnnt => {
                 "cf51b300af47cea099e17c806f8fecce2c46e9e8deb4709ec203f8970a067389"
             }
+            // TODO: fill after HF upload (only used on the prequantized path,
+            // not exercised yet).
+            ModelVariant::MlCtc => "",
         }
     }
 
@@ -260,13 +282,16 @@ impl ModelVariant {
     /// encoder (no FP32 download, no on-device quantization) plus the decoder,
     /// joiner, and vocab. The engine runs from these alone — it prefers the INT8
     /// encoder when present.
-    pub fn prequantized_files(self) -> [&'static str; 4] {
-        [
-            self.encoder_int8_file(),
-            self.decoder_file(),
-            self.joint_file(),
-            self.vocab_file(),
-        ]
+    pub fn prequantized_files(self) -> Vec<&'static str> {
+        match self {
+            ModelVariant::Rnnt | ModelVariant::E2eRnnt => vec![
+                self.encoder_int8_file(),
+                self.decoder_file(),
+                self.joint_file(),
+                self.vocab_file(),
+            ],
+            ModelVariant::MlCtc => vec![self.encoder_int8_file(), self.vocab_file()],
+        }
     }
 
     /// Pinned SHA-256 for a pre-quantized bundle file. The INT8 encoder uses
@@ -286,12 +311,16 @@ impl ModelVariant {
     /// variant's encoder is present. `Rnnt` takes precedence when (anomalously)
     /// both encoders coexist, mirroring the engine's default.
     pub fn detect_in_dir(dir: &Path) -> Option<Self> {
-        [ModelVariant::Rnnt, ModelVariant::E2eRnnt]
-            .into_iter()
-            .find(|&variant| {
-                dir.join(variant.encoder_file()).exists()
-                    || dir.join(variant.encoder_int8_file()).exists()
-            })
+        [
+            ModelVariant::Rnnt,
+            ModelVariant::E2eRnnt,
+            ModelVariant::MlCtc,
+        ]
+        .into_iter()
+        .find(|&variant| {
+            dir.join(variant.encoder_file()).exists()
+                || dir.join(variant.encoder_int8_file()).exists()
+        })
     }
 
     /// Stable model identifier surfaced by the REST API (`/health`,
@@ -301,6 +330,7 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "gigaam-v3-rnnt",
             ModelVariant::E2eRnnt => "gigaam-v3-e2e-rnnt",
+            ModelVariant::MlCtc => "gigaam-multilingual-ctc",
         }
     }
 
@@ -310,6 +340,7 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "rnnt",
             ModelVariant::E2eRnnt => "e2e_rnnt",
+            ModelVariant::MlCtc => "ml_ctc",
         }
     }
 
@@ -318,6 +349,7 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "GigaAM v3 RNN-T",
             ModelVariant::E2eRnnt => "GigaAM v3 E2E RNN-T",
+            ModelVariant::MlCtc => "GigaAM Multilingual CTC",
         }
     }
 }
@@ -329,8 +361,9 @@ impl std::str::FromStr for ModelVariant {
         match s.trim().to_ascii_lowercase().as_str() {
             "rnnt" => Ok(ModelVariant::Rnnt),
             "e2e_rnnt" | "e2e-rnnt" => Ok(ModelVariant::E2eRnnt),
+            "ml_ctc" | "ml-ctc" => Ok(ModelVariant::MlCtc),
             other => Err(format!(
-                "unknown model variant '{other}' (expected 'rnnt' or 'e2e_rnnt')"
+                "unknown model variant '{other}' (expected 'rnnt', 'e2e_rnnt', or 'ml_ctc')"
             )),
         }
     }
@@ -375,6 +408,14 @@ const E2E_RNNT_CHECKSUMS: &[(&str, Option<&str>)] = &[
         "v3_e2e_rnnt_vocab.txt",
         Some("39abae20e692998290c574e606f11a9edef2902a1995463fcff63d1490cf22b7"),
     ),
+];
+
+/// SHA-256 checksums for the GigaAM Multilingual CTC head's downloaded files
+/// (encoder + vocab; it is encoder-only). Both entries are `None` until the
+/// ONNX is uploaded to HuggingFace — `None` skips verification for now.
+const ML_CTC_CHECKSUMS: &[(&str, Option<&str>)] = &[
+    ("multilingual_ctc_encoder.onnx", None),
+    ("multilingual_ctc_vocab.txt", None),
 ];
 
 #[cfg(feature = "diarization")]

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -62,7 +62,8 @@ impl DownloadProgress {
     }
 }
 
-#[cfg(feature = "net")]
+/// HuggingFace repo hosting the RNN-T heads' shared v3 ONNX files. The
+/// Multilingual CTC head ships from its own repo (see [`ModelVariant::hf_repo`]).
 const HF_REPO: &str = "istupakov/gigaam-v3-onnx";
 
 /// Base URL of the pinned GitHub Release hosting the **pre-quantized** INT8
@@ -150,30 +151,43 @@ const PUNCT_FILES: &[(&str, &str)] = &[
     ),
 ];
 
-/// Selectable GigaAM v3 recognition head.
+/// Selectable GigaAM recognition head.
 ///
-/// Both heads ship in the same HuggingFace repo (`HF_REPO`) and share the
-/// inference pipeline; they differ only in their ONNX files and vocabulary.
+/// The RNN-T heads ship in the shared v3 HuggingFace repo (`HF_REPO`); the
+/// Multilingual CTC head ships from its own repo (see [`ModelVariant::hf_repo`]).
+/// All heads share the mel frontend and inference pipeline; they differ in their
+/// ONNX files, vocabulary, and recognition head.
 ///
 /// - [`ModelVariant::Rnnt`] (default): plain RNN-T head. Lower WER on the
 ///   golos_crowd_1k set (3.29% vs 9.65%) but emits bare lowercase Russian with
 ///   no punctuation / casing / ITN. Uses a 34-token character vocabulary.
 /// - [`ModelVariant::E2eRnnt`]: end-to-end head with punctuation, casing, and
 ///   inverse text normalization baked in. Uses a 1025-token BPE vocabulary.
+/// - [`ModelVariant::MlCtc`]: GigaAM Multilingual charwise-CTC head (220M),
+///   encoder-only, 71-class multilingual char vocab (ru/en/kk/ky/uz), bare
+///   lowercase output. Downloads istupakov's pre-quantized INT8 encoder.
 ///
 /// Real upstream filenames are kept on disk (no canonical-prefix rename), and
 /// the engine auto-detects the variant from the encoder file present in the
 /// model directory, so on-disk layout fully determines which head runs.
+///
+/// `#[non_exhaustive]`: recognition heads are added over time (this is an
+/// opt-in, additive catalog), so downstream matches must include a wildcard arm.
+/// New heads are shipped as minor releases, not breaking changes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum ModelVariant {
     /// Plain RNN-T head (default). Bare lowercase output, lower WER.
     #[default]
     Rnnt,
     /// End-to-end RNN-T head with punctuation / casing / ITN.
     E2eRnnt,
-    /// GigaAM Multilingual CTC head; single encoder-only ONNX, 71-class char
-    /// vocab, blank id 70.
+    /// GigaAM Multilingual CTC head (220M); single encoder-only ONNX, 71-class
+    /// char vocab, blank id 70.
     MlCtc,
+    /// GigaAM Multilingual CTC head, large (600M) encoder; same 71-class char
+    /// vocab and CTC decoding as [`ModelVariant::MlCtc`], higher WER headroom.
+    MlCtcLarge,
 }
 
 impl ModelVariant {
@@ -182,16 +196,20 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "v3_rnnt_encoder.onnx",
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_encoder.onnx",
-            ModelVariant::MlCtc => "multilingual_ctc_encoder.onnx",
+            ModelVariant::MlCtc => "multilingual_ctc.onnx",
+            ModelVariant::MlCtcLarge => "multilingual_large_ctc.onnx",
         }
     }
 
-    /// Basename of the locally-generated INT8 quantized encoder ONNX file.
+    /// Basename of the INT8 quantized encoder ONNX file. For the RNN-T heads
+    /// this is generated locally by the native quantizer; for the Multilingual
+    /// CTC head it is downloaded pre-quantized from HuggingFace.
     pub fn encoder_int8_file(self) -> &'static str {
         match self {
             ModelVariant::Rnnt => "v3_rnnt_encoder_int8.onnx",
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_encoder_int8.onnx",
-            ModelVariant::MlCtc => "multilingual_ctc_encoder_int8.onnx",
+            ModelVariant::MlCtc => "multilingual_ctc.int8.onnx",
+            ModelVariant::MlCtcLarge => "multilingual_large_ctc.int8.onnx",
         }
     }
 
@@ -202,8 +220,8 @@ impl ModelVariant {
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_decoder.onnx",
             // CTC is encoder-only: no decoder/joiner ONNX exists. This empty
             // path is never loaded — the CTC branch in `run_inference` returns
-            // before the decoder/joiner sessions are touched (see task C).
-            ModelVariant::MlCtc => "",
+            // before the decoder/joiner sessions are touched.
+            ModelVariant::MlCtc | ModelVariant::MlCtcLarge => "",
         }
     }
 
@@ -214,7 +232,7 @@ impl ModelVariant {
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_joint.onnx",
             // CTC is encoder-only: no decoder/joiner ONNX exists (see
             // `decoder_file`). Never loaded.
-            ModelVariant::MlCtc => "",
+            ModelVariant::MlCtc | ModelVariant::MlCtcLarge => "",
         }
     }
 
@@ -226,14 +244,16 @@ impl ModelVariant {
         match self {
             ModelVariant::Rnnt => "v3_vocab.txt",
             ModelVariant::E2eRnnt => "v3_e2e_rnnt_vocab.txt",
-            ModelVariant::MlCtc => "multilingual_ctc_vocab.txt",
+            // Both CTC heads share the identical 71-token multilingual vocab.
+            ModelVariant::MlCtc | ModelVariant::MlCtcLarge => "multilingual_vocab.txt",
         }
     }
 
     /// Files downloaded from HuggingFace for this variant. RNN-T heads ship
-    /// encoder + decoder + joiner + vocab; the CTC head is encoder-only, so it
-    /// downloads only encoder + vocab. The INT8 encoder is generated locally,
-    /// not downloaded.
+    /// encoder (FP32) + decoder + joiner + vocab, and the INT8 encoder is
+    /// generated locally. The Multilingual CTC head is encoder-only and ships a
+    /// ready-made INT8 encoder upstream, so it downloads that INT8 encoder + vocab
+    /// directly (no FP32 download, no on-device quantization).
     pub fn download_files(self) -> Vec<&'static str> {
         match self {
             ModelVariant::Rnnt | ModelVariant::E2eRnnt => vec![
@@ -242,7 +262,20 @@ impl ModelVariant {
                 self.joint_file(),
                 self.vocab_file(),
             ],
-            ModelVariant::MlCtc => vec![self.encoder_file(), self.vocab_file()],
+            ModelVariant::MlCtc | ModelVariant::MlCtcLarge => {
+                vec![self.encoder_int8_file(), self.vocab_file()]
+            }
+        }
+    }
+
+    /// HuggingFace repo hosting this variant's ONNX files. The RNN-T heads live
+    /// in the shared v3 repo; the Multilingual CTC head ships from istupakov's
+    /// dedicated `gigaam-multilingual-ctc-onnx` repo.
+    pub fn hf_repo(self) -> &'static str {
+        match self {
+            ModelVariant::Rnnt | ModelVariant::E2eRnnt => HF_REPO,
+            ModelVariant::MlCtc => "istupakov/gigaam-multilingual-ctc-onnx",
+            ModelVariant::MlCtcLarge => "istupakov/gigaam-multilingual-large-ctc-onnx",
         }
     }
 
@@ -253,6 +286,7 @@ impl ModelVariant {
             ModelVariant::Rnnt => RNNT_CHECKSUMS,
             ModelVariant::E2eRnnt => E2E_RNNT_CHECKSUMS,
             ModelVariant::MlCtc => ML_CTC_CHECKSUMS,
+            ModelVariant::MlCtcLarge => ML_CTC_LARGE_CHECKSUMS,
         };
         table
             .iter()
@@ -260,10 +294,11 @@ impl ModelVariant {
             .and_then(|(_, hash)| *hash)
     }
 
-    /// SHA-256 of the pre-quantized INT8 encoder for this variant, as published
-    /// in the pinned GitHub Release (`PREQUANT_RELEASE_BASE`). Produced by
-    /// gigastt's deterministic quantizer; bump this together with the release
-    /// tag if the model is ever re-quantized.
+    /// SHA-256 of the pre-quantized INT8 encoder for this variant. For the RNN-T
+    /// heads this is gigastt's own quantizer output, published in the pinned
+    /// GitHub Release (`PREQUANT_RELEASE_BASE`); bump it together with the release
+    /// tag on re-quantization. For the Multilingual CTC head it is istupakov's
+    /// upstream INT8 encoder, downloaded directly from HuggingFace.
     pub fn encoder_int8_checksum(self) -> &'static str {
         match self {
             ModelVariant::Rnnt => {
@@ -272,9 +307,16 @@ impl ModelVariant {
             ModelVariant::E2eRnnt => {
                 "cf51b300af47cea099e17c806f8fecce2c46e9e8deb4709ec203f8970a067389"
             }
-            // TODO: fill after HF upload (only used on the prequantized path,
-            // not exercised yet).
-            ModelVariant::MlCtc => "",
+            // Downloaded pre-quantized from istupakov's HuggingFace repo (not our
+            // GitHub Release); this is the SHA-256 of `multilingual_ctc.int8.onnx`.
+            ModelVariant::MlCtc => {
+                "e08e27ae5669b39f0c378fae101bbbb9a80505f74f9b66719c309bf5b894a480"
+            }
+            // SHA-256 of `multilingual_large_ctc.int8.onnx`, from
+            // istupakov/gigaam-multilingual-large-ctc-onnx.
+            ModelVariant::MlCtcLarge => {
+                "b2ad9c38fc04197ba758105d33f7404fd13d977958722e0f49e3f3e22521f1c6"
+            }
         }
     }
 
@@ -290,7 +332,9 @@ impl ModelVariant {
                 self.joint_file(),
                 self.vocab_file(),
             ],
-            ModelVariant::MlCtc => vec![self.encoder_int8_file(), self.vocab_file()],
+            ModelVariant::MlCtc | ModelVariant::MlCtcLarge => {
+                vec![self.encoder_int8_file(), self.vocab_file()]
+            }
         }
     }
 
@@ -315,6 +359,7 @@ impl ModelVariant {
             ModelVariant::Rnnt,
             ModelVariant::E2eRnnt,
             ModelVariant::MlCtc,
+            ModelVariant::MlCtcLarge,
         ]
         .into_iter()
         .find(|&variant| {
@@ -331,6 +376,7 @@ impl ModelVariant {
             ModelVariant::Rnnt => "gigaam-v3-rnnt",
             ModelVariant::E2eRnnt => "gigaam-v3-e2e-rnnt",
             ModelVariant::MlCtc => "gigaam-multilingual-ctc",
+            ModelVariant::MlCtcLarge => "gigaam-multilingual-large-ctc",
         }
     }
 
@@ -341,6 +387,7 @@ impl ModelVariant {
             ModelVariant::Rnnt => "rnnt",
             ModelVariant::E2eRnnt => "e2e_rnnt",
             ModelVariant::MlCtc => "ml_ctc",
+            ModelVariant::MlCtcLarge => "ml_ctc_large",
         }
     }
 
@@ -350,7 +397,14 @@ impl ModelVariant {
             ModelVariant::Rnnt => "GigaAM v3 RNN-T",
             ModelVariant::E2eRnnt => "GigaAM v3 E2E RNN-T",
             ModelVariant::MlCtc => "GigaAM Multilingual CTC",
+            ModelVariant::MlCtcLarge => "GigaAM Multilingual CTC (large)",
         }
+    }
+
+    /// True for the encoder-only CTC heads (greedy CTC decode, no prediction
+    /// network / joiner). Both the 220M and 600M Multilingual heads are CTC.
+    pub fn is_ctc(self) -> bool {
+        matches!(self, ModelVariant::MlCtc | ModelVariant::MlCtcLarge)
     }
 }
 
@@ -362,8 +416,10 @@ impl std::str::FromStr for ModelVariant {
             "rnnt" => Ok(ModelVariant::Rnnt),
             "e2e_rnnt" | "e2e-rnnt" => Ok(ModelVariant::E2eRnnt),
             "ml_ctc" | "ml-ctc" => Ok(ModelVariant::MlCtc),
+            "ml_ctc_large" | "ml-ctc-large" => Ok(ModelVariant::MlCtcLarge),
             other => Err(format!(
-                "unknown model variant '{other}' (expected 'rnnt', 'e2e_rnnt', or 'ml_ctc')"
+                "unknown model variant '{other}' \
+                 (expected 'rnnt', 'e2e_rnnt', 'ml_ctc', or 'ml_ctc_large')"
             )),
         }
     }
@@ -411,11 +467,33 @@ const E2E_RNNT_CHECKSUMS: &[(&str, Option<&str>)] = &[
 ];
 
 /// SHA-256 checksums for the GigaAM Multilingual CTC head's downloaded files
-/// (encoder + vocab; it is encoder-only). Both entries are `None` until the
-/// ONNX is uploaded to HuggingFace — `None` skips verification for now.
+/// (the pre-quantized INT8 encoder + vocab; it is encoder-only). Computed from
+/// the canonical copies at `istupakov/gigaam-multilingual-ctc-onnx` on
+/// 2026-07-17.
 const ML_CTC_CHECKSUMS: &[(&str, Option<&str>)] = &[
-    ("multilingual_ctc_encoder.onnx", None),
-    ("multilingual_ctc_vocab.txt", None),
+    (
+        "multilingual_ctc.int8.onnx",
+        Some("e08e27ae5669b39f0c378fae101bbbb9a80505f74f9b66719c309bf5b894a480"),
+    ),
+    (
+        "multilingual_vocab.txt",
+        Some("4d130287892e1099fedfb3f93c4b4cf8a263151158801680b28977d1be4133f4"),
+    ),
+];
+
+/// SHA-256 checksums for the GigaAM Multilingual CTC *large* (600M) head's
+/// downloaded files (pre-quantized INT8 encoder + the shared vocab, which is
+/// byte-identical to the 220M head's). Computed from the canonical copies at
+/// `istupakov/gigaam-multilingual-large-ctc-onnx` on 2026-07-17.
+const ML_CTC_LARGE_CHECKSUMS: &[(&str, Option<&str>)] = &[
+    (
+        "multilingual_large_ctc.int8.onnx",
+        Some("b2ad9c38fc04197ba758105d33f7404fd13d977958722e0f49e3f3e22521f1c6"),
+    ),
+    (
+        "multilingual_vocab.txt",
+        Some("4d130287892e1099fedfb3f93c4b4cf8a263151158801680b28977d1be4133f4"),
+    ),
 ];
 
 #[cfg(feature = "diarization")]
@@ -1094,7 +1172,10 @@ fn finalize_download(
 
 #[cfg(feature = "net")]
 async fn download_file(variant: ModelVariant, filename: &str, dir: &Path) -> Result<()> {
-    let url = format!("https://huggingface.co/{HF_REPO}/resolve/main/{filename}");
+    let url = format!(
+        "https://huggingface.co/{}/resolve/main/{filename}",
+        variant.hf_repo()
+    );
     let final_dest = dir.join(filename);
     let expected = variant.checksum(filename);
     stream_to_partial_then_finalize(&url, &final_dest, expected, filename).await
@@ -1618,14 +1699,110 @@ mod tests {
             ModelVariant::from_str(" RNNT ").unwrap(),
             ModelVariant::Rnnt
         );
+        assert_eq!(
+            ModelVariant::from_str("ml_ctc").unwrap(),
+            ModelVariant::MlCtc
+        );
+        assert_eq!(
+            ModelVariant::from_str("ML-CTC").unwrap(),
+            ModelVariant::MlCtc
+        );
+        assert_eq!(
+            ModelVariant::from_str("ml_ctc_large").unwrap(),
+            ModelVariant::MlCtcLarge
+        );
+        assert_eq!(
+            ModelVariant::from_str("ML-CTC-LARGE").unwrap(),
+            ModelVariant::MlCtcLarge
+        );
         assert!(ModelVariant::from_str("whisper").is_err());
     }
 
     #[test]
+    fn test_model_variant_ml_ctc_file_mapping() {
+        let v = ModelVariant::MlCtc;
+        // Real istupakov filenames (gigaam-multilingual-ctc-onnx).
+        assert_eq!(v.encoder_file(), "multilingual_ctc.onnx");
+        assert_eq!(v.encoder_int8_file(), "multilingual_ctc.int8.onnx");
+        assert_eq!(v.vocab_file(), "multilingual_vocab.txt");
+        // Encoder-only: no decoder/joiner ONNX exists.
+        assert_eq!(v.decoder_file(), "");
+        assert_eq!(v.joint_file(), "");
+        // Downloads the pre-quantized INT8 encoder directly + vocab.
+        assert_eq!(
+            v.download_files(),
+            ["multilingual_ctc.int8.onnx", "multilingual_vocab.txt"]
+        );
+        assert_eq!(v.hf_repo(), "istupakov/gigaam-multilingual-ctc-onnx");
+        assert_eq!(v.as_str(), "ml_ctc");
+        assert_eq!(v.model_id(), "gigaam-multilingual-ctc");
+    }
+
+    #[test]
+    fn test_hf_repo_per_variant() {
+        assert_eq!(ModelVariant::Rnnt.hf_repo(), "istupakov/gigaam-v3-onnx");
+        assert_eq!(ModelVariant::E2eRnnt.hf_repo(), "istupakov/gigaam-v3-onnx");
+        assert_eq!(
+            ModelVariant::MlCtc.hf_repo(),
+            "istupakov/gigaam-multilingual-ctc-onnx"
+        );
+        assert_eq!(
+            ModelVariant::MlCtcLarge.hf_repo(),
+            "istupakov/gigaam-multilingual-large-ctc-onnx"
+        );
+    }
+
+    #[test]
+    fn test_model_variant_ml_ctc_large_file_mapping() {
+        let v = ModelVariant::MlCtcLarge;
+        assert_eq!(v.encoder_file(), "multilingual_large_ctc.onnx");
+        assert_eq!(v.encoder_int8_file(), "multilingual_large_ctc.int8.onnx");
+        // Vocab is byte-identical to (and shares the filename with) the 220M head.
+        assert_eq!(v.vocab_file(), "multilingual_vocab.txt");
+        assert_eq!(v.vocab_file(), ModelVariant::MlCtc.vocab_file());
+        assert_eq!(v.decoder_file(), "");
+        assert_eq!(v.joint_file(), "");
+        assert_eq!(
+            v.download_files(),
+            ["multilingual_large_ctc.int8.onnx", "multilingual_vocab.txt"]
+        );
+        assert_eq!(v.as_str(), "ml_ctc_large");
+        assert_eq!(v.model_id(), "gigaam-multilingual-large-ctc");
+        assert!(v.is_ctc());
+        assert!(ModelVariant::MlCtc.is_ctc());
+        assert!(!ModelVariant::Rnnt.is_ctc());
+    }
+
+    #[test]
+    fn test_detect_in_dir_ml_ctc_large_by_int8_encoder() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("multilingual_large_ctc.int8.onnx"), b"int8").unwrap();
+        assert_eq!(
+            ModelVariant::detect_in_dir(tmp.path()),
+            Some(ModelVariant::MlCtcLarge)
+        );
+    }
+
+    #[test]
+    fn test_detect_in_dir_ml_ctc_by_int8_encoder() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("multilingual_ctc.int8.onnx"), b"int8").unwrap();
+        assert_eq!(
+            ModelVariant::detect_in_dir(tmp.path()),
+            Some(ModelVariant::MlCtc)
+        );
+    }
+
+    #[test]
     fn test_model_variant_checksums_are_pinned() {
-        // Every downloaded file for both variants has a pinned 64-char hex
+        // Every downloaded file for every variant has a pinned 64-char hex
         // checksum — security parity, no placeholder slipping into a release.
-        for variant in [ModelVariant::Rnnt, ModelVariant::E2eRnnt] {
+        for variant in [
+            ModelVariant::Rnnt,
+            ModelVariant::E2eRnnt,
+            ModelVariant::MlCtc,
+            ModelVariant::MlCtcLarge,
+        ] {
             for file in variant.download_files() {
                 let sum = variant
                     .checksum(file)
@@ -1989,11 +2166,25 @@ mod tests {
                 "v3_e2e_rnnt_vocab.txt",
             ]
         );
+        // CTC is encoder-only: pre-quantized set is just the INT8 encoder + vocab.
+        assert_eq!(
+            ModelVariant::MlCtc.prequantized_files(),
+            ["multilingual_ctc.int8.onnx", "multilingual_vocab.txt"]
+        );
+        assert_eq!(
+            ModelVariant::MlCtcLarge.prequantized_files(),
+            ["multilingual_large_ctc.int8.onnx", "multilingual_vocab.txt"]
+        );
     }
 
     #[test]
     fn test_encoder_int8_checksums_are_pinned() {
-        for variant in [ModelVariant::Rnnt, ModelVariant::E2eRnnt] {
+        for variant in [
+            ModelVariant::Rnnt,
+            ModelVariant::E2eRnnt,
+            ModelVariant::MlCtc,
+            ModelVariant::MlCtcLarge,
+        ] {
             let sum = variant.encoder_int8_checksum();
             assert_eq!(
                 sum.len(),

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -47,8 +47,10 @@ enum Commands {
         /// Recognition head to use. Omit to auto-detect from the model
         /// directory: if a model is already installed its variant is used as-is
         /// (no download). Only required when the directory is empty or you want
-        /// to switch variants. `rnnt` (lower WER, bare lowercase) or
-        /// `e2e_rnnt` (punctuation / casing / ITN). Env: GIGASTT_MODEL_VARIANT.
+        /// to switch variants. `rnnt` (lower WER, bare lowercase), `e2e_rnnt`
+        /// (punctuation / casing / ITN), or `ml_ctc` / `ml_ctc_large` (GigaAM
+        /// Multilingual charwise CTC, 220M / 600M — ru/en/kk/ky/uz, bare
+        /// lowercase). Env: GIGASTT_MODEL_VARIANT.
         #[arg(
             long,
             env = "GIGASTT_MODEL_VARIANT",
@@ -288,7 +290,9 @@ enum Commands {
         model_dir: String,
 
         /// Recognition head to download: `rnnt` (default — lower WER, bare
-        /// lowercase) or `e2e_rnnt` (punctuation / casing / ITN).
+        /// lowercase), `e2e_rnnt` (punctuation / casing / ITN), or `ml_ctc` /
+        /// `ml_ctc_large` (GigaAM Multilingual charwise CTC, 220M / 600M —
+        /// ru/en/kk/ky/uz, pre-quantized INT8 fetched directly).
         #[arg(
             long,
             env = "GIGASTT_MODEL_VARIANT",
@@ -347,8 +351,10 @@ enum Commands {
 
         /// Recognition head to use. Omit to auto-detect from the model
         /// directory (existing install used as-is; only downloads if empty).
-        /// `rnnt` (lower WER, bare lowercase) or `e2e_rnnt` (punctuation /
-        /// casing / ITN). Env: GIGASTT_MODEL_VARIANT.
+        /// `rnnt` (lower WER, bare lowercase), `e2e_rnnt` (punctuation /
+        /// casing / ITN), or `ml_ctc` / `ml_ctc_large` (GigaAM Multilingual
+        /// charwise CTC, 220M / 600M — ru/en/kk/ky/uz, bare lowercase).
+        /// Env: GIGASTT_MODEL_VARIANT.
         #[arg(
             long,
             env = "GIGASTT_MODEL_VARIANT",
@@ -651,8 +657,8 @@ fn resolve_encoder_intra_threads(
     }
 }
 
-/// clap value parser for `--model-variant`. Accepts `rnnt` / `e2e_rnnt`
-/// (case-insensitive); see [`ModelVariant::from_str`].
+/// clap value parser for `--model-variant`. Accepts `rnnt` / `e2e_rnnt` /
+/// `ml_ctc` / `ml_ctc_large` (case-insensitive); see [`ModelVariant::from_str`].
 fn parse_model_variant(s: &str) -> Result<ModelVariant, String> {
     s.parse()
 }
@@ -1148,11 +1154,16 @@ async fn main() -> anyhow::Result<()> {
             // `download` is an explicit action: the requested variant maps to
             // the default (Rnnt) so a bare `gigastt download` fetches something
             // useful.
-            if prequantized {
+            if prequantized && !model_variant.is_ctc() {
                 // Lean path: fetch the INT8 bundle from the pinned Release — no
                 // FP32 download, no on-device quantization, no protoc.
                 model::ensure_prequantized_model_variant(Some(model_variant), &model_dir).await?;
             } else {
+                // The Multilingual CTC heads' standard download already fetches
+                // istupakov's pre-quantized INT8 encoder directly from HuggingFace,
+                // so `--prequantized` is a no-op refinement for them (no separate
+                // GitHub-Release bundle). `ensure_int8_encoder` then finds the INT8
+                // encoder already present and skips on-device quantization.
                 let resolved = model::ensure_model_variant(Some(model_variant), &model_dir).await?;
                 ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
             }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,18 @@ head (`rnnt` 34-token char — the v2.3 default — or `e2e_rnnt` 1025-token BPE
 mono input, MIT licensed. Download ~850 MB (encoder 844 MB, decoder 4.4 MB, joiner
 2.6 MB); INT8 encoder ~215 MB. Trained on 700K+ hours of Russian speech.
 
+Two opt-in heads (`--model-variant ml_ctc` / `ml_ctc_large`) use
+[**GigaAM Multilingual**](https://huggingface.co/istupakov/gigaam-multilingual-ctc-onnx)
+instead: an encoder-only charwise-CTC model (no LSTM decoder / joiner, greedy CTC
+decoding), MIT licensed, sharing the 64-mel / FFT 320 / hop 160 / 16 kHz frontend above.
+`ml_ctc` has a 220M-param encoder, `ml_ctc_large`
+([`istupakov/gigaam-multilingual-large-ctc-onnx`](https://huggingface.co/istupakov/gigaam-multilingual-large-ctc-onnx))
+600M; both use a shared 71-class multilingual character vocabulary (blank id 70) and
+emit bare lowercase text. Trained across 70+ languages, best-in-class on Russian,
+Kazakh, Kyrgyz, and Uzbek. Both download istupakov's pre-quantized INT8 encoder
+directly — no FP32 download, no on-device quantization (`ml_ctc` ~225 MB, `ml_ctc_large`
+~592 MB).
+
 ## Hardware acceleration
 
 | Platform | Feature flag | Execution Provider |

--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -220,7 +220,10 @@ components:
         model:
           type: string
           example: gigaam-v3-e2e-rnnt
-          description: Identifier of the loaded speech recognition model
+          description: >-
+            Identifier of the loaded speech recognition model
+            (`gigaam-v3-rnnt`, `gigaam-v3-e2e-rnnt`, `gigaam-multilingual-ctc`, or
+            `gigaam-multilingual-large-ctc`).
         sample_rate:
           type: integer
           example: 48000

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,10 +20,12 @@ gigastt serve [OPTIONS]
   --port <PORT>             Listen port [default: 9876]
   --host <HOST>             Bind address [default: 127.0.0.1]
   --model-dir <DIR>         Model directory [default: ~/.gigastt/models]
-  --model-variant <V>       Recognition head: rnnt | e2e_rnnt. Omit to use the model
-                            already installed; fresh installs default to rnnt (lower WER,
-                            no punctuation). e2e_rnnt keeps punctuation/casing/ITN.
-                            Env: GIGASTT_MODEL_VARIANT.
+  --model-variant <V>       Recognition head: rnnt | e2e_rnnt | ml_ctc | ml_ctc_large.
+                            Omit to use the model already installed; fresh installs
+                            default to rnnt (lower WER, no punctuation). e2e_rnnt keeps
+                            punctuation/casing/ITN. ml_ctc / ml_ctc_large are the GigaAM
+                            Multilingual charwise-CTC heads (220M / 600M encoder,
+                            ru/en/kk/ky/uz, bare lowercase). Env: GIGASTT_MODEL_VARIANT.
   --punctuation <MODE>      Restore punctuation/casing on output: auto | on | off
                             [default: auto = on for rnnt, off for e2e_rnnt].
                             Optional ONNX pass; absent model → text unchanged.
@@ -80,14 +82,15 @@ gigastt serve [OPTIONS]
 
 gigastt download [OPTIONS]
   --model-dir <DIR>      Model directory [default: ~/.gigastt/models]
-  --model-variant <V>    Head to download: rnnt (default) | e2e_rnnt. Env: GIGASTT_MODEL_VARIANT.
+  --model-variant <V>    Head to download: rnnt (default) | e2e_rnnt | ml_ctc | ml_ctc_large.
+                         Env: GIGASTT_MODEL_VARIANT.
   --skip-diarization     Skip downloading the speaker diarization model
   --skip-quantize        Skip auto-quantization after download (FP32 only)
 
 gigastt transcribe [OPTIONS] <FILE>
   --model-dir <DIR>           Model directory [default: ~/.gigastt/models]
-  --model-variant <V>         Recognition head: rnnt | e2e_rnnt. Omit to auto-detect.
-                              Env: GIGASTT_MODEL_VARIANT.
+  --model-variant <V>         Recognition head: rnnt | e2e_rnnt | ml_ctc | ml_ctc_large.
+                              Omit to auto-detect. Env: GIGASTT_MODEL_VARIANT.
   --punctuation <MODE>        Restore punctuation/casing: auto | on | off
                               [default: auto = on for rnnt, off for e2e_rnnt].
                               Env: GIGASTT_PUNCTUATION.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -272,7 +272,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [rnnt, e2e_rnnt]
+            enum: [rnnt, e2e_rnnt, ml_ctc, ml_ctc_large]
           description: |
             Forward-compatibility guard naming the recognition head the request
             expects. A single-model server can't switch heads, so any value
@@ -719,11 +719,11 @@ components:
           example: gigaam-v3-rnnt
           description: >-
             Stable identifier of the head actually loaded
-            (`gigaam-v3-rnnt` or `gigaam-v3-e2e-rnnt`). During first-run model
+            (`gigaam-v3-rnnt`, `gigaam-v3-e2e-rnnt`, `gigaam-multilingual-ctc`, or `gigaam-multilingual-large-ctc`). During first-run model
             download / quantization the bootstrap responder reports `loading`.
         variant:
           type: string
-          enum: [rnnt, e2e_rnnt]
+          enum: [rnnt, e2e_rnnt, ml_ctc, ml_ctc_large]
           example: rnnt
           description: Recognition head in use
         version:
@@ -790,13 +790,13 @@ components:
           example: gigaam-v3-rnnt
           description: >-
             Stable identifier of the head actually loaded
-            (`gigaam-v3-rnnt` or `gigaam-v3-e2e-rnnt`).
+            (`gigaam-v3-rnnt`, `gigaam-v3-e2e-rnnt`, `gigaam-multilingual-ctc`, or `gigaam-multilingual-large-ctc`).
         name:
           type: string
           example: GigaAM v3 RNN-T
         variant:
           type: string
-          enum: [rnnt, e2e_rnnt]
+          enum: [rnnt, e2e_rnnt, ml_ctc, ml_ctc_large]
           example: rnnt
           description: Recognition head in use
         version:

--- a/scripts/export_ml_ctc.py
+++ b/scripts/export_ml_ctc.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Export ai-sage/GigaAM-Multilingual (charwise-CTC) to a single ONNX for gigastt.
+
+The multilingual CTC model shares GigaAM v3's frontend (torchaudio MelSpectrogram:
+64 mel, n_fft=320, win=320, hop=160, center=false, natural-log) and Conformer-768
+encoder, so gigastt's existing `features.rs` feeds it unchanged. The CTC head is a
+single self-contained ONNX (no separate decoder/joiner like RNN-T).
+
+Outputs (in --out):
+  multilingual_ctc.onnx   features[B,64,T] + feature_lengths[B]
+                          -> log_probs[B,T',71] + encoded_lengths[B]   (opset 17, fp32)
+  multilingual_ctc.yaml   model cfg (emitted by to_onnx)
+  ml_ctc_vocab.txt        the 70-token CTC vocabulary, one per line; CTC blank id = 70
+  golden.npz              (features, log_probs) reference for validating the Rust CTC head
+
+Env (local Python 3.14 is broken -> use uv + python3.13):
+  uv venv --python 3.13 .venv-gigaam
+  uv pip install --python .venv-gigaam/bin/python \
+      torch torchaudio transformers huggingface_hub hydra-core omegaconf \
+      soundfile sentencepiece numpy onnx onnxruntime
+  HF_HUB_DISABLE_XET=1 .venv-gigaam/bin/python scripts/export_ml_ctc.py --out onnx_ml_ctc
+
+Reproduces the export path from the model's own `modeling_gigaam.py::GigaAMASR._to_onnx`
+(the "ctc" branch): swaps forward -> forward_for_export and traces encoder+CTCHead.
+"""
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from transformers import AutoModel
+
+# The GigaAM modeling file lazily imports optional heavy deps — pyannote.audio
+# (VAD/diarization) and flash_attn/einops (flash attention) — inside functions a
+# CTC-encoder export never calls (flash attention is off; config `flash_attn: false`).
+# transformers' static `check_imports` would still demand all of them, and flash_attn
+# cannot even build on macOS. Neutralize the check: the real imports stay lazy and are
+# never triggered by `from_pretrained` + `to_onnx`.
+import transformers.dynamic_module_utils as _dmu  # noqa: E402
+
+_dmu.check_imports = lambda *_a, **_k: []
+
+REPO = "ai-sage/GigaAM-Multilingual"
+REVISION = "ctc"  # == main; the CTC ASR checkpoint (220M). Use "large_ctc" for the 600M.
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default="onnx_ml_ctc", help="output directory")
+    ap.add_argument("--revision", default=REVISION, help="ctc | large_ctc")
+    args = ap.parse_args()
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"[1/4] loading {REPO}@{args.revision} (trust_remote_code) ...")
+    model = AutoModel.from_pretrained(REPO, revision=args.revision, trust_remote_code=True)
+    model.eval()
+    # The HF `GigaAMModel` wrapper holds the real GigaAMASR at `.model`; cfg / encoder /
+    # decoding / forward_for_export live there. Its `to_onnx` takes only `dir_path`.
+    inner = model.model
+
+    # --- vocab (CTC blank id = len(vocab)) ---
+    vocab = list(inner.cfg.decoding.vocabulary)
+    (out / "ml_ctc_vocab.txt").write_text("\n".join(vocab) + "\n", encoding="utf-8")
+    print(f"[2/4] wrote ml_ctc_vocab.txt: {len(vocab)} tokens, blank_id={len(vocab)}")
+
+    # --- ONNX export via the model's own to_onnx() ---
+    print("[3/4] exporting ONNX via model.to_onnx() ...")
+    model.to_onnx(str(out))
+    onnx_path = out / f"{inner.cfg.model_name}.onnx"
+    print(f"      -> {onnx_path}")
+
+    # --- golden-reference numerical equivalence (PyTorch vs onnxruntime) ---
+    print("[4/4] golden-reference check (PyTorch forward_for_export vs onnxruntime) ...")
+    import onnxruntime as ort
+
+    feats, flens = inner.encoder.input_example()
+    # to_onnx traces under encoder.onnx_export_mode() (flash/SDPA attention disabled),
+    # so the reference MUST run in the same mode or the logits diverge (this bit us once).
+    with torch.no_grad(), inner.encoder.onnx_export_mode():
+        log_probs_pt, _enc_len_pt = inner.forward_for_export(feats, flens)
+
+    sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    log_probs_onnx = sess.run(
+        None,
+        {"features": feats.numpy().astype(np.float32), "feature_lengths": flens.numpy()},
+    )[0]
+    lp_pt = log_probs_pt.numpy()
+    delta = float(np.max(np.abs(lp_pt - log_probs_onnx)))
+    # For CTC greedy decoding the per-frame argmax is what matters; require an exact match.
+    argmax_agree = float((lp_pt.argmax(-1) == log_probs_onnx.argmax(-1)).mean())
+    print(f"      features={tuple(feats.shape)} log_probs={tuple(log_probs_onnx.shape)}")
+    print(f"      max|Δ log_probs| = {delta:.3e}   argmax agreement = {argmax_agree:.4f}")
+    ok = delta < 1e-2 and argmax_agree == 1.0
+    print(f"      -> {'OK' if ok else 'FAIL'}")
+
+    np.savez(out / "golden.npz", features=feats.numpy(), log_probs=lp_pt)
+    print(f"      wrote {out / 'golden.npz'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds an opt-in **GigaAM Multilingual CTC** recognition head. The default Russian `rnnt` head is untouched.

## What
- `ModelVariant::MlCtc` (`--model-variant ml_ctc`) — a single **encoder-only** ONNX: `features [1,64,T]` → `log_probs [1,T',71]`, decoded with charwise **CTC greedy** (per-frame argmax → collapse repeats → drop blank id 70) over a 71-token multilingual char vocab (ru/en/kk/ky/uz).
- Reuses the existing GigaAM v3 mel frontend **unchanged** (64 mel / n_fft 320 / hop 160 / HTK / log) — the multilingual model shares it.
- The native INT8 quantizer works on the encoder via `quantize_model` (885 MB → 225 MB, no code change).
- `inference/ctc.rs` (pure decode + unit tests), a CTC word joiner that splits on the vocab's literal space token, and an encoder-only session-load branch.
- `scripts/export_ml_ctc.py` — reproducible ONNX export from `ai-sage/GigaAM-Multilingual` (MIT); `examples/quantize_file.rs` — dev helper to INT8 an arbitrary ONNX.

## Validation
- `cargo clippy -p gigastt-core -p gigastt` clean; `ctc::` unit tests pass.
- **End-to-end:** `transcribe golos_00.wav` with the INT8 CTC model → `шестьдесят тысяч тенге сколько будет стоить` (int8, RTF 0.069). WER fp32 vs int8 on 15 golos fixtures: 4.00% vs 4.00%, 0.00% divergence.

## Not in scope / follow-ups
- Streaming and hotword biasing are not wired for this head (file transcription only); decoder/joiner slots load the encoder as a placeholder (TODO: make them `Option`).
- Download SHA-256s are `None` (verification skipped) until the ONNX + INT8 encoder are uploaded to a HuggingFace repo and the manifest is filled.
- KK/KY/UZ WER benchmark (Common Voice / FLEURS) still to run before release.
