### PR TITLE
ci: fix benchmark gate on fork PRs + cover the model-variant & diarization fixes

### DIFF
--- a/.github/workflows/android-aar.yml
+++ b/.github/workflows/android-aar.yml
@@ -42,6 +42,15 @@ jobs:
           distribution: temurin
           java-version: '17'
 
+      # Pin Gradle instead of relying on whatever the runner image happens to
+      # ship: there is no committed Gradle wrapper, and `setup-java` does not
+      # install Gradle, so `gradle …` below would otherwise use an unpinned,
+      # image-version-dependent binary. 8.7 is the minimum Gradle for AGP 8.5.2
+      # (packaging/android/build.gradle.kts).
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.7'
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
@@ -119,9 +128,7 @@ jobs:
 
       - name: Assemble AAR
         working-directory: packaging/android
-        run: |
-          chmod +x ./gradlew 2>/dev/null || true
-          gradle :gigastt:assembleRelease --no-daemon
+        run: gradle :gigastt:assembleRelease --no-daemon
 
       - name: Upload AAR
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,12 @@ jobs:
       - name: Check WER threshold
         run: |
           THRESHOLD=$(cat .github/wer-threshold.txt | tr -d '[:space:]')
-          WER=$(sed -n 's/.*WER: \([0-9.]*\)%.*/\1/p' benchmark_output.txt | head -1)
+          # Anchor to the normalized-WER line only. benchmark.rs prints two
+          # `WER:`-bearing lines — `  WER: N%` (normalized, the gate target) and
+          # `  Verbatim (naive) WER: N%`. The old `.*WER:` matched both and relied
+          # on print order + `head -1`; `^  WER:` matches only the normalized line
+          # (the verbatim line starts with `  Verbatim`).
+          WER=$(sed -n 's/^  WER: \([0-9.]*\)%.*/\1/p' benchmark_output.txt | head -1)
           if [ -z "$WER" ]; then
             echo "ERROR: Could not extract WER from benchmark output"
             exit 1
@@ -635,16 +640,22 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Save baseline from main
-        # Branch refs are untrusted input — pass them through env vars rather
-        # than interpolating into the shell directly (script-injection guard).
+        # Branch refs are untrusted input — pass the base through an env var
+        # rather than interpolating into the shell directly (script-injection
+        # guard). Return to the PR head by the SHA captured up front, NOT by
+        # `github.head_ref`: on a fork PR the head branch name is not a local ref
+        # in this checkout, so `git checkout "$HEAD_REF"` dies with "pathspec did
+        # not match" — which (under the default `bash -e`) aborted this step and
+        # skipped the benchmark + regression gate, failing the job for every fork
+        # PR. `git checkout --detach <sha>` works for fork and same-repo alike.
         env:
           BASE_REF: ${{ github.base_ref }}
-          HEAD_REF: ${{ github.head_ref }}
         run: |
+          head_sha="$(git rev-parse HEAD)"
           git stash --include-untracked || true
-          git checkout "$BASE_REF"
+          git checkout "origin/$BASE_REF"
           cargo bench -p gigastt-core --features __internals -- --save-baseline main || true
-          git checkout "$HEAD_REF"
+          git checkout --detach "$head_sha"
           git stash pop || true
 
       - name: Run benchmarks

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -16,12 +16,17 @@ categories = ["multimedia::audio"]
 # cargo-semver-checks otherwise flags as a major-only change.
 [package.metadata.cargo-semver-checks.lints]
 enum_marked_non_exhaustive = "allow"
