### PR TITLE
feat(sdks): Go and TypeScript WebSocket client SDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -875,3 +875,46 @@ jobs:
           tags: gigastt-${{ matrix.name }}:ci
           cache-from: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:${{ matrix.name }}
           cache-to: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:${{ matrix.name }},mode=max
+
+  sdk-tests:
+    runs-on: ubuntu-latest
+    name: SDK Tests
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+      # Mock-server tests only (no model, no live server): the gated live
+      # integration tests self-skip without GIGASTT_TEST_WS_URL.
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            sdks:
+              - 'sdks/**'
+      - uses: actions/setup-go@v6
+        if: steps.filter.outputs.sdks == 'true'
+        with:
+          go-version: 'stable'
+          cache-dependency-path: sdks/go/go.sum
+      - name: Go SDK checks
+        if: steps.filter.outputs.sdks == 'true'
+        working-directory: sdks/go
+        run: |
+          test -z "$(gofmt -l .)"
+          go vet ./...
+          go test ./...
+      - uses: actions/setup-node@v6
+        if: steps.filter.outputs.sdks == 'true'
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: sdks/js/package-lock.json
+      - name: JS SDK checks
+        if: steps.filter.outputs.sdks == 'true'
+        working-directory: sdks/js
+        run: |
+          npm ci
+          npx tsc --noEmit
+          npx vitest run
+          npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,9 @@ crates/
     e2e_*.rs              # E2E test suites
     load_test.rs          # Load tests
     soak_test.rs          # Soak test
+sdks/
+  go/                   # Go module: typed WS client (protocol v1.0), reconnect honoring retry_after_ms
+  js/                   # npm @gigastt/client: TypeScript WS client, Node >= 20 + browsers, vitest
 ```
 
 ## Key Constants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Client SDKs for the WebSocket protocol: `gigastt-go` and `@gigastt/client` (TypeScript).**
+  Two idiomatic, typed clients of protocol v1.0 under `sdks/` — typed
+  `Ready`/`Partial`/`Final`/`Error` events (all fields, including `words[]`, `code`, and
+  `retry_after_ms`), a single socket writer, reconnect with exponential backoff that honors
+  the server's `retry_after_ms` on pool saturation, and context/AbortSignal lifecycles. The
+  TypeScript package runs on Node and in browsers (global `WebSocket` with an injectable
+  transport and `ws` fallback). Both ship mock-server test suites (run in CI on `sdks/`
+  changes) plus a live-server integration test gated on `GIGASTT_TEST_WS_URL`, and README
+  quickstarts. Additive protocol fields are ignored by design, matching the compatibility
+  convention. Package publication (npm / Go module tags) is a separate release step.
+
 ### Fixed
 
 - **WebSocket resampling no longer resets filter state when frame sizes grow.** The cached

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ $ gigastt serve
 | Stereo telephony recordings | Optional channel-speaker mode (`--stereo-speakers` CLI / `channels=split` REST) labels the left/right channels as `speaker_0` and `speaker_1` |
 | Speaker diarization | WeSpeaker ResNet34 embeddings + polyvoice clustering, compiled in by default (speaker model fetched by `gigastt download`, `--skip-diarization` to opt out) — offline files opt in per request (`?diarization=true`, exclusive with `channels=split`), live sessions via WS `Configure`; words &amp; segments gain `speaker` labels |
 | Async jobs | Long-file / batch transcription queue via `/v1/jobs` (opt-in with `--enable-jobs`): submit, poll, cancel, SSE progress, retry, and TTL eviction |
+| Client SDKs | Typed WebSocket clients for protocol v1.0 with reconnect honoring `retry_after_ms`: [Go (`sdks/go`)](sdks/go) · [TypeScript `@gigastt/client` (`sdks/js`)](sdks/js) |
 | Export | JSON · TXT · SRT · VTT · Markdown — per-word timings + confidence, or segment-level (`?segments=true` JSON, `### [mm:ss]` Markdown) |
 | Server hardening | loopback-only by default · origin allowlist · per-IP rate limiting · graceful drain · Prometheus `/metrics` on a separate port · loopback-only model hot-reload (`POST /v1/admin/reload`) |
 

--- a/docs/quickstarts.md
+++ b/docs/quickstarts.md
@@ -115,3 +115,39 @@ in Python, `transcribeFile`/`startS` in Node/Swift/Kotlin.)
 Packages are self-contained (onnxruntime is statically linked — see
 [embedding-packaging.md](embedding-packaging.md)); only the model directory is
 side-loaded.
+
+## Client SDKs for the server (Go / TypeScript)
+
+Different beast: these talk **to a running `gigastt serve`** over the
+WebSocket protocol v1.0 instead of embedding the engine. Typed
+`ready`/`partial`/`final`/`error` events (all wire fields, including `words[]`,
+`error.code`, `retry_after_ms`), callback dispatch, automatic reconnect with
+backoff that honors the server's `retry_after_ms` hint on pool saturation.
+
+- **Go** — module `github.com/ekhodzitsky/gigastt/sdks/go`, see
+  [sdks/go/README.md](../sdks/go/README.md):
+
+  ```go
+  client, err := gigastt.Dial(ctx, gigastt.DefaultURL,
+      gigastt.WithSampleRate(16000),
+      gigastt.WithReconnect(250*time.Millisecond, 5*time.Second, 10),
+      gigastt.WithHandlers(gigastt.Handlers{
+          OnFinal: func(t gigastt.Transcript) { fmt.Println(t.Text) },
+      }))
+  // client.SendPCM(pcm16) ... client.Stop()
+  ```
+
+- **TypeScript** — package `@gigastt/client` (Node ≥ 20 and browsers), see
+  [sdks/js/README.md](../sdks/js/README.md):
+
+  ```ts
+  const client = await GigasttClient.connect(DEFAULT_URL, {
+    sampleRate: 16000,
+    reconnect: { minDelayMs: 250, maxDelayMs: 5000, maxAttempts: 10 },
+    handlers: { onFinal: (t) => console.log(t.text) },
+  });
+  // client.sendPCM(pcm16) ... client.stop()
+  ```
+
+For one-file scripts without a library dependency, the `examples/` directory
+has minimal clients (Go, Bun/TypeScript, Python, Kotlin, Rust).

