### PR TITLE
feat(streaming): punctuation and ITN on streaming final segments (2.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     reconfiguration, post-panic session reset). SSE follows the server boot policy —
     per-request parameters for `/v1/transcribe/stream` are not part of this release.
   - Measured cost at the finalization boundary: `restore` on 1–10-word segments is
-    p95 ≈ 0.5–1.0 ms (debug build, Apple Silicon) — three orders of magnitude under a
-    100 ms budget, so enrichment runs unconditionally regardless of segment length.
+    p95 ≈ 0.5–1.0 ms (debug build, Apple Silicon) — roughly two orders of magnitude under
+    a 100 ms budget, so enrichment runs unconditionally regardless of segment length.
   - The `ClientMessage::Configure` struct variant is now `#[non_exhaustive]` (match it
     with a `..` rest pattern): the wire protocol grows by additive optional fields, and
     the marking lets future ones ship as minor releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-07-20
+
+### Added
+
+- **Streaming `final` segments now carry ITN + punctuation/casing restoration.** Both the
+  WebSocket and SSE streaming paths post-process each segment at its finalization boundary
+  (endpoint flush / stop flush) with the same policy as file transcription: inverse text
+  normalization first, then punctuation/casing restoration when a punctuation model is
+  attached (`--punctuation` / `--itn`, default `auto` = on for the bare `rnnt` head, off
+  for `e2e_rnnt`, which is already punctuated by the model). `partial` messages stay the
+  raw decoder hypothesis, and `words[]` payloads keep the raw output — only the joined
+  `text` is rewritten, exactly like the file path. Live-dictation clients no longer have
+  to choose between streaming previews and readable transcripts.
+  - Additive WS `configure` fields `punctuation` / `itn` override the server policy per
+    session (sent before the first audio frame; an omitted field keeps the server
+    default; `punctuation: true` on a server without a punctuation model is a graceful
+    no-op). The overrides survive mid-session state recreation (diarization
+    reconfiguration, post-panic session reset). SSE follows the server boot policy —
+    per-request parameters for `/v1/transcribe/stream` are not part of this release.
+  - Measured cost at the finalization boundary: `restore` on 1–10-word segments is
+    p95 ≈ 0.5–1.0 ms (debug build, Apple Silicon) — three orders of magnitude under a
+    100 ms budget, so enrichment runs unconditionally regardless of segment length.
+  - The `ClientMessage::Configure` struct variant is now `#[non_exhaustive]` (match it
+    with a `..` rest pattern): the wire protocol grows by additive optional fields, and
+    the marking lets future ones ship as minor releases.
+
 ## [2.11.3] - 2026-07-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.11.3"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.11.3"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.11.3"
+version = "2.12.0"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.11.3"
+version = "2.12.0"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.11.3"
+version = "2.12.0"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.11.3"
+version = "2.12.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -28,6 +28,15 @@ enum_marked_non_exhaustive = "allow"
 # next major (either restore the auto traits upstream in polyvoice or make the
 # adapter genuinely `pub(crate)`).
 auto_trait_impl_removed = "allow"
