### PR TITLE
feat(cli): machine-readable download progress (--progress=json) with exit-code taxonomy (2.13.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,7 @@ All CLI flags have corresponding env vars:
 | `GIGASTT_JOBS_MAX` | `--jobs-max` | 100 |
 | `GIGASTT_JOBS_RETRY` | `--jobs-retry` | 3 |
 | `GIGASTT_SKIP_QUANTIZE` | `--skip-quantize` | false |
+| `GIGASTT_DOWNLOAD_PROGRESS` | `download --progress` | human |
 | `GIGASTT_METRICS` | `--metrics` | false |
 | `GIGASTT_METRICS_LISTEN` | `--metrics-listen` | 127.0.0.1:9090 |
 | `GIGASTT_MODEL_VARIANT` | `--model-variant` | rnnt (fresh installs) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Machine-readable `gigastt download` progress (`--progress=json`).** A new opt-in
   flag (env `GIGASTT_DOWNLOAD_PROGRESS`) switches model download reporting to NDJSON on
-  stdout — one JSON event per line and nothing else on stdout (human progress and logs
-  stay on stderr): throttled per-file byte progress (`download`), `verify` at each
-  SHA-256 check, `quantize` when the ~2-minute on-device INT8 pass starts (previously
-  invisible to integrators and easily mistaken for a hang), a terminal `done`, and an
-  `error` event before any non-zero exit. Sidecar integrators can now drive an exact
-  progress bar per file and phase instead of polling the model directory size. The
-  default `human` mode is unchanged. `gigastt download` failures also gain a documented
-  exit-code taxonomy — `2` network, `3` disk, `4` checksum, `130` interrupted (Ctrl-C),
-  `1` other — keeping the historical `!= 0` failure contract. See
+  stdout — one JSON event per line and nothing else on stdout (the human `\r`-progress
+  renderer is disabled; tracing logs go to stderr): throttled per-file byte progress
+  (`download`), `verify` at each SHA-256 check, `quantize` when the ~2-minute on-device
+  INT8 pass starts (previously invisible to integrators and easily mistaken for a hang),
+  a terminal `done`, and an `error` event before any non-zero exit. Sidecar integrators
+  can now drive an exact progress bar per file and phase instead of polling the model
+  directory size. The default `human` mode is unchanged. `gigastt download` failures
+  also gain a documented, sysexits-flavored exit-code taxonomy — `69` network, `74`
+  disk, `65` checksum, `130` interrupted (Ctrl-C), `1` other — keeping the historical
+  `!= 0` failure contract; `2` is deliberately left to clap's usage errors so a
+  misconfigured invocation is never mistaken for a transient network failure. Ctrl-C
+  stays responsive through the whole run, including the synchronous quantize pass. See
   [docs/cli.md](docs/cli.md).
 - **Client SDKs for the WebSocket protocol: `gigastt-go` and `@gigastt/client` (TypeScript).**
   Two idiomatic, typed clients of protocol v1.0 under `sdks/` — typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Machine-readable `gigastt download` progress (`--progress=json`).** A new opt-in
+  flag (env `GIGASTT_DOWNLOAD_PROGRESS`) switches model download reporting to NDJSON on
+  stdout — one JSON event per line and nothing else on stdout (human progress and logs
+  stay on stderr): throttled per-file byte progress (`download`), `verify` at each
+  SHA-256 check, `quantize` when the ~2-minute on-device INT8 pass starts (previously
+  invisible to integrators and easily mistaken for a hang), a terminal `done`, and an
+  `error` event before any non-zero exit. Sidecar integrators can now drive an exact
+  progress bar per file and phase instead of polling the model directory size. The
+  default `human` mode is unchanged. `gigastt download` failures also gain a documented
+  exit-code taxonomy — `2` network, `3` disk, `4` checksum, `130` interrupted (Ctrl-C),
+  `1` other — keeping the historical `!= 0` failure contract. See
+  [docs/cli.md](docs/cli.md).
 - **Client SDKs for the WebSocket protocol: `gigastt-go` and `@gigastt/client` (TypeScript).**
   Two idiomatic, typed clients of protocol v1.0 under `sdks/` — typed
   `Ready`/`Partial`/`Final`/`Error` events (all fields, including `words[]`, `code`, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.12.0"
+version = "2.13.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -13,6 +13,7 @@ use futures_util::StreamExt;
 #[cfg(feature = "net")]
 use sha2::{Digest, Sha256};
 use std::path::Path;
+use std::sync::atomic::{AtomicU8, Ordering};
 #[cfg(feature = "net")]
 use tokio::io::AsyncWriteExt;
 
@@ -20,12 +21,245 @@ use tokio::io::AsyncWriteExt;
 #[cfg(feature = "net")]
 use std::os::fd::AsRawFd;
 
-/// Simple download progress reporter (no external deps).
+/// Progress reporting mode for `gigastt download` (and any other caller that
+/// sets it process-wide): `Human` keeps the interactive `\r` stderr reporter,
+/// `Json` emits NDJSON events — one [`ProgressEvent`] per line — on stdout
+/// for sidecar integrators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProgressMode {
+    /// Interactive human reporter: a `\r`-redrawn percentage line on stderr.
+    #[default]
+    Human,
+    /// Machine-readable NDJSON events on stdout; nothing else may write there.
+    Json,
+}
+
+impl ProgressMode {
+    /// Stable token accepted by `--progress` / `GIGASTT_DOWNLOAD_PROGRESS`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProgressMode::Human => "human",
+            ProgressMode::Json => "json",
+        }
+    }
+}
+
+impl std::str::FromStr for ProgressMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "human" => Ok(ProgressMode::Human),
+            "json" => Ok(ProgressMode::Json),
+            other => Err(format!(
+                "unknown progress mode '{other}' (expected 'human' or 'json')"
+            )),
+        }
+    }
+}
+
+/// Failure category surfaced in the NDJSON `error` event and mapped to the
+/// documented `gigastt download` exit-code taxonomy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProgressErrorKind {
+    /// Network failure: unreachable host, TLS, broken stream, HTTP error status.
+    Network,
+    /// Local filesystem failure: create/write/rename of a staging or model file.
+    Disk,
+    /// SHA-256 mismatch on a staged download (corrupt or tampered artefact).
+    Checksum,
+    /// Cancelled by the operator (SIGINT / Ctrl-C).
+    Interrupted,
+    /// Anything else; keeps the four primary kinds stable to match on.
+    Other,
+}
+
+impl ProgressErrorKind {
+    /// `gigastt download` process exit code for this failure category. `0` is
+    /// success; every category keeps the historical `!= 0` failure contract.
+    pub fn exit_code(self) -> i32 {
+        match self {
+            ProgressErrorKind::Network => 2,
+            ProgressErrorKind::Disk => 3,
+            ProgressErrorKind::Checksum => 4,
+            // Conventional 128 + SIGINT.
+            ProgressErrorKind::Interrupted => 130,
+            // Historical generic failure code (anyhow's `Termination`).
+            ProgressErrorKind::Other => 1,
+        }
+    }
+}
+
+/// Machine-readable `gigastt download` progress event, serialized as a single
+/// NDJSON line on stdout when [`ProgressMode::Json`] is active. One line = one
+/// event; the `phase` tag is the discriminator integrators match on.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum ProgressEvent {
+    /// Byte progress of one file's download (throttled to ~200 ms per file,
+    /// plus an unconditional event at 100%).
+    Download {
+        file: String,
+        bytes_done: u64,
+        bytes_total: u64,
+    },
+    /// The on-device INT8 quantization pass started for `file` (~2 min, no
+    /// byte progress — its presence tells a sidecar the CLI is busy, not hung).
+    Quantize { file: String },
+    /// SHA-256 verification of a staged download started.
+    Verify { file: String },
+    /// All requested artefacts are ready; emitted once, last.
+    Done { model_dir: String },
+    /// Fatal failure, emitted right before the non-zero exit.
+    Error {
+        kind: ProgressErrorKind,
+        message: String,
+    },
+}
+
+impl ProgressEvent {
+    /// Serialize as one NDJSON line (no trailing newline). This POD enum
+    /// cannot realistically fail serialization; a minimal valid `error`
+    /// object is the fallback rather than panicking on a progress path.
+    pub fn to_ndjson(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| {
+            "{\"phase\":\"error\",\"kind\":\"other\",\"message\":\"progress event serialization failed\"}"
+                .to_string()
+        })
+    }
+}
+
+/// Process-wide download progress mode, set once by the CLI before any
+/// download call. Library users get the `Human` default (identical to the
+/// historical `\r` reporter) unless they opt into JSON events.
+static PROGRESS_MODE: AtomicU8 = AtomicU8::new(ProgressMode::Human as u8);
+
+/// Set the process-wide download progress mode. Call once at startup, before
+/// any `ensure_*` download function runs.
+pub fn set_progress_mode(mode: ProgressMode) {
+    PROGRESS_MODE.store(mode as u8, Ordering::Relaxed);
+}
+
+/// The process-wide download progress mode (`Human` unless set).
+pub fn progress_mode() -> ProgressMode {
+    match PROGRESS_MODE.load(Ordering::Relaxed) {
+        1 => ProgressMode::Json,
+        _ => ProgressMode::Human,
+    }
+}
+
+/// Emit `event` as one NDJSON line on stdout — but only in
+/// [`ProgressMode::Json`]; in `Human` mode this is a no-op so call sites never
+/// branch on the mode. Public because phases only the CLI can see (quantize
+/// entry, terminal done/error) are emitted from the binary crate.
+///
+/// Write failures (e.g. the reader closed the pipe) are ignored: progress
+/// reporting must never take down an in-flight download.
+pub fn emit_progress_event(event: &ProgressEvent) {
+    if progress_mode() != ProgressMode::Json {
+        return;
+    }
+    use std::io::Write;
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    let _ = writeln!(lock, "{}", event.to_ndjson());
+    let _ = lock.flush();
+}
+
+/// Classify a failed download for the NDJSON `error` event / exit-code
+/// taxonomy. Typed root causes win (reqwest → network, io → disk); the
+/// remaining cases are recognized by the stable messages of the two
+/// `anyhow::bail!` sites in this module (SHA-256 mismatch, HTTP error status).
+#[cfg(feature = "net")]
+pub fn classify_download_error(err: &anyhow::Error) -> ProgressErrorKind {
+    for cause in err.chain() {
+        if cause.downcast_ref::<reqwest::Error>().is_some() {
+            return ProgressErrorKind::Network;
+        }
+        if cause.downcast_ref::<std::io::Error>().is_some() {
+            return ProgressErrorKind::Disk;
+        }
+    }
+    let msg = format!("{err:#}");
+    if msg.contains("SHA-256 mismatch") {
+        return ProgressErrorKind::Checksum;
+    }
+    // `stream_to_partial_then_finalize` bails with "…: HTTP <status>" on a
+    // non-2xx response; that is a network-class failure for integrators.
+    if msg.contains("HTTP ") {
+        return ProgressErrorKind::Network;
+    }
+    ProgressErrorKind::Other
+}
+
+/// Throttle for NDJSON `download` events: at most one per 200 ms per file,
+/// plus an unconditional event at 100% so integrators always see completion.
+#[cfg(feature = "net")]
+const JSON_PROGRESS_THROTTLE: std::time::Duration = std::time::Duration::from_millis(200);
+
+/// Where progress output goes. `Human` renders the legacy `\r` stderr line;
+/// `Json` routes [`ProgressEvent`]s to the emitter (process stdout in the CLI,
+/// a captured buffer in tests).
+#[cfg(feature = "net")]
+struct ProgressSink {
+    mode: ProgressMode,
+    emit: Box<dyn Fn(&ProgressEvent) + Send + Sync>,
+}
+
+#[cfg(feature = "net")]
+impl ProgressSink {
+    /// Sink honouring the process-wide [`ProgressMode`] set by the CLI.
+    fn global() -> Self {
+        Self {
+            mode: progress_mode(),
+            emit: Box::new(emit_progress_event),
+        }
+    }
+
+    /// Human-mode sink for tests that exercise the legacy renderer.
+    #[cfg(test)]
+    fn human() -> Self {
+        Self {
+            mode: ProgressMode::Human,
+            emit: Box::new(|_| {}),
+        }
+    }
+
+    /// Capturing Json-mode sink: returns the sink plus the shared event log.
+    #[cfg(test)]
+    fn capturing() -> (Self, std::sync::Arc<std::sync::Mutex<Vec<ProgressEvent>>>) {
+        let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink_log = std::sync::Arc::clone(&log);
+        (
+            Self {
+                mode: ProgressMode::Json,
+                emit: Box::new(move |e| {
+                    if let Ok(mut guard) = sink_log.lock() {
+                        guard.push(e.clone());
+                    }
+                }),
+            },
+            log,
+        )
+    }
+
+    fn event(&self, event: &ProgressEvent) {
+        (self.emit)(event);
+    }
+}
+
+/// Per-file download progress reporter. Human mode keeps the historical
+/// stderr `\r` rendering byte-for-byte; Json mode emits throttled NDJSON
+/// `download` events through the sink (first chunk immediately, then at most
+/// one per [`JSON_PROGRESS_THROTTLE`], and always exactly one at 100%).
 #[cfg(feature = "net")]
 struct DownloadProgress {
     total: u64,
     current: u64,
     last_percent: u8,
+    last_json_emit: Option<std::time::Instant>,
+    json_final_emitted: bool,
 }
 
 #[cfg(feature = "net")]
