### PR TITLE
docs: surface ANE/Candle backends, GHCR images, bindings, diarization; reconcile ANE numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,14 @@ brew tap ekhodzitsky/gigastt https://github.com/ekhodzitsky/gigastt && brew inst
 # crates.io — needs protoc on PATH (brew install protobuf / apt install protobuf-compiler)
 cargo install gigastt
 
-# Docker (CUDA: Dockerfile.cuda; bake the model with --build-arg GIGASTT_BAKE_MODEL=1)
+# Prebuilt image from GHCR (CPU, multi-arch amd64+arm64; append -cuda for the CUDA variant)
+docker pull ghcr.io/ekhodzitsky/gigastt:latest
+
+# Or build your own image (CUDA: Dockerfile.cuda; bake the model with --build-arg GIGASTT_BAKE_MODEL=1)
 docker build -t gigastt . && docker run -p 9876:9876 gigastt
 ```
+
+Embedding instead of serving? `npm install gigastt` (Node.js) · `pip install gigastt` (Python on PyPI) · Swift / Kotlin bindings in progress — all wrap the same engine, model side-loaded: [In-process quickstarts](docs/quickstarts.md).
 
 The GigaAM v3 model (~850 MB) auto-downloads on first run and is INT8-quantized to ~225 MB.
 
@@ -92,10 +97,11 @@ $ gigastt serve
 | Heads | `rnnt` (34-token char, default — lowest WER) · `e2e_rnnt` (1025-token BPE, punctuation / casing / ITN baked in) · `ml_ctc` / `ml_ctc_large` (GigaAM Multilingual charwise CTC, 220M / 600M, 71-token multilingual char — ru/en/kk/ky/uz) |
 | Post-processing | optional punctuation, casing &amp; Russian ITN — native on `e2e_rnnt`, or a bundled RuPunct + ITN pass on `rnnt` (auto-downloaded; `--punctuation` / `--itn`), overridable per request (`?punctuation=` / `?itn=` / `?vad=`) |
 | Delivery | static binary · C-ABI FFI `cdylib` (Android / mobile) · `gigastt-core` crate (no server deps) |
-| Execution providers | CPU (any platform) · CoreML EP (macOS ARM64) · CUDA 12+ (Linux x86_64) · NNAPI (Android) |
+| Execution providers | CPU (any platform) · CoreML EP (macOS ARM64) · CUDA 12+ (Linux x86_64) · NNAPI (Android) · [ANE](docs/ane-backend.md) (`--features ane`, macOS ARM64 — encoder ≈15.6× on the Neural Engine, warm e2e ≈10× over the CPU build, WER ≈1.11% vs `ort`; file-mode only) · [Candle/Metal](docs/candle-backend.md) (`--features candle`, experimental — output byte-for-byte identical to `ort`) |
 | Streaming | incremental WebSocket partials · REST + SSE for files · single port 9876 |
 | Audio in | WAV · M4A/AAC · MP3 · OGG/Vorbis · FLAC (auto mono mix for multi-channel) |
 | Stereo telephony recordings | Optional channel-speaker mode (`--stereo-speakers` CLI / `channels=split` REST) labels the left/right channels as `speaker_0` and `speaker_1` |
+| Speaker diarization | WeSpeaker ResNet34 embeddings + polyvoice clustering, compiled in by default (speaker model fetched by `gigastt download`, `--skip-diarization` to opt out) — offline files opt in per request (`?diarization=true`, exclusive with `channels=split`), live sessions via WS `Configure`; words &amp; segments gain `speaker` labels |
 | Async jobs | Long-file / batch transcription queue via `/v1/jobs` (opt-in with `--enable-jobs`): submit, poll, cancel, SSE progress, retry, and TTL eviction |
 | Export | JSON · TXT · SRT · VTT · Markdown — per-word timings + confidence, or segment-level (`?segments=true` JSON, `### [mm:ss]` Markdown) |
 | Server hardening | loopback-only by default · origin allowlist · per-IP rate limiting · graceful drain · Prometheus `/metrics` on a separate port · loopback-only model hot-reload (`POST /v1/admin/reload`) |

--- a/README_RU.md
+++ b/README_RU.md
@@ -65,9 +65,14 @@ brew tap ekhodzitsky/gigastt https://github.com/ekhodzitsky/gigastt && brew inst
 # crates.io — нужен protoc в PATH (brew install protobuf / apt install protobuf-compiler)
 cargo install gigastt
 
