### PR TITLE
chore(release): finalize CHANGELOG for 2.11.0 + version-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Benchmarks: measured Russian WER for the GigaAM Multilingual CTC heads.** Through the
-  same Python harness, manifests, and normalization as the other engines
-  (`docs/benchmarks.md`): `ml_ctc_large` (600M) 4.44% clean read / 5.70% far-field,
-  `ml_ctc` (220M) 6.15% / 8.28% — the 600M head approaches the Russian-specialized `rnnt`
-  (3.55% / 4.08%) and beats the old `e2e_rnnt` (8.60% clean). Adds `gigastt-ml-ctc` /
-  `gigastt-ml-ctc-large` benchmark runners. Phone / YouTube WER are not measured (no local
-  reference audio).
-- **Benchmarks: measured English WER for the GigaAM Multilingual CTC heads.** On a
-  1000-sample slice of LibriSpeech `test-clean` (verbatim WER; `docs/benchmarks.md`):
-  `ml_ctc_large` (600M) **4.63%**, `ml_ctc` (220M) 6.67% — only ~0.2 pp behind their Russian
-  clean-read WER, so the model card's "moderate on English" understates them on clean read.
-  The Russian-only `rnnt` / `e2e_rnnt` heads are Cyrillic-only and score 100% on English.
-  Adds `scripts/prepare_librispeech.py`.
-- **Benchmarks: measured Kazakh / Kyrgyz / Uzbek WER for the GigaAM Multilingual CTC heads.**
-  On FLEURS test splits (`docs/benchmarks.md`), digit-free Unicode-verbatim WER: `ml_ctc_large`
-  (600M) Kazakh **6.52%** / Kyrgyz **7.39%** / Uzbek **9.21%**, `ml_ctc` (220M) 7.21 / 8.82 /
-  11.96. Across all five supported languages the 600M head is 4.4–9.2% clean-read WER. Adds
-  `scripts/prepare_fleurs.py` and `scripts/wer_unicode.py` (Unicode-complete WER that keeps the
-  Turkic Cyrillic letters, folds Uzbek apostrophe variants, and excludes number-bearing
-  sentences where the charwise heads spell digits out and no words↔digits ITN exists).
-
 ## [2.11.0] - 2026-07-17
 
 ### Added
@@ -54,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     via `--model-variant` (or `GIGASTT_MODEL_VARIANT`); the engine also auto-detects the head
     from the encoder present on disk. REST `/v1/models` reports them as
     `gigaam-multilingual-ctc` / `gigaam-multilingual-large-ctc`.
+- **Benchmark WER for the Multilingual CTC heads across all five supported languages**
+  (`docs/benchmarks.md`). Clean-read WER for the 600M head: Russian 4.44% (`golos_crowd_1k`),
+  English 4.63% (LibriSpeech `test-clean`), Kazakh 6.52% / Kyrgyz 7.39% / Uzbek 9.21% (FLEURS,
+  digit-free) — 4.4–9.2% across languages; the 220M head is 6.15–11.96%. The Russian-only
+  `rnnt` / `e2e_rnnt` heads are Cyrillic-only (100% WER on English). Adds the `gigastt-ml-ctc`
+  / `gigastt-ml-ctc-large` benchmark runners and `scripts/prepare_librispeech.py`,
+  `scripts/prepare_fleurs.py`, `scripts/wer_unicode.py` (a Unicode-complete WER with the
+  number / apostrophe normalization these languages need). Russian phone / YouTube WER are not
+  measured (no local reference audio).
 
 ### Fixed
 

--- a/crates/gigastt-node/package.json
+++ b/crates/gigastt-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gigastt",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "On-device Russian speech-to-text (GigaAM v3) — Node.js binding",
   "license": "MIT",
   "repository": "https://github.com/ekhodzitsky/gigastt",

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -27,7 +27,7 @@ diarization = ["gigastt-core/diarization"]
 quantize = ["gigastt-core/quantize"]
 
 [dependencies]
-gigastt-core = { version = "2.4.0", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
+gigastt-core = { version = "2.11.0", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
 
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }


### PR DESCRIPTION
Release prep for **2.11.0** (the Multilingual CTC heads + benchmarks currently in main, untagged).

- Fold the benchmark notes from `[Unreleased]` into the `[2.11.0]` section (same release), leaving an empty `[Unreleased]`.
- Bump `gigastt-node` npm package `2.10.0` → `2.11.0`.
- Tighten `gigastt`'s `gigastt-core` dep `2.4.0` → `2.11.0` (it now uses `ModelVariant::is_ctc`), enforcing the publish order core→gigastt.

After merge: tag `v2.11.0` (triggers release.yml), then manual `cargo publish` (core → gigastt) and the npm / Homebrew updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)