@@ -35,30 +269,81 @@ impl DownloadProgress {
             total,
             current: 0,
             last_percent: 0,
+            last_json_emit: None,
+            json_final_emitted: false,
         }
     }
 
-    fn update(&mut self, bytes: u64) {
-        self.current += bytes;
+    /// The legacy human line for the current state, or `None` when the
+    /// percentage did not move (the historical throttle).
+    fn human_tick(&mut self) -> Option<String> {
         let percent = (self.current * 100)
             .checked_div(self.total)
             .map(|p| p as u8)
             .unwrap_or(0);
-        if percent != self.last_percent {
-            self.last_percent = percent;
-            eprint!(
-                "\rDownloading... {percent}% ({:.1}MB / {:.1}MB)",
-                self.current as f64 / 1_048_576.0,
-                self.total as f64 / 1_048_576.0
-            );
+        if percent == self.last_percent {
+            return None;
+        }
+        self.last_percent = percent;
+        Some(format!(
+            "\rDownloading... {percent}% ({:.1}MB / {:.1}MB)",
+            self.current as f64 / 1_048_576.0,
+            self.total as f64 / 1_048_576.0
+        ))
+    }
+
+    /// The legacy human completion line (redraws over the progress line).
+    fn human_finish(&self) -> String {
+        format!(
+            "\rDownload complete ({:.1}MB)                    ",
+            self.current as f64 / 1_048_576.0
+        )
+    }
+
+    fn update(&mut self, bytes: u64, sink: &ProgressSink, label: &str) {
+        self.current += bytes;
+        match sink.mode {
+            ProgressMode::Human => {
+                if let Some(line) = self.human_tick() {
+                    eprint!("{line}");
+                }
+            }
+            ProgressMode::Json => {
+                let complete = self.total > 0 && self.current >= self.total;
+                let due = self
+                    .last_json_emit
+                    .is_none_or(|t| t.elapsed() >= JSON_PROGRESS_THROTTLE);
+                if (complete && !self.json_final_emitted) || (due && !complete) {
+                    sink.event(&ProgressEvent::Download {
+                        file: label.to_string(),
+                        bytes_done: self.current,
+                        bytes_total: self.total,
+                    });
+                    self.last_json_emit = Some(std::time::Instant::now());
+                    if complete {
+                        self.json_final_emitted = true;
+                    }
+                }
+            }
         }
     }
 
-    fn finish(&self) {
-        eprintln!(
-            "\rDownload complete ({:.1}MB)                    ",
-            self.current as f64 / 1_048_576.0
-        );
+    fn finish(&mut self, sink: &ProgressSink, label: &str) {
+        match sink.mode {
+            ProgressMode::Human => eprintln!("{}", self.human_finish()),
+            ProgressMode::Json => {
+                // An unknown (chunked) total never hits the 100% branch in
+                // `update`; close the file out with exactly one final event.
+                if !self.json_final_emitted {
+                    self.json_final_emitted = true;
+                    sink.event(&ProgressEvent::Download {
+                        file: label.to_string(),
+                        bytes_done: self.current,
+                        bytes_total: self.total,
+                    });
+                }
+            }
+        }
     }
 }
 
@@ -1200,6 +1485,27 @@ async fn stream_to_partial_then_finalize(
     expected_sha256: Option<&str>,
     label: &str,
 ) -> Result<()> {
+    stream_to_partial_then_finalize_with_sink(
+        url,
+        final_dest,
+        expected_sha256,
+        label,
+        &ProgressSink::global(),
+    )
+    .await
+}
+
+/// Sink-parameterized core of [`stream_to_partial_then_finalize`] so tests
+/// can capture the emitted [`ProgressEvent`]s instead of parsing process
+/// stdout.
+#[cfg(feature = "net")]
+async fn stream_to_partial_then_finalize_with_sink(
+    url: &str,
+    final_dest: &Path,
+    expected_sha256: Option<&str>,
+    label: &str,
+    sink: &ProgressSink,
+) -> Result<()> {
     let partial = partial_path_unique(final_dest);
 
     tracing::info!("Downloading {label}...");
@@ -1238,14 +1544,19 @@ async fn stream_to_partial_then_finalize(
             .await
             .context("Failed to write chunk")?;
         downloaded += chunk.len() as u64;
-        progress.update(chunk.len() as u64);
+        progress.update(chunk.len() as u64, sink, label);
     }
 
     file.flush().await?;
     drop(file);
-    progress.finish();
+    progress.finish(sink, label);
     tracing::info!("Wrote partial {} ({downloaded} bytes)", partial.display());
 
+    if expected_sha256.is_some() {
+        sink.event(&ProgressEvent::Verify {
+            file: label.to_string(),
+        });
+    }
     finalize_download(&partial, final_dest, expected_sha256, label)?;
     tracing::info!("Saved {label}");
 
@@ -1277,21 +1588,280 @@ mod tests {
 
     #[test]
     fn test_download_progress_basic() {
+        let sink = ProgressSink::human();
         let mut progress = DownloadProgress::new(1_000_000);
         // Should not panic on normal update.
-        progress.update(500_000);
+        progress.update(500_000, &sink, "model.onnx");
         assert_eq!(progress.current, 500_000);
         assert_eq!(progress.last_percent, 50);
-        progress.finish();
+        progress.finish(&sink, "model.onnx");
     }
 
     #[test]
     fn test_download_progress_zero_total() {
+        let sink = ProgressSink::human();
         let mut progress = DownloadProgress::new(0);
         // Must not divide by zero.
-        progress.update(100);
+        progress.update(100, &sink, "model.onnx");
         assert_eq!(progress.last_percent, 0);
-        progress.finish();
+        progress.finish(&sink, "model.onnx");
+    }
+
+    // ── progress events (NDJSON / human sink) ───────────────────────────────
+
+    #[test]
+    fn test_progress_mode_from_str() {
+        use std::str::FromStr;
+        assert_eq!(
+            ProgressMode::from_str("human").unwrap(),
+            ProgressMode::Human
+        );
+        assert_eq!(ProgressMode::from_str("json").unwrap(), ProgressMode::Json);
+        assert_eq!(
+            ProgressMode::from_str(" JSON ").unwrap(),
+            ProgressMode::Json
+        );
+        assert!(ProgressMode::from_str("xml").is_err());
+        assert_eq!(ProgressMode::default(), ProgressMode::Human);
+        assert_eq!(ProgressMode::Json.as_str(), "json");
+    }
+
+    /// The NDJSON wire shape is the integrator contract: one line per event,
+    /// `phase` as the discriminator, exactly the fields sidecars match on.
+    #[test]
+    fn test_progress_event_ndjson_schema() {
+        let cases: Vec<(ProgressEvent, &str)> = vec![
+            (
+                ProgressEvent::Download {
+                    file: "v3_rnnt_encoder.onnx".to_string(),
+                    bytes_done: 50,
+                    bytes_total: 100,
+                },
+                "{\"phase\":\"download\",\"file\":\"v3_rnnt_encoder.onnx\",\"bytes_done\":50,\"bytes_total\":100}",
+            ),
+            (
+                ProgressEvent::Quantize {
+                    file: "v3_rnnt_encoder.onnx".to_string(),
+                },
+                "{\"phase\":\"quantize\",\"file\":\"v3_rnnt_encoder.onnx\"}",
+            ),
+            (
+                ProgressEvent::Verify {
+                    file: "v3_vocab.txt".to_string(),
+                },
+                "{\"phase\":\"verify\",\"file\":\"v3_vocab.txt\"}",
+            ),
+            (
+                ProgressEvent::Done {
+                    model_dir: "/home/u/.gigastt/models".to_string(),
+                },
+                "{\"phase\":\"done\",\"model_dir\":\"/home/u/.gigastt/models\"}",
+            ),
+            (
+                ProgressEvent::Error {
+                    kind: ProgressErrorKind::Network,
+                    message: "connection refused".to_string(),
+                },
+                "{\"phase\":\"error\",\"kind\":\"network\",\"message\":\"connection refused\"}",
+            ),
+            (
+                ProgressEvent::Error {
+                    kind: ProgressErrorKind::Interrupted,
+                    message: "SIGINT".to_string(),
+                },
+                "{\"phase\":\"error\",\"kind\":\"interrupted\",\"message\":\"SIGINT\"}",
+            ),
+        ];
+        for (event, want) in cases {
+            let line = event.to_ndjson();
+            assert_eq!(line, want);
+            // Every line must round-trip as a JSON object with a `phase` tag.
+            let parsed: serde_json::Value =
+                serde_json::from_str(&line).expect("NDJSON line must parse");
+            assert!(parsed.get("phase").is_some(), "phase tag missing: {line}");
+        }
+    }
+
+    #[test]
+    fn test_progress_error_kind_exit_codes_keep_nonzero_contract() {
+        assert_eq!(ProgressErrorKind::Other.exit_code(), 1);
+        assert_eq!(ProgressErrorKind::Network.exit_code(), 2);
+        assert_eq!(ProgressErrorKind::Disk.exit_code(), 3);
+        assert_eq!(ProgressErrorKind::Checksum.exit_code(), 4);
+        assert_eq!(ProgressErrorKind::Interrupted.exit_code(), 130);
+        for kind in [
+            ProgressErrorKind::Network,
+            ProgressErrorKind::Disk,
+            ProgressErrorKind::Checksum,
+            ProgressErrorKind::Interrupted,
+            ProgressErrorKind::Other,
+        ] {
+            assert_ne!(kind.exit_code(), 0, "{kind:?} must keep != 0");
+        }
+    }
+
+    /// Human mode must stay byte-for-byte identical to the legacy `\r`
+    /// reporter: same format strings, same trailing-space padding.
+    #[test]
+    fn test_download_progress_human_render_matches_legacy() {
+        let mut progress = DownloadProgress::new(10 * 1_048_576);
+        // current=0, percent 0 == last_percent 0 -> no redraw.
+        assert_eq!(progress.human_tick(), None);
+        progress.current = 5 * 1_048_576;
+        assert_eq!(
+            progress.human_tick().as_deref(),
+            Some("\rDownloading... 50% (5.0MB / 10.0MB)")
+        );
+        // Same percentage -> throttled (no redraw).
+        assert_eq!(progress.human_tick(), None);
+        progress.current = 10 * 1_048_576;
+        assert_eq!(
+            progress.human_tick().as_deref(),
+            Some("\rDownloading... 100% (10.0MB / 10.0MB)")
+        );
+        assert_eq!(
+            progress.human_finish(),
+            "\rDownload complete (10.0MB)                    "
+        );
+    }
+
+    /// Json mode: first chunk emits immediately, rapid chunks within the 200 ms
+    /// window are throttled, and 100% always emits exactly once.
+    #[test]
+    fn test_download_progress_json_first_throttled_then_final() {
+        let (sink, log) = ProgressSink::capturing();
+        let mut progress = DownloadProgress::new(1_000);
+        // 100 chunks of 10 bytes, all well inside the throttle window.
+        for _ in 0..100 {
+            progress.update(10, &sink, "model.onnx");
+        }
+        let events = log.lock().unwrap();
+        assert_eq!(
+            events.as_slice(),
+            [
+                ProgressEvent::Download {
+                    file: "model.onnx".to_string(),
+                    bytes_done: 10,
+                    bytes_total: 1_000,
+                },
+                ProgressEvent::Download {
+                    file: "model.onnx".to_string(),
+                    bytes_done: 1_000,
+                    bytes_total: 1_000,
+                },
+            ]
+        );
+        // finish() must not duplicate the already-emitted 100% event.
+        drop(events);
+        progress.finish(&sink, "model.onnx");
+        assert_eq!(log.lock().unwrap().len(), 2);
+    }
+
+    /// Json mode: once the throttle window has elapsed, mid-file progress
+    /// emits again (integrators get a steady cadence on long downloads).
+    #[test]
+    fn test_download_progress_json_emits_after_throttle_window() {
+        let (sink, log) = ProgressSink::capturing();
+        let mut progress = DownloadProgress::new(1_000);
+        progress.update(10, &sink, "model.onnx");
+        // Backdate the last emission past the throttle window.
+        progress.last_json_emit = Some(
+            std::time::Instant::now()
+                - JSON_PROGRESS_THROTTLE
+                - std::time::Duration::from_millis(50),
+        );
+        progress.update(10, &sink, "model.onnx");
+        let events = log.lock().unwrap();
+        assert_eq!(events.len(), 2, "elapsed window must re-emit: {events:?}");
+        assert_eq!(
+            events[1],
+            ProgressEvent::Download {
+                file: "model.onnx".to_string(),
+                bytes_done: 20,
+                bytes_total: 1_000,
+            }
+        );
+    }
+
+    /// Json mode with an unknown (chunked) total: throttled events carry
+    /// `bytes_total: 0`, and `finish` closes the file with one final event.
+    #[test]
+    fn test_download_progress_json_zero_total_emits_final_on_finish() {
+        let (sink, log) = ProgressSink::capturing();
+        let mut progress = DownloadProgress::new(0);
+        progress.update(512, &sink, "model.onnx");
+        progress.finish(&sink, "model.onnx");
+        let events = log.lock().unwrap();
+        assert_eq!(
+            events.as_slice(),
+            [
+                ProgressEvent::Download {
+                    file: "model.onnx".to_string(),
+                    bytes_done: 512,
+                    bytes_total: 0,
+                },
+                ProgressEvent::Download {
+                    file: "model.onnx".to_string(),
+                    bytes_done: 512,
+                    bytes_total: 0,
+                },
+            ]
+        );
+    }
+
+    /// Human mode never routes events to the sink (the `\r` line is the whole
+    /// output), so an integrator never sees a stray JSON line.
+    #[test]
+    fn test_download_progress_human_sink_emits_no_events() {
+        let (sink, log) = ProgressSink::capturing();
+        let sink = ProgressSink {
+            mode: ProgressMode::Human,
+            ..sink
+        };
+        let mut progress = DownloadProgress::new(1_000);
+        progress.update(1_000, &sink, "model.onnx");
+        progress.finish(&sink, "model.onnx");
+        assert!(log.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_classify_download_error_checksum_message() {
+        let err = anyhow::anyhow!("SHA-256 mismatch for encoder.onnx: expected aa, got bb");
+        assert_eq!(classify_download_error(&err), ProgressErrorKind::Checksum);
+    }
+
+    #[test]
+    fn test_classify_download_error_http_status_is_network() {
+        let err = anyhow::anyhow!("Download failed for model.onnx: HTTP 404");
+        assert_eq!(classify_download_error(&err), ProgressErrorKind::Network);
+    }
+
+    #[test]
+    fn test_classify_download_error_io_root_cause_is_disk() {
+        let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let err = anyhow::Error::from(io).context("Failed to create partial model file");
+        assert_eq!(classify_download_error(&err), ProgressErrorKind::Disk);
+    }
+
+    #[test]
+    fn test_classify_download_error_other() {
+        let err =
+            anyhow::anyhow!("Failed to acquire download lock (another process is downloading)");
+        assert_eq!(classify_download_error(&err), ProgressErrorKind::Other);
+    }
+
+    /// A real reqwest connection failure classifies as network via the typed
+    /// root cause, not message matching.
+    #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
+    async fn test_classify_download_error_reqwest_is_network() {
+        let err = reqwest::Client::new()
+            .get("http://127.0.0.1:9/unreachable")
+            .send()
+            .await
+            .expect_err("port 9 must refuse");
+        let err = anyhow::Error::from(err).context("HTTP request failed");
+        assert_eq!(classify_download_error(&err), ProgressErrorKind::Network);
     }
 
     /// Compute the SHA-256 of a byte slice as a lowercase hex digest.
@@ -1593,6 +2163,103 @@ mod tests {
         assert!(
             msg.contains("SHA-256 mismatch"),
             "error should mention mismatch: {msg}"
+        );
+    }
+
+    /// End-to-end NDJSON contract on a local HTTP stub: the download of one
+    /// file emits a 100% `download` event followed by a `verify` event, and
+    /// every line round-trips through a JSON parser (true NDJSON).
+    #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
+    async fn test_stream_to_partial_then_finalize_json_event_sequence() {
+        let server = wiremock::MockServer::start().await;
+        let payload = b"fake model bytes";
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/model.onnx"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_bytes(payload.as_slice())
+                    .insert_header("content-length", payload.len().to_string()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let final_path = tmp.path().join("model.onnx");
+        let url = format!("{}/model.onnx", server.uri());
+        let expected = sha256_hex(payload);
+        let (sink, log) = ProgressSink::capturing();
+
+        stream_to_partial_then_finalize_with_sink(
+            &url,
+            &final_path,
+            Some(&expected),
+            "model.onnx",
+            &sink,
+        )
+        .await
+        .expect("download should succeed");
+
+        let events = log.lock().unwrap();
+        assert_eq!(
+            events.as_slice(),
+            [
+                ProgressEvent::Download {
+                    file: "model.onnx".to_string(),
+                    bytes_done: payload.len() as u64,
+                    bytes_total: payload.len() as u64,
+                },
+                ProgressEvent::Verify {
+                    file: "model.onnx".to_string(),
+                },
+            ]
+        );
+        // The integrator view: serialize each event to a line and parse it
+        // back — the stream must be well-formed NDJSON with a phase tag.
+        for event in events.iter() {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&event.to_ndjson()).expect("event must be NDJSON");
+            assert!(parsed.get("phase").is_some());
+        }
+    }
+
+    /// No checksum pinned → no `verify` event (verification did not happen).
+    #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
+    async fn test_stream_to_partial_then_finalize_json_no_verify_without_checksum() {
+        let server = wiremock::MockServer::start().await;
+        let payload = b"fake model bytes";
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/model.onnx"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_bytes(payload.as_slice())
+                    .insert_header("content-length", payload.len().to_string()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let final_path = tmp.path().join("model.onnx");
+        let url = format!("{}/model.onnx", server.uri());
+        let (sink, log) = ProgressSink::capturing();
+
+        stream_to_partial_then_finalize_with_sink(&url, &final_path, None, "model.onnx", &sink)
+            .await
+            .expect("download should succeed");
+
+        let events = log.lock().unwrap();
+        assert!(
+            events
+                .iter()
+                .all(|e| !matches!(e, ProgressEvent::Verify { .. })),
+            "no checksum -> no verify event: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ProgressEvent::Download { .. })),
+            "download events expected: {events:?}"
         );
     }
 

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -26,6 +26,7 @@ use std::os::fd::AsRawFd;
 /// `Json` emits NDJSON events — one [`ProgressEvent`] per line — on stdout
 /// for sidecar integrators.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum ProgressMode {
     /// Interactive human reporter: a `\r`-redrawn percentage line on stderr.
     #[default]
@@ -62,6 +63,7 @@ impl std::str::FromStr for ProgressMode {
 /// documented `gigastt download` exit-code taxonomy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ProgressErrorKind {
     /// Network failure: unreachable host, TLS, broken stream, HTTP error status.
     Network,
@@ -79,10 +81,17 @@ impl ProgressErrorKind {
     /// `gigastt download` process exit code for this failure category. `0` is
     /// success; every category keeps the historical `!= 0` failure contract.
     pub fn exit_code(self) -> i32 {
+        // BSD `sysexits`-flavored codes, deliberately avoiding 2: clap exits 2
+        // on argument/usage errors (before any event can be emitted), and an
+        // integrator keying retries off "network" must be able to tell the two
+        // apart.
         match self {
-            ProgressErrorKind::Network => 2,
-            ProgressErrorKind::Disk => 3,
-            ProgressErrorKind::Checksum => 4,
+            // EX_UNAVAILABLE: the remote end could not be reached / served.
+            ProgressErrorKind::Network => 69,
+            // EX_IOERR: local create/write/rename failure.
+            ProgressErrorKind::Disk => 74,
+            // EX_DATAERR: SHA-256 mismatch on a staged download.
+            ProgressErrorKind::Checksum => 65,
             // Conventional 128 + SIGINT.
             ProgressErrorKind::Interrupted => 130,
             // Historical generic failure code (anyhow's `Termination`).
@@ -96,6 +105,7 @@ impl ProgressErrorKind {
 /// event; the `phase` tag is the discriminator integrators match on.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "phase", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ProgressEvent {
     /// Byte progress of one file's download (throttled to ~200 ms per file,
     /// plus an unconditional event at 100%).
@@ -1685,10 +1695,21 @@ mod tests {
     #[test]
     fn test_progress_error_kind_exit_codes_keep_nonzero_contract() {
         assert_eq!(ProgressErrorKind::Other.exit_code(), 1);
-        assert_eq!(ProgressErrorKind::Network.exit_code(), 2);
-        assert_eq!(ProgressErrorKind::Disk.exit_code(), 3);
-        assert_eq!(ProgressErrorKind::Checksum.exit_code(), 4);
+        assert_eq!(ProgressErrorKind::Network.exit_code(), 69);
+        assert_eq!(ProgressErrorKind::Disk.exit_code(), 74);
+        assert_eq!(ProgressErrorKind::Checksum.exit_code(), 65);
         assert_eq!(ProgressErrorKind::Interrupted.exit_code(), 130);
+        // 2 stays reserved for clap usage errors: a misconfigured invocation
+        // must never look like a transient (retryable) download failure.
+        for kind in [
+            ProgressErrorKind::Other,
+            ProgressErrorKind::Network,
+            ProgressErrorKind::Disk,
+            ProgressErrorKind::Checksum,
+            ProgressErrorKind::Interrupted,
+        ] {
+            assert_ne!(kind.exit_code(), 2, "{kind:?} must not collide with clap");
+        }
         for kind in [
             ProgressErrorKind::Network,
             ProgressErrorKind::Disk,

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -27,7 +27,7 @@ diarization = ["gigastt-core/diarization"]
 quantize = ["gigastt-core/quantize"]
 
 [dependencies]
-gigastt-core = { version = "2.12.0", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
+gigastt-core = { version = "2.13.0", path = "../gigastt-core", default-features = false, features = ["net", "async-pool", "file-decode"] }
 
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "signal", "macros", "fs"] }

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -1193,7 +1193,14 @@ async fn main() -> anyhow::Result<()> {
             // `download` is an explicit action: the requested variant maps to
             // the default (Rnnt) so a bare `gigastt download` fetches something
             // useful.
-            let download = async {
+            //
+            // The flow runs on its own task: the INT8 quantization pass and the
+            // large-file SHA-256 verify are synchronous, and polled inline they
+            // would starve the select's signal branch — Ctrl-C must interrupt
+            // immediately at any phase (a sidecar's cancel path relies on it).
+            let dl_model_dir = model_dir.clone();
+            let mut download = tokio::spawn(async move {
+                let model_dir = dl_model_dir;
                 if prequantized && !model_variant.is_ctc() {
                     // Lean path: fetch the INT8 bundle from the pinned Release — no
                     // FP32 download, no on-device quantization, no protoc.
@@ -1223,9 +1230,26 @@ async fn main() -> anyhow::Result<()> {
                 }
                 tracing::info!("Model ready at {model_dir}");
                 anyhow::Ok(())
+            });
+            // Resolves only on a *delivered* SIGINT. A failed handler
+            // registration is logged and parks forever — it must not fabricate
+            // an interrupt and abort a healthy download with exit 130.
+            let interrupted = async {
+                match tokio::signal::ctrl_c().await {
+                    Ok(()) => (),
+                    Err(e) => {
+                        tracing::warn!("Failed to listen for Ctrl-C: {e}");
+                        std::future::pending::<()>().await
+                    }
+                }
             };
             tokio::select! {
-                result = download => {
+                joined = &mut download => {
+                    // Flatten the JoinHandle: a panic inside the download task
+                    // is reported through the same error contract.
+                    let result = joined
+                        .map_err(|e| anyhow::anyhow!("download task failed: {e}"))
+                        .and_then(|r| r);
                     match result {
                         Ok(()) => {
                             model::emit_progress_event(&model::ProgressEvent::Done {
@@ -1245,10 +1269,7 @@ async fn main() -> anyhow::Result<()> {
                         }
                     }
                 }
-                sig = tokio::signal::ctrl_c() => {
-                    if let Err(e) = sig {
-                        tracing::warn!("Failed to listen for Ctrl-C: {e}");
-                    }
+                _ = interrupted => {
                     model::emit_progress_event(&model::ProgressEvent::Error {
                         kind: model::ProgressErrorKind::Interrupted,
                         message: "interrupted by SIGINT".to_string(),

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 use gigastt::server;
 use gigastt::server::{OriginPolicy, RuntimeLimits, ServerConfig};
 use gigastt_core::export::{ExportFormat, RenderOpts};
-use gigastt_core::model::ModelVariant;
+use gigastt_core::model::{ModelVariant, ProgressMode};
 use gigastt_core::{inference, model};
 use std::net::IpAddr;
 use std::str::FromStr;
@@ -320,6 +320,18 @@ enum Commands {
         /// FP32 download path).
         #[arg(long, default_value_t = false)]
         prequantized: bool,
+
+        /// Progress reporting format: `human` (default — interactive `\r`
+        /// progress on stderr) or `json` (NDJSON events on stdout, one object
+        /// per line, for sidecar integrators; human progress and tracing logs
+        /// stay off stdout in this mode).
+        #[arg(
+            long,
+            env = "GIGASTT_DOWNLOAD_PROGRESS",
+            default_value = "human",
+            value_parser = parse_progress_mode
+        )]
+        progress: ProgressMode,
 
         /// Also fetch the per-bucket palettized ANE (Core ML) encoder packages
         /// into `~/.gigastt/models/ane/` for the macOS Neural Engine backend.
@@ -663,6 +675,11 @@ fn parse_model_variant(s: &str) -> Result<ModelVariant, String> {
     s.parse()
 }
 
+/// Parse the `download --progress` value (`human` | `json`).
+fn parse_progress_mode(s: &str) -> Result<ProgressMode, String> {
+    s.parse()
+}
+
 /// Whether to run the optional punctuation / casing restoration pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PunctuationMode {
@@ -934,6 +951,11 @@ fn ensure_int8_encoder(variant: ModelVariant, model_dir: &str, skip: bool) -> an
         );
     }
     tracing::info!("Quantizing encoder to INT8 (~2 min, one-time)…");
+    // Surface the ~2-minute pass as its own phase so a sidecar watching the
+    // NDJSON stream does not read it as a hang.
+    model::emit_progress_event(&model::ProgressEvent::Quantize {
+        file: variant.encoder_file().to_string(),
+    });
     gigastt_core::quantize::quantize_model(&input, &int8_path)?;
     tracing::info!("INT8 encoder saved to {}", int8_path.display());
     Ok(())
@@ -969,10 +991,24 @@ fn log_ane_backend(resolved: ModelVariant) {
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    // NDJSON download progress owns stdout: in `--progress=json` mode the
+    // tracing writer moves to stderr so stdout carries nothing but event
+    // lines (the default writer is stdout).
+    let json_progress = matches!(
+        &cli.command,
+        Commands::Download { progress, .. } if *progress == ProgressMode::Json
+    );
+
     let directive = format!("gigastt={}", cli.log_level);
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env().add_directive(directive.parse()?))
-        .init();
+    let filter = EnvFilter::from_default_env().add_directive(directive.parse()?);
+    if json_progress {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    }
 
     match cli.command {
         Commands::Serve {
@@ -1149,38 +1185,78 @@ async fn main() -> anyhow::Result<()> {
             skip_diarization,
             skip_quantize,
             prequantized,
+            progress,
             #[cfg(feature = "ane")]
             ane,
         } => {
+            model::set_progress_mode(progress);
             // `download` is an explicit action: the requested variant maps to
             // the default (Rnnt) so a bare `gigastt download` fetches something
             // useful.
-            if prequantized && !model_variant.is_ctc() {
-                // Lean path: fetch the INT8 bundle from the pinned Release — no
-                // FP32 download, no on-device quantization, no protoc.
-                model::ensure_prequantized_model_variant(Some(model_variant), &model_dir).await?;
-            } else {
-                // The Multilingual CTC heads' standard download already fetches
-                // istupakov's pre-quantized INT8 encoder directly from HuggingFace,
-                // so `--prequantized` is a no-op refinement for them (no separate
-                // GitHub-Release bundle). `ensure_int8_encoder` then finds the INT8
-                // encoder already present and skips on-device quantization.
-                let resolved = model::ensure_model_variant(Some(model_variant), &model_dir).await?;
-                ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
-            }
-            #[cfg(feature = "diarization")]
-            {
-                if !skip_diarization {
-                    model::ensure_speaker_model(&model_dir).await?;
+            let download = async {
+                if prequantized && !model_variant.is_ctc() {
+                    // Lean path: fetch the INT8 bundle from the pinned Release — no
+                    // FP32 download, no on-device quantization, no protoc.
+                    model::ensure_prequantized_model_variant(Some(model_variant), &model_dir)
+                        .await?;
+                } else {
+                    // The Multilingual CTC heads' standard download already fetches
+                    // istupakov's pre-quantized INT8 encoder directly from HuggingFace,
+                    // so `--prequantized` is a no-op refinement for them (no separate
+                    // GitHub-Release bundle). `ensure_int8_encoder` then finds the INT8
+                    // encoder already present and skips on-device quantization.
+                    let resolved =
+                        model::ensure_model_variant(Some(model_variant), &model_dir).await?;
+                    ensure_int8_encoder(resolved, &model_dir, skip_quantize)?;
+                }
+                #[cfg(feature = "diarization")]
+                {
+                    if !skip_diarization {
+                        model::ensure_speaker_model(&model_dir).await?;
+                    }
+                }
+                #[cfg(feature = "ane")]
+                if ane {
+                    let ane_dir = model::default_ane_model_dir();
+                    model::ensure_ane_packages(&ane_dir).await?;
+                    tracing::info!("ANE encoder packages ready at {ane_dir}");
+                }
+                tracing::info!("Model ready at {model_dir}");
+                anyhow::Ok(())
+            };
+            tokio::select! {
+                result = download => {
+                    match result {
+                        Ok(()) => {
+                            model::emit_progress_event(&model::ProgressEvent::Done {
+                                model_dir: model_dir.clone(),
+                            });
+                        }
+                        Err(e) => {
+                            let kind = model::classify_download_error(&e);
+                            model::emit_progress_event(&model::ProgressEvent::Error {
+                                kind,
+                                message: format!("{e:#}"),
+                            });
+                            // Same rendering anyhow's `Termination` would print,
+                            // then the documented per-kind exit code (all != 0).
+                            eprintln!("Error: {e:?}");
+                            std::process::exit(kind.exit_code());
+                        }
+                    }
+                }
+                sig = tokio::signal::ctrl_c() => {
+                    if let Err(e) = sig {
+                        tracing::warn!("Failed to listen for Ctrl-C: {e}");
+                    }
+                    model::emit_progress_event(&model::ProgressEvent::Error {
+                        kind: model::ProgressErrorKind::Interrupted,
+                        message: "interrupted by SIGINT".to_string(),
+                    });
+                    eprintln!("Interrupted by Ctrl-C");
+                    std::process::exit(model::ProgressErrorKind::Interrupted.exit_code());
                 }
             }
-            #[cfg(feature = "ane")]
-            if ane {
-                let ane_dir = model::default_ane_model_dir();
-                model::ensure_ane_packages(&ane_dir).await?;
-                tracing::info!("ANE encoder packages ready at {ane_dir}");
-            }
-            tracing::info!("Model ready at {model_dir}");
         }
         Commands::Quantize { model_dir, force } => {
             // Quantize an existing model dir: detect the head already on disk
@@ -2625,6 +2701,64 @@ mod tests {
             Commands::Download { skip_quantize, .. } => assert!(skip_quantize),
             _ => panic!("expected Download"),
         }
+    }
+
+    #[test]
+    fn test_cli_download_progress_defaults_to_human() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(
+            "GIGASTT_DOWNLOAD_PROGRESS",
+            std::env::var("GIGASTT_DOWNLOAD_PROGRESS").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_DOWNLOAD_PROGRESS");
+        }
+        let cli = Cli::parse_from(["gigastt", "download"]);
+        match cli.command {
+            Commands::Download { progress, .. } => assert_eq!(progress, ProgressMode::Human),
+            _ => panic!("expected Download"),
+        }
+    }
+
+    #[test]
+    fn test_cli_download_progress_json_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(
+            "GIGASTT_DOWNLOAD_PROGRESS",
+            std::env::var("GIGASTT_DOWNLOAD_PROGRESS").ok(),
+        );
+        unsafe {
+            std::env::remove_var("GIGASTT_DOWNLOAD_PROGRESS");
+        }
+        let cli = Cli::parse_from(["gigastt", "download", "--progress", "json"]);
+        match cli.command {
+            Commands::Download { progress, .. } => assert_eq!(progress, ProgressMode::Json),
+            _ => panic!("expected Download"),
+        }
+    }
+
+    #[test]
+    fn test_cli_download_progress_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _restore = EnvRestore(
+            "GIGASTT_DOWNLOAD_PROGRESS",
+            std::env::var("GIGASTT_DOWNLOAD_PROGRESS").ok(),
+        );
+        unsafe {
+            std::env::set_var("GIGASTT_DOWNLOAD_PROGRESS", "json");
+        }
+        let cli = Cli::parse_from(["gigastt", "download"]);
+        match cli.command {
+            Commands::Download { progress, .. } => assert_eq!(progress, ProgressMode::Json),
+            _ => panic!("expected Download"),
+        }
+    }
+
+    #[test]
+    fn test_parse_progress_mode_value_parser() {
+        assert_eq!(parse_progress_mode("human").unwrap(), ProgressMode::Human);
+        assert_eq!(parse_progress_mode("json").unwrap(), ProgressMode::Json);
+        assert!(parse_progress_mode("xml").is_err());
     }
 
     #[cfg(feature = "ane")]

--- a/crates/gigastt/tests/e2e_cli.rs
+++ b/crates/gigastt/tests/e2e_cli.rs
@@ -397,3 +397,156 @@ fn cli_serve_boots_and_graceful_shutdown() {
         }
     }
 }
+
+// ─── model-gated: download --progress=json (NDJSON contract) ────────────────
+
+/// Symlink the named files from the real model dir into `dst`, skipping any
+/// that are absent (the caller's gating decides what is required).
+#[cfg(unix)]
+fn link_model_files(dst: &std::path::Path, names: &[&str]) {
+    let src = std::path::PathBuf::from(common::model_dir());
+    for name in names {
+        let from = src.join(name);
+        if from.exists() {
+            std::os::unix::fs::symlink(&from, dst.join(name)).expect("symlink model file");
+        }
+    }
+}
+
+/// Happy path with everything already present: stdout must be pure NDJSON —
+/// every line parses as a JSON object with a `phase` tag and the final line is
+/// `{"phase":"done",…}`. Human `\r`-progress and tracing logs must not leak
+/// into stdout.
+#[cfg(unix)]
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[test]
+fn cli_download_json_happy_path_stdout_is_pure_ndjson() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    link_model_files(
+        tmp.path(),
+        &[
+            "v3_rnnt_encoder.onnx",
+            "v3_rnnt_decoder.onnx",
+            "v3_rnnt_joint.onnx",
+            "v3_vocab.txt",
+            "v3_rnnt_encoder_int8.onnx",
+        ],
+    );
+
+    let out = Command::new(bin())
+        .args([
+            "download",
+            "--model-dir",
+            tmp.path().to_str().unwrap(),
+            "--model-variant",
+            "rnnt",
+            "--progress=json",
+            "--skip-diarization",
+        ])
+        .output()
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "download failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout must be UTF-8");
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert!(!lines.is_empty(), "json mode must emit at least one event");
+    for line in &lines {
+        let v: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("non-JSON stdout line {line:?}: {e}"));
+        assert!(
+            v.get("phase").and_then(|p| p.as_str()).is_some(),
+            "every event carries a phase tag: {line}"
+        );
+    }
+    let last: serde_json::Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+    assert_eq!(last["phase"], "done", "final event must be done: {last}");
+    assert!(
+        last["model_dir"].as_str().is_some(),
+        "done event carries model_dir: {last}"
+    );
+}
+
+/// The ~2-minute INT8 quantization pass must announce itself as its own
+/// `quantize` phase as soon as it starts (a sidecar reading the stream would
+/// otherwise mistake it for a hang). FP32 weights are linked in without the
+/// INT8 encoder to force the pass; the subprocess is killed right after the
+/// event arrives — the test asserts the emission, not the quantization.
+#[cfg(unix)]
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[test]
+fn cli_download_json_emits_quantize_phase() {
+    use std::io::BufRead;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    link_model_files(
+        tmp.path(),
+        &[
+            "v3_rnnt_encoder.onnx",
+            "v3_rnnt_decoder.onnx",
+            "v3_rnnt_joint.onnx",
+            "v3_vocab.txt",
+        ],
+    );
+
+    let mut child = Command::new(bin())
+        .args([
+            "download",
+            "--model-dir",
+            tmp.path().to_str().unwrap(),
+            "--model-variant",
+            "rnnt",
+            "--progress=json",
+            "--skip-diarization",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+
+    let stdout = child.stdout.take().expect("piped stdout");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        for line in std::io::BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    let mut saw_quantize = false;
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(500)) {
+            Ok(line) if line.is_empty() => continue,
+            Ok(line) => {
+                let v: serde_json::Value = serde_json::from_str(&line)
+                    .unwrap_or_else(|e| panic!("non-JSON stdout line {line:?}: {e}"));
+                if v["phase"] == "quantize" {
+                    assert_eq!(
+                        v["file"], "v3_rnnt_encoder.onnx",
+                        "quantize event names the encoder being quantized: {v}"
+                    );
+                    saw_quantize = true;
+                    break;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                if let Some(status) = child.try_wait().expect("try_wait") {
+                    panic!("download exited ({status}) before emitting a quantize event");
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    assert!(
+        saw_quantize,
+        "quantize phase event must be emitted when the INT8 encoder is missing"
+    );
+}

--- a/crates/gigastt/tests/e2e_cli.rs
+++ b/crates/gigastt/tests/e2e_cli.rs
@@ -400,16 +400,33 @@ fn cli_serve_boots_and_graceful_shutdown() {
 
 // ─── model-gated: download --progress=json (NDJSON contract) ────────────────
 
-/// Symlink the named files from the real model dir into `dst`, skipping any
-/// that are absent (the caller's gating decides what is required).
+/// Symlink the named files from the real model dir into `dst`. Returns `false`
+/// (test must self-skip) when any of them is absent — e.g. a machine installed
+/// via `download --prequantized` has no FP32 encoder; running anyway would
+/// silently turn the test into a live ~850 MB network download.
 #[cfg(unix)]
-fn link_model_files(dst: &std::path::Path, names: &[&str]) {
+#[must_use]
+fn link_model_files(dst: &std::path::Path, names: &[&str]) -> bool {
     let src = std::path::PathBuf::from(common::model_dir());
     for name in names {
         let from = src.join(name);
-        if from.exists() {
-            std::os::unix::fs::symlink(&from, dst.join(name)).expect("symlink model file");
+        if !from.exists() {
+            eprintln!("skipping: {} not present in {}", name, src.display());
+            return false;
         }
+        std::os::unix::fs::symlink(&from, dst.join(name)).expect("symlink model file");
+    }
+    true
+}
+
+/// Kill the child on drop so a panicking assertion can never leak a running
+/// subprocess (nor let a TempDir be deleted out from under it mid-quantize).
+struct KillOnDrop(std::process::Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
     }
 }
 
@@ -422,7 +439,7 @@ fn link_model_files(dst: &std::path::Path, names: &[&str]) {
 #[test]
 fn cli_download_json_happy_path_stdout_is_pure_ndjson() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    link_model_files(
+    if !link_model_files(
         tmp.path(),
         &[
             "v3_rnnt_encoder.onnx",
@@ -431,7 +448,9 @@ fn cli_download_json_happy_path_stdout_is_pure_ndjson() {
             "v3_vocab.txt",
             "v3_rnnt_encoder_int8.onnx",
         ],
-    );
+    ) {
+        return;
+    }
 
     let out = Command::new(bin())
         .args([
@@ -482,7 +501,7 @@ fn cli_download_json_emits_quantize_phase() {
     use std::io::BufRead;
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    link_model_files(
+    if !link_model_files(
         tmp.path(),
         &[
             "v3_rnnt_encoder.onnx",
@@ -490,24 +509,28 @@ fn cli_download_json_emits_quantize_phase() {
             "v3_rnnt_joint.onnx",
             "v3_vocab.txt",
         ],
+    ) {
+        return;
+    }
+
+    let mut child = KillOnDrop(
+        Command::new(bin())
+            .args([
+                "download",
+                "--model-dir",
+                tmp.path().to_str().unwrap(),
+                "--model-variant",
+                "rnnt",
+                "--progress=json",
+                "--skip-diarization",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn"),
     );
 
-    let mut child = Command::new(bin())
-        .args([
-            "download",
-            "--model-dir",
-            tmp.path().to_str().unwrap(),
-            "--model-variant",
-            "rnnt",
-            "--progress=json",
-            "--skip-diarization",
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn");
-
-    let stdout = child.stdout.take().expect("piped stdout");
+    let stdout = child.0.stdout.take().expect("piped stdout");
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         for line in std::io::BufReader::new(stdout).lines() {
@@ -536,17 +559,59 @@ fn cli_download_json_emits_quantize_phase() {
                 }
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                if let Some(status) = child.try_wait().expect("try_wait") {
+                if let Some(status) = child.0.try_wait().expect("try_wait") {
                     panic!("download exited ({status}) before emitting a quantize event");
                 }
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
-    let _ = child.kill();
-    let _ = child.wait();
+    drop(child);
     assert!(
         saw_quantize,
         "quantize phase event must be emitted when the INT8 encoder is missing"
+    );
+}
+
+/// The json error contract end-to-end without a model or network: an
+/// impossible `--model-dir` (a path under `/dev/null`) makes the download flow
+/// fail locally; stdout must then carry a single `{"phase":"error",…}` event
+/// whose `kind` matches the documented per-kind process exit code.
+#[cfg(unix)]
+#[test]
+fn cli_download_json_error_event_and_exit_code_are_consistent() {
+    let out = Command::new(bin())
+        .args([
+            "download",
+            "--model-dir",
+            "/dev/null/impossible",
+            "--model-variant",
+            "rnnt",
+            "--progress=json",
+            "--skip-diarization",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "impossible model dir must fail");
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout must be UTF-8");
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let last: serde_json::Value =
+        serde_json::from_str(lines.last().expect("json mode must emit an error event"))
+            .expect("last stdout line must be JSON");
+    assert_eq!(last["phase"], "error", "final event must be error: {last}");
+    let kind = last["kind"].as_str().expect("error event carries kind");
+    let expected_exit = match kind {
+        "network" => 69,
+        "disk" => 74,
+        "checksum" => 65,
+        "interrupted" => 130,
+        "other" => 1,
+        other => panic!("unknown error kind {other}"),
+    };
+    assert_eq!(
+        out.status.code(),
+        Some(expected_exit),
+        "exit code must match the documented mapping for kind={kind}"
     );
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,6 +86,34 @@ gigastt download [OPTIONS]
                          Env: GIGASTT_MODEL_VARIANT.
   --skip-diarization     Skip downloading the speaker diarization model
   --skip-quantize        Skip auto-quantization after download (FP32 only)
+  --prequantized         Fetch the pre-quantized INT8 bundle from the pinned
+                         GitHub Release (no FP32 download, no on-device quantize)
+  --progress <FORMAT>    Progress output: human (default) | json.
+                         Env: GIGASTT_DOWNLOAD_PROGRESS.
+
+  Machine-readable progress (--progress=json)
+    stdout carries one NDJSON event per line and nothing else (human progress
+    and logs stay on stderr), so a sidecar can drive an exact progress bar:
+
+      {"phase":"download","file":"v3_rnnt_encoder.onnx","bytes_done":N,"bytes_total":M}
+      {"phase":"verify","file":"v3_rnnt_encoder.onnx"}
+      {"phase":"quantize","file":"v3_rnnt_encoder.onnx"}
+      {"phase":"done","model_dir":"/home/u/.gigastt/models"}
+      {"phase":"error","kind":"network|disk|checksum|interrupted|other","message":"..."}
+
+    download events fire on the first chunk, then at most once per ~200 ms per
+    file, and always once at 100% (bytes_total is 0 when the server does not
+    send a length). verify fires per SHA-256 check; quantize marks the start
+    of the ~2-minute on-device INT8 pass. done is emitted once, last, on
+    success; error is emitted right before a non-zero exit.
+
+  Exit codes
+    0    success
+    1    other error
+    2    network error (unreachable host, broken stream, HTTP error status)
+    3    disk error (cannot create/write/rename model files)
+    4    checksum mismatch (corrupt or tampered download)
+    130  interrupted (Ctrl-C / SIGINT)
 
 gigastt transcribe [OPTIONS] <FILE>
   --model-dir <DIR>           Model directory [default: ~/.gigastt/models]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,8 +92,9 @@ gigastt download [OPTIONS]
                          Env: GIGASTT_DOWNLOAD_PROGRESS.
 
   Machine-readable progress (--progress=json)
-    stdout carries one NDJSON event per line and nothing else (human progress
-    and logs stay on stderr), so a sidecar can drive an exact progress bar:
+    stdout carries one NDJSON event per line and nothing else (the human
+    `\r`-progress renderer is disabled and tracing logs go to stderr), so a
+    sidecar can drive an exact progress bar:
 
       {"phase":"download","file":"v3_rnnt_encoder.onnx","bytes_done":N,"bytes_total":M}
       {"phase":"verify","file":"v3_rnnt_encoder.onnx"}
@@ -107,12 +108,14 @@ gigastt download [OPTIONS]
     of the ~2-minute on-device INT8 pass. done is emitted once, last, on
     success; error is emitted right before a non-zero exit.
 
-  Exit codes
+  Exit codes (sysexits-flavored; 2 is deliberately unused — clap exits 2 on
+  argument/usage errors before any NDJSON event can be emitted, so a code-2
+  exit always means a misconfigured invocation, never a download failure)
     0    success
     1    other error
-    2    network error (unreachable host, broken stream, HTTP error status)
-    3    disk error (cannot create/write/rename model files)
-    4    checksum mismatch (corrupt or tampered download)
+    65   checksum mismatch (corrupt or tampered download)
+    69   network error (unreachable host, broken stream, HTTP error status)
+    74   disk error (cannot create/write/rename model files)
     130  interrupted (Ctrl-C / SIGINT)
 
 gigastt transcribe [OPTIONS] <FILE>


### PR DESCRIPTION
## Summary

`gigastt download --progress=json` (env `GIGASTT_DOWNLOAD_PROGRESS`) switches model-download reporting to NDJSON on stdout — one event per line and nothing else there (the human `\r`-renderer is disabled; tracing logs go to stderr). Sidecar integrators can drive an exact per-file, per-phase progress bar instead of polling the model directory size against a hard-coded total; the previously invisible ~2-minute INT8 quantization pass announces itself as its own `quantize` phase. The default `human` mode is byte-for-byte unchanged.

Events: throttled `download` (~200 ms per file + always at 100%), `verify` per SHA-256 check, `quantize`, terminal `done`, and an `error` event before any non-zero exit. Both download paths (HF and `--prequantized`) are covered.

Exit codes are now documented and sysexits-flavored: `69` network, `74` disk, `65` checksum, `130` interrupted, `1` other — keeping the historical `!= 0` contract. `2` is deliberately left to clap's usage errors so a misconfigured invocation is never mistaken for a retryable network failure.

Also fixed while hardening:
- **Ctrl-C stays responsive through the whole run.** The flow runs on its own task; previously the synchronous quantize pass starved the signal branch and SIGINT was swallowed for up to ~2 minutes. Verified by hand: SIGINT mid-quantize → `interrupted` event + exit 130 in 80 ms.
- A failed Ctrl-C handler registration parks instead of fabricating an interrupt (no more false exit-130 on a healthy download).
- `ProgressMode` / `ProgressEvent` / `ProgressErrorKind` are `#[non_exhaustive]` so future phases and error kinds ship as minor releases.

Workspace bumped to 2.13.0 (new public gigastt-core API), gigastt-core dependency pin moved in lockstep.

## Testing

- ~20 unit tests including wiremock HTTP-stub tests (throttle contract, event sequence, error classification incl. real reqwest root causes) — run in PR CI.
- Hermetic subprocess test drives the error path end-to-end with no model and no network: emitted error `kind` and process exit code must agree with the documented mapping — runs in PR CI.
- Model-gated subprocess tests (run locally): stdout purity on the happy path (pure NDJSON ending in `done`) and the `quantize` phase emission (child killed right after the event; kill-on-drop guard, self-skip when the FP32 set is absent so the test can never silently become a live download).
- `cargo semver-checks` green (2.12.0 → 2.13.0 minor); fmt/clippy/units green post-rebase.