-# Docker (CUDA: Dockerfile.cuda; вшить модель в образ: --build-arg GIGASTT_BAKE_MODEL=1)
+# Готовый образ из GHCR (CPU, multi-arch amd64+arm64; суффикс -cuda для CUDA-варианта)
+docker pull ghcr.io/ekhodzitsky/gigastt:latest
+
+# Или соберите свой образ (CUDA: Dockerfile.cuda; вшить модель в образ: --build-arg GIGASTT_BAKE_MODEL=1)
 docker build -t gigastt . && docker run -p 9876:9876 gigastt
 ```
+
+Встраивание вместо сервера? `npm install gigastt` (Node.js) · `pip install gigastt` (Python на PyPI) · Swift / Kotlin биндинги в работе — все оборачивают тот же движок, модель подкладывается отдельно: [In-process quickstarts](docs/quickstarts.md).
 
 Модель GigaAM v3 (~850 МБ) скачивается автоматически при первом запуске и квантуется в INT8 до ~225 МБ.
 
@@ -92,9 +97,11 @@ $ gigastt serve
 | Головы | `rnnt` (34-токенный char, дефолт — ниже всех WER) · `e2e_rnnt` (1025-токенный BPE, пунктуация / регистр / ITN встроены) · `ml_ctc` / `ml_ctc_large` (GigaAM Multilingual charwise-CTC, 220M / 600M, 71-токенный multilingual char — ru/en/kk/ky/uz) |
 | Постобработка | опциональные пунктуация, регистр и русский ITN — нативно на `e2e_rnnt` или встроенный проход RuPunct + ITN на `rnnt` (авто-докачка; `--punctuation` / `--itn`), переопределяемо на каждый запрос (`?punctuation=` / `?itn=` / `?vad=`) |
 | Доставка | статический бинарник · C-ABI FFI `cdylib` (Android / mobile) · крейт `gigastt-core` (без серверных зависимостей) |
-| Провайдеры исполнения | CPU (любая платформа) · CoreML / Neural Engine (macOS ARM64) · CUDA 12+ (Linux x86_64) · NNAPI (Android) |
+| Провайдеры исполнения | CPU (любая платформа) · CoreML / Neural Engine (macOS ARM64) · CUDA 12+ (Linux x86_64) · NNAPI (Android) · [ANE](docs/ane-backend.md) (`--features ane`, macOS ARM64 — энкодер ≈15.6× на Neural Engine, тёплый e2e ≈10× быстрее CPU-сборки, WER ≈1.11% против `ort`; только файловый режим) · [Candle/Metal](docs/candle-backend.md) (`--features candle`, экспериментальный — вывод побайтово совпадает с `ort`) |
 | Стриминг | инкрементальные partial'ы по WebSocket · REST + SSE для файлов · один порт 9876 |
 | Аудио на вход | WAV · M4A/AAC · MP3 · OGG/Vorbis · FLAC (авто-микс в моно) |
+| Стерео-телефония | Опциональный режим «канал = спикер» (`--stereo-speakers` в CLI / `channels=split` в REST) помечает левый/правый каналы как `speaker_0` и `speaker_1` |
+| Диаризация | Эмбеддинги WeSpeaker ResNet34 + кластеризация polyvoice, встроена по умолчанию (speaker-модель скачивается командой `gigastt download`, отказ — `--skip-diarization`) — файлы включают её на каждый запрос (`?diarization=true`, несовместимо с `channels=split`), живые сессии — через WS `Configure`; слова и сегменты получают метки `speaker` |
 | Асинхронные задачи | Очередь для длинных файлов / batch-распознавания через `/v1/jobs` (включается `--enable-jobs`): submit, poll, отмена, SSE-прогресс, retry и TTL-евикция |
 | Экспорт | JSON · TXT · SRT · VTT · Markdown — пословные тайминги + confidence или посегментно (`?segments=true` JSON, `### [mm:ss]` Markdown) |
 | Защита сервера | loopback по умолчанию · origin-allowlist · rate-limiting по IP · graceful drain · Prometheus `/metrics` на отдельном порту · loopback-only горячая перезагрузка модели (`POST /v1/admin/reload`) |

