### PR TITLE
fix(server): make offline diarization opt-in (2.11.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.3] - 2026-07-19
+
+### Fixed
+
+- **Offline file transcription no longer diarizes unless asked.** After the 2.11.2 WeSpeaker
+  fix made the speaker encoder actually work, every `/v1/transcribe` (and SSE stream) began
+  attaching speaker labels whenever the diarization model was present — ignoring the opt-in
+  `?diarization=true` parameter and, in particular, labelling the `channels=split` dual-mono
+  fallback. Offline speaker diarization is now gated on the request: a plain transcript carries
+  no `speaker` fields, and only `?diarization=true` runs the speaker pass. Streaming (WebSocket)
+  was already correctly gated. Adds the additive `Engine::transcribe_bytes_shared_with_overrides_diarized`
+  entry point.
+
 ## [2.11.2] - 2026-07-19
 
 ### Fixed
@@ -1583,7 +1596,8 @@ _Release candidate for v0.9.0 — bundles five P0 fixes plus two supporting item
 - Multi-format audio support: WAV, MP3, M4A/AAC, OGG/Vorbis, FLAC (via symphonia).
 - 39 unit tests (tokenizer, features, decode, inference, protocol).
 
-[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.2...HEAD
+[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.3...HEAD
+[2.11.3]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.2...v2.11.3
 [2.11.2]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.1...v2.11.2
 [2.11.1]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.0...v2.11.1
 [2.11.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.10.0...v2.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.11.2"
+version = "2.11.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1887,7 +1887,7 @@ impl Engine {
             audio::decode_audio_file(path).map_err(|e| GigasttError::InvalidAudio {
                 reason: format!("{e:#}"),
             })?;
-        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides)
+        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides, false)
     }
 
     /// Transcribe audio from raw bytes in memory (no temp file needed).
@@ -1938,7 +1938,28 @@ impl Engine {
             audio::decode_audio_bytes_shared(data).map_err(|e| GigasttError::InvalidAudio {
                 reason: format!("{e:#}"),
             })?;
-        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides)
+        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides, false)
+    }
+
+    /// Like [`Engine::transcribe_bytes_shared_with_overrides`], but also runs
+    /// offline speaker diarization (labels each word's `speaker`) when a speaker
+    /// encoder is loaded. Diarization is **opt-in per request** (`?diarization=true`
+    /// on the REST surface): the non-diarized transcribe methods never label
+    /// speakers, so a plain transcript — and the `channels=split` dual-mono
+    /// fallback — carries no speaker labels. Without the `diarization` feature or a
+    /// loaded speaker encoder this is byte-for-byte the non-diarized method.
+    #[cfg(feature = "file-decode")]
+    pub fn transcribe_bytes_shared_with_overrides_diarized(
+        &self,
+        data: bytes::Bytes,
+        triplet: &mut SessionTriplet,
+        overrides: &TranscribeOverrides,
+    ) -> Result<TranscribeResult, GigasttError> {
+        let float_samples =
+            audio::decode_audio_bytes_shared(data).map_err(|e| GigasttError::InvalidAudio {
+                reason: format!("{e:#}"),
+            })?;
+        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides, true)
     }
 
     /// Transcribe a multi-channel recording with one speaker label per channel.
@@ -1993,6 +2014,7 @@ impl Engine {
             float_samples,
             triplet,
             &TranscribeOverrides::default(),
+            false,
         )
     }
 
