### PR TITLE
fix(core): honor --model-variant when a model dir holds multiple heads (2.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.1] - 2026-07-19
+
+### Fixed
+
+- **`--model-variant` is now honored when a model directory holds more than one head.**
+  Previously the engine re-detected the head from the files on disk (with `rnnt` precedence)
+  at load time, so `--model-variant e2e_rnnt` (or any non-default head) was silently ignored
+  whenever a directory contained more than one head's files — the highest-precedence head
+  loaded instead. The resolved variant is now threaded through to the engine loader, so the
+  requested head is the one that loads (and the load fails with a clear error if that head's
+  files are absent). With no `--model-variant`, on-disk auto-detection is unchanged. Adds the
+  additive `Engine::load_with_pools_threads_variant` entry point.
+
 ## [2.11.0] - 2026-07-17
 
 ### Added
@@ -1562,7 +1575,8 @@ _Release candidate for v0.9.0 — bundles five P0 fixes plus two supporting item
 - Multi-format audio support: WAV, MP3, M4A/AAC, OGG/Vorbis, FLAC (via symphonia).
 - 39 unit tests (tokenizer, features, decode, inference, protocol).
 
-[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.0...HEAD
+[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.1...HEAD
+[2.11.1]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.0...v2.11.1
 [2.11.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.10.0...v2.11.0
 [2.10.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.8.0...v2.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.11.0"
+version = "2.11.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -70,7 +70,7 @@ use crate::model::ModelVariant;
 use crate::runtime::factory::Runtime;
 #[allow(unused_imports)]
 use crate::runtime::factory::RuntimeFactory;
-use crate::runtime::production_factory;
+use crate::runtime::production_factory_variant;
 use crate::runtime::session::RuntimeSession;
 use crate::runtime::tensor::{Shape, Tensor, TensorData, TensorDataView};
 
@@ -143,6 +143,15 @@ fn total_ram_bytes() -> u64 {
     {
         0
     }
+}
+
+/// Resolve which recognition head the engine should load: an explicit
+/// `override_` (from `--model-variant`) always wins, else auto-detect from the
+/// on-disk layout (`rnnt` precedence). Extracted so the override precedence —
+/// the fix that keeps `--model-variant` effective when a directory holds more
+/// than one head — is unit-testable without model files.
+fn resolve_load_variant(override_: Option<ModelVariant>, model_dir: &Path) -> Option<ModelVariant> {
+    override_.or_else(|| ModelVariant::detect_in_dir(model_dir))
 }
 
 /// Encoder time subsampling factor (4 frames → 1 encoder output frame).
@@ -1063,11 +1072,38 @@ impl Engine {
         batch_pool_size: usize,
         encoder_intra_threads: usize,
     ) -> Result<Self, GigasttError> {
+        Self::load_with_pools_threads_variant(
+            model_dir,
+            None,
+            pool_size,
+            min_size,
+            batch_pool_size,
+            encoder_intra_threads,
+        )
+    }
+
+    /// Like [`Engine::load_with_pools_threads`], but lets the caller force which
+    /// recognition head to load instead of auto-detecting it.
+    ///
+    /// When `variant` is `Some(v)`, head `v` is loaded (and the load fails with a
+    /// clear `ModelLoad` error if `v`'s files aren't in `model_dir`). When it is
+    /// `None`, the on-disk layout is auto-detected with `rnnt` precedence, exactly
+    /// as [`Engine::load_with_pools_threads`]. This is the entry point that makes
+    /// `--model-variant` effective when a directory holds more than one head.
+    pub fn load_with_pools_threads_variant(
+        model_dir: &str,
+        variant: Option<ModelVariant>,
+        pool_size: usize,
+        min_size: usize,
+        batch_pool_size: usize,
+        encoder_intra_threads: usize,
+    ) -> Result<Self, GigasttError> {
         let dir = Path::new(model_dir);
-        // Auto-detect which recognition head is present on disk (rnnt encoder
-        // takes precedence, else e2e_rnnt). The on-disk layout fully determines
-        // which head runs — callers select the variant only at download time.
-        let Some(variant) = ModelVariant::detect_in_dir(dir) else {
+        // Resolve the head once, up front: an explicit `variant` wins, else detect
+        // from disk (rnnt precedence). Resolving here (not just inside
+        // `load_with_factory`) keeps the RAM cap below sized to the head that will
+        // actually load.
+        let Some(variant) = resolve_load_variant(variant, dir) else {
             return Err(GigasttError::ModelLoad {
                 path: dir.display().to_string(),
                 source: None,
@@ -1089,9 +1125,10 @@ impl Engine {
         let encoder_intra_threads =
             Self::clamp_encoder_intra_threads(pool_size, encoder_intra_threads, logical_cpus);
 
-        let factory = production_factory(dir);
+        let factory = production_factory_variant(dir, Some(variant));
         Self::load_with_factory(
             dir,
+            Some(variant),
             pool_size,
             min_size,
             batch_pool_size,
@@ -1104,13 +1141,19 @@ impl Engine {
     /// by tests that inject a [`crate::runtime::factory::RuntimeFactory`].
     pub(crate) fn load_with_factory(
         model_dir: &Path,
+        variant_override: Option<ModelVariant>,
         pool_size: usize,
         min_size: usize,
         batch_pool_size: usize,
         factory: Box<dyn crate::runtime::factory::RuntimeFactory>,
         encoder_intra_threads: usize,
     ) -> Result<Self, GigasttError> {
-        let Some(variant) = ModelVariant::detect_in_dir(model_dir) else {
+        // Honor an explicit variant (e.g. from `--model-variant`) when the caller
+        // resolved one; otherwise auto-detect from the on-disk layout (rnnt
+        // precedence). Passing the override through is what makes `--model-variant`
+        // effective when a directory holds more than one head — without it the
+        // engine always re-detects and silently loads the highest-precedence head.
+        let Some(variant) = resolve_load_variant(variant_override, model_dir) else {
             return Err(GigasttError::ModelLoad {
                 path: model_dir.display().to_string(),
                 source: None,
@@ -3072,6 +3115,44 @@ mod tests {
         assert!(matches!(result, Err(GigasttError::ModelLoad { .. })));
     }
 
+    #[test]
+    fn test_resolve_load_variant_override_beats_disk_detection() {
+        // A directory holding BOTH the rnnt and e2e_rnnt encoders: on-disk
+        // detection returns rnnt (precedence), so without an explicit override the
+        // engine would silently ignore `--model-variant e2e_rnnt`. This is the
+        // regression this fix guards.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(ModelVariant::Rnnt.encoder_file()), b"x").unwrap();
+        std::fs::write(dir.path().join(ModelVariant::E2eRnnt.encoder_file()), b"x").unwrap();
+
+        // Sanity: bare on-disk detection prefers rnnt.
+        assert_eq!(
+            ModelVariant::detect_in_dir(dir.path()),
+            Some(ModelVariant::Rnnt)
+        );
+        // No override → auto-detect (rnnt precedence): behavior is unchanged.
+        assert_eq!(
+            resolve_load_variant(None, dir.path()),
+            Some(ModelVariant::Rnnt)
+        );
+        // Explicit override wins over the higher-precedence head on disk.
+        assert_eq!(
+            resolve_load_variant(Some(ModelVariant::E2eRnnt), dir.path()),
+            Some(ModelVariant::E2eRnnt)
+        );
+
+        // The override is honored even when its files aren't present — the engine
+        // load then fails with a clear ModelLoad error instead of silently loading
+        // whatever else is on disk.
+        let empty = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            resolve_load_variant(Some(ModelVariant::E2eRnnt), empty.path()),
+            Some(ModelVariant::E2eRnnt)
+        );
+        // No override + empty dir → nothing to load.
+        assert_eq!(resolve_load_variant(None, empty.path()), None);
+    }
+
     // ---- Pool tests (B.7) ---------------------------------------------------
     //
     // These exercise `Pool<T>` with synthetic items so the contract is
@@ -3935,6 +4016,7 @@ mod tests {
 
         let ort_engine = Engine::load_with_factory(
             model_path,
+            None,
             1,
             1,
             0,
@@ -3944,6 +4026,7 @@ mod tests {
         .expect("ort engine should load");
         let candle_engine = Engine::load_with_factory(
             model_path,
+            None,
             1,
             1,
             0,
@@ -4011,6 +4094,7 @@ mod tests {
 
         let ort_engine = Engine::load_with_factory(
             model_path,
+            None,
             1,
             1,
             0,
@@ -4020,6 +4104,7 @@ mod tests {
         .expect("ort engine should load");
         let candle_engine = Engine::load_with_factory(
             model_path,
+            None,
             1,
             1,
             0,
@@ -4191,6 +4276,7 @@ mod tests {
 
         let ort_engine = Engine::load_with_factory(
             model_path,
+            None,
             1,
             1,
             0,
@@ -4200,6 +4286,7 @@ mod tests {
         .expect("ort engine should load");
         let ane_engine = Engine::load_with_factory(
             model_path,
+            None,
             1,
             1,
             0,
@@ -4652,7 +4739,7 @@ mod tests {
             );
 
             let factory = Box::new(MockFactory::new(sessions));
-            let engine = Engine::load_with_factory(dir, 1, 1, 0, factory, 1)
+            let engine = Engine::load_with_factory(dir, None, 1, 1, 0, factory, 1)
                 .expect("engine should load with mock runtime");
             (engine, tmp)
         }

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -167,9 +167,11 @@ const PUNCT_FILES: &[(&str, &str)] = &[
 ///   encoder-only, 71-class multilingual char vocab (ru/en/kk/ky/uz), bare
 ///   lowercase output. Downloads istupakov's pre-quantized INT8 encoder.
 ///
-/// Real upstream filenames are kept on disk (no canonical-prefix rename), and
-/// the engine auto-detects the variant from the encoder file present in the
-/// model directory, so on-disk layout fully determines which head runs.
+/// Real upstream filenames are kept on disk (no canonical-prefix rename). An
+/// explicit `--model-variant` (the resolved variant threaded into the engine
+/// loader) selects the head; when none is given the engine auto-detects it from
+/// the encoder file present in the model directory (`rnnt` precedence when more
+/// than one head's files coexist).
 ///
 /// `#[non_exhaustive]`: recognition heads are added over time (this is an
 /// opt-in, additive catalog), so downstream matches must include a wildcard arm.

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -29,6 +29,7 @@ pub fn ane_factory() -> Box<dyn RuntimeFactory> {
 pub use error::RuntimeError;
 #[allow(unused_imports)]
 pub use factory::{Runtime, RuntimeFactory};
+pub(crate) use ort::factory::production_factory_variant;
 #[allow(unused_imports)]
 pub use ort::factory::{cpu_factory, production_factory};
 #[allow(unused_imports)]

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -181,29 +181,49 @@ pub fn cpu_factory() -> Box<dyn RuntimeFactory> {
 
 /// Returns a production `ort` factory that preserves the provider selection and
 /// disk-cache layout used by the engine before the runtime abstraction.
+///
+/// Public, stable 1-arg form: selects the backend from the variant detected on
+/// disk. The engine calls the crate-internal `production_factory_variant`
+/// instead, passing the head it has already resolved so an explicit
+/// `--model-variant` is honored.
 pub fn production_factory(model_dir: &Path) -> Box<dyn RuntimeFactory> {
+    production_factory_variant(
+        model_dir,
+        crate::model::ModelVariant::detect_in_dir(model_dir),
+    )
+}
+
+/// Like [`production_factory`], but the caller supplies the resolved recognition
+/// head. The rnnt-only candle/ane backends are gated on `variant` directly —
+/// re-detecting from disk here would reintroduce the multi-head bug where an
+/// explicit `--model-variant` override is overruled by `rnnt`-precedence
+/// detection. `None` (nothing resolved/detected) selects the ort factory, never
+/// the rnnt-only backends — matching the historical `production_factory`.
+pub(crate) fn production_factory_variant(
+    model_dir: &Path,
+    variant: Option<crate::model::ModelVariant>,
+) -> Box<dyn RuntimeFactory> {
+    // The candle/ane backends are rnnt-only, so they fire only for an explicit
+    // (or detected) `Rnnt` head. `is_rnnt` gates only those feature-gated blocks;
+    // on plain ort builds (cpu / coreml / cuda) it is otherwise unused.
+    let is_rnnt = variant == Some(crate::model::ModelVariant::Rnnt);
+    let _ = is_rnnt;
     // The Candle backend is rnnt-only (34-token char vocab,
-    // `EncoderConfig::v3_rnnt()`); for an `e2e_rnnt` model it would produce wrong
-    // output / fail to load. Use it only when the detected variant is `Rnnt`,
-    // otherwise fall back to the ort factory below.
+    // `EncoderConfig::v3_rnnt()`); for any other head it would produce wrong
+    // output / fail to load. Use it only for the `Rnnt` head, otherwise fall back
+    // to the ort factory below.
     #[cfg(feature = "candle")]
     {
-        if matches!(
-            crate::model::ModelVariant::detect_in_dir(model_dir),
-            Some(crate::model::ModelVariant::Rnnt)
-        ) {
+        if is_rnnt {
             return Box::new(crate::runtime::candle::factory::CandleFactory::new());
         }
     }
     // The ANE backend is rnnt-only (same restriction as Candle) and macOS-only
-    // (Apple frameworks); use it only when the detected variant is `Rnnt`,
-    // otherwise fall back to the ort factory below.
+    // (Apple frameworks); use it only for the `Rnnt` head, otherwise fall back to
+    // the ort factory below.
     #[cfg(all(feature = "ane", target_os = "macos"))]
     {
-        if matches!(
-            crate::model::ModelVariant::detect_in_dir(model_dir),
-            Some(crate::model::ModelVariant::Rnnt)
-        ) {
+        if is_rnnt {
             return Box::new(crate::runtime::coreml::factory::AneFactory::new());
         }
     }

--- a/crates/gigastt-core/tests/candle_rnnt_parity.rs
+++ b/crates/gigastt-core/tests/candle_rnnt_parity.rs
@@ -17,8 +17,7 @@
 use std::path::Path;
 
 use gigastt_core::runtime_api::{
-    Runtime, RuntimeSession, Shape, Tensor, TensorData, TensorDataView, candle_factory,
-    production_factory,
+    Runtime, RuntimeSession, Shape, Tensor, TensorData, TensorDataView, candle_factory, cpu_factory,
 };
 
 const PRED_HIDDEN: usize = 320;
@@ -71,7 +70,10 @@ fn candle_decoder_matches_ort() {
         dir.display()
     );
 
-    let ort = production_factory(&dir).create(1).expect("ort runtime");
+    // Use the raw ort factory directly: `production_factory` auto-selects the
+    // Candle backend for an rnnt model dir, which would make this a candle-vs-candle
+    // comparison instead of the intended ort-vs-candle parity gate.
+    let ort = cpu_factory().create(1).expect("ort runtime");
     let ort_sess = ort
         .load_session(&dec_onnx, false)
         .expect("ort load decoder");
@@ -142,7 +144,10 @@ fn candle_joiner_matches_ort() {
         dir.display()
     );
 
-    let ort = production_factory(&dir).create(1).expect("ort runtime");
+    // Use the raw ort factory directly: `production_factory` auto-selects the
+    // Candle backend for an rnnt model dir, which would make this a candle-vs-candle
+    // comparison instead of the intended ort-vs-candle parity gate.
+    let ort = cpu_factory().create(1).expect("ort runtime");
     let ort_sess = ort
         .load_session(&joint_onnx, false)
         .expect("ort load joiner");

--- a/crates/gigastt-node/package.json
+++ b/crates/gigastt-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gigastt",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "On-device Russian speech-to-text (GigaAM v3) — Node.js binding",
   "license": "MIT",
   "repository": "https://github.com/ekhodzitsky/gigastt",

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -27,7 +27,7 @@ diarization = ["gigastt-core/diarization"]
 quantize = ["gigastt-core/quantize"]
 
 [dependencies]
-gigastt-core = { version = "2.11.0", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
+gigastt-core = { version = "2.11.1", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
 
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -1092,8 +1092,9 @@ async fn main() -> anyhow::Result<()> {
                             .map(|n| n.get())
                             .unwrap_or(1),
                     );
-                    let mut engine = inference::Engine::load_with_pools_threads(
+                    let mut engine = inference::Engine::load_with_pools_threads_variant(
                         &model_dir,
+                        Some(resolved),
                         pool_size,
                         pool_min_size,
                         batch_pool_size,
@@ -1233,8 +1234,9 @@ async fn main() -> anyhow::Result<()> {
                     .map(|n| n.get())
                     .unwrap_or(1),
             );
-            let mut engine = inference::Engine::load_with_pools_threads(
+            let mut engine = inference::Engine::load_with_pools_threads_variant(
                 &model_dir,
+                Some(resolved),
                 1,
                 1,
                 0,


### PR DESCRIPTION
## The bug

`--model-variant` was **silently ignored** whenever a model directory held more than one
head's files. The engine's loader re-ran `ModelVariant::detect_in_dir` (which has `rnnt`
precedence) at load time and discarded the CLI-resolved variant — so `--model-variant
e2e_rnnt` (or any non-default head) loaded the wrong head, plus a 34-token vocab against an
e2e model, etc. It only worked by accident when a dir held exactly one head.

Surfaced while benchmarking `e2e_rnnt` vs `rnnt`+RuPunct (#156): forcing the head via the
flag didn't work; the logs showed `Detected model variant: Rnnt` regardless.

## The fix

Thread the already-resolved variant through to the loader (single source of truth):

- `Engine::load_with_pools_threads_variant(model_dir, Option<ModelVariant>, …)` — new additive
  entry point. `Some(v)` forces head `v`; `None` keeps the current on-disk auto-detection.
  Old `load_with_pools_threads` delegates with `None` (unchanged behavior).
- `load_with_factory` gains a `variant_override`; a private `resolve_load_variant(override, dir)`
  centralizes *explicit override wins, else `detect_in_dir`*.
- **`production_factory` now takes the resolved variant** and gates the rnnt-only candle/ane
  backends on it instead of re-running `detect_in_dir`. Without this the feature-gated
  candle/ane builds *still* ignored the override (encoder loaded as rnnt while the
  tokenizer/decoder used the requested head → garbled output). **This gap was found by an
  adversarial review of the first cut of the fix** — see below.
- `serve` + `transcribe` pass `Some(resolved)`. Bonus: the punctuation/ITN pipeline and the
  loaded head can no longer disagree (previously they could).
- `candle_rnnt_parity`: use `cpu_factory()` for the ort side — `production_factory` auto-selects
  candle for an rnnt dir, which would have made it a candle-vs-candle comparison.

## Verification

- **End-to-end**, on `~/.gigastt/models` (holds both `rnnt` + `e2e_rnnt`):
  - `serve --model-variant e2e_rnnt` → `Detected model variant: E2eRnnt`, `Loaded vocabulary: 1025 tokens` ✅
  - `serve --model-variant rnnt` → `Rnnt`, `34 tokens` ✅ (before: **both** loaded rnnt/34)
- New unit test `test_resolve_load_variant_override_beats_disk_detection` pins override-beats-precedence.
- `cargo test` (core+gigastt lib/bins) 403+116+80 pass; clippy clean on **default + candle + ane**;
  `cargo fmt --check` clean; `cargo-semver-checks` → *patch change, no semver update required*
  (the new method is additive).

## Adversarial review

Ran a 3-dimension review workflow (loader-correctness / wiring / release-hygiene) with
independent verification of each finding. 2 confirmed, both fixed in this PR:
1. **medium** — candle/ane `production_factory` re-detected the head, defeating the override on
   those builds (fixed by threading the variant into the factory).
2. **low** — stale `ModelVariant` doc-comment still claimed "on-disk layout fully determines
   which head runs" (corrected).

## Versioning

`2.11.0 → 2.11.1` (patch): workspace `Cargo.toml`, `gigastt` dep pin, `gigastt-node`
`package.json`, `Cargo.lock`; CHANGELOG entry + footer link.