--- a/sdks/go/LICENSE
+++ b/sdks/go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Evgeny Khodzitsky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,0 +1,144 @@
+# gigastt-go
+
+Typed Go WebSocket client for the [gigastt](https://github.com/ekhodzitsky/gigastt)
+speech-to-text server (GigaAM v3, Russian ASR). Protocol version **1.0**
+(`PROTOCOL_VERSION` in `crates/gigastt-core/src/protocol/mod.rs`).
+
+- Typed `Ready` / `Transcript` (partial & final) / `ServerError` events with all
+  protocol fields, including `words[]`, `error.code` and `error.retry_after_ms`
+- Callback-based dispatch (`OnPartial` / `OnFinal` / `OnError` / `OnClose`)
+- Optional automatic reconnect with exponential backoff that honors the
+  server's `retry_after_ms` hint exactly on pool-saturation backpressure
+- Single serialized writer; safe for concurrent `SendPCM` / `Stop` / `Close`
+- `context.Context` governs the whole client lifetime
+
+## Install
+
+```sh
+go get github.com/ekhodzitsky/gigastt/sdks/go@latest
+```
+
+Requires Go 1.23+.
+
+## Quickstart
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	gigastt "github.com/ekhodzitsky/gigastt/sdks/go"
+)
+
+func main() {
+	finals := make(chan gigastt.Transcript, 1)
+
+	client, err := gigastt.Dial(context.Background(), gigastt.DefaultURL,
+		gigastt.WithSampleRate(16000), // must be one of the server's supported_rates
+		gigastt.WithReconnect(250*time.Millisecond, 5*time.Second, 10),
+		gigastt.WithHandlers(gigastt.Handlers{
+			OnPartial: func(t gigastt.Transcript) { fmt.Printf("\r  ... %s", t.Text) },
+			OnFinal:   func(t gigastt.Transcript) { finals <- t },
+			OnError:   func(e *gigastt.ServerError) { log.Printf("server error: %v", e) },
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	wav, _ := os.ReadFile("recording.wav") // 16 kHz mono PCM16 WAV
+	for offset := 44; offset < len(wav); offset += 32768 {
+		end := min(offset+32768, len(wav))
+		if err := client.SendPCM(wav[offset:end]); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if err := client.Stop(); err != nil { // ask the server to finalize
+		log.Fatal(err)
+	}
+	t := <-finals
+	fmt.Printf("\n>>> %s (%.0f%% avg confidence)\n", t.Text, avgConfidence(t)*100)
+}
+
+func avgConfidence(t gigastt.Transcript) float64 {
+	var sum float64
+	for _, w := range t.Words {
+		sum += w.Confidence
+	}
+	if len(t.Words) == 0 {
+		return 0
+	}
+	return sum / float64(len(t.Words))
+}
+```
+
+## Behavior notes
+
+- **Configure first.** `Dial` always sends a `configure` frame pinning
+  `protocol_version` (plus `sample_rate` / `diarization` when set) and waits
+  for the server's `ready` before returning. A version mismatch fails loudly
+  with an `unsupported_protocol_version` `*ServerError` (use `errors.As`).
+- **Stop finalizes.** `Stop()` asks the server to flush and emit a final
+  transcript; the server then ends the session. This close is treated as a
+  normal end — `OnClose(nil)` fires and no reconnect is attempted.
+- **Reconnect.** Transient failures (network drops, abnormal closes) retry with
+  exponential backoff from `minBackoff` up to `maxBackoff`, bounded by
+  `maxAttempts` (0 = unlimited). Server errors are retried **only** when they
+  carry `retry_after_ms` (transient backpressure such as pool saturation), and
+  then the client waits exactly that hint. Fatal errors
+  (`unsupported_protocol_version`, `invalid_sample_rate`, …) are never retried.
+  While a reconnect is in flight, `SendPCM` fails fast with `ErrReconnecting` —
+  the SDK does not buffer audio across reconnects.
+- **Callbacks** run on the client's read goroutine: keep them fast and do not
+  call `Stop`/`Close` synchronously from inside one (use a goroutine).
+
+## Compatibility policy
+
+The SDK pins protocol `1.0` (`gigastt.ProtocolVersion`). Additive protocol
+changes are tolerated by design: unknown JSON fields and unknown message types
+are ignored on decode. A server that cannot speak protocol 1.x rejects the
+session during the handshake.
+
+## Testing
+
+Unit tests run against an in-process mock WebSocket server
+(`httptest` + `gorilla/websocket`):
+
+```sh
+go test ./...
+```
+
+### Integration test against a live server
+
+Requires a running server with the model (~850 MB download):
+
+```sh
+# once: download the model (~850 MB), then start the server from the repository root
+cargo run -- download
+cargo run --release -- serve
+
+# in another terminal, from this directory
+GIGASTT_TEST_WS_URL=ws://127.0.0.1:9876/v1/ws go test -run Live -v
+```
+
+The live test (`live_test.go`) is skipped unless `GIGASTT_TEST_WS_URL` is set;
+it streams a generated sine tone and asserts a complete
+ready → audio → final session.
+
+## Publishing
+
+The module path is `github.com/ekhodzitsky/gigastt/sdks/go`. Releases are cut
+from the monorepo with subdirectory tags of the form `sdks/go/vX.Y.Z` (Go
+modules convention). Publishing is part of the human release process and is
+**not** performed from CI in this change.
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -1,0 +1,498 @@
+package gigastt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// ErrClosed is returned by SendPCM and Stop after the client was closed.
+var ErrClosed = errors.New("gigastt: client is closed")
+
+// ErrReconnecting is returned by SendPCM and Stop while the client is between
+// connections during an automatic reconnect. The SDK does not buffer audio
+// across reconnects; callers must retry or drop the frame explicitly.
+var ErrReconnecting = errors.New("gigastt: reconnecting, not connected")
+
+// Handlers holds the event callbacks invoked by the client.
+//
+// Callbacks run on the client's internal read goroutine. They must return
+// quickly (hand long work off to your own goroutine) and must not call
+// Stop/Close synchronously from within a callback — use a goroutine instead.
+type Handlers struct {
+	// OnReady is called after each successful handshake, including reconnects.
+	OnReady func(Ready)
+	// OnPartial is called for every partial (interim) transcript.
+	OnPartial func(Transcript)
+	// OnFinal is called for every final transcript (utterance complete).
+	OnFinal func(Transcript)
+	// OnError is called for every server error message.
+	OnError func(*ServerError)
+	// OnClose is called exactly once when the client is permanently done:
+	// after Close, after a session ended by Stop, or when a connection
+	// failure could not be recovered. err is nil for an intentional shutdown.
+	OnClose func(err error)
+}
+
+type config struct {
+	sampleRate  uint32
+	diarization *bool
+	dialTimeout time.Duration
+
+	reconnect   bool
+	minBackoff  time.Duration
+	maxBackoff  time.Duration
+	maxAttempts int // 0 = unlimited
+
+	handlers Handlers
+}
+
+func defaultConfig() config {
+	return config{
+		dialTimeout: 10 * time.Second,
+	}
+}
+
+// Option configures a Client.
+type Option func(*config)
+
+// WithSampleRate negotiates the input audio sample rate in Hz (one of the
+// server's supported_rates, e.g. 16000). When unset, the server default
+// (48000) applies.
+func WithSampleRate(hz uint32) Option {
+	return func(c *config) { c.sampleRate = hz }
+}
+
+// WithDiarization enables speaker diarization for the session (if the server
+// was built and started with diarization support).
+func WithDiarization(enabled bool) Option {
+	return func(c *config) { c.diarization = &enabled }
+}
+
+// WithDialTimeout sets the timeout for the WebSocket handshake and for
+// waiting for the server's ready message. Default: 10s.
+func WithDialTimeout(d time.Duration) Option {
+	return func(c *config) { c.dialTimeout = d }
+}
+
+// WithReconnect enables automatic reconnect. Transient failures (network
+// errors, dropped connections) are retried with exponential backoff from
+// minBackoff, doubling up to maxBackoff. When the server asks for a specific
+// delay via retry_after_ms (pool saturation backpressure), that delay is
+// honored exactly instead of the exponential value. maxAttempts bounds the
+// number of retries per outage; 0 retries until the context is cancelled or
+// Close is called.
+func WithReconnect(minBackoff, maxBackoff time.Duration, maxAttempts int) Option {
+	return func(c *config) {
+		c.reconnect = true
+		c.minBackoff = minBackoff
+		c.maxBackoff = maxBackoff
+		c.maxAttempts = maxAttempts
+	}
+}
+
+// WithHandlers registers the event callbacks.
+func WithHandlers(h Handlers) Option {
+	return func(c *config) { c.handlers = h }
+}
+
+// Client is a typed WebSocket client for one gigastt transcription session.
+//
+// A Client is safe for concurrent use: SendPCM, Stop and Close may be called
+// from any goroutine. All writes to the socket are serialized through a
+// single internal writer path.
+type Client struct {
+	url string
+	cfg config
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// stateMu guards conn, ready, stopSent, closed.
+	stateMu sync.Mutex
+	conn    *websocket.Conn
+	ready   Ready
+	// stopSent marks a session that was finalized via Stop: the following
+	// server-side close is a normal end, not a reconnect trigger.
+	stopSent bool
+	closed   bool
+
+	// writeMu serializes all frame writes (single writer).
+	writeMu sync.Mutex
+
+	// onCloseOnce guarantees OnClose fires exactly once.
+	onCloseOnce sync.Once
+	// done is closed when the client is permanently done.
+	done chan struct{}
+}
+
+// Dial connects to url (pass DefaultURL for a default local server), performs
+// the handshake, sends the configure message (protocol version pinning plus
+// any negotiated options), and waits for the server's ready message.
+//
+// The passed context governs the whole client lifetime: cancelling it shuts
+// the client down, including any in-flight reconnect backoff.
+//
+// On failure Dial returns an error; a *ServerError (check with errors.As) is
+// returned when the server rejected the session. With WithReconnect enabled,
+// transient failures are retried before Dial gives up.
+func Dial(ctx context.Context, url string, opts ...Option) (*Client, error) {
+	cfg := defaultConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	c := &Client{
+		url:    url,
+		cfg:    cfg,
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	conn, ready, err := c.connectWithRetry(ctx)
+	if err != nil {
+		cancel()
+		close(c.done)
+		return nil, err
+	}
+	c.conn = conn
+	c.ready = ready
+	go c.readLoop(conn)
+	if h := cfg.handlers.OnReady; h != nil {
+		h(ready)
+	}
+	return c, nil
+}
+
+// Ready returns the ready message from the current connection.
+func (c *Client) Ready() Ready {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.ready
+}
+
+// Done returns a channel that is closed when the client is permanently done
+// (after Close, after a Stop-finalized session ends, or after an
+// unrecoverable failure).
+func (c *Client) Done() <-chan struct{} {
+	return c.done
+}
+
+// SendPCM sends one binary frame of raw PCM16 signed little-endian mono audio
+// at the negotiated sample rate. Frames may be up to the server's
+// --ws-frame-max-bytes (default 512 KiB). While a reconnect is in flight,
+// SendPCM fails fast with ErrReconnecting; after Close, with ErrClosed.
+func (c *Client) SendPCM(pcm []byte) error {
+	return c.write(websocket.BinaryMessage, pcm)
+}
+
+// Stop asks the server to finalize the session. The server flushes any
+// buffered audio, emits a final transcript (delivered via OnFinal), and ends
+// the session; OnClose then fires with a nil error. The connection is not
+// reused after Stop; call Close to release resources.
+func (c *Client) Stop() error {
+	c.stateMu.Lock()
+	if c.closed {
+		c.stateMu.Unlock()
+		return ErrClosed
+	}
+	c.stopSent = true
+	c.stateMu.Unlock()
+	return c.write(websocket.TextMessage, []byte(`{"type":"stop"}`))
+}
+
+// Close terminates the client: it cancels the internal context, sends a
+// WebSocket close frame on a best-effort basis, and closes the connection.
+// It is idempotent and safe to call multiple times.
+func (c *Client) Close() error {
+	c.stateMu.Lock()
+	if c.closed {
+		c.stateMu.Unlock()
+		return nil
+	}
+	c.closed = true
+	conn := c.conn
+	c.stateMu.Unlock()
+
+	c.cancel()
+	if conn != nil {
+		// Best-effort close handshake; ignore errors — we are tearing down anyway.
+		_ = c.writeFrame(conn, websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		_ = conn.Close()
+	}
+	c.finish(nil)
+	return nil
+}
+
+// write sends a frame on the current connection through the single writer path.
+func (c *Client) write(messageType int, data []byte) error {
+	c.stateMu.Lock()
+	if c.closed {
+		c.stateMu.Unlock()
+		return ErrClosed
+	}
+	conn := c.conn
+	c.stateMu.Unlock()
+	if conn == nil {
+		return ErrReconnecting
+	}
+	return c.writeFrame(conn, messageType, data)
+}
+
+// writeFrame is the single write path to the socket. gorilla/websocket
+// requires one concurrent writer; writeMu serializes all callers.
+func (c *Client) writeFrame(conn *websocket.Conn, messageType int, data []byte) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return conn.WriteMessage(messageType, data)
+}
+
+// connectWithRetry dials until success, a non-transient error, the attempt
+// budget is exhausted, or ctx is cancelled.
+func (c *Client) connectWithRetry(ctx context.Context) (*websocket.Conn, Ready, error) {
+	backoff := c.cfg.minBackoff
+	for attempt := 0; ; {
+		conn, ready, err := c.dialAndHandshake(ctx)
+		if err == nil {
+			return conn, ready, nil
+		}
+		if !c.cfg.reconnect || !isTransient(err) {
+			return nil, Ready{}, err
+		}
+		attempt++
+		if c.cfg.maxAttempts > 0 && attempt > c.cfg.maxAttempts {
+			return nil, Ready{}, fmt.Errorf("gigastt: giving up after %d attempts: %w", attempt, err)
+		}
+		wait := backoff
+		var se *ServerError
+		if errors.As(err, &se) && se.RetryAfterMs != nil {
+			// Honor the server's explicit retry hint exactly.
+			wait = time.Duration(*se.RetryAfterMs) * time.Millisecond
+		}
+		select {
+		case <-ctx.Done():
+			return nil, Ready{}, ctx.Err()
+		case <-time.After(wait):
+		}
+		backoff *= 2
+		if c.cfg.maxBackoff > 0 && backoff > c.cfg.maxBackoff {
+			backoff = c.cfg.maxBackoff
+		}
+	}
+}
+
+// isTransient reports whether a dial/handshake failure is worth retrying.
+// Network-level failures are transient; server errors are transient only when
+// the server attached a retry_after_ms hint (backpressure).
+func isTransient(err error) bool {
+	var se *ServerError
+	if errors.As(err, &se) {
+		return se.RetryAfterMs != nil
+	}
+	return true
+}
+
+// dialAndHandshake establishes one WebSocket connection, sends the configure
+// message, and waits for the server's ready message. A server error received
+// before ready (e.g. pool saturation) is returned as a *ServerError.
+func (c *Client) dialAndHandshake(ctx context.Context) (*websocket.Conn, Ready, error) {
+	dialer := websocket.Dialer{HandshakeTimeout: c.cfg.dialTimeout}
+	conn, _, err := dialer.DialContext(ctx, c.url, nil)
+	if err != nil {
+		return nil, Ready{}, fmt.Errorf("gigastt: dial %s: %w", c.url, err)
+	}
+	fail := func(err error) (*websocket.Conn, Ready, error) {
+		_ = conn.Close()
+		return nil, Ready{}, err
+	}
+	if err := c.writeFrame(conn, websocket.TextMessage, c.configureMessage()); err != nil {
+		return fail(fmt.Errorf("gigastt: send configure: %w", err))
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(c.cfg.dialTimeout)); err != nil {
+		return fail(fmt.Errorf("gigastt: set read deadline: %w", err))
+	}
+	for {
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			return fail(fmt.Errorf("gigastt: waiting for ready: %w", err))
+		}
+		var env envelope
+		if err := json.Unmarshal(raw, &env); err != nil {
+			continue // not JSON or no type tag: ignore, keep waiting
+		}
+		switch env.Type {
+		case "ready":
+			var r Ready
+			if err := json.Unmarshal(raw, &r); err != nil {
+				return fail(fmt.Errorf("gigastt: decode ready: %w", err))
+			}
+			// Clear the handshake deadline; the session has no read deadline.
+			if err := conn.SetReadDeadline(time.Time{}); err != nil {
+				return fail(fmt.Errorf("gigastt: clear read deadline: %w", err))
+			}
+			return conn, r, nil
+		case "error":
+			var se ServerError
+			if err := json.Unmarshal(raw, &se); err != nil {
+				return fail(fmt.Errorf("gigastt: decode error message: %w", err))
+			}
+			return fail(&se)
+		default:
+			// Unexpected pre-ready message type: ignore (forward compatibility).
+		}
+	}
+}
+
+// configureMessage builds the configure frame. It is always sent: it pins the
+// protocol version so a version mismatch fails loudly instead of silently.
+func (c *Client) configureMessage() []byte {
+	msg := map[string]any{
+		"type":             "configure",
+		"protocol_version": ProtocolVersion,
+	}
+	if c.cfg.sampleRate != 0 {
+		msg["sample_rate"] = c.cfg.sampleRate
+	}
+	if c.cfg.diarization != nil {
+		msg["diarization"] = *c.cfg.diarization
+	}
+	// The map is fully controlled above; marshaling cannot fail.
+	data, _ := json.Marshal(msg)
+	return data
+}
+
+// envelope is the type tag shared by all server messages.
+type envelope struct {
+	Type string `json:"type"`
+}
+
+// readLoop dispatches server messages until the connection fails or closes.
+func (c *Client) readLoop(conn *websocket.Conn) {
+	for {
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			c.handleDisconnect(conn, err)
+			return
+		}
+		c.dispatch(raw)
+	}
+}
+
+// dispatch parses one server message and invokes the matching handler.
+// Unknown message types and unparseable frames are ignored: additive protocol
+// evolution must never break the session.
+func (c *Client) dispatch(raw []byte) {
+	var env envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return
+	}
+	switch env.Type {
+	case "ready":
+		// A second ready within one connection is unexpected; ignore it.
+	case "partial":
+		var t Transcript
+		if err := json.Unmarshal(raw, &t); err == nil {
+			if h := c.cfg.handlers.OnPartial; h != nil {
+				h(t)
+			}
+		}
+	case "final":
+		var t Transcript
+		if err := json.Unmarshal(raw, &t); err == nil {
+			if h := c.cfg.handlers.OnFinal; h != nil {
+				h(t)
+			}
+		}
+	case "error":
+		var se ServerError
+		if err := json.Unmarshal(raw, &se); err == nil {
+			if h := c.cfg.handlers.OnError; h != nil {
+				h(&se)
+			}
+		}
+	default:
+		// Unknown type: additive protocol change, ignore.
+	}
+}
+
+// handleDisconnect decides whether a read failure ends the client or triggers
+// a reconnect. conn is the connection whose read loop failed.
+func (c *Client) handleDisconnect(conn *websocket.Conn, readErr error) {
+	c.stateMu.Lock()
+	if c.closed {
+		c.stateMu.Unlock()
+		return
+	}
+	if c.conn == conn {
+		c.conn = nil
+	}
+	intentional := c.stopSent
+	reconnect := c.cfg.reconnect && !c.stopSent
+	c.stateMu.Unlock()
+
+	if intentional {
+		// Session finalized via Stop: the server closes after the final
+		// transcript. This is the normal end of a session.
+		c.finish(nil)
+		return
+	}
+	if !reconnect {
+		c.finish(normalizeCloseError(readErr))
+		return
+	}
+
+	newConn, ready, err := c.connectWithRetry(c.ctx)
+	if err != nil {
+		c.finish(err)
+		return
+	}
+	c.stateMu.Lock()
+	if c.closed {
+		c.stateMu.Unlock()
+		_ = newConn.Close()
+		return
+	}
+	c.conn = newConn
+	c.ready = ready
+	c.stateMu.Unlock()
+	if h := c.cfg.handlers.OnReady; h != nil {
+		h(ready)
+	}
+	go c.readLoop(newConn)
+}
+
+// finish terminates the client permanently and fires OnClose exactly once.
+func (c *Client) finish(err error) {
+	c.stateMu.Lock()
+	alreadyClosed := c.closed
+	c.closed = true
+	conn := c.conn
+	c.conn = nil
+	c.stateMu.Unlock()
+
+	c.cancel()
+	if conn != nil && !alreadyClosed {
+		_ = conn.Close()
+	}
+	c.onCloseOnce.Do(func() {
+		if h := c.cfg.handlers.OnClose; h != nil {
+			h(err)
+		}
+		close(c.done)
+	})
+}
+
+// normalizeCloseError converts WebSocket close frames into a compact error.
+func normalizeCloseError(err error) error {
+	var closeErr *websocket.CloseError
+	if errors.As(err, &closeErr) {
+		return fmt.Errorf("gigastt: connection closed by server (code %d: %s)", closeErr.Code, closeErr.Text)
+	}
+	return fmt.Errorf("gigastt: connection lost: %w", err)
+}

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -318,7 +318,11 @@ func TestReconnectAfterAbnormalDrop(t *testing.T) {
 		expectConfigure(t, conn)
 		writeJSON(t, conn, readyPayload())
 		if n == 1 {
-			// Abnormal close: no close frame.
+			// Wait for one audio frame (proving the client processed ready),
+			// then drop the connection abnormally: no close frame.
+			if _, _, err := conn.ReadMessage(); err != nil {
+				t.Errorf("read before drop: %v", err)
+			}
 			return
 		}
 		_, _, _ = conn.ReadMessage()
@@ -338,6 +342,9 @@ func TestReconnectAfterAbnormalDrop(t *testing.T) {
 	}
 
 	waitFor(t, readyCount, "initial ready")
+	if err := c.SendPCM([]byte{0x00, 0x00}); err != nil {
+		t.Fatalf("SendPCM: %v", err)
+	}
 	waitFor(t, readyCount, "ready after reconnect")
 	if got := m.conns.Load(); got != 2 {
 		t.Errorf("connections = %d, want 2", got)

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -1,0 +1,601 @@
+package gigastt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// mockServer upgrades every HTTP request to WebSocket and runs the script for
+// the connection. script runs in the handler goroutine; n is the 1-based
+// connection counter. Returning from script closes the connection without a
+// close frame (abnormal close), unless the script already closed it cleanly.
+type mockServer struct {
+	srv   *httptest.Server
+	url   string
+	conns atomic.Int32
+}
+
+func newMockServer(t *testing.T, script func(conn *websocket.Conn, n int)) *mockServer {
+	t.Helper()
+	m := &mockServer{}
+	up := websocket.Upgrader{}
+	m.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		n := int(m.conns.Add(1))
+		script(conn, n)
+		_ = conn.Close()
+	}))
+	m.url = "ws" + strings.TrimPrefix(m.srv.URL, "http") + "/v1/ws"
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+// writeJSON sends v as a text frame.
+func writeJSON(t *testing.T, conn *websocket.Conn, v map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Errorf("marshal: %v", err)
+		return
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Errorf("write JSON: %v", err)
+	}
+}
+
+// readJSON reads one text frame and decodes it.
+func readJSON(t *testing.T, conn *websocket.Conn) map[string]any {
+	t.Helper()
+	mt, raw, err := conn.ReadMessage()
+	if err != nil {
+		t.Errorf("read JSON: %v", err)
+		return nil
+	}
+	if mt != websocket.TextMessage {
+		t.Errorf("expected text frame, got message type %d", mt)
+		return nil
+	}
+	var v map[string]any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Errorf("unmarshal: %v", err)
+		return nil
+	}
+	return v
+}
+
+func readyPayload() map[string]any {
+	return map[string]any{
+		"type":                 "ready",
+		"model":                "gigaam-v3-e2e-rnnt",
+		"sample_rate":          48000,
+		"version":              "1.0",
+		"supported_rates":      []int{8000, 16000, 24000, 44100, 48000},
+		"diarization":          true,
+		"min_protocol_version": "1.0",
+	}
+}
+
+// expectConfigure reads the configure frame the client must send first.
+func expectConfigure(t *testing.T, conn *websocket.Conn) map[string]any {
+	t.Helper()
+	msg := readJSON(t, conn)
+	if msg["type"] != "configure" {
+		t.Errorf("expected configure, got %v", msg["type"])
+	}
+	return msg
+}
+
+// waitFor receives from ch with a timeout.
+func waitFor[T any](t *testing.T, ch <-chan T, what string) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout waiting for %s", what)
+		var zero T
+		return zero
+	}
+}
+
+func TestDialSendsConfigureAndReceivesReady(t *testing.T) {
+	configureCh := make(chan map[string]any, 1)
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		configureCh <- expectConfigure(t, conn)
+		writeJSON(t, conn, readyPayload())
+		// Keep the session open until the client disconnects.
+		_, _, _ = conn.ReadMessage()
+	})
+
+	c, err := Dial(context.Background(), m.url,
+		WithSampleRate(16000),
+		WithDiarization(true),
+	)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	cfg := waitFor(t, configureCh, "configure")
+	if cfg["protocol_version"] != ProtocolVersion {
+		t.Errorf("protocol_version = %v, want %q", cfg["protocol_version"], ProtocolVersion)
+	}
+	if cfg["sample_rate"] != float64(16000) {
+		t.Errorf("sample_rate = %v, want 16000", cfg["sample_rate"])
+	}
+	if cfg["diarization"] != true {
+		t.Errorf("diarization = %v, want true", cfg["diarization"])
+	}
+
+	r := c.Ready()
+	if r.Model != "gigaam-v3-e2e-rnnt" {
+		t.Errorf("Model = %q", r.Model)
+	}
+	if r.SampleRate != 48000 {
+		t.Errorf("SampleRate = %d", r.SampleRate)
+	}
+	if r.Version != "1.0" {
+		t.Errorf("Version = %q", r.Version)
+	}
+	if len(r.SupportedRates) != 5 || r.SupportedRates[0] != 8000 {
+		t.Errorf("SupportedRates = %v", r.SupportedRates)
+	}
+	if !r.Diarization {
+		t.Errorf("Diarization = false, want true")
+	}
+	if r.MinProtocolVersion != "1.0" {
+		t.Errorf("MinProtocolVersion = %q", r.MinProtocolVersion)
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	<-c.Done()
+}
+
+func TestPartialAndFinalDispatch(t *testing.T) {
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		writeJSON(t, conn, readyPayload())
+		writeJSON(t, conn, map[string]any{
+			"type":      "partial",
+			"text":      "привет",
+			"timestamp": 1712700000.5,
+			"is_final":  false,
+			"words": []map[string]any{
+				{"word": "привет", "start": 0.1, "end": 0.6, "confidence": 0.95, "speaker": 2},
+			},
+		})
+		writeJSON(t, conn, map[string]any{
+			"type":      "final",
+			"text":      "привет как дела",
+			"timestamp": 1712700001.0,
+			"is_final":  true,
+			"words": []map[string]any{
+				{"word": "привет", "start": 0.1, "end": 0.6, "confidence": 0.95},
+				{"word": "как", "start": 0.7, "end": 0.9, "confidence": 0.9},
+				{"word": "дела", "start": 1.0, "end": 1.4, "confidence": 0.88},
+			},
+		})
+		_, _, _ = conn.ReadMessage()
+	})
+
+	partials := make(chan Transcript, 1)
+	finals := make(chan Transcript, 1)
+	c, err := Dial(context.Background(), m.url, WithHandlers(Handlers{
+		OnPartial: func(tr Transcript) { partials <- tr },
+		OnFinal:   func(tr Transcript) { finals <- tr },
+	}))
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	p := waitFor(t, partials, "partial")
+	if p.Text != "привет" || p.IsFinal {
+		t.Errorf("partial = %+v", p)
+	}
+	if p.Timestamp != 1712700000.5 {
+		t.Errorf("partial timestamp = %v", p.Timestamp)
+	}
+	if len(p.Words) != 1 {
+		t.Fatalf("partial words = %v", p.Words)
+	}
+	w := p.Words[0]
+	if w.Word != "привет" || w.Start != 0.1 || w.End != 0.6 || w.Confidence != 0.95 {
+		t.Errorf("word = %+v", w)
+	}
+	if w.Speaker == nil || *w.Speaker != 2 {
+		t.Errorf("speaker = %v, want 2", w.Speaker)
+	}
+
+	f := waitFor(t, finals, "final")
+	if f.Text != "привет как дела" || !f.IsFinal {
+		t.Errorf("final = %+v", f)
+	}
+	if len(f.Words) != 3 {
+		t.Fatalf("final words = %v", f.Words)
+	}
+	if f.Words[1].Speaker != nil {
+		t.Errorf("speaker must be nil when omitted, got %v", f.Words[1].Speaker)
+	}
+
+	_ = c.Close()
+	<-c.Done()
+}
+
+func TestErrorDispatch(t *testing.T) {
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		writeJSON(t, conn, readyPayload())
+		writeJSON(t, conn, map[string]any{
+			"type":    "error",
+			"message": "Inference failed. Please check audio format.",
+			"code":    "inference_error",
+		})
+		_, _, _ = conn.ReadMessage()
+	})
+
+	errs := make(chan *ServerError, 1)
+	c, err := Dial(context.Background(), m.url, WithHandlers(Handlers{
+		OnError: func(se *ServerError) { errs <- se },
+	}))
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	se := waitFor(t, errs, "error")
+	if se.Code != ErrCodeInferenceError {
+		t.Errorf("code = %q", se.Code)
+	}
+	if se.RetryAfterMs != nil {
+		t.Errorf("retry_after_ms must be nil when omitted, got %v", *se.RetryAfterMs)
+	}
+	if !strings.Contains(se.Error(), "inference_error") {
+		t.Errorf("Error() = %q", se.Error())
+	}
+
+	_ = c.Close()
+	<-c.Done()
+}
+
+func TestRetryAfterMsHonoredOnReconnect(t *testing.T) {
+	const retryAfterMs = 250
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		if n == 1 {
+			// Pool saturation: reject with an explicit retry hint.
+			writeJSON(t, conn, map[string]any{
+				"type":           "error",
+				"message":        "Server busy, try again later",
+				"code":           "timeout",
+				"retry_after_ms": retryAfterMs,
+			})
+			return
+		}
+		writeJSON(t, conn, readyPayload())
+		_, _, _ = conn.ReadMessage()
+	})
+
+	start := time.Now()
+	c, err := Dial(context.Background(), m.url,
+		WithReconnect(5*time.Millisecond, 100*time.Millisecond, 5),
+	)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if got := m.conns.Load(); got != 2 {
+		t.Errorf("connections = %d, want 2", got)
+	}
+	// The 250ms server hint must be honored exactly; the 5ms exponential
+	// backoff would have reconnected almost immediately.
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("reconnected after %v, want >= ~%dms (retry_after_ms not honored)", elapsed, retryAfterMs)
+	}
+	if elapsed > 10*time.Second {
+		t.Errorf("reconnect took suspiciously long: %v", elapsed)
+	}
+
+	_ = c.Close()
+	<-c.Done()
+}
+
+func TestReconnectAfterAbnormalDrop(t *testing.T) {
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		writeJSON(t, conn, readyPayload())
+		if n == 1 {
+			// Abnormal close: no close frame.
+			return
+		}
+		_, _, _ = conn.ReadMessage()
+	})
+
+	readyCount := make(chan Ready, 4)
+	closeCh := make(chan error, 1)
+	c, err := Dial(context.Background(), m.url,
+		WithReconnect(10*time.Millisecond, 50*time.Millisecond, 5),
+		WithHandlers(Handlers{
+			OnReady: func(r Ready) { readyCount <- r },
+			OnClose: func(err error) { closeCh <- err },
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	waitFor(t, readyCount, "initial ready")
+	waitFor(t, readyCount, "ready after reconnect")
+	if got := m.conns.Load(); got != 2 {
+		t.Errorf("connections = %d, want 2", got)
+	}
+
+	_ = c.Close()
+	if err := waitFor(t, closeCh, "OnClose"); err != nil {
+		t.Errorf("OnClose err = %v, want nil after Close", err)
+	}
+}
+
+func TestStopFinalizesSessionWithoutReconnect(t *testing.T) {
+	stopReceived := make(chan struct{}, 1)
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		writeJSON(t, conn, readyPayload())
+		msg := readJSON(t, conn)
+		if msg["type"] != "stop" {
+			t.Errorf("expected stop, got %v", msg["type"])
+			return
+		}
+		stopReceived <- struct{}{}
+		writeJSON(t, conn, map[string]any{
+			"type":      "final",
+			"text":      "готово",
+			"timestamp": 1712700002.0,
+			"is_final":  true,
+			"words":     []map[string]any{},
+		})
+		// Server ends the session after the final transcript.
+	})
+
+	finals := make(chan Transcript, 1)
+	closeCh := make(chan error, 1)
+	c, err := Dial(context.Background(), m.url,
+		WithReconnect(10*time.Millisecond, 50*time.Millisecond, 5),
+		WithHandlers(Handlers{
+			OnFinal: func(tr Transcript) { finals <- tr },
+			OnClose: func(err error) { closeCh <- err },
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	if err := c.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	waitFor(t, stopReceived, "stop frame")
+	if f := waitFor(t, finals, "final"); f.Text != "готово" {
+		t.Errorf("final text = %q", f.Text)
+	}
+
+	select {
+	case <-c.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("Done not closed after session end")
+	}
+	if err := <-closeCh; err != nil {
+		t.Errorf("OnClose err = %v, want nil for Stop-finalized session", err)
+	}
+	// The session ended intentionally: no reconnect must have happened.
+	if got := m.conns.Load(); got != 1 {
+		t.Errorf("connections = %d, want 1 (no reconnect after stop)", got)
+	}
+}
+
+func TestFatalServerErrorNotRetried(t *testing.T) {
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		writeJSON(t, conn, map[string]any{
+			"type":    "error",
+			"message": "Unsupported protocol version",
+			"code":    "unsupported_protocol_version",
+		})
+	})
+
+	_, err := Dial(context.Background(), m.url,
+		WithReconnect(5*time.Millisecond, 50*time.Millisecond, 5),
+	)
+	if err == nil {
+		t.Fatal("Dial must fail on unsupported protocol version")
+	}
+	var se *ServerError
+	if !errors.As(err, &se) {
+		t.Fatalf("error %v is not a *ServerError", err)
+	}
+	if se.Code != ErrCodeUnsupportedProtocolVersion {
+		t.Errorf("code = %q", se.Code)
+	}
+	if got := m.conns.Load(); got != 1 {
+		t.Errorf("connections = %d, want 1 (fatal errors are not retried)", got)
+	}
+}
+
+func TestUnknownFieldsIgnored(t *testing.T) {
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		ready := readyPayload()
+		ready["future_field"] = map[string]any{"nested": true}
+		writeJSON(t, conn, ready)
+		writeJSON(t, conn, map[string]any{
+			"type":       "partial",
+			"text":       "ok",
+			"timestamp":  1.0,
+			"is_final":   false,
+			"confidence": 0.5, // hypothetical additive field
+		})
+		writeJSON(t, conn, map[string]any{"type": "brand_new_message", "x": 1})
+		_, _, _ = conn.ReadMessage()
+	})
+
+	partials := make(chan Transcript, 1)
+	c, err := Dial(context.Background(), m.url, WithHandlers(Handlers{
+		OnPartial: func(tr Transcript) { partials <- tr },
+	}))
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	if p := waitFor(t, partials, "partial"); p.Text != "ok" {
+		t.Errorf("partial text = %q", p.Text)
+	}
+	_ = c.Close()
+	<-c.Done()
+}
+
+func TestContextCancelDuringRetryBackoff(t *testing.T) {
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		writeJSON(t, conn, map[string]any{
+			"type":           "error",
+			"message":        "Server busy, try again later",
+			"code":           "timeout",
+			"retry_after_ms": 60000,
+		})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := Dial(ctx, m.url, WithReconnect(5*time.Millisecond, 100*time.Millisecond, 0))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if time.Since(start) > 10*time.Second {
+		t.Errorf("cancel during backoff took too long: %v", time.Since(start))
+	}
+	if got := m.conns.Load(); got != 1 {
+		t.Errorf("connections = %d, want 1", got)
+	}
+}
+
+func TestSendPCM(t *testing.T) {
+	frames := make(chan []byte, 3)
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		writeJSON(t, conn, readyPayload())
+		for i := 0; i < 3; i++ {
+			mt, raw, err := conn.ReadMessage()
+			if err != nil {
+				t.Errorf("read frame %d: %v", i, err)
+				return
+			}
+			if mt != websocket.BinaryMessage {
+				t.Errorf("frame %d type = %d, want binary", i, mt)
+				return
+			}
+			frames <- raw
+		}
+		_, _, _ = conn.ReadMessage()
+	})
+
+	c, err := Dial(context.Background(), m.url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	payloads := [][]byte{
+		{0x01, 0x02, 0x03},
+		{0x00, 0x00},
+		make([]byte, 320), // 10ms of 16kHz PCM16, silence
+	}
+	for _, p := range payloads {
+		if err := c.SendPCM(p); err != nil {
+			t.Fatalf("SendPCM: %v", err)
+		}
+	}
+	for i, want := range payloads {
+		got := waitFor(t, frames, "pcm frame")
+		if len(got) != len(want) {
+			t.Errorf("frame %d len = %d, want %d", i, len(got), len(want))
+			continue
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Errorf("frame %d byte %d = %d, want %d", i, j, got[j], want[j])
+				break
+			}
+		}
+	}
+
+	_ = c.Close()
+	<-c.Done()
+}
+
+func TestSendAfterCloseFails(t *testing.T) {
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		writeJSON(t, conn, readyPayload())
+		_, _, _ = conn.ReadMessage()
+	})
+
+	c, err := Dial(context.Background(), m.url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := c.SendPCM([]byte{0x01}); !errors.Is(err, ErrClosed) {
+		t.Errorf("SendPCM after Close = %v, want ErrClosed", err)
+	}
+	if err := c.Stop(); !errors.Is(err, ErrClosed) {
+		t.Errorf("Stop after Close = %v, want ErrClosed", err)
+	}
+	// Close is idempotent.
+	if err := c.Close(); err != nil {
+		t.Errorf("second Close = %v", err)
+	}
+}
+
+func TestMaxReconnectAttemptsExceeded(t *testing.T) {
+	m := newMockServer(t, func(conn *websocket.Conn, n int) {
+		expectConfigure(t, conn)
+		writeJSON(t, conn, map[string]any{
+			"type":           "error",
+			"message":        "Server busy, try again later",
+			"code":           "timeout",
+			"retry_after_ms": 20,
+		})
+	})
+
+	_, err := Dial(context.Background(), m.url,
+		WithReconnect(5*time.Millisecond, 50*time.Millisecond, 2),
+	)
+	if err == nil {
+		t.Fatal("Dial must fail after exhausting reconnect attempts")
+	}
+	var se *ServerError
+	if !errors.As(err, &se) {
+		t.Errorf("wrapped error should still expose *ServerError, got %v", err)
+	}
+	// 1 initial attempt + 2 retries.
+	if got := m.conns.Load(); got != 3 {
+		t.Errorf("connections = %d, want 3", got)
+	}
+}

--- a/sdks/go/example_test.go
+++ b/sdks/go/example_test.go
@@ -1,0 +1,61 @@
+package gigastt_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	gigastt "github.com/ekhodzitsky/gigastt/sdks/go"
+)
+
+// ExampleDial streams a WAV file to a local gigastt server and prints partial
+// and final transcripts. It is compile-checked only; run it against a live
+// server as described in the README.
+func ExampleDial() {
+	ctx := context.Background()
+
+	finals := make(chan gigastt.Transcript, 1)
+	client, err := gigastt.Dial(ctx, gigastt.DefaultURL,
+		gigastt.WithSampleRate(16000),
+		gigastt.WithReconnect(250*time.Millisecond, 5*time.Second, 10),
+		gigastt.WithHandlers(gigastt.Handlers{
+			OnPartial: func(t gigastt.Transcript) {
+				fmt.Printf("\r  ... %s", t.Text)
+			},
+			OnFinal: func(t gigastt.Transcript) {
+				fmt.Printf("\r  >>> %s\n", t.Text)
+				finals <- t
+			},
+			OnError: func(e *gigastt.ServerError) {
+				log.Printf("server error: %v", e)
+			},
+		}),
+	)
+	if err != nil {
+		log.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	fmt.Printf("connected: %s @ %d Hz\n", client.Ready().Model, client.Ready().SampleRate)
+
+	// Stream a 16 kHz mono WAV file (skipping the 44-byte header) in chunks.
+	wav, err := os.ReadFile("recording.wav")
+	if err != nil {
+		log.Fatalf("read wav: %v", err)
+	}
+	const header, chunk = 44, 32768
+	for offset := header; offset < len(wav); offset += chunk {
+		end := min(offset+chunk, len(wav))
+		if err := client.SendPCM(wav[offset:end]); err != nil {
+			log.Fatalf("send: %v", err)
+		}
+	}
+
+	// Ask the server to finalize, then wait for the last transcript.
+	if err := client.Stop(); err != nil {
+		log.Fatalf("stop: %v", err)
+	}
+	<-finals
+}

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/ekhodzitsky/gigastt/sdks/go
+
+go 1.23
+
+require github.com/gorilla/websocket v1.5.3

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/sdks/go/live_test.go
+++ b/sdks/go/live_test.go
@@ -1,0 +1,73 @@
+package gigastt
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestLiveServer exercises the full wire protocol against a live gigastt
+// server. It is skipped unless GIGASTT_TEST_WS_URL points at a running server
+// (which requires the model, ~850 MB):
+//
+//	cargo run --release -- serve   # in the repository root
+//	GIGASTT_TEST_WS_URL=ws://127.0.0.1:9876/v1/ws go test -run Live -v
+func TestLiveServer(t *testing.T) {
+	url := os.Getenv("GIGASTT_TEST_WS_URL")
+	if url == "" {
+		t.Skip("GIGASTT_TEST_WS_URL not set; skipping live-server integration test")
+	}
+
+	finals := make(chan Transcript, 1)
+	c, err := Dial(context.Background(), url,
+		WithSampleRate(16000),
+		WithHandlers(Handlers{
+			OnFinal: func(tr Transcript) { finals <- tr },
+			OnError: func(se *ServerError) { t.Errorf("server error: %v", se) },
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer c.Close()
+
+	if c.Ready().Model == "" {
+		t.Error("ready.model is empty")
+	}
+
+	// Stream 2 seconds of a 440 Hz sine tone as 16 kHz PCM16 in 20ms frames.
+	const (
+		rate       = 16000
+		frameSamps = rate / 50
+		duration   = 2 * time.Second
+	)
+	frame := make([]byte, frameSamps*2)
+	totalFrames := int(duration.Seconds() * 50)
+	for i := 0; i < totalFrames; i++ {
+		for j := 0; j < frameSamps; j++ {
+			sample := int16(12000 * math.Sin(2*math.Pi*440*float64(i*frameSamps+j)/rate))
+			binary.LittleEndian.PutUint16(frame[j*2:], uint16(sample))
+		}
+		if err := c.SendPCM(frame); err != nil {
+			t.Fatalf("SendPCM: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := c.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	select {
+	case f := <-finals:
+		if !f.IsFinal {
+			t.Error("final transcript has is_final=false")
+		}
+		t.Logf("live final transcript: %q (%d words)", f.Text, len(f.Words))
+	case <-time.After(30 * time.Second):
+		t.Fatal("no final transcript within 30s")
+	}
+}

--- a/sdks/go/types.go
+++ b/sdks/go/types.go
@@ -1,0 +1,100 @@
+// Package gigastt provides a typed WebSocket client for the gigastt
+// speech-to-text server (WebSocket protocol version 1.0).
+//
+// The client connects to the server's /v1/ws endpoint, negotiates the input
+// sample rate, streams raw PCM16 mono audio as binary frames, and dispatches
+// typed Ready/Partial/Final/Error events to user callbacks. Optional
+// automatic reconnect uses exponential backoff and honors the server's
+// retry_after_ms hint on transient backpressure errors (pool saturation).
+//
+// Wire protocol reference: docs/asyncapi.yaml in the gigastt repository.
+package gigastt
+
+// ProtocolVersion is the WebSocket protocol version this SDK speaks. The SDK
+// pins to protocol "1.0" and announces it in the configure message; the
+// server rejects the session with an unsupported_protocol_version error if it
+// cannot speak it. Additive wire changes (new fields on existing messages)
+// are tolerated: unknown JSON fields are ignored on decode.
+const ProtocolVersion = "1.0"
+
+// DefaultURL is the default server endpoint (loopback bind, default port).
+const DefaultURL = "ws://127.0.0.1:9876/v1/ws"
+
+// Machine-readable error codes sent by the server in Error messages
+// (see docs/asyncapi.yaml, ErrorMessage.code).
+const (
+	ErrCodeInferenceError             = "inference_error"
+	ErrCodeInferencePanic             = "inference_panic"
+	ErrCodeInferenceTimeout           = "inference_timeout"
+	ErrCodeConfigureTooLate           = "configure_too_late"
+	ErrCodeInvalidSampleRate          = "invalid_sample_rate"
+	ErrCodeTimeout                    = "timeout" // pool saturation; carries RetryAfterMs
+	ErrCodePoolClosed                 = "pool_closed"
+	ErrCodeMaxSessionDurationExceeded = "max_session_duration_exceeded"
+	ErrCodePayloadTooLarge            = "payload_too_large"
+	ErrCodeUnsupportedProtocolVersion = "unsupported_protocol_version"
+	ErrCodeIdleTimeout                = "idle_timeout"
+	ErrCodePolicyViolation            = "policy_violation"
+)
+
+// WordInfo is a single recognized word with timing and confidence metadata.
+type WordInfo struct {
+	// Word is the recognized word text (BPE tokens joined).
+	Word string `json:"word"`
+	// Start is the word start time in seconds from the stream beginning.
+	Start float64 `json:"start"`
+	// End is the word end time in seconds from the stream beginning.
+	End float64 `json:"end"`
+	// Confidence is the mean softmax confidence over the word's tokens (0.0-1.0).
+	Confidence float64 `json:"confidence"`
+	// Speaker is the zero-based diarization speaker label; nil when
+	// diarization is disabled.
+	Speaker *uint32 `json:"speaker,omitempty"`
+}
+
+// Ready is sent by the server immediately after the WebSocket handshake.
+type Ready struct {
+	// Model is the identifier of the loaded model (e.g. "gigaam-v3-e2e-rnnt").
+	Model string `json:"model"`
+	// SampleRate is the audio sample rate in Hz the server expects by default.
+	SampleRate uint32 `json:"sample_rate"`
+	// Version is the server's WebSocket protocol version (e.g. "1.0").
+	Version string `json:"version"`
+	// SupportedRates lists the accepted input sample rates in Hz.
+	SupportedRates []uint32 `json:"supported_rates,omitempty"`
+	// Diarization reports whether speaker diarization is available.
+	Diarization bool `json:"diarization,omitempty"`
+	// MinProtocolVersion is the minimum protocol version the server accepts.
+	MinProtocolVersion string `json:"min_protocol_version,omitempty"`
+}
+
+// Transcript is a partial (interim, may change) or final (utterance complete)
+// transcript segment.
+type Transcript struct {
+	// Text is the recognized text for this segment.
+	Text string `json:"text"`
+	// Words carries word-level timing metadata.
+	Words []WordInfo `json:"words,omitempty"`
+	// IsFinal reports whether this segment is final.
+	IsFinal bool `json:"is_final"`
+	// Timestamp is the Unix time (seconds since epoch) when the segment was produced.
+	Timestamp float64 `json:"timestamp"`
+}
+
+// ServerError is an error message sent by the server. It implements the error
+// interface; use errors.As to extract it from Dial or callback paths.
+type ServerError struct {
+	// Message is a user-facing description (internal details are hidden by the server).
+	Message string `json:"message"`
+	// Code is a machine-readable error code (see the ErrCode* constants).
+	Code string `json:"code"`
+	// RetryAfterMs is the server-suggested delay before retrying, in
+	// milliseconds. Present only for transient backpressure errors (e.g. pool
+	// saturation); nil otherwise.
+	RetryAfterMs *uint32 `json:"retry_after_ms,omitempty"`
+}
+
+// Error returns a human-readable description of the server error.
+func (e *ServerError) Error() string {
+	return "gigastt: server error " + e.Code + ": " + e.Message
+}

--- a/sdks/js/.gitignore
+++ b/sdks/js/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/sdks/js/LICENSE
+++ b/sdks/js/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Evgeny Khodzitsky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdks/js/README.md
+++ b/sdks/js/README.md
@@ -1,0 +1,133 @@
+# @gigastt/client
+
+Typed TypeScript WebSocket client for the
+[gigastt](https://github.com/ekhodzitsky/gigastt) speech-to-text server
+(GigaAM v3, Russian ASR). Protocol version **1.0** (`PROTOCOL_VERSION` in
+`crates/gigastt-core/src/protocol/mod.rs`). Works in **Node.js ≥ 20** and in
+**browsers**.
+
+- Typed `ReadyMessage` / `Transcript` (partial & final) / `ServerError` events
+  with all protocol fields, including `words[]`, `error.code` and
+  `error.retry_after_ms`
+- Callback-based dispatch (`onPartial` / `onFinal` / `onError` / `onClose`)
+- Optional automatic reconnect with exponential backoff that honors the
+  server's `retry_after_ms` hint exactly on pool-saturation backpressure
+- `AbortController` governs the whole client lifetime
+- Transport: the global `WebSocket` (browsers, Node ≥ 22), the `ws` package as
+  an automatic Node fallback, or any transport injected via `webSocketFactory`
+
+## Install
+
+```sh
+npm install @gigastt/client
+```
+
+The `ws` package is a regular dependency but is only loaded (via dynamic
+import) when no global `WebSocket` exists; browser bundlers can safely mark it
+external — it is never imported on the browser path.
+
+## Quickstart
+
+```ts
+import { GigasttClient, DEFAULT_URL } from "@gigastt/client";
+import { readFile } from "node:fs/promises";
+
+const controller = new AbortController();
+
+const client = await GigasttClient.connect(DEFAULT_URL, {
+  sampleRate: 16000, // must be one of the server's supported_rates
+  signal: controller.signal,
+  reconnect: { minDelayMs: 250, maxDelayMs: 5000, maxAttempts: 10 },
+  handlers: {
+    onPartial: (t) => process.stdout.write(`\r  ... ${t.text}`),
+    onFinal: (t) => {
+      console.log(`\n>>> ${t.text}`);
+      for (const w of t.words ?? []) {
+        console.log(`    ${w.start.toFixed(2)}s-${w.end.toFixed(2)}s ${w.word} (${w.confidence})`);
+      }
+    },
+    onError: (err) => console.error(`server error ${err.code}: ${err.message}`),
+    onClose: ({ intentional, error }) => {
+      if (!intentional) console.error("connection lost:", error);
+    },
+  },
+});
+
+console.log(`connected: ${client.ready.model} @ ${client.ready.sample_rate} Hz`);
+
+// Stream a 16 kHz mono PCM16 WAV file (skipping the 44-byte header) in chunks.
+const wav = await readFile("recording.wav");
+for (let offset = 44; offset < wav.byteLength; offset += 32768) {
+  client.sendPCM(wav.subarray(offset, offset + 32768));
+}
+
+client.stop(); // ask the server to flush and emit the final transcript
+```
+
+## Behavior notes
+
+- **Configure first.** `connect` always sends a `configure` frame pinning
+  `protocol_version` (plus `sample_rate` / `diarization` when set) and resolves
+  only after the server's `ready`. A version mismatch rejects with a
+  `ServerError` whose `code` is `unsupported_protocol_version`.
+- **Stop finalizes.** `stop()` asks the server to flush and emit a final
+  transcript; the server then ends the session. This close is treated as a
+  normal end — `onClose` fires with `intentional: true` and no reconnect is
+  attempted.
+- **Reconnect.** Transient failures (network drops, abnormal closes) retry with
+  exponential backoff from `minDelayMs` up to `maxDelayMs`, bounded by
+  `maxAttempts` (0 = unlimited). Server errors are retried **only** when they
+  carry `retry_after_ms` (transient backpressure such as pool saturation), and
+  then the client waits exactly that hint. Fatal errors
+  (`unsupported_protocol_version`, `invalid_sample_rate`, …) are never retried.
+  While a reconnect is in flight, `sendPCM` throws — the SDK does not buffer
+  audio across reconnects; drop or retry frames explicitly.
+- **Abort.** Aborting the signal rejects a pending `connect`, interrupts
+  reconnect backoff with an `AbortError`, and closes an established session.
+
+## Compatibility policy
+
+The SDK pins protocol `1.0` (`PROTOCOL_VERSION`). Additive protocol changes are
+tolerated by design: unknown JSON fields and unknown message types are ignored
+on decode. A server that cannot speak protocol 1.x rejects the session during
+the handshake.
+
+## Testing
+
+Unit tests run against an in-process mock WebSocket server (`ws` package +
+vitest):
+
+```sh
+npm install
+npm test          # vitest run
+npm run typecheck # tsc --noEmit (strict)
+npm run build     # emit dist/ (ESM + .d.ts)
+```
+
+### Integration test against a live server
+
+Requires a running server with the model (~850 MB download):
+
+```sh
+# once: download the model, then start the server from the repository root
+cargo run -- download
+cargo run --release -- serve
+
+# then point any script using GigasttClient at it, e.g. the quickstart above:
+GIGASTT_URL=ws://127.0.0.1:9876/v1/ws node yourscript.mjs
+```
+
+The unit tests assert the same wire contract the live server speaks
+(`docs/asyncapi.yaml`); the connect → configure → ready → PCM → stop → final
+flow is exercised end-to-end against the mock server.
+
+## Publishing
+
+The package manifest (`package.json`) is release-ready:
+`npm publish --access public` from this directory (runs `prepublishOnly` →
+`npm run build`). Versioning follows the monorepo release process; publishing
+is done by a human during the release, **not** from CI in this change.
+
+## License
+
+MIT — see [LICENSE](../../LICENSE).

--- a/sdks/js/README.md
+++ b/sdks/js/README.md
@@ -109,17 +109,17 @@ npm run build     # emit dist/ (ESM + .d.ts)
 Requires a running server with the model (~850 MB download):
 
 ```sh
-# once: download the model, then start the server from the repository root
+# once: download the model (~850 MB), then start the server from the repository root
 cargo run -- download
 cargo run --release -- serve
 
-# then point any script using GigasttClient at it, e.g. the quickstart above:
-GIGASTT_URL=ws://127.0.0.1:9876/v1/ws node yourscript.mjs
+# in another terminal, from this directory
+GIGASTT_TEST_WS_URL=ws://127.0.0.1:9876/v1/ws npx vitest run test/live.test.ts
 ```
 
-The unit tests assert the same wire contract the live server speaks
-(`docs/asyncapi.yaml`); the connect → configure → ready → PCM → stop → final
-flow is exercised end-to-end against the mock server.
+The live test (`test/live.test.ts`) is skipped unless `GIGASTT_TEST_WS_URL` is
+set; it streams a generated sine tone and asserts a complete
+ready → audio → stop → final session.
 
 ## Publishing
 

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,0 +1,1696 @@
+{
+  "name": "@gigastt/client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@gigastt/client",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "@types/ws": "^8.18.0",
+        "typescript": "^5.8.0",
+        "vitest": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@gigastt/client",
+  "version": "0.1.0",
+  "description": "Typed WebSocket client for the gigastt speech-to-text server (protocol v1.0), for Node.js and browsers",
+  "keywords": [
+    "gigastt",
+    "gigaam",
+    "speech-to-text",
+    "stt",
+    "asr",
+    "russian",
+    "websocket"
+  ],
+  "license": "MIT",
+  "author": "gigastt contributors",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ekhodzitsky/gigastt",
+    "directory": "sdks/js"
+  },
+  "homepage": "https://github.com/ekhodzitsky/gigastt/tree/main/sdks/js",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@types/ws": "^8.18.0",
+    "typescript": "^5.8.0",
+    "vitest": "^3.2.0"
+  }
+}

--- a/sdks/js/src/client.ts
+++ b/sdks/js/src/client.ts
@@ -1,0 +1,515 @@
+import {
+  PROTOCOL_VERSION,
+  ServerError,
+  parseServerMessage,
+} from "./types.js";
+import type { ReadyMessage, Transcript } from "./types.js";
+
+/** Automatic-reconnect policy. Presence of this option enables reconnects. */
+export interface ReconnectOptions {
+  /** Initial backoff in milliseconds (default 250). */
+  minDelayMs?: number;
+  /** Maximum backoff in milliseconds (default 5000). */
+  maxDelayMs?: number;
+  /** Retry budget per outage; 0 retries forever (default 0). */
+  maxAttempts?: number;
+}
+
+/** Terminal close notification delivered exactly once. */
+export interface CloseInfo {
+  /**
+   * True when the session ended intentionally: `close()` was called, the
+   * session was finalized via `stop()`, or the AbortSignal fired.
+   */
+  intentional: boolean;
+  /** Underlying error for unintentional closes. */
+  error?: unknown;
+}
+
+/** Event callbacks. Callbacks must not call `stop()`/`close()` re-entrantly. */
+export interface ClientHandlers {
+  /** Called after each successful handshake, including reconnects. */
+  onReady?: (msg: ReadyMessage) => void;
+  /** Called for every partial (interim) transcript. */
+  onPartial?: (t: Transcript) => void;
+  /** Called for every final transcript (utterance complete). */
+  onFinal?: (t: Transcript) => void;
+  /** Called for every server error message. */
+  onError?: (err: ServerError) => void;
+  /** Called exactly once when the client is permanently done. */
+  onClose?: (info: CloseInfo) => void;
+}
+
+/** Minimal structural subset of the WebSocket API used by this SDK. */
+export interface WebSocketLike {
+  binaryType: string;
+  readonly readyState: number;
+  send(data: string | ArrayBufferLike | ArrayBufferView): void;
+  close(code?: number, reason?: string): void;
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: unknown }) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  onclose:
+    | ((ev: { code?: number; reason?: string; wasClean?: boolean }) => void)
+    | null;
+}
+
+/** Factory for WebSocket instances (inject a custom transport). */
+export type WebSocketFactory = (url: string) => WebSocketLike;
+
+export interface ClientOptions {
+  /**
+   * Input audio sample rate in Hz; must be one of the server's
+   * `supported_rates`. Default: server default (48000).
+   */
+  sampleRate?: number;
+  /** Enable speaker diarization for the session (if the server supports it). */
+  diarization?: boolean;
+  /**
+   * AbortSignal governing the whole client lifetime: aborting rejects a
+   * pending `connect`, interrupts reconnect backoff, and closes the socket.
+   */
+  signal?: AbortSignal;
+  /** Reconnect policy. Absent: a dropped connection ends the client. */
+  reconnect?: ReconnectOptions;
+  /** Event callbacks. */
+  handlers?: ClientHandlers;
+  /**
+   * Custom WebSocket transport. Default: the global `WebSocket` (browsers,
+   * Node 22+), falling back to the `ws` package when no global exists.
+   */
+  webSocketFactory?: WebSocketFactory;
+  /** Handshake + ready-wait timeout in milliseconds (default 10000). */
+  dialTimeoutMs?: number;
+}
+
+/** PCM audio accepted by {@link GigasttClient.sendPCM}. */
+export type PcmData = ArrayBufferLike | ArrayBufferView;
+
+const WS_OPEN = 1;
+
+/**
+ * Typed WebSocket client for one gigastt transcription session.
+ *
+ * Create with {@link GigasttClient.connect}, stream PCM16 audio with
+ * {@link sendPCM}, finalize with {@link stop}, release with {@link close}.
+ */
+export class GigasttClient {
+  private ws: WebSocketLike | null = null;
+  private readyMessage: ReadyMessage | null = null;
+  private closed = false;
+  private stopSent = false;
+  private closeFired = false;
+  private abortHandler: (() => void) | null = null;
+  private factoryPromise: Promise<WebSocketFactory> | null = null;
+
+  private constructor(
+    private readonly url: string,
+    private readonly opts: ClientOptions,
+  ) {}
+
+  /**
+   * Connects to `url` (pass {@link DEFAULT_URL} for a default local server),
+   * sends the `configure` frame (protocol version pinning plus negotiated
+   * options), and waits for the server's `ready` message.
+   *
+   * Throws a {@link ServerError} when the server rejects the session. With
+   * `reconnect` set, transient failures are retried first (see
+   * {@link ReconnectOptions}); the server's `retry_after_ms` hint is honored
+   * exactly.
+   */
+  static async connect(
+    url: string,
+    options: ClientOptions = {},
+  ): Promise<GigasttClient> {
+    if (options.signal?.aborted === true) throw abortError();
+    const client = new GigasttClient(url, options);
+    client.registerAbortHandler();
+    try {
+      const ready = await client.dialWithRetry();
+      client.readyMessage = ready;
+      options.handlers?.onReady?.(ready);
+      return client;
+    } catch (err) {
+      // The session never started; onClose is not fired for connect failures.
+      client.unregisterAbortHandler();
+      client.closed = true;
+      throw err;
+    }
+  }
+
+  /** The ready message from the current connection. */
+  get ready(): ReadyMessage {
+    if (this.readyMessage === null) {
+      throw new Error("gigastt: not connected");
+    }
+    return this.readyMessage;
+  }
+
+  /** Whether the socket is currently connected. */
+  get connected(): boolean {
+    return this.ws !== null && this.ws.readyState === WS_OPEN;
+  }
+
+  /**
+   * Sends one binary frame of raw PCM16 signed little-endian mono audio at
+   * the negotiated sample rate. Frames may be up to the server's
+   * `--ws-frame-max-bytes` (default 512 KiB).
+   *
+   * Throws while a reconnect is in flight and after `close()` — the SDK does
+   * not buffer audio across reconnects; callers must retry or drop frames.
+   */
+  sendPCM(data: PcmData): void {
+    if (this.closed) throw new Error("gigastt: client is closed");
+    const ws = this.ws;
+    if (ws === null || ws.readyState !== WS_OPEN) {
+      throw new Error("gigastt: reconnecting, not connected");
+    }
+    ws.send(data);
+  }
+
+  /**
+   * Asks the server to finalize the session: it flushes buffered audio,
+   * emits a final transcript (delivered via `onFinal`), and ends the session.
+   * The following server-side close is treated as a normal end — no reconnect
+   * is attempted and `onClose` fires with `intentional: true`.
+   */
+  stop(): void {
+    if (this.closed) throw new Error("gigastt: client is closed");
+    const ws = this.ws;
+    if (ws === null || ws.readyState !== WS_OPEN) {
+      throw new Error("gigastt: reconnecting, not connected");
+    }
+    this.stopSent = true;
+    ws.send(JSON.stringify({ type: "stop" }));
+  }
+
+  /**
+   * Terminates the client: closes the socket and cancels any in-flight
+   * reconnect backoff. Idempotent.
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.unregisterAbortHandler();
+    const ws = this.ws;
+    this.ws = null;
+    if (ws !== null) {
+      try {
+        ws.close(1000, "client closing");
+      } catch {
+        // Tearing down anyway.
+      }
+    }
+    this.fireClose({ intentional: true });
+  }
+
+  // ---------------------------------------------------------------------
+
+  private registerAbortHandler(): void {
+    if (this.opts.signal === undefined) return;
+    this.abortHandler = () => this.close();
+    if (this.opts.signal.aborted) {
+      // Defer so callers observe a consistent async failure path.
+      queueMicrotask(() => this.abortHandler?.());
+      return;
+    }
+    this.opts.signal.addEventListener("abort", this.abortHandler, {
+      once: true,
+    });
+  }
+
+  private unregisterAbortHandler(): void {
+    if (this.opts.signal !== undefined && this.abortHandler !== null) {
+      this.opts.signal.removeEventListener("abort", this.abortHandler);
+      this.abortHandler = null;
+    }
+  }
+
+  /** Fires onClose exactly once. */
+  private fireClose(info: CloseInfo): void {
+    if (this.closeFired) return;
+    this.closeFired = true;
+    this.opts.handlers?.onClose?.(info);
+  }
+
+  private async resolveFactory(): Promise<WebSocketFactory> {
+    if (this.opts.webSocketFactory !== undefined) {
+      return this.opts.webSocketFactory;
+    }
+    if (this.factoryPromise === null) {
+      this.factoryPromise = (async () => {
+        if (typeof WebSocket !== "undefined") {
+          return (url: string) =>
+            new WebSocket(url) as unknown as WebSocketLike;
+        }
+        // Node without a global WebSocket: use the `ws` package.
+        const mod = await import("ws");
+        const WS = mod.WebSocket;
+        return (url: string) => new WS(url) as unknown as WebSocketLike;
+      })();
+    }
+    return this.factoryPromise;
+  }
+
+  /**
+   * Dials until success, a non-transient error, the attempt budget is
+   * exhausted, or the AbortSignal fires.
+   */
+  private async dialWithRetry(): Promise<ReadyMessage> {
+    const rec = this.opts.reconnect;
+    const minDelay = rec?.minDelayMs ?? 250;
+    const maxDelay = rec?.maxDelayMs ?? 5000;
+    const maxAttempts = rec?.maxAttempts ?? 0;
+    let backoff = minDelay;
+    let attempt = 0;
+    for (;;) {
+      try {
+        return await this.dialOnce();
+      } catch (err) {
+        if (rec === undefined || !isTransient(err)) throw err;
+        attempt++;
+        if (maxAttempts > 0 && attempt > maxAttempts) {
+          throw err instanceof Error
+            ? err
+            : new Error(`gigastt: giving up after ${attempt} attempts`);
+        }
+        let wait = backoff;
+        if (err instanceof ServerError && err.retryAfterMs !== undefined) {
+          // Honor the server's explicit retry hint exactly.
+          wait = err.retryAfterMs;
+        }
+        await sleep(wait, this.opts.signal);
+        backoff = Math.min(backoff * 2, maxDelay);
+      }
+    }
+  }
+
+  /**
+   * Opens one WebSocket, sends the configure frame, and waits for `ready`.
+   * A server error received before ready rejects with a {@link ServerError}.
+   */
+  private async dialOnce(): Promise<ReadyMessage> {
+    this.throwIfAborted();
+    const factory = await this.resolveFactory();
+    const ws = factory(this.url);
+    ws.binaryType = "arraybuffer";
+    const dialTimeoutMs = this.opts.dialTimeoutMs ?? 10_000;
+
+    return await new Promise<ReadyMessage>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        fail(new Error("gigastt: timed out waiting for ready"));
+      }, dialTimeoutMs);
+
+      const onAbort = (): void => fail(abortError());
+
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        this.opts.signal?.removeEventListener("abort", onAbort);
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.onclose = null;
+      };
+      const fail = (err: unknown): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        try {
+          ws.close();
+        } catch {
+          // Ignore.
+        }
+        reject(err);
+      };
+
+      this.opts.signal?.addEventListener("abort", onAbort, { once: true });
+
+      ws.onopen = () => {
+        ws.send(
+          JSON.stringify({
+            type: "configure",
+            protocol_version: PROTOCOL_VERSION,
+            ...(this.opts.sampleRate !== undefined
+              ? { sample_rate: this.opts.sampleRate }
+              : {}),
+            ...(this.opts.diarization !== undefined
+              ? { diarization: this.opts.diarization }
+              : {}),
+          }),
+        );
+      };
+      ws.onmessage = (ev) => {
+        const msg = parseServerMessage(normalizeData(ev.data));
+        if (msg === null) return; // Not a server message: keep waiting.
+        if (settled) return;
+        if (msg.type === "ready") {
+          settled = true;
+          const { type: _type, ...ready } = msg;
+          cleanup();
+          if (this.closed) {
+            // Aborted while the handshake was completing: do not leak the socket.
+            try {
+              ws.close();
+            } catch {
+              // Ignore.
+            }
+            reject(abortError());
+            return;
+          }
+          this.ws = ws;
+          this.attachSessionHandlers(ws);
+          resolve(ready);
+        } else if (msg.type === "error") {
+          fail(new ServerError(msg));
+        }
+        // Other pre-ready message types: ignore (forward compatibility).
+      };
+      ws.onerror = () => {
+        // A close event follows; failure is reported there.
+      };
+      ws.onclose = (ev) => {
+        fail(
+          new Error(
+            `gigastt: connection closed before ready (code ${ev.code ?? "unknown"})`,
+          ),
+        );
+      };
+    });
+  }
+
+  /** Attaches the steady-state handlers to an established connection. */
+  private attachSessionHandlers(ws: WebSocketLike): void {
+    ws.onmessage = (ev) => {
+      const msg = parseServerMessage(normalizeData(ev.data));
+      if (msg === null) return;
+      const handlers = this.opts.handlers;
+      switch (msg.type) {
+        case "ready":
+          // A second ready within one connection is unexpected; ignore it.
+          break;
+        case "partial":
+        case "final": {
+          const { type, ...segment } = msg;
+          if (type === "partial") {
+            handlers?.onPartial?.(segment);
+          } else {
+            handlers?.onFinal?.(segment);
+          }
+          break;
+        }
+        case "error":
+          handlers?.onError?.(new ServerError(msg));
+          break;
+      }
+    };
+    ws.onerror = () => {
+      // A close event follows; handled there.
+    };
+    ws.onclose = (ev) => {
+      this.handleSessionClose(ev);
+    };
+  }
+
+  /** Decides whether a session-level close ends the client or reconnects. */
+  private handleSessionClose(ev: {
+    code?: number;
+    reason?: string;
+  }): void {
+    this.ws = null;
+    if (this.closed) return;
+    if (this.stopSent) {
+      // Session finalized via stop(): the server closes after the final
+      // transcript. Normal end of a session.
+      this.closed = true;
+      this.unregisterAbortHandler();
+      this.fireClose({ intentional: true });
+      return;
+    }
+    if (this.opts.reconnect === undefined) {
+      this.closed = true;
+      this.unregisterAbortHandler();
+      this.fireClose({
+        intentional: false,
+        error: new Error(
+          `gigastt: connection closed by server (code ${ev.code ?? "unknown"})`,
+        ),
+      });
+      return;
+    }
+    // Reconnect in the background; handlers observe onReady on success or
+    // onClose on failure.
+    void this.dialWithRetry()
+      .then((ready) => {
+        if (this.closed) return;
+        this.readyMessage = ready;
+        this.opts.handlers?.onReady?.(ready);
+      })
+      .catch((err: unknown) => {
+        if (this.closed) return;
+        this.closed = true;
+        this.unregisterAbortHandler();
+        this.fireClose({ intentional: isAbortError(err), error: err });
+      });
+  }
+
+  private throwIfAborted(): void {
+    if (this.opts.signal?.aborted === true) throw abortError();
+  }
+}
+
+/** Converts any incoming frame payload to a string for JSON parsing. */
+function normalizeData(data: unknown): unknown {
+  if (typeof data === "string") return data;
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+  return null;
+}
+
+/**
+ * Network-level failures are transient; server errors are transient only
+ * when the server attached a retry_after_ms hint (backpressure).
+ */
+function isTransient(err: unknown): boolean {
+  if (isAbortError(err)) return false;
+  if (err instanceof ServerError) return err.retryAfterMs !== undefined;
+  return true;
+}
+
+function abortError(): Error {
+  const err = new Error("gigastt: aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+/** Sleeps for `ms`, rejecting early if the signal aborts. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted === true) {
+      reject(abortError());
+      return;
+    }
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      cleanup();
+      reject(abortError());
+    };
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1,0 +1,24 @@
+export {
+  DEFAULT_URL,
+  PROTOCOL_VERSION,
+  ServerError,
+  parseServerMessage,
+} from "./types.js";
+export type {
+  ErrorMessage,
+  ReadyMessage,
+  ServerErrorCode,
+  ServerWireMessage,
+  Transcript,
+  WordInfo,
+} from "./types.js";
+export { GigasttClient } from "./client.js";
+export type {
+  ClientHandlers,
+  ClientOptions,
+  CloseInfo,
+  PcmData,
+  ReconnectOptions,
+  WebSocketFactory,
+  WebSocketLike,
+} from "./client.js";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1,0 +1,135 @@
+/**
+ * Wire protocol types for the gigastt WebSocket API, protocol version 1.0.
+ *
+ * Field names match the JSON wire format exactly (see docs/asyncapi.yaml in
+ * the gigastt repository). Additive protocol changes are tolerated: unknown
+ * fields are ignored on decode and unknown message types are dropped.
+ */
+
+/**
+ * Protocol version this SDK speaks. It is pinned into the `configure` frame
+ * so a version mismatch fails loudly with an `unsupported_protocol_version`
+ * error instead of silently misbehaving.
+ */
+export const PROTOCOL_VERSION = "1.0";
+
+/** Default server endpoint (loopback bind, default port). */
+export const DEFAULT_URL = "ws://127.0.0.1:9876/v1/ws";
+
+/** A single recognized word with timing and confidence metadata. */
+export interface WordInfo {
+  /** The recognized word text (BPE tokens joined). */
+  word: string;
+  /** Word start time in seconds from the stream beginning. */
+  start: number;
+  /** Word end time in seconds from the stream beginning. */
+  end: number;
+  /** Mean softmax confidence over the word's tokens (0.0–1.0). */
+  confidence: number;
+  /** Zero-based diarization speaker label; omitted when diarization is off. */
+  speaker?: number;
+}
+
+/** Sent by the server immediately after the WebSocket handshake. */
+export interface ReadyMessage {
+  /** Identifier of the loaded model (e.g. "gigaam-v3-e2e-rnnt"). */
+  model: string;
+  /** Audio sample rate in Hz the server expects by default. */
+  sample_rate: number;
+  /** Server's WebSocket protocol version (e.g. "1.0"). */
+  version: string;
+  /** Accepted input sample rates in Hz. */
+  supported_rates?: number[];
+  /** Whether speaker diarization is available. */
+  diarization?: boolean;
+  /** Minimum protocol version the server accepts. */
+  min_protocol_version?: string;
+}
+
+/** A partial (interim, may change) or final (utterance complete) segment. */
+export interface Transcript {
+  /** Recognized text for this segment. */
+  text: string;
+  /** Word-level timing metadata. */
+  words?: WordInfo[];
+  /** Whether this segment is final. */
+  is_final: boolean;
+  /** Unix time (seconds since epoch) when the segment was produced. */
+  timestamp: number;
+}
+
+/** Machine-readable error codes sent by the server (docs/asyncapi.yaml). */
+export type ServerErrorCode =
+  | "inference_error"
+  | "inference_panic"
+  | "inference_timeout"
+  | "configure_too_late"
+  | "invalid_sample_rate"
+  /** Pool saturation backpressure; the message carries `retry_after_ms`. */
+  | "timeout"
+  | "pool_closed"
+  | "max_session_duration_exceeded"
+  | "payload_too_large"
+  | "unsupported_protocol_version"
+  | "idle_timeout"
+  | "policy_violation";
+
+/** Error message payload as sent by the server. */
+export interface ErrorMessage {
+  /** User-facing description (internal details are hidden by the server). */
+  message: string;
+  /** Machine-readable error code. */
+  code: ServerErrorCode | (string & {});
+  /**
+   * Server-suggested delay before retrying, in milliseconds. Present only for
+   * transient backpressure errors (e.g. pool saturation).
+   */
+  retry_after_ms?: number;
+}
+
+/** Error raised from a server `error` message. */
+export class ServerError extends Error {
+  /** Machine-readable error code. */
+  readonly code: string;
+  /** Server-suggested retry delay in milliseconds, when present. */
+  readonly retryAfterMs?: number;
+
+  constructor(msg: ErrorMessage) {
+    super(`gigastt: server error ${msg.code}: ${msg.message}`);
+    this.name = "ServerError";
+    this.code = msg.code;
+    this.retryAfterMs = msg.retry_after_ms;
+  }
+}
+
+/** Raw server message, discriminated by the `type` tag. */
+export type ServerWireMessage =
+  | ({ type: "ready" } & ReadyMessage)
+  | ({ type: "partial" } & Transcript)
+  | ({ type: "final" } & Transcript)
+  | ({ type: "error" } & ErrorMessage);
+
+/**
+ * Parses one raw WebSocket text payload into a typed server message.
+ * Returns null for non-JSON payloads, unknown message types (additive
+ * protocol evolution), and malformed frames — callers must ignore them.
+ */
+export function parseServerMessage(data: unknown): ServerWireMessage | null {
+  if (typeof data !== "string") return null;
+  let msg: unknown;
+  try {
+    msg = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (msg === null || typeof msg !== "object") return null;
+  switch ((msg as { type?: unknown }).type) {
+    case "ready":
+    case "partial":
+    case "final":
+    case "error":
+      return msg as ServerWireMessage;
+    default:
+      return null;
+  }
+}

--- a/sdks/js/test/client.test.ts
+++ b/sdks/js/test/client.test.ts
@@ -1,0 +1,543 @@
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+import { WebSocketServer, WebSocket as WsSocket } from "ws";
+import {
+  GigasttClient,
+  PROTOCOL_VERSION,
+  ServerError,
+} from "../src/index.js";
+import type { Transcript, WebSocketLike } from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Mock gigastt server: speaks the wire protocol per a per-connection script.
+// ---------------------------------------------------------------------------
+
+type Script = (ws: WsSocket, n: number) => void;
+
+class MockServer {
+  readonly url: string;
+  connections = 0;
+
+  private constructor(private readonly wss: WebSocketServer, port: number) {
+    this.url = `ws://127.0.0.1:${port}/v1/ws`;
+  }
+
+  static async create(script: Script): Promise<MockServer> {
+    const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await new Promise<void>((resolve, reject) => {
+      wss.once("listening", () => resolve());
+      wss.once("error", reject);
+    });
+    const server = new MockServer(wss, (wss.address() as AddressInfo).port);
+    wss.on("connection", (ws) => {
+      server.connections += 1;
+      script(ws, server.connections);
+    });
+    return server;
+  }
+
+  async close(): Promise<void> {
+    for (const client of this.wss.clients) client.terminate();
+    await new Promise<void>((resolve) => this.wss.close(() => resolve()));
+  }
+}
+
+function sendJson(ws: WsSocket, value: unknown): void {
+  ws.send(JSON.stringify(value));
+}
+
+/** Narrows a ws RawData payload to a Buffer. */
+function rawToBuffer(data: unknown): Buffer {
+  if (Buffer.isBuffer(data)) return data;
+  if (Array.isArray(data)) return Buffer.concat(data);
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  throw new Error("unexpected frame payload type");
+}
+
+/** Resolves with the next incoming text frame parsed as JSON. */
+function nextJson(ws: WsSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    ws.once("message", (data, isBinary) => {
+      if (isBinary) {
+        reject(new Error("expected a text frame"));
+        return;
+      }
+      resolve(JSON.parse(rawToBuffer(data).toString()) as Record<string, unknown>);
+    });
+    ws.once("error", reject);
+  });
+}
+
+/** Resolves with the next incoming binary frame. */
+function nextBinary(ws: WsSocket): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    ws.once("message", (data, isBinary) => {
+      if (!isBinary) {
+        reject(new Error("expected a binary frame"));
+        return;
+      }
+      resolve(rawToBuffer(data));
+    });
+    ws.once("error", reject);
+  });
+}
+
+/** Reads the configure frame the client must send first. */
+async function expectConfigure(
+  ws: WsSocket,
+): Promise<Record<string, unknown>> {
+  const msg = await nextJson(ws);
+  expect(msg.type).toBe("configure");
+  return msg;
+}
+
+const READY_PAYLOAD = {
+  type: "ready",
+  model: "gigaam-v3-e2e-rnnt",
+  sample_rate: 48000,
+  version: "1.0",
+  supported_rates: [8000, 16000, 24000, 44100, 48000],
+  diarization: true,
+  min_protocol_version: "1.0",
+} as const;
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+} {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Rejects if `promise` does not settle within `ms`. */
+function withTimeout<T>(promise: Promise<T>, ms = 5000): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error("timed out waiting for event")), ms),
+    ),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+
+describe("GigasttClient", () => {
+  it("sends configure with protocol pinning and receives ready", async () => {
+    const configureSeen = deferred<Record<string, unknown>>();
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then((msg) => {
+        configureSeen.resolve(msg);
+        sendJson(ws, READY_PAYLOAD);
+      });
+    });
+    try {
+      const client = await GigasttClient.connect(server.url, {
+        sampleRate: 16000,
+        diarization: true,
+      });
+
+      const configure = await withTimeout(configureSeen.promise);
+      expect(configure.protocol_version).toBe(PROTOCOL_VERSION);
+      expect(configure.sample_rate).toBe(16000);
+      expect(configure.diarization).toBe(true);
+
+      expect(client.ready.model).toBe("gigaam-v3-e2e-rnnt");
+      expect(client.ready.sample_rate).toBe(48000);
+      expect(client.ready.version).toBe("1.0");
+      expect(client.ready.supported_rates).toEqual([
+        8000, 16000, 24000, 44100, 48000,
+      ]);
+      expect(client.ready.diarization).toBe(true);
+      expect(client.ready.min_protocol_version).toBe("1.0");
+      expect(client.connected).toBe(true);
+
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("dispatches partial and final transcripts with words", async () => {
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(() => {
+        sendJson(ws, READY_PAYLOAD);
+        sendJson(ws, {
+          type: "partial",
+          text: "привет",
+          timestamp: 1712700000.5,
+          is_final: false,
+          words: [
+            { word: "привет", start: 0.1, end: 0.6, confidence: 0.95, speaker: 2 },
+          ],
+        });
+        sendJson(ws, {
+          type: "final",
+          text: "привет как дела",
+          timestamp: 1712700001.0,
+          is_final: true,
+          words: [
+            { word: "привет", start: 0.1, end: 0.6, confidence: 0.95 },
+            { word: "как", start: 0.7, end: 0.9, confidence: 0.9 },
+            { word: "дела", start: 1.0, end: 1.4, confidence: 0.88 },
+          ],
+        });
+      });
+    });
+    try {
+      const partialSeen = deferred<Transcript>();
+      const finalSeen = deferred<Transcript>();
+      const client = await GigasttClient.connect(server.url, {
+        handlers: {
+          onPartial: (t) => partialSeen.resolve(t),
+          onFinal: (t) => finalSeen.resolve(t),
+        },
+      });
+
+      const partial = await withTimeout(partialSeen.promise);
+      expect(partial.text).toBe("привет");
+      expect(partial.is_final).toBe(false);
+      expect(partial.timestamp).toBe(1712700000.5);
+      expect(partial.words).toHaveLength(1);
+      expect(partial.words?.[0]).toEqual({
+        word: "привет",
+        start: 0.1,
+        end: 0.6,
+        confidence: 0.95,
+        speaker: 2,
+      });
+
+      const final = await withTimeout(finalSeen.promise);
+      expect(final.text).toBe("привет как дела");
+      expect(final.is_final).toBe(true);
+      expect(final.words).toHaveLength(3);
+      // speaker is omitted when diarization is disabled.
+      expect(final.words?.[1]?.speaker).toBeUndefined();
+
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("dispatches server errors with code and no retry hint", async () => {
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(() => {
+        sendJson(ws, READY_PAYLOAD);
+        sendJson(ws, {
+          type: "error",
+          message: "Inference failed. Please check audio format.",
+          code: "inference_error",
+        });
+      });
+    });
+    try {
+      const errorSeen = deferred<ServerError>();
+      const client = await GigasttClient.connect(server.url, {
+        handlers: { onError: (e) => errorSeen.resolve(e) },
+      });
+
+      const err = await withTimeout(errorSeen.promise);
+      expect(err).toBeInstanceOf(ServerError);
+      expect(err.code).toBe("inference_error");
+      expect(err.retryAfterMs).toBeUndefined();
+      expect(err.message).toContain("inference_error");
+
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("honors retry_after_ms exactly when reconnecting", async () => {
+    const server = await MockServer.create((ws, n) => {
+      void expectConfigure(ws).then(() => {
+        if (n === 1) {
+          // Pool saturation: reject with an explicit retry hint.
+          sendJson(ws, {
+            type: "error",
+            message: "Server busy, try again later",
+            code: "timeout",
+            retry_after_ms: 250,
+          });
+          ws.close();
+          return;
+        }
+        sendJson(ws, READY_PAYLOAD);
+      });
+    });
+    try {
+      const start = Date.now();
+      const client = await GigasttClient.connect(server.url, {
+        reconnect: { minDelayMs: 5, maxDelayMs: 100, maxAttempts: 5 },
+      });
+      const elapsed = Date.now() - start;
+
+      expect(server.connections).toBe(2);
+      // The 250ms server hint must win over the 5ms exponential backoff.
+      expect(elapsed).toBeGreaterThanOrEqual(200);
+
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("reconnects after an abnormal drop and re-fires onReady", async () => {
+    const server = await MockServer.create((ws, n) => {
+      void expectConfigure(ws).then(() => {
+        sendJson(ws, READY_PAYLOAD);
+        if (n === 1) {
+          // Wait for one audio frame (proving the client processed ready),
+          // then drop the connection abnormally.
+          void nextBinary(ws).then(() => ws.terminate());
+        }
+      });
+    });
+    try {
+      const readyEvents: string[] = [];
+      const secondReady = deferred<void>();
+      const client = await GigasttClient.connect(server.url, {
+        reconnect: { minDelayMs: 10, maxDelayMs: 50, maxAttempts: 5 },
+        handlers: {
+          onReady: (r) => {
+            readyEvents.push(r.model);
+            if (readyEvents.length === 2) secondReady.resolve();
+          },
+        },
+      });
+
+      client.sendPCM(new Uint8Array([0, 0]));
+      await withTimeout(secondReady.promise);
+      expect(server.connections).toBe(2);
+      expect(readyEvents).toHaveLength(2);
+
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("treats the close after stop() as a normal end (no reconnect)", async () => {
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(async () => {
+        sendJson(ws, READY_PAYLOAD);
+        const stop = await nextJson(ws);
+        expect(stop.type).toBe("stop");
+        sendJson(ws, {
+          type: "final",
+          text: "готово",
+          timestamp: 1712700002.0,
+          is_final: true,
+          words: [],
+        });
+        // The server ends the session after the final transcript.
+        ws.close(1000);
+      });
+    });
+    try {
+      const events: string[] = [];
+      const closed = deferred<{ intentional: boolean }>();
+      const client = await GigasttClient.connect(server.url, {
+        reconnect: { minDelayMs: 10, maxDelayMs: 50, maxAttempts: 5 },
+        handlers: {
+          onFinal: () => events.push("final"),
+          onClose: (info) => {
+            events.push("close");
+            closed.resolve(info);
+          },
+        },
+      });
+
+      client.stop();
+      const info = await withTimeout(closed.promise);
+      expect(events).toEqual(["final", "close"]);
+      expect(info.intentional).toBe(true);
+      expect(server.connections).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not retry fatal server errors", async () => {
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(() => {
+        sendJson(ws, {
+          type: "error",
+          message: "Unsupported protocol version",
+          code: "unsupported_protocol_version",
+        });
+        ws.close();
+      });
+    });
+    try {
+      await expect(
+        GigasttClient.connect(server.url, {
+          reconnect: { minDelayMs: 5, maxDelayMs: 50, maxAttempts: 5 },
+        }),
+      ).rejects.toSatisfy(
+        (err) =>
+          err instanceof ServerError &&
+          err.code === "unsupported_protocol_version",
+      );
+      expect(server.connections).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("ignores unknown fields and unknown message types", async () => {
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(() => {
+        sendJson(ws, { ...READY_PAYLOAD, future_field: { nested: true } });
+        sendJson(ws, { type: "brand_new_message", x: 1 });
+        sendJson(ws, {
+          type: "partial",
+          text: "ok",
+          timestamp: 1.0,
+          is_final: false,
+          confidence: 0.5, // hypothetical additive field
+        });
+      });
+    });
+    try {
+      const partialSeen = deferred<Transcript>();
+      const client = await GigasttClient.connect(server.url, {
+        handlers: { onPartial: (t) => partialSeen.resolve(t) },
+      });
+
+      const partial = await withTimeout(partialSeen.promise);
+      expect(partial.text).toBe("ok");
+
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("AbortSignal cancels connect during reconnect backoff", async () => {
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(() => {
+        sendJson(ws, {
+          type: "error",
+          message: "Server busy, try again later",
+          code: "timeout",
+          retry_after_ms: 60_000,
+        });
+        ws.close();
+      });
+    });
+    try {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 100);
+      const start = Date.now();
+      await expect(
+        GigasttClient.connect(server.url, {
+          signal: controller.signal,
+          reconnect: { minDelayMs: 5, maxDelayMs: 100 },
+        }),
+      ).rejects.toSatisfy(
+        (err) => err instanceof Error && err.name === "AbortError",
+      );
+      expect(Date.now() - start).toBeLessThan(10_000);
+      expect(server.connections).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("sendPCM delivers binary frames unchanged", async () => {
+    const frames: Buffer[] = [];
+    const gotTwo = deferred<void>();
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(() => {
+        sendJson(ws, READY_PAYLOAD);
+        // Persistent collector: back-to-back frames can arrive in one
+        // synchronous socket drain, faster than promise re-registration.
+        ws.on("message", (data, isBinary) => {
+          if (!isBinary) return;
+          frames.push(rawToBuffer(data));
+          if (frames.length === 2) gotTwo.resolve();
+        });
+      });
+    });
+    try {
+      const client = await GigasttClient.connect(server.url);
+
+      client.sendPCM(new Uint8Array([1, 2, 3]));
+      client.sendPCM(new Int16Array([1000, -1000]).buffer);
+
+      await withTimeout(gotTwo.promise);
+      expect([...frames[0]!]).toEqual([1, 2, 3]);
+      expect(frames[1]).toHaveLength(4);
+      expect(frames[1]!.readInt16LE(0)).toBe(1000);
+      expect(frames[1]!.readInt16LE(2)).toBe(-1000);
+
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("throws when sending after close; close is idempotent", async () => {
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(() => sendJson(ws, READY_PAYLOAD));
+    });
+    try {
+      const client = await GigasttClient.connect(server.url);
+      client.close();
+      expect(() => client.sendPCM(new Uint8Array([1]))).toThrow(/closed/);
+      expect(() => client.stop()).toThrow(/closed/);
+      expect(() => client.close()).not.toThrow();
+      expect(client.connected).toBe(false);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("gives up after maxAttempts reconnects", async () => {
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(() => {
+        sendJson(ws, {
+          type: "error",
+          message: "Server busy, try again later",
+          code: "timeout",
+          retry_after_ms: 20,
+        });
+        ws.close();
+      });
+    });
+    try {
+      await expect(
+        GigasttClient.connect(server.url, {
+          reconnect: { minDelayMs: 5, maxDelayMs: 50, maxAttempts: 2 },
+        }),
+      ).rejects.toBeInstanceOf(ServerError);
+      // 1 initial attempt + 2 retries.
+      expect(server.connections).toBe(3);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("works over an injected ws-package transport", async () => {
+    const server = await MockServer.create((ws) => {
+      void expectConfigure(ws).then(() => sendJson(ws, READY_PAYLOAD));
+    });
+    try {
+      const client = await GigasttClient.connect(server.url, {
+        webSocketFactory: (url) =>
+          new WsSocket(url) as unknown as WebSocketLike,
+      });
+      expect(client.ready.model).toBe("gigaam-v3-e2e-rnnt");
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/sdks/js/test/live.test.ts
+++ b/sdks/js/test/live.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { GigasttClient } from "../src/index.js";
+import type { Transcript } from "../src/index.js";
+
+// Live-server integration test. Skipped unless GIGASTT_TEST_WS_URL points at
+// a running gigastt server (which requires the model, ~850 MB):
+//
+//   cargo run --release -- serve   # in the repository root
+//   GIGASTT_TEST_WS_URL=ws://127.0.0.1:9876/v1/ws npx vitest run test/live.test.ts
+
+const LIVE_URL = process.env.GIGASTT_TEST_WS_URL;
+
+/** Generates `seconds` of a 440 Hz sine tone as 16 kHz PCM16 frames (20 ms). */
+function* sineFrames(seconds: number): Generator<Uint8Array> {
+  const rate = 16_000;
+  const frameSamples = rate / 50;
+  const totalFrames = seconds * 50;
+  for (let i = 0; i < totalFrames; i++) {
+    const frame = new Int16Array(frameSamples);
+    for (let j = 0; j < frameSamples; j++) {
+      frame[j] = Math.round(
+        12_000 * Math.sin((2 * Math.PI * 440 * (i * frameSamples + j)) / rate),
+      );
+    }
+    yield new Uint8Array(frame.buffer);
+  }
+}
+
+describe("GigasttClient against a live server", () => {
+  it.skipIf(LIVE_URL === undefined)(
+    "completes a ready -> audio -> stop -> final session",
+    async () => {
+      const finals: Transcript[] = [];
+      const errors: string[] = [];
+
+      let resolveFinal!: () => void;
+      const finalPromise = new Promise<void>((resolve) => {
+        resolveFinal = resolve;
+      });
+
+      const client = await GigasttClient.connect(LIVE_URL as string, {
+        sampleRate: 16_000,
+        handlers: {
+          onFinal: (t) => {
+            finals.push(t);
+            resolveFinal();
+          },
+          onError: (e) => errors.push(`${e.code}: ${e.message}`),
+        },
+      });
+
+      expect(client.ready.model).not.toBe("");
+
+      for (const frame of sineFrames(2)) {
+        client.sendPCM(frame);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      client.stop();
+
+      await Promise.race([
+        finalPromise,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("no final within 30s")), 30_000),
+        ),
+      ]);
+
+      expect(errors).toEqual([]);
+      expect(finals.length).toBeGreaterThanOrEqual(1);
+      expect(finals.at(-1)?.is_final).toBe(true);
+
+      client.close();
+    },
+    45_000,
+  );
+});

--- a/sdks/js/tsconfig.build.json
+++ b/sdks/js/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/sdks/js/tsconfig.json
+++ b/sdks/js/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary

Two idiomatic, typed client SDKs for the WebSocket protocol v1.0 under `sdks/`, replacing the raw quickstart scripts as the recommended integration path:

- **`sdks/go` — `gigastt-go`**: `Client` with functional options (sample rate, timeouts), typed `Ready`/`Partial`/`Final`/`Error` events covering every protocol field (`words[]`, `code`, `retry_after_ms`), `OnPartial`/`OnFinal`/`OnError` callbacks, a single socket writer, reconnect with exponential backoff honoring `retry_after_ms` on pool saturation, context lifecycle, godoc `Example`. Subdirectory-tag module path prepared for publishing.
- **`sdks/js` — `@gigastt/client`** (TypeScript): same event/callback surface, `AbortSignal` lifecycle, Node + browser transport (global `WebSocket`, injectable transport, `ws` fallback), release-ready `package.json`, tsc-strict + build clean.

Additive protocol fields are ignored by design per the compatibility convention. Publication (npm scope / `sdks/go/vX.Y.Z` tags) is a separate human release step and not part of this PR.

## Testing

- Mock-server suites: Go 12/12 (`go vet`/`gofmt` clean), vitest 13/13 + strict typecheck + build — all green locally post-rebase.
- New `SDK Tests` CI job (path-filtered on `sdks/**`, mirroring the docker-paths pattern) runs both suites on every PR that touches the SDKs — previously no workflow exercised this directory.
- Live-server acceptance executed locally against a fully-loaded fresh 2.12.0 server (`rnnt` head, punctuation on): Go `TestLiveServer` PASS, JS live test PASS (`GIGASTT_TEST_WS_URL=ws://127.0.0.1:<port>/v1/ws`); commands documented in the SDK READMEs. The gated live tests self-skip without the env var, so no CI job needs a model.