@@ -2008,7 +2030,14 @@ impl Engine {
         float_samples: &[f32],
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
+        diarize: bool,
     ) -> Result<TranscribeResult, GigasttError> {
+        // `diarize` is opt-in per request: offline speaker diarization only runs
+        // when the caller asked for it (REST `?diarization=true`). A plain
+        // transcript — and the `channels=split` dual-mono fallback — must carry no
+        // speaker labels, so the default paths pass `false`.
+        #[cfg(not(feature = "diarization"))]
+        let _ = diarize;
         let wall_start = std::time::Instant::now();
         let duration_s = float_samples.len() as f64 / 16000.0;
 
@@ -2016,7 +2045,7 @@ impl Engine {
         let mut words = self.decode_words_for_samples(float_samples, triplet, overrides)?;
 
         #[cfg(feature = "diarization")]
-        if let Some(ref enc) = self.speaker_encoder {
+        if diarize && let Some(ref enc) = self.speaker_encoder {
             let config = DiaConfig::default();
             let vad_config = VadConfig::default();
             let pipeline = Pipeline::new(config, vad_config);
@@ -4891,6 +4920,7 @@ mod tests {
                         vad: Some(false),
                         ..Default::default()
                     },
+                    false,
                 )
                 .expect("vad-off decode");
             assert_eq!(baseline.text, with_vad_off.text);

--- a/crates/gigastt-node/package.json
+++ b/crates/gigastt-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gigastt",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "On-device Russian speech-to-text (GigaAM v3) — Node.js binding",
   "license": "MIT",
   "repository": "https://github.com/ekhodzitsky/gigastt",

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -27,7 +27,7 @@ diarization = ["gigastt-core/diarization"]
 quantize = ["gigastt-core/quantize"]
 
 [dependencies]
-gigastt-core = { version = "2.11.2", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
+gigastt-core = { version = "2.11.3", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
 
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -702,12 +702,18 @@ pub async fn transcribe(
                 } else {
                     engine.transcribe_channels(&channels, &mut reservation)
                 }
+            } else if request_diarization {
+                // Diarization is opt-in (`?diarization=true`): only then run the
+                // offline speaker pass. `body` is `axum::body::Bytes` (a
+                // `bytes::Bytes` re-export) so the decode shares the upload buffer.
+                engine.transcribe_bytes_shared_with_overrides_diarized(
+                    body,
+                    &mut reservation,
+                    &overrides,
+                )
             } else {
-                // `body` is an `axum::body::Bytes` (re-export of `bytes::Bytes`):
-                // `clone()` is a refcount bump, not a data copy, so the decode
-                // path shares the original upload buffer. `overrides` is `Copy`
-                // and already validated above; with all fields absent this is
-                // byte-identical to `transcribe_bytes_shared`.
+                // No diarization requested: byte-identical to the pre-existing
+                // zero-copy path. `overrides` is `Copy` and already validated above.
                 engine.transcribe_bytes_shared_with_overrides(body, &mut reservation, &overrides)
             }
         }));

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -719,6 +719,14 @@ impl JobExecution for RealJobExecutor {
                         } else {
                             engine_for_inference.transcribe_channels(&channels, &mut reservation)
                         }
+                    } else if params.diarization == Some(true) {
+                        // Diarization is opt-in (`?diarization=true`): only then run
+                        // the offline speaker pass, matching the sync REST path.
+                        engine_for_inference.transcribe_bytes_shared_with_overrides_diarized(
+                            body_for_inference,
+                            &mut reservation,
+                            &overrides,
+                        )
                     } else {
                         engine_for_inference.transcribe_bytes_shared_with_overrides(
                             body_for_inference,

--- a/crates/gigastt/tests/e2e_rest.rs
+++ b/crates/gigastt/tests/e2e_rest.rs
@@ -1046,6 +1046,54 @@ async fn test_transcribe_channels_split_dual_mono_fallback() {
     let _ = shutdown.send(());
 }
 
+// Offline diarization is opt-in per request: a plain `/v1/transcribe` must NOT
+// label speakers, and only `?diarization=true` runs the speaker pass. This guards
+// the 2.11.2 regression where the working fbank extractor made every offline
+// transcript diarize unconditionally (the dual-mono fallback above then emitted
+// speakers). Single-speaker fixture → the diarized pass labels every word speaker_0.
+#[ignore]
+#[tokio::test]
+async fn test_transcribe_diarization_is_opt_in() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let wav = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/golos_00.wav"
+    ))
+    .expect("read fixture");
+
+    let words_for = |query: &str, wav: Vec<u8>| {
+        let url = format!("http://127.0.0.1:{port}/v1/transcribe{query}");
+        async move {
+            let resp = reqwest::Client::new()
+                .post(url)
+                .body(wav)
+                .send()
+                .await
+                .expect("POST /v1/transcribe failed");
+            assert_eq!(resp.status(), 200);
+            let body: serde_json::Value =
+                serde_json::from_str(&resp.text().await.expect("text body")).expect("JSON");
+            body["words"].as_array().cloned().expect("words array")
+        }
+    };
+
+    // Default: no diarization requested → no speaker labels.
+    let default_words = words_for("", wav.clone()).await;
+    assert!(
+        default_words.iter().all(|w| w["speaker"].is_null()),
+        "plain /v1/transcribe must not emit speaker labels"
+    );
+
+    // Opt-in: ?diarization=true → the offline speaker pass labels words.
+    let diarized_words = words_for("?diarization=true", wav).await;
+    assert!(
+        diarized_words.iter().any(|w| !w["speaker"].is_null()),
+        "?diarization=true must label at least one word with a speaker"
+    );
+
+    let _ = shutdown.send(());
+}
+
 #[ignore]
 #[tokio::test]
 async fn test_transcribe_channels_split_with_diarization_returns_400() {


### PR DESCRIPTION
## Why CI went red on main

The main-push **E2E Tests** job has been failing since **2.11.2** (`test_transcribe_channels_split_dual_mono_fallback`, first red on the #154 merge). PR CI never caught it — e2e runs on main-push only. #158/#159 inherited the already-broken main.

**Root cause:** `Engine::transcribe_samples_with_overrides` (offline file transcription) always ran speaker diarization when a speaker encoder was loaded — with no gate on the request. Before 2.11.2 the encoder was broken (`Got: 2 Expected: 3`), so the pass silently failed and no `speaker` fields appeared. The 2.11.2 WeSpeaker fbank fix made it *work*, so every `/v1/transcribe` (and SSE stream) began attaching speaker labels — ignoring the opt-in `?diarization=true` param and labelling the `channels=split` dual-mono fallback, which the test asserts must be speaker-free.

Confirmed by local repro (dual-mono fallback emitted a speaker) and by bisecting the main-push CI: last green = `90082ae` (#157, 2.11.1), first red = `282b89f2` (#154, 2.11.2).

## Fix

Gate the **offline** speaker pass on request intent (streaming was already gated via `create_state(diarization_enabled)`):
- private `transcribe_samples_with_overrides` gains `diarize: bool`; the diarization block runs only when `true`. All existing call sites pass `false`.
- add the additive `Engine::transcribe_bytes_shared_with_overrides_diarized` (opt-in entry point).
- `http.rs` + `jobs.rs` call the diarized variant only when `?diarization=true`. Plain transcripts and the dual-mono fallback stay speaker-free; `channels=split` positional labelling is unchanged.

No public breaking change (private signature + additive method; `cargo-semver-checks` → patch).

## Tests

- Adds `test_transcribe_diarization_is_opt_in`: default `/v1/transcribe` → no `speaker` fields; `?diarization=true` → words are labelled.
- Verified locally with the model: **all 34 `e2e_rest` ignored tests pass** (incl. the previously-red dual-mono fallback and the 5 channel/diarization tests). `fmt` / `clippy` (default + candle) / `--no-default-features` / unit tests (406+116+80) / `semver-checks` all green.

Bump 2.11.2 → 2.11.3.