-# The internal `SharedExtractor` diarization adapter lost the `UnwindSafe` /
-# `RefUnwindSafe` auto traits when its inner extractor was swapped to polyvoice's
-# fbank extractor (the fix for WeSpeaker rank-3 input). `SharedExtractor` is an
-# internal adapter — not re-exported at the crate root and unused outside this
-# crate — so the panic-safety auto-trait loss is not a real downstream break and
-# must not force a major bump for a diarization bugfix.
+# The `SharedExtractor` diarization adapter lost the `UnwindSafe` / `RefUnwindSafe`
+# auto traits when its inner extractor was swapped to polyvoice's fbank extractor
+# (the fix for WeSpeaker rank-3 input, 2.11.2). `SharedExtractor` IS public
+# (reachable as `inference::SharedExtractor` and via the `pub diarization_state`
+# field of `inference::StreamingState`), so this is technically observable — but
+# only to a consumer that `catch_unwind`s across a `StreamingState`, and these two
+# panic-safety auto traits are among the least-relied-upon (Send/Sync have their
+# own dedicated lints, unaffected). We accept it as a tolerated minor break on the
+# diarization-only path rather than force a major bump for a bugfix; revisit at the
+# next major (either restore the auto traits upstream in polyvoice or make the
+# adapter genuinely `pub(crate)`).
 auto_trait_impl_removed = "allow"
 
 [lib]

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -3829,6 +3829,25 @@ mod tests {
         assert!(state.audio_buffer.is_empty());
     }
 
+    // Model-free guard for the 2.11.2 diarization fix: `load_speaker_encoder` must
+    // stay wired to polyvoice's `FbankOnnxExtractor` (rank-3 fbank input) via its
+    // 3-arg constructor, NOT the old rank-2 raw-waveform `OnnxEmbeddingExtractor`
+    // (4-arg, with a segment-samples window) that caused the `Got: 2 Expected: 3`
+    // failure. The extractor reads the ONNX model at construction, so a nonexistent
+    // path returns Err (never panics/Ok). This runs on every PR without the ~26 MB
+    // model, and won't compile if the loader's return type / constructor arity
+    // regresses to the waveform extractor.
+    #[cfg(feature = "diarization")]
+    #[test]
+    fn test_load_speaker_encoder_missing_model_errors() {
+        let missing = Path::new("/nonexistent/gigastt-test/wespeaker_resnet34.onnx");
+        let result = load_speaker_encoder(missing, 1);
+        assert!(
+            result.is_err(),
+            "a missing WeSpeaker model must surface as Err, not panic or Ok"
+        );
+    }
+
     #[cfg(feature = "diarization")]
     #[test]
     #[ignore = "requires the WeSpeaker diarization model"]

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -193,40 +193,60 @@ pub fn production_factory(model_dir: &Path) -> Box<dyn RuntimeFactory> {
     )
 }
 
+/// Which runtime backend [`production_factory_variant`] selects for a resolved head.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackendKind {
+    /// Default `ort` backend (CPU / CoreML EP / CUDA EP, by compile-time feature).
+    Ort,
+    /// Pure-Rust Candle backend — rnnt-only.
+    Candle,
+    /// Apple Neural Engine backend — rnnt-only, macOS-only.
+    Ane,
+}
+
+/// Pure backend selection for [`production_factory_variant`]. The rnnt-only
+/// Candle/ANE backends are chosen ONLY for a resolved `Rnnt` head on a build that
+/// compiled them in; every other head — and `None` — uses the `ort` backend.
+/// Extracted so the `--model-variant` → backend gate (the candle/ane half of the
+/// multi-head fix) is unit-testable without model files.
+pub(crate) fn select_backend(variant: Option<crate::model::ModelVariant>) -> BackendKind {
+    let is_rnnt = variant == Some(crate::model::ModelVariant::Rnnt);
+    #[cfg(feature = "candle")]
+    if is_rnnt {
+        return BackendKind::Candle;
+    }
+    #[cfg(all(feature = "ane", target_os = "macos"))]
+    if is_rnnt {
+        return BackendKind::Ane;
+    }
+    let _ = is_rnnt;
+    BackendKind::Ort
+}
+
 /// Like [`production_factory`], but the caller supplies the resolved recognition