--- a/docs/ane-backend.md
+++ b/docs/ane-backend.md
@@ -143,8 +143,17 @@ package per bucket in the ladder `[512, 768, 1536, 3000]` mel frames (≈5 s / 8
 ~/.gigastt/models/ane/gigaam_v3_encoder_3000.mlpackage
 ```
 
-**Today (no published ANE release):** convert + palettize them locally from the
-PyTorch model. Run on macOS ARM64:
+**Pre-built packages (default):** the per-bucket packages are published on the
+[`ane-v3-2026-06-24` GitHub release](https://github.com/ekhodzitsky/gigastt/releases/tag/ane-v3-2026-06-24);
+`gigastt download --ane` fetches them (SHA-256-verified) into the same
+directory:
+
+```sh
+gigastt download --ane
+```
+
+**Convert locally instead:** to rebuild the packages from the PyTorch model
+(e.g. with a different bucket ladder), run on macOS ARM64:
 
 ```sh
 uv run --python 3.13 \
@@ -153,16 +162,6 @@ uv run --python 3.13 \
 ```
 
 This writes the per-bucket `.mlpackage`s into `~/.gigastt/models/ane/`.
-
-**Once an ANE release is published** (maintainer-gated; deferred for now):
-
-```sh
-gigastt download --ane
-```
-
-fetches the per-bucket packages (SHA-256-verified) into the same directory.
-Until then `gigastt download --ane` has no release to pull from — use the local
-conversion above.
 
 The bucket-768 package alone is enough to engage the ANE path for short files;
 the engine logs which buckets it found and compiles each present package once
@@ -208,14 +207,22 @@ pointing at the conversion / `gigastt download --ane` step.
 
 ## Performance & accuracy (honest numbers)
 
-- **End-to-end RTFx ≈ 3.7× over the `ort` CPU build** (≈ 8.7 → 32 RTFx on the
-  measured Golos clips), **decode-bound**: the ANE makes the encoder almost free
-  (~230× encoder speedup), but the CPU RNN-T greedy decode loop dominates the
-  full pipeline, so the e2e win is far smaller than the raw encoder win.
+Measured on an Apple M1 Pro at the v2.5.0 ship gate (`rnnt` head, Golos clips) —
+these are the numbers carried in the v2.5.0 CHANGELOG entry and `specs/todo.md`.
+An earlier revision of this section quoted a pre-ship measurement round
+(≈ 3.7× e2e, ~230× encoder); it is superseded by the shipped figures below.
+
+- **Warm end-to-end ≈ 10× over the `ort` CPU build** (≈ 112 RTFx warm),
+  **decode-bound**: the ANE cuts the encoder to ≈ 23.6 ms from ≈ 369 ms per
+  window (≈ 15.6×, 99.8% ANE residency), but the CPU RNN-T greedy decode loop
+  and feature extraction dominate the full pipeline once the encoder is
+  offloaded, so the e2e win is far smaller than the raw encoder win.
 - **WER vs `ort` ≈ 1.11%** on the 15-clip Golos set: transcripts are
   byte-identical except for a single borderline FP16-pad-up token flip on one
   clip. The ANE encoder is FP16 (not byte-exact), so parity is "near-lossless",
   not bit-exact (unlike the `candle` backend, which is byte-for-byte identical).
+- **Cold-start:** a compiled-model disk cache cuts the ~20 s first load to
+  ~86 ms on later starts.
 
 ## Confirming the ANE path is engaged
 


### PR DESCRIPTION
## Summary

Docs-only. The README (EN/RU, mirrored) had fallen behind the shipped surface — half of the embedded/backends wave was invisible:

- Install: `docker pull ghcr.io/ekhodzitsky/gigastt:latest` (multi-arch, `-cuda` variant) + one-liners for `npm install gigastt` / `pip install gigastt` with a link to the in-process quickstarts.
- Execution providers row: ANE (`--features ane`, encoder ≈15.6× on the Neural Engine, warm e2e ≈10×, WER ≈1.11% vs `ort`, file-mode only) and Candle/Metal (`--features candle`, byte-for-byte identical output) with links to their docs.
- Capabilities: speaker diarization row (WeSpeaker + polyvoice, `?diarization=true` opt-in per the current semantics, exclusive with `channels=split`); RU README also gains the stereo-telephony row that EN already had.
- `docs/ane-backend.md`: the "honest numbers" section contradicted the shipped CHANGELOG figures (pre-ship ≈3.7× e2e / ~230× encoder measurement round) — reconciled to the shipped numbers with a note superseding the earlier revision; the stale "no published ANE release" section replaced with the actual `gigastt download --ane` flow (release tag exists), local conversion kept as the alternative.

Claims verified against the current tree: GHCR tags in release.yml, `download --ane` + pinned release tag, `--skip-diarization` flag, npm/PyPI package names, `?diarization=true` opt-in.

Also (outside the diff, part of the same showcase pass): the HF Space demo was stuck in RUNTIME_ERROR since 2026-06-22 — factory reboot brought it back; it now transcribes the golos fixture and the backlink on the istupakov/gigaam-v3-onnx model card is live.