+# The WS wire protocol evolves by adding optional fields to existing messages
+# (documented compatibility convention in `protocol/mod.rs`), so the
+# `ClientMessage::Configure` struct variant is `#[non_exhaustive]`: foreign
+# matches need a `..` rest pattern, and each future additive field ships as a
+# minor release instead of a major one. `ClientMessage` is Deserialize-only
+# (the server's inbound parse type), so losing foreign construction of the
+# variant costs nothing real. Allow the one-time marking, which
+# cargo-semver-checks otherwise flags as a major-only change.
+enum_variant_marked_non_exhaustive = "allow"
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1875,6 +1875,12 @@ impl Engine {
     /// file path. Runs only at finalization boundaries (endpoint flush /
     /// Stop-flush), so `partial` payloads are never rewritten and live previews
     /// don't flicker between hypotheses.
+    ///
+    /// Latency: measured via `punctuation::tests::test_restore_latency_short_segments`
+    /// (debug build, Apple Silicon), `restore` costs p95 ≈ 0.45–1.0 ms on 1–10
+    /// word segments — three orders of magnitude below the 100 ms budget that
+    /// would force a segment-length gate, so enrichment always runs regardless
+    /// of segment length.
     fn enrich_final_segment(&self, seg: &mut TranscriptSegment, state: &StreamingState) {
         let text = std::mem::take(&mut seg.text);
         let text = if state.itn.unwrap_or(self.itn) {

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1883,9 +1883,9 @@ impl Engine {
     ///
     /// Latency: measured via `punctuation::tests::test_restore_latency_short_segments`
     /// (debug build, Apple Silicon), `restore` costs p95 ≈ 0.45–1.0 ms on 1–10
-    /// word segments — three orders of magnitude below the 100 ms budget that
-    /// would force a segment-length gate, so enrichment always runs regardless
-    /// of segment length.
+    /// word segments — roughly two orders of magnitude below the 100 ms budget
+    /// that would force a segment-length gate, so enrichment always runs
+    /// regardless of segment length.
     fn enrich_final_segment(&self, seg: &mut TranscriptSegment, state: &StreamingState) {
         let text = std::mem::take(&mut seg.text);
         let text = if state.itn.unwrap_or(self.itn) {

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -672,6 +672,14 @@ pub struct StreamingState {
     /// `process_chunk` finalizes the current segment. `None` = no VAD, and
     /// endpointing falls back to the decoder's blank-run heuristic alone.
     pub vad_endpointer: Option<crate::vad::VadEndpointer>,
+    /// Per-session punctuation/casing-restoration override applied to **final**
+    /// segments only (`None` = engine boot default). Set by the WS `configure`
+    /// message; SSE and FFI streaming leave it `None` so the boot policy
+    /// applies. Partials always stay raw.
+    pub punctuation: Option<bool>,
+    /// Per-session inverse-text-normalization override applied to **final**
+    /// segments only (`None` = engine boot default).
+    pub itn: Option<bool>,
     /// Diarization state (present only when diarization is enabled).
     #[cfg(feature = "diarization")]
     pub diarization_state: Option<StreamingPipeline<EnergyVad, SharedExtractor>>,
@@ -1664,6 +1672,8 @@ impl Engine {
                 .vad
                 .as_ref()
                 .map(|_| crate::vad::VadEndpointer::new(&self.vad_config)),
+            punctuation: None,
+            itn: None,
             #[cfg(feature = "diarization")]
             diarization_state,
         }
@@ -1745,7 +1755,8 @@ impl Engine {
         let ts = now_timestamp();
 
         if endpoint || over_cap || vad_endpoint {
-            let seg = state.assembler.finalize(ts);
+            let mut seg = state.assembler.finalize(ts);
+            self.enrich_final_segment(&mut seg, state);
             // Slide: retain the trailing left-context window for the next decode.
             let keep = STREAM_LEFT_CONTEXT_SAMPLES.min(state.audio_buffer.len());
             let slide_off = state.audio_buffer.len() - keep;
@@ -1850,7 +1861,31 @@ impl Engine {
         if state.assembler.is_empty() {
             return None;
         }
-        Some(state.assembler.finalize(now_timestamp()))
+        let mut seg = state.assembler.finalize(now_timestamp());
+        self.enrich_final_segment(&mut seg, state);
+        Some(seg)
+    }
+
+    /// Post-process a finalized streaming segment: ITN, then punctuation/casing
+    /// restoration on the joined `text`. Mirrors
+    /// [`Engine::finish_transcribe_result`]'s policy exactly — the per-session
+    /// override wins over the engine boot default (`None` keeps it), and the
+    /// `punctuator` guard makes the pass a graceful no-op when no punct model
+    /// is attached. Word payloads keep the raw decoder output, exactly like the
+    /// file path. Runs only at finalization boundaries (endpoint flush /
+    /// Stop-flush), so `partial` payloads are never rewritten and live previews
+    /// don't flicker between hypotheses.
+    fn enrich_final_segment(&self, seg: &mut TranscriptSegment, state: &StreamingState) {
+        let text = std::mem::take(&mut seg.text);
+        let text = if state.itn.unwrap_or(self.itn) {
+            crate::itn::apply_itn(&text)
+        } else {
+            text
+        };
+        seg.text = match &self.punctuator {
+            Some(p) if state.punctuation.unwrap_or(true) => p.restore(&text),
+            _ => text,
+        };
     }
 
     /// Transcribe an audio file to text (supports WAV, MP3, M4A/AAC, OGG, FLAC).
@@ -4925,6 +4960,78 @@ mod tests {
                 .expect("vad-off decode");
             assert_eq!(baseline.text, with_vad_off.text);
             assert_eq!(baseline.words.len(), with_vad_off.words.len());
+        }
+
+        #[test]
+        fn test_create_state_postprocess_overrides_default_to_none() {
+            // A fresh streaming state inherits the engine boot policy: both
+            // per-session overrides start unset.
+            let (engine, _tmp) = tiny_mock_engine();
+            let state = engine.create_state(false);
+            assert_eq!(state.punctuation, None);
+            assert_eq!(state.itn, None);
+        }
+
+        #[test]
+        fn test_flush_state_applies_itn_per_engine_default() {
+            // Streaming finals go through the same ITN pass as the file path:
+            // with the engine default on, number-words are digitized at flush.
+            let (engine, _tmp) = tiny_mock_engine();
+            let engine = engine.with_itn(true);
+            let mut state = engine.create_state(false);
+            state.assembler.set_words(vec![
+                super::word("двадцать", 0.0, 0.4),
+                super::word("один", 0.4, 0.8),
+            ]);
+            let seg = engine.flush_state(&mut state).expect("flush");
+            assert_eq!(seg.text, "21");
+            // Word payloads stay raw — only the joined text is rewritten.
+            assert_eq!(seg.words[0].word, "двадцать");
+            assert_eq!(seg.words[1].word, "один");
+        }
+
+        #[test]
+        fn test_flush_state_session_override_disables_itn() {
+            // `Configure{itn:false}` wins over an ITN-on engine boot policy.
+            let (engine, _tmp) = tiny_mock_engine();
+            let engine = engine.with_itn(true);
+            let mut state = engine.create_state(false);
+            state.itn = Some(false);
+            state.assembler.set_words(vec![
+                super::word("двадцать", 0.0, 0.4),
+                super::word("один", 0.4, 0.8),
+            ]);
+            let seg = engine.flush_state(&mut state).expect("flush");
+            assert_eq!(seg.text, "двадцать один");
+        }
+
+        #[test]
+        fn test_flush_state_default_leaves_text_raw() {
+            // Boot defaults (ITN off, no punctuator) reproduce the pre-feature
+            // behaviour byte-for-byte.
+            let (engine, _tmp) = tiny_mock_engine();
+            let mut state = engine.create_state(false);
+            state.assembler.set_words(vec![
+                super::word("двадцать", 0.0, 0.4),
+                super::word("один", 0.4, 0.8),
+            ]);
+            let seg = engine.flush_state(&mut state).expect("flush");
+            assert_eq!(seg.text, "двадцать один");
+        }
+
+        #[test]
+        fn test_flush_state_punctuation_request_without_punctuator_is_noop() {
+            // `Configure{punctuation:true}` on a punct-less server degrades
+            // gracefully: the final is emitted unchanged (streaming never
+            // errors on post-processing, unlike the REST 409).
+            let (engine, _tmp) = tiny_mock_engine();
+            let mut state = engine.create_state(false);
+            state.punctuation = Some(true);
+            state
+                .assembler
+                .set_words(vec![super::word("hello", 0.0, 0.4)]);
+            let seg = engine.flush_state(&mut state).expect("flush");
+            assert_eq!(seg.text, "hello");
         }
     }
 }

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -861,12 +861,14 @@ pub struct Engine {
     /// off for [`ModelVariant::E2eRnnt`] (already punctuated).
     variant: ModelVariant,
     /// Optional punctuation / casing restorer applied to file-transcription
-    /// output. `None` = pass-through (the default, and the only behaviour when
-    /// no punct model is installed). Attached via [`Engine::with_punctuator`].
+    /// output and to finalized streaming segments. `None` = pass-through (the
+    /// default, and the only behaviour when no punct model is installed).
+    /// Attached via [`Engine::with_punctuator`].
     punctuator: Option<crate::punctuation::Punctuator>,
     /// Whether to run inverse text normalization (Russian number-words →
-    /// digits) on file-transcription output, *before* the punctuation pass.
-    /// Off by default; toggled via [`Engine::with_itn`].
+    /// digits) on file-transcription output and finalized streaming segments,
+    /// *before* the punctuation pass. Off by default; toggled via
+    /// [`Engine::with_itn`].
     itn: bool,
     /// Optional contextual hotword biaser applied inside the greedy RNN-T decode
     /// loop (shallow fusion). `None` = no biasing (the default), and the decode
@@ -908,7 +910,9 @@ impl Engine {
     /// Attach an optional punctuation / casing restorer, consuming and
     /// returning `self` (builder style). Pass `None` for pass-through. When set,
     /// the restorer post-processes the final text of file transcription
-    /// ([`Engine::transcribe_file`] / [`Engine::transcribe_bytes_shared`]).
+    /// ([`Engine::transcribe_file`] / [`Engine::transcribe_bytes_shared`]) and
+    /// of finalized streaming segments ([`Engine::process_chunk`] /
+    /// [`Engine::flush_state`]).
     pub fn with_punctuator(mut self, punctuator: Option<crate::punctuation::Punctuator>) -> Self {
         self.punctuator = punctuator;
         self
@@ -942,9 +946,10 @@ impl Engine {
     }
 
     /// Enable or disable inverse text normalization (Russian number-words →
-    /// digits) on file-transcription output, consuming and returning `self`
-    /// (builder style). When enabled, ITN runs *before* the punctuation pass so
-    /// the restorer cases the already-digitized text.
+    /// digits) on file-transcription output and finalized streaming segments,
+    /// consuming and returning `self` (builder style). When enabled, ITN runs
+    /// *before* the punctuation pass so the restorer cases the
+    /// already-digitized text.
     pub fn with_itn(mut self, enabled: bool) -> Self {
         self.itn = enabled;
         self

--- a/crates/gigastt-core/src/protocol/mod.rs
+++ b/crates/gigastt-core/src/protocol/mod.rs
@@ -59,6 +59,11 @@ pub enum ClientMessage {
     /// Request server to stop and finalize.
     Stop,
     /// Configure session parameters (must be sent before first audio frame).
+    ///
+    /// `#[non_exhaustive]`: the wire protocol evolves by adding optional
+    /// fields (see the compatibility convention above), so this variant gains
+    /// fields in minor releases — always match it with a `..` rest pattern.
+    #[non_exhaustive]
     Configure {
         /// Audio sample rate in Hz (e.g., 8000, 16000, 24000, 44100, 48000). Optional.
         #[serde(default)]

--- a/crates/gigastt-core/src/protocol/mod.rs
+++ b/crates/gigastt-core/src/protocol/mod.rs
@@ -72,6 +72,18 @@ pub enum ClientMessage {
         /// (`unsupported_protocol_version`) listing the supported range.
         #[serde(default)]
         protocol_version: Option<String>,
+        /// Per-session punctuation/casing-restoration override applied to
+        /// `final` segments only (`partial` payloads always stay raw).
+        /// Omitted = server default (on iff the server has a punctuator
+        /// attached). A `true` on a server without a punctuation model is a
+        /// graceful no-op. Optional.
+        #[serde(default)]
+        punctuation: Option<bool>,
+        /// Per-session inverse text normalization override (number-words →
+        /// digits) applied to `final` segments only. Omitted = server default.
+        /// Optional.
+        #[serde(default)]
+        itn: Option<bool>,
     },
 }
 
@@ -284,6 +296,38 @@ mod tests {
             ClientMessage::Configure {
                 protocol_version, ..
             } => assert_eq!(protocol_version, None),
+            _ => panic!("Expected Configure"),
+        }
+    }
+
+    #[test]
+    fn test_configure_punctuation_itn_deserialize() {
+        let json = r#"{"type":"configure","punctuation":false,"itn":true}"#;
+        let msg: ClientMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            ClientMessage::Configure {
+                punctuation, itn, ..
+            } => {
+                assert_eq!(punctuation, Some(false));
+                assert_eq!(itn, Some(true));
+            }
+            _ => panic!("Expected Configure"),
+        }
+    }
+
+    #[test]
+    fn test_configure_punctuation_itn_absent() {
+        // Older clients omit the post-processing knobs entirely; both must
+        // deserialize to None (server default) — additive backward compat.
+        let json = r#"{"type":"configure","sample_rate":16000}"#;
+        let msg: ClientMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            ClientMessage::Configure {
+                punctuation, itn, ..
+            } => {
+                assert_eq!(punctuation, None);
+                assert_eq!(itn, None);
+            }
             _ => panic!("Expected Configure"),
         }
     }

--- a/crates/gigastt-core/src/protocol/mod.rs
+++ b/crates/gigastt-core/src/protocol/mod.rs
@@ -61,8 +61,9 @@ pub enum ClientMessage {
     /// Configure session parameters (must be sent before first audio frame).
     ///
     /// `#[non_exhaustive]`: the wire protocol evolves by adding optional
-    /// fields (see the compatibility convention above), so this variant gains
-    /// fields in minor releases — always match it with a `..` rest pattern.
+    /// fields only (existing fields are never renamed or removed), so this
+    /// variant gains fields in minor releases — always match it with a `..`
+    /// rest pattern.
     #[non_exhaustive]
     Configure {
         /// Audio sample rate in Hz (e.g., 8000, 16000, 24000, 44100, 48000). Optional.

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -557,5 +557,52 @@ mod tests {
         );
     }
 
+    /// Latency probe for the streaming use case: `restore` runs synchronously
+    /// on the finalization boundary of every streaming segment, so its cost on
+    /// short (1–10 word) segments adds directly to final-segment latency.
+    /// Prints p50/p95 per segment length; a generous sanity ceiling keeps the
+    /// run self-checking without flaking on slow machines (the probe is
+    /// model-gated and runs manually, not in CI).
+    #[test]
+    #[ignore = "requires punct model at ~/.gigastt/models/punct"]
+    fn test_restore_latency_short_segments() {
+        let dir = default_punct_model_dir();
+        let punct = Punctuator::load(Path::new(&dir)).expect("load punct model");
+
+        let cases: &[(&str, &str)] = &[
+            ("1 word", "привет"),
+            ("5 words", "привет меня зовут анна"),
+            (
+                "10 words",
+                "привет меня зовут анна сколько будет стоить шестьдесят тысяч тенге",
+            ),
+        ];
+        const ITERS: usize = 50;
+
+        for (label, text) in cases {
+            // Warmup: first runs pay tokenizer/thread-pool lazy init.
+            for _ in 0..5 {
+                let _ = punct.restore(text);
+            }
+            let mut samples = Vec::with_capacity(ITERS);
+            for _ in 0..ITERS {
+                let start = std::time::Instant::now();
+                let _ = punct.restore(text);
+                samples.push(start.elapsed());
+            }
+            samples.sort();
+            let p50 = samples[ITERS / 2];
+            let p95 = samples[ITERS * 95 / 100];
+            eprintln!(
+                "restore latency {label}: p50={p50:?} p95={p95:?} max={:?}",
+                samples[ITERS - 1]
+            );
+            assert!(
+                p95 < std::time::Duration::from_millis(500),
+                "restore p95 on a short segment must stay well under 500ms, got {p95:?} ({label})"
+            );
+        }
+    }
+
     use crate::model::default_punct_model_dir;
 }

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -27,7 +27,7 @@ diarization = ["gigastt-core/diarization"]
 quantize = ["gigastt-core/quantize"]
 
 [dependencies]
-gigastt-core = { version = "2.11.3", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
+gigastt-core = { version = "2.12.0", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
 
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }

--- a/crates/gigastt/src/server/ws.rs
+++ b/crates/gigastt/src/server/ws.rs
@@ -462,7 +462,14 @@ async fn handle_configure_message(
     #[cfg(feature = "diarization")]
     if let Some(enable_dia) = diarization {
         tracing::info!("Client {peer} configured diarization: {enable_dia}");
-        *state_opt = Some(engine.create_state(enable_dia));
+        let mut new_state = engine.create_state(enable_dia);
+        // The state is recreated wholesale; carry over any post-processing
+        // overrides an earlier Configure already set on this session.
+        if let Some(old) = state_opt.as_ref() {
+            new_state.punctuation = old.punctuation;
+            new_state.itn = old.itn;
+        }
+        *state_opt = Some(new_state);
     }
     #[cfg(not(feature = "diarization"))]
     let _ = (engine, diarization);

--- a/crates/gigastt/src/server/ws.rs
+++ b/crates/gigastt/src/server/ws.rs
@@ -364,15 +364,22 @@ async fn handle_binary_frame(
             .await?;
             Ok(FrameOutcome::Continue)
         }
-        Ok((Err(_panic), _state_back, reservation_back)) => {
+        Ok((Err(_panic), state_back, reservation_back)) => {
             // Inference panicked: reservation is recovered, but the streaming
             // state (LSTM h/c buffers) may be mid-update and unsafe to reuse.
-            // Drop it and install a fresh state so the session continues.
+            // Drop it and install a fresh state so the session continues. The
+            // per-session post-processing overrides are plain session policy
+            // (never touched by inference), and configure-after-audio is
+            // rejected, so they must survive the reset — the client has no
+            // way to re-send them.
             tracing::error!(
                 "Panic in WS inference for {peer} — triplet recovered, streaming state reset"
             );
             *reservation = Some(reservation_back);
-            *state_opt = Some(engine.create_state(false));
+            let mut fresh = engine.create_state(false);
+            fresh.punctuation = state_back.punctuation;
+            fresh.itn = state_back.itn;
+            *state_opt = Some(fresh);
             send_server_message(
                 sink,
                 &ServerMessage::Error {
@@ -771,6 +778,7 @@ async fn handle_ws_inner(
                             protocol_version,
                             punctuation,
                             itn,
+                            ..
                         }) => {
                             handle_configure_message(
                                 &mut sink,

--- a/crates/gigastt/src/server/ws.rs
+++ b/crates/gigastt/src/server/ws.rs
@@ -395,8 +395,9 @@ async fn handle_binary_frame(
 }
 
 /// Handle `{"type":"configure",…}`. Rejects configure-after-first-audio,
-/// validates sample rate against `SUPPORTED_RATES`, and (with diarization
-/// feature) recreates the streaming state.
+/// validates sample rate against `SUPPORTED_RATES`, (with diarization
+/// feature) recreates the streaming state, and stores the per-session
+/// post-processing overrides (`punctuation` / `itn`) on it.
 #[allow(clippy::too_many_arguments)]
 async fn handle_configure_message(
     sink: &mut WsSink,
@@ -407,6 +408,8 @@ async fn handle_configure_message(
     sample_rate: Option<u32>,
     diarization: Option<bool>,
     protocol_version: Option<String>,
+    punctuation: Option<bool>,
+    itn: Option<bool>,
     peer: SocketAddr,
 ) -> Result<FrameOutcome> {
     if audio_received {
@@ -462,8 +465,21 @@ async fn handle_configure_message(
         *state_opt = Some(engine.create_state(enable_dia));
     }
     #[cfg(not(feature = "diarization"))]
-    {
-        let _ = (engine, state_opt, diarization);
+    let _ = (engine, diarization);
+
+    // Post-processing overrides apply to whatever state the session now holds
+    // (the diarization branch above may have just recreated it). An absent
+    // field leaves the previous value, so repeated Configures compose the same
+    // way `sample_rate` does.
+    if let Some(state) = state_opt.as_mut() {
+        if let Some(p) = punctuation {
+            tracing::info!("Client {peer} configured punctuation: {p}");
+            state.punctuation = Some(p);
+        }
+        if let Some(i) = itn {
+            tracing::info!("Client {peer} configured itn: {i}");
+            state.itn = Some(i);
+        }
     }
     Ok(FrameOutcome::Continue)
 }
@@ -746,6 +762,8 @@ async fn handle_ws_inner(
                             sample_rate,
                             diarization,
                             protocol_version,
+                            punctuation,
+                            itn,
                         }) => {
                             handle_configure_message(
                                 &mut sink,
@@ -756,6 +774,8 @@ async fn handle_ws_inner(
                                 sample_rate,
                                 diarization,
                                 protocol_version,
+                                punctuation,
+                                itn,
                                 peer,
                             )
                             .await

--- a/crates/gigastt/tests/e2e_rest.rs
+++ b/crates/gigastt/tests/e2e_rest.rs
@@ -688,8 +688,9 @@ async fn test_ready_returns_503_when_pool_exhausted() {
 // These exercise the ADDITIVE query params `punctuation` / `itn` / `vad` and
 // the forward-compat `variant` guard. Absent params must reproduce the default
 // response byte-for-byte; a knob turned on without its backing resource must
-// 409 *before* the pool checkout. SSE and WebSocket are out of scope (they
-// don't run the punctuation / ITN passes at all).
+// 409 *before* the pool checkout. SSE and WebSocket are out of scope for the
+// REST query-param surface (streaming enriches final segments by the engine
+// boot policy / WS Configure instead — see e2e_ws.rs).
 // ---------------------------------------------------------------------------
 
 /// GET `/health` and parse it as JSON (the repo's `reqwest` build has no `json`

--- a/crates/gigastt/tests/e2e_ws.rs
+++ b/crates/gigastt/tests/e2e_ws.rs
@@ -1416,3 +1416,55 @@ async fn test_ws_configure_punctuation_true_without_punctuator_is_noop() {
         "no punctuator attached → final text stays raw: {text}"
     );
 }
+
+/// Post-processing overrides survive mid-session state recreation: a
+/// `configure` that sets `diarization` rebuilds the streaming state wholesale
+/// (in diarization-enabled builds), and a previously sent `punctuation: false`
+/// must carry over to the new state — configure-after-audio is rejected, so
+/// the client has no way to re-send it.
+#[ignore]
+#[tokio::test]
+async fn test_ws_punctuation_override_survives_diarization_reconfigure() {
+    let Some(punctuator) = load_punctuator_or_skip() else {
+        return;
+    };
+    let engine = gigastt::inference::Engine::load(&common::model_dir())
+        .expect("engine")
+        .with_punctuator(Some(punctuator));
+    let (port, _shutdown) = common::start_server_with_engine(engine).await;
+    if get_health(port).await["variant"].as_str().unwrap_or("") != "rnnt" {
+        eprintln!("skipping: e2e_rnnt head is already punctuated by the model");
+        return;
+    }
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+    sink.send(Message::Text(
+        serde_json::to_string(
+            &serde_json::json!({"type": "configure", "sample_rate": 16000, "punctuation": false}),
+        )
+        .unwrap()
+        .into(),
+    ))
+    .await
+    .unwrap();
+    // This second configure recreates the streaming state (diarization
+    // branch); the punctuation override above must survive the rebuild.
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "configure", "diarization": false}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    let (_partials, final_seg) = stream_golos_and_collect(&mut sink, &mut stream).await;
+    let text = final_seg["text"].as_str().unwrap_or_default();
+    let raw = joined_words(&final_seg);
+    eprintln!("final after diarization reconfigure: {text}");
+
+    assert!(!raw.is_empty(), "speech fixture must decode to words");
+    assert_eq!(
+        text, raw,
+        "punctuation=false must survive the diarization state recreation: {text}"
+    );
+}

--- a/crates/gigastt/tests/e2e_ws.rs
+++ b/crates/gigastt/tests/e2e_ws.rs
@@ -1092,3 +1092,327 @@ async fn test_ws_tone_audio_produces_final_text() {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// 24. Streaming finals get ITN + punctuation; partials stay raw
+//
+// The engine enriches a segment's joined `text` at finalization time only
+// (endpoint flush / Stop flush): ITN, then punctuation/casing restoration.
+// `words[]` payloads always keep the raw decoder output, and `partial`
+// messages are never rewritten. The enrichment-positive tests assume the
+// bare `rnnt` head (the default download since v2.3) and self-skip on
+// `e2e_rnnt`, which is already punctuated by the model itself.
+// ---------------------------------------------------------------------------
+
+const GOLOS_FIXTURE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/golos_00.wav");
+
+type WsSink = futures_util::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    tokio_tungstenite::tungstenite::Message,
+>;
+type WsStream = futures_util::stream::SplitStream<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+>;
+
+/// Decode the golos fixture (real Russian speech, contains the spoken number
+/// "шестьдесят тысяч") to PCM16 bytes at 16 kHz for WS streaming.
+fn golos_pcm16() -> Vec<u8> {
+    let samples =
+        gigastt::inference::audio::decode_audio_file(GOLOS_FIXTURE).expect("decode golos fixture");
+    let mut bytes = Vec::with_capacity(samples.len() * 2);
+    for s in samples {
+        let v = (s * 32767.0).clamp(-32768.0, 32767.0) as i16;
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    bytes
+}
+
+/// GET `/health` as JSON (used to read the loaded head / post-processing
+/// capabilities when deciding whether a test is meaningful).
+async fn get_health(port: u16) -> serde_json::Value {
+    let text = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .send()
+        .await
+        .expect("GET /health failed")
+        .text()
+        .await
+        .expect("health body");
+    serde_json::from_str(&text).expect("health JSON")
+}
+
+/// Load the punct model from the default dir, or return None (test self-skips).
+fn load_punctuator_or_skip() -> Option<gigastt::punctuation::Punctuator> {
+    let punct_dir = common::home_dir()
+        .expect("home")
+        .join(".gigastt")
+        .join("models")
+        .join("punct");
+    match gigastt::punctuation::Punctuator::load(&punct_dir) {
+        Ok(p) => Some(p),
+        Err(e) => {
+            eprintln!("skipping: punct model unavailable ({e:#})");
+            None
+        }
+    }
+}
+
+/// Stream the golos fixture over an established WS session (the caller must
+/// have configured 16 kHz first), send Stop, and collect every partial plus
+/// the first final as raw JSON payloads.
+async fn stream_golos_and_collect(
+    sink: &mut WsSink,
+    stream: &mut WsStream,
+) -> (Vec<serde_json::Value>, serde_json::Value) {
+    let pcm = golos_pcm16();
+    // ~100 ms per frame at 16 kHz PCM16 mono.
+    for chunk in pcm.chunks(3200) {
+        sink.send(Message::Binary(chunk.to_vec().into()))
+            .await
+            .unwrap();
+    }
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "stop"}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    let mut partials = Vec::new();
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(30), stream.next())
+            .await
+            .expect("timeout waiting for Final")
+            .expect("stream ended")
+            .expect("ws error");
+        let text = msg.into_text().expect("expected text message");
+        let v: serde_json::Value = serde_json::from_str(&text).expect("expected JSON");
+        match v["type"].as_str().unwrap_or("") {
+            "partial" => partials.push(v),
+            "final" => return (partials, v),
+            other => panic!("Unexpected message type {other}: {text}"),
+        }
+    }
+}
+
+/// Rebuild the raw transcript from a segment's `words[]` payload (what the
+/// `text` field looked like before any post-processing).
+fn joined_words(segment: &serde_json::Value) -> String {
+    segment["words"]
+        .as_array()
+        .map(|words| {
+            words
+                .iter()
+                .filter_map(|w| w["word"].as_str())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .unwrap_or_default()
+}
+
+/// With a punctuator attached, the WS final segment's text is enriched
+/// (capitalized / punctuated) while its `words[]` stay raw decoder output.
+#[ignore]
+#[tokio::test]
+async fn test_ws_final_punctuated_with_punctuator() {
+    let Some(punctuator) = load_punctuator_or_skip() else {
+        return;
+    };
+    let engine = gigastt::inference::Engine::load(&common::model_dir())
+        .expect("engine")
+        .with_punctuator(Some(punctuator));
+    let (port, _shutdown) = common::start_server_with_engine(engine).await;
+    if get_health(port).await["variant"].as_str().unwrap_or("") != "rnnt" {
+        eprintln!("skipping: e2e_rnnt head is already punctuated by the model");
+        return;
+    }
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "configure", "sample_rate": 16000}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    let (_partials, final_seg) = stream_golos_and_collect(&mut sink, &mut stream).await;
+    let text = final_seg["text"].as_str().unwrap_or_default();
+    let raw = joined_words(&final_seg);
+    eprintln!("final (enriched): {text}");
+    eprintln!("words (raw join): {raw}");
+
+    assert!(!raw.is_empty(), "speech fixture must decode to words");
+    assert!(
+        text != raw,
+        "enriched final text must differ from the raw words join: {text}"
+    );
+    let first = text.chars().next().unwrap_or(' ');
+    assert!(
+        first.is_uppercase() || text.contains(['.', ',', '?', '!']),
+        "final should carry restored casing/punctuation, got: {text}"
+    );
+    // Word payloads are never rewritten: joined words equal the bare decoder
+    // hypothesis (all lowercase, no sentence punctuation).
+    assert_eq!(raw, raw.to_lowercase(), "words stay raw: {raw}");
+    assert!(
+        !raw.contains(['.', ',', '?', '!']),
+        "words carry no restored punctuation: {raw}"
+    );
+}
+
+/// Partial messages must stay raw even when the punctuator is attached:
+/// a partial's `text` is byte-identical to the join of its `words[]`.
+#[ignore]
+#[tokio::test]
+async fn test_ws_partials_stay_raw_with_punctuator() {
+    let Some(punctuator) = load_punctuator_or_skip() else {
+        return;
+    };
+    let engine = gigastt::inference::Engine::load(&common::model_dir())
+        .expect("engine")
+        .with_punctuator(Some(punctuator));
+    let (port, _shutdown) = common::start_server_with_engine(engine).await;
+    if get_health(port).await["variant"].as_str().unwrap_or("") != "rnnt" {
+        eprintln!("skipping: e2e_rnnt head is already punctuated by the model");
+        return;
+    }
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "configure", "sample_rate": 16000}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    let (partials, _final_seg) = stream_golos_and_collect(&mut sink, &mut stream).await;
+    assert!(
+        !partials.is_empty(),
+        "streaming speech must produce at least one partial"
+    );
+    for p in &partials {
+        let text = p["text"].as_str().unwrap_or_default();
+        assert_eq!(
+            text,
+            joined_words(p),
+            "partial text must equal the raw words join (never enriched): {text}"
+        );
+    }
+}
+
+/// `Configure{punctuation:false}` on a punctuator-equipped server disables the
+/// pass for this session only: the final text is the raw words join.
+#[ignore]
+#[tokio::test]
+async fn test_ws_configure_punctuation_false_disables_final_enrichment() {
+    let Some(punctuator) = load_punctuator_or_skip() else {
+        return;
+    };
+    let engine = gigastt::inference::Engine::load(&common::model_dir())
+        .expect("engine")
+        .with_punctuator(Some(punctuator));
+    let (port, _shutdown) = common::start_server_with_engine(engine).await;
+    if get_health(port).await["variant"].as_str().unwrap_or("") != "rnnt" {
+        eprintln!("skipping: e2e_rnnt head is already punctuated by the model");
+        return;
+    }
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+    sink.send(Message::Text(
+        serde_json::to_string(
+            &serde_json::json!({"type": "configure", "sample_rate": 16000, "punctuation": false}),
+        )
+        .unwrap()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let (_partials, final_seg) = stream_golos_and_collect(&mut sink, &mut stream).await;
+    let text = final_seg["text"].as_str().unwrap_or_default();
+    let raw = joined_words(&final_seg);
+    eprintln!("final with punctuation=false: {text}");
+
+    assert!(!raw.is_empty(), "speech fixture must decode to words");
+    assert_eq!(
+        text, raw,
+        "punctuation=false must leave the final text raw: {text}"
+    );
+    assert!(
+        !text.contains(['.', ',', '?', '!']),
+        "no restored punctuation expected: {text}"
+    );
+}
+
+/// `Configure{itn:false}` on an ITN-equipped server leaves number-words as
+/// words: no ASCII digits appear that ITN would have produced.
+#[ignore]
+#[tokio::test]
+async fn test_ws_configure_itn_false_disables_final_enrichment() {
+    let engine = gigastt::inference::Engine::load(&common::model_dir())
+        .expect("engine")
+        .with_itn(true);
+    let (port, _shutdown) = common::start_server_with_engine(engine).await;
+    if get_health(port).await["variant"].as_str().unwrap_or("") != "rnnt" {
+        eprintln!("skipping: e2e_rnnt head has ITN baked into the model");
+        return;
+    }
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+    sink.send(Message::Text(
+        serde_json::to_string(
+            &serde_json::json!({"type": "configure", "sample_rate": 16000, "itn": false}),
+        )
+        .unwrap()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let (_partials, final_seg) = stream_golos_and_collect(&mut sink, &mut stream).await;
+    let text = final_seg["text"].as_str().unwrap_or_default();
+    eprintln!("final with itn=false: {text}");
+    assert!(
+        !text.chars().any(|c| c.is_ascii_digit()),
+        "itn=false should leave number-words as words, got: {text}"
+    );
+}
+
+/// A server WITHOUT a punctuator keeps the legacy behavior even when the
+/// client asks for punctuation: `Configure{punctuation:true}` is a graceful
+/// no-op — the session works and the final text is the raw words join.
+#[ignore]
+#[tokio::test]
+async fn test_ws_configure_punctuation_true_without_punctuator_is_noop() {
+    let (port, _shutdown) = common::start_server(&common::model_dir()).await;
+    let health = get_health(port).await;
+    if health["punctuation"].as_bool().unwrap_or(false) {
+        eprintln!("skipping: default engine already has a punctuator loaded");
+        return;
+    }
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+    sink.send(Message::Text(
+        serde_json::to_string(
+            &serde_json::json!({"type": "configure", "sample_rate": 16000, "punctuation": true}),
+        )
+        .unwrap()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let (_partials, final_seg) = stream_golos_and_collect(&mut sink, &mut stream).await;
+    let text = final_seg["text"].as_str().unwrap_or_default();
+    let raw = joined_words(&final_seg);
+    eprintln!("final without punctuator: {text}");
+
+    assert!(!raw.is_empty(), "speech fixture must decode to words");
+    assert_eq!(
+        text, raw,
+        "no punctuator attached → final text stays raw: {text}"
+    );
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -23,6 +23,28 @@ Client                            Server
 16 kHz internally). Protocol messages are versioned via the `type` field; new fields
 are additive only.
 
+**Transcript post-processing.** `partial` messages are always the raw decoder
+hypothesis (lowercase, no punctuation) and may change with more audio. `final`
+messages are enriched at the finalization boundary when the server has the
+resources loaded: inverse text normalization (number-words → digits), then
+punctuation/casing restoration (`--punctuation` / `--itn`; default `auto` = on
+for the bare `rnnt` head, off for `e2e_rnnt` which is already punctuated). The
+`words[]` payload always keeps the raw decoder output — only the joined `text`
+is rewritten. The same applies to SSE `final` events on `/v1/transcribe/stream`
+(server defaults; there are no per-request parameters there yet).
+
+Per session, the client can override the server policy with additive `configure`
+fields (sent before the first audio frame):
+
+```json
+{"type": "configure", "sample_rate": 16000, "punctuation": false, "itn": false}
+```
+
+Omitting a field keeps the server default; repeated `configure` messages compose
+(an absent field leaves the previous value). Asking for `punctuation: true` on a
+server without a punctuation model is a graceful no-op — finals stay raw, no
+error is emitted.
+
 ## REST
 
 | Endpoint | Method | Description |

--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -12,10 +12,23 @@ info:
     1. Client connects to `ws://{host}:{port}/v1/ws` (default: `ws://127.0.0.1:9876/v1/ws`).
        - Server binds `127.0.0.1` by default; use `--bind-all` (or `GIGASTT_ALLOW_BIND_ANY=1`) plus `--host 0.0.0.0` for Docker.
     2. Server sends `ready` message with model info, protocol version, `supported_rates`, and `diarization` capability
-    3. (Optional) Client sends `configure` to pick a non-default `sample_rate` and/or enable `diarization`
+    3. (Optional) Client sends `configure` to pick a non-default `sample_rate`, enable `diarization`,
+       and/or override the post-processing policy (`punctuation`, `itn`)
     4. Client streams raw PCM16 audio as binary frames (default 48 kHz mono, or the negotiated rate)
     5. Server responds with `partial` and `final` transcript messages
     6. Client sends `stop` (JSON) or closes connection to end session
+
+    ## Transcript Post-processing
+
+    - `partial` messages are always the raw decoder hypothesis (lowercase, no punctuation) and may change with more audio.
+    - `final` messages are enriched at the finalization boundary when the server has the resources loaded:
+      inverse text normalization (number-words → digits), then punctuation/casing restoration.
+      Word payloads (`words[]`) always keep the raw decoder output — only the joined `text` is rewritten.
+    - Server default: enrichment on for the bare `rnnt` head when a punctuation model is installed
+      (`--punctuation auto`), off for `e2e_rnnt` (already punctuated by the model itself).
+    - Per-session opt-out: `configure` with `punctuation: false` / `itn: false`; omitting a field keeps
+      the server default. Requesting `punctuation: true` on a server without a punctuation model is a
+      graceful no-op (finals stay raw).
 
     ## Audio Format
 
@@ -257,7 +270,10 @@ components:
         text:
           type: string
           example: "привет как"
-          description: Current interim transcription (may change as more audio arrives)
+          description: >-
+            Current interim transcription (may change as more audio arrives).
+            Always the raw decoder output — ITN/punctuation are applied to
+            `final` segments only.
         timestamp:
           type: number
           format: double
@@ -282,8 +298,12 @@ components:
           description: Message type discriminator
         text:
           type: string
-          example: "привет как дела"
-          description: Finalized transcription for the completed utterance
+          example: "Привет, как дела?"
+          description: >-
+            Finalized transcription for the completed utterance. Enriched with
+            ITN + punctuation/casing restoration when enabled (server default
+            or per-session `configure` override); `words[]` always keep the
+            raw decoder output.
         timestamp:
           type: number
           format: double
@@ -351,6 +371,20 @@ components:
           type: boolean
           example: true
           description: Enable speaker diarization (if available)
+        punctuation:
+          type: boolean
+          example: false
+          description: >-
+            Per-session punctuation/casing-restoration override applied to
+            `final` segments only. Omitted = server default (on iff the server
+            has a punctuation model attached). `true` on a server without a
+            punctuation model is a graceful no-op.
+        itn:
+          type: boolean
+          example: false
+          description: >-
+            Per-session inverse text normalization override (number-words →
+            digits) applied to `final` segments only. Omitted = server default.
 
     StopMessage:
       type: object


### PR DESCRIPTION
## Summary

Streaming `final` segments (WebSocket and SSE) now run the same post-processing as file transcription: inverse text normalization first, then punctuation/casing restoration when a punctuation model is attached. `partial` messages stay the raw decoder hypothesis and `words[]` payloads keep the raw decoder output — only the joined `text` is rewritten, mirroring the file path exactly. Live-dictation clients no longer have to choose between streaming previews and readable transcripts.

- Additive WS `configure` fields `punctuation` / `itn` override the server policy per session (omitted = server default; `punctuation: true` without a punctuation model is a graceful no-op). Overrides survive mid-session state recreation (diarization reconfigure, post-panic session reset).
- SSE follows the server boot policy; per-request streaming parameters are intentionally out of scope here.
- The `e2e_rnnt` head keeps its baked-in punctuation: the boot-policy guard (`--punctuation auto` / `--itn auto`) stays off for it, same as the file path.
- `ClientMessage::Configure` is now `#[non_exhaustive]` so additive protocol fields ship as minor releases (one-time cargo-semver-checks allow documented in package metadata). Workspace bumped to 2.12.0.

## Latency

`restore` on short final segments (the streaming case), 50 iterations after warmup, debug build, Apple Silicon:

| segment | p50 | p95 |
|---|---|---|
| 1 word | 0.28 ms | 0.55 ms |
| 5 words | 0.53 ms | 0.75 ms |
| 10 words | 0.79 ms | 1.03 ms |

Roughly two orders of magnitude under a 100 ms budget, so enrichment runs unconditionally (no segment-length gate). Probe: `cargo test -p gigastt-core --lib test_restore_latency_short_segments -- --ignored --nocapture`.

## Testing

- New engine/protocol unit tests (enrichment policy, per-session overrides, graceful no-op, additive deserialization) — run in PR CI.
- 6 new e2e WS tests: enriched finals, raw partials, `configure` opt-out for punctuation and ITN, no-punctuator no-op, override survival across diarization state recreation. Full `e2e_ws` (30/30) + `e2e_rest` suites green locally against the real model and punctuation model.
- The override-survival test is mutation-verified: disabling the carry-over makes it fail.
- `cargo semver-checks` green against main (2.11.3 → 2.12.0, minor); fmt/clippy clean.

Note for CI: the punctuator-positive e2e tests self-skip when the punct model is absent (the main-push model cache does not include it); they were executed locally against the real model.