-/// head. The rnnt-only candle/ane backends are gated on `variant` directly —
-/// re-detecting from disk here would reintroduce the multi-head bug where an
-/// explicit `--model-variant` override is overruled by `rnnt`-precedence
-/// detection. `None` (nothing resolved/detected) selects the ort factory, never
-/// the rnnt-only backends — matching the historical `production_factory`.
+/// head. The rnnt-only candle/ane backends are gated on `variant` directly (see
+/// [`select_backend`]) — re-detecting from disk here would reintroduce the
+/// multi-head bug where an explicit `--model-variant` override is overruled by
+/// `rnnt`-precedence detection. `None` (nothing resolved/detected) selects the ort
+/// factory, never the rnnt-only backends — matching the historical
+/// `production_factory`.
 pub(crate) fn production_factory_variant(
     model_dir: &Path,
     variant: Option<crate::model::ModelVariant>,
 ) -> Box<dyn RuntimeFactory> {
-    // The candle/ane backends are rnnt-only, so they fire only for an explicit
-    // (or detected) `Rnnt` head. `is_rnnt` gates only those feature-gated blocks;
-    // on plain ort builds (cpu / coreml / cuda) it is otherwise unused.
-    let is_rnnt = variant == Some(crate::model::ModelVariant::Rnnt);
-    let _ = is_rnnt;
-    // The Candle backend is rnnt-only (34-token char vocab,
-    // `EncoderConfig::v3_rnnt()`); for any other head it would produce wrong
-    // output / fail to load. Use it only for the `Rnnt` head, otherwise fall back
-    // to the ort factory below.
+    let backend = select_backend(variant);
+    // The Candle/ANE backends are rnnt-only (34-token char vocab,
+    // `EncoderConfig::v3_rnnt()`); for any other head they would produce wrong
+    // output / fail to load, so `select_backend` only picks them for `Rnnt`.
     #[cfg(feature = "candle")]
-    {
-        if is_rnnt {
-            return Box::new(crate::runtime::candle::factory::CandleFactory::new());
-        }
+    if backend == BackendKind::Candle {
+        return Box::new(crate::runtime::candle::factory::CandleFactory::new());
     }
-    // The ANE backend is rnnt-only (same restriction as Candle) and macOS-only
-    // (Apple frameworks); use it only for the `Rnnt` head, otherwise fall back to
-    // the ort factory below.
     #[cfg(all(feature = "ane", target_os = "macos"))]
-    {
-        if is_rnnt {
-            return Box::new(crate::runtime::coreml::factory::AneFactory::new());
-        }
+    if backend == BackendKind::Ane {
+        return Box::new(crate::runtime::coreml::factory::AneFactory::new());
     }
+    let _ = backend;
 
     let factory = if cfg!(feature = "coreml") {
         OrtFactory::coreml()
@@ -236,4 +256,65 @@ pub(crate) fn production_factory_variant(
         OrtFactory::cpu().with_optimized_cache_dir(model_dir.join("optimized_cache"))
     };
     Box::new(factory)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ModelVariant;
+
+    // The rnnt-only candle/ane backends must NEVER be selected for a non-rnnt head
+    // or for `None`, on any build — this is the exact gate the multi-head
+    // `--model-variant` fix added so candle/ane honor the resolved head instead of
+    // re-detecting `rnnt` from disk. Model-free; runs in the PR-gating unit tests.
+    #[test]
+    fn select_backend_non_rnnt_and_none_are_always_ort() {
+        assert_eq!(
+            select_backend(Some(ModelVariant::E2eRnnt)),
+            BackendKind::Ort
+        );
+        assert_eq!(select_backend(Some(ModelVariant::MlCtc)), BackendKind::Ort);
+        assert_eq!(
+            select_backend(Some(ModelVariant::MlCtcLarge)),
+            BackendKind::Ort
+        );
+        assert_eq!(select_backend(None), BackendKind::Ort);
+    }
+
+    // On the default ort builds (cpu / coreml / cuda) even `Rnnt` uses the ort
+    // backend — the rnnt-only accelerated backends aren't compiled in.
+    #[cfg(not(any(feature = "candle", all(feature = "ane", target_os = "macos"))))]
+    #[test]
+    fn select_backend_rnnt_is_ort_without_accelerated_backend() {
+        assert_eq!(select_backend(Some(ModelVariant::Rnnt)), BackendKind::Ort);
+    }
+
+    // On a candle build, `Rnnt` picks the Candle backend but every other head (and
+    // `None`) still falls through to ort — proving the fix's `is_rnnt` gate.
+    #[cfg(feature = "candle")]
+    #[test]
+    fn select_backend_candle_only_for_rnnt() {
+        assert_eq!(
+            select_backend(Some(ModelVariant::Rnnt)),
+            BackendKind::Candle
+        );
+        assert_eq!(
+            select_backend(Some(ModelVariant::E2eRnnt)),
+            BackendKind::Ort
+        );
+        assert_eq!(select_backend(Some(ModelVariant::MlCtc)), BackendKind::Ort);
+        assert_eq!(select_backend(None), BackendKind::Ort);
+    }
+
+    // Same for the ANE (macOS) build.
+    #[cfg(all(feature = "ane", target_os = "macos"))]
+    #[test]
+    fn select_backend_ane_only_for_rnnt() {
+        assert_eq!(select_backend(Some(ModelVariant::Rnnt)), BackendKind::Ane);
+        assert_eq!(
+            select_backend(Some(ModelVariant::E2eRnnt)),
+            BackendKind::Ort
+        );
+        assert_eq!(select_backend(None), BackendKind::Ort);
+    }
 }


### PR DESCRIPTION
## Why

The `Benchmarks (regression gate)` job failed on **every fork PR** (e.g. #154 from a fork). Its
`Save baseline from main` step ran `git checkout "$HEAD_REF"` (`github.head_ref`), but on a fork
PR that branch name is **not a local ref** in the CI checkout — so it died with `pathspec did not
match` (under the default `bash -e`), which skipped the benchmark + regression steps and failed
the job. It never even measured a regression.

Then an audit workflow (3 dimensions — CI robustness / test coverage / release consistency, each
finding independently verified) surfaced four more real issues, all fixed here.

## Changes

**CI green-blockers**
- **`ci.yml` benchmark gate** — return to the PR head by the SHA captured up front, not by
  `github.head_ref`. Works for fork and same-repo PRs. Validated locally by simulating the
  fork-PR detached-HEAD state (old approach reproduces `pathspec did not match`; new approach
  returns to the exact commit).
- **`ci.yml` WER threshold** — anchor the `sed` to the normalized `^  WER:` line so it can't read
  the `Verbatim (naive) WER:` line (it only worked by print order + `head -1`). Validated against
  a simulated benchmark output.
- **`android-aar.yml`** — pin Gradle via `gradle/actions/setup-gradle@v4` (8.7, the minimum for
  AGP 8.5.2) instead of the runner's unpinned system `gradle`; drop the no-op `chmod +x ./gradlew`
  against a nonexistent wrapper. (workflow_dispatch-only job; would break the AAR release the first
  time the runner's Gradle drifts.)

**Test coverage** (both run in the existing PR-gating jobs, no model needed)
- **`factory.rs`** — extract the candle/ane backend gate into a pure `select_backend` +
  `BackendKind` and unit-test it: `rnnt` → candle/ane, every other head and `None` → ort. This is
  the candle/ane half of the 2.11.1 `--model-variant` fix, which previously had **no** test. Runs
  under default, `candle`, and `ane`.
- **`inference/mod.rs`** — model-free test that `load_speaker_encoder` returns `Err` (not panic) on
  a missing model, guarding the 2.11.2 diarization `FbankOnnxExtractor` (rank-3) wiring on every PR
  — its only other test is `#[ignore]` (needs the 26 MB WeSpeaker model) and never ran on PRs.

**Consistency**
- **`gigastt-core/Cargo.toml`** — correct the `auto_trait_impl_removed` override comment: it wrongly
  called `SharedExtractor` internal, but it's public via `inference::StreamingState`. The rationale
  now states accurately that the panic-safety auto-trait loss is a tolerated minor break.

## Verification

`cargo fmt --check`, `clippy` (default + candle + ane), `semver-checks` (patch, no change),
`RUSTDOCFLAGS=-D warnings cargo doc`, and 406+116+80 unit tests — all green. New tests pass under
default, candle, and ane. `actionlint` clean on the changed steps. No version bump / CHANGELOG entry
— these are CI + test + internal-comment changes with no user-facing behavior.