### PR TITLE
feat(packaging): air-gapped offline bundle, Debian packages, systemd unit, offline mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
             asset_suffix: x86_64-unknown-linux-gnu
             cuda: false
             ffi: true
+            offline: true
+            deb: true
           - name: linux-aarch64-cpu
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
@@ -48,6 +50,7 @@ jobs:
             asset_suffix: aarch64-unknown-linux-gnu
             cuda: false
             ffi: true
+            offline: true
             # Cross-compiled on x86_64 via gcc-aarch64-linux-gnu (see the
             # "Install aarch64 cross-linker" step). Relies on a prebuilt
             # aarch64 onnxruntime being fetched by `ort` (download-binaries);
@@ -215,6 +218,106 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      # Offline all-in-one tarball: binary + pre-quantized INT8 model bundle +
+      # RUPunct punctuation model + install.sh + hardened systemd unit, for
+      # air-gapped sites that cannot fetch models from HuggingFace/GitHub at
+      # install time. Linux only (deb targets are Linux-first: Astra / ALT /
+      # RED OS via the tarball). Flows into the same SHA256SUMS / SLSA /
+      # minisign / release pipeline via the *.tar.gz globs in the publish job.
+      - name: Fetch offline model files
+        if: matrix.offline || matrix.deb
+        shell: bash
+        run: scripts/fetch_offline_models.sh "${{ runner.temp }}/offline-models"
+
+      - name: Build offline bundle
+        if: matrix.offline
+        id: package_offline
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          SUFFIX: ${{ matrix.asset_suffix }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          ASSET="gigastt-${VERSION}-offline-${SUFFIX}.tar.gz"
+          scripts/build_offline_bundle.sh \
+            --version "$VERSION" \
+            --suffix "$SUFFIX" \
+            --binary "target/${TARGET}/release/gigastt" \
+            --models "${{ runner.temp }}/offline-models" \
+            --output .
+          echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
+          echo "sha_file=${ASSET}.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload offline bundle artifact
+        if: matrix.offline
+        uses: actions/upload-artifact@v4
+        with:
+          name: gigastt-offline-${{ matrix.asset_suffix }}
+          path: |
+            ${{ steps.package_offline.outputs.asset }}
+            ${{ steps.package_offline.outputs.sha_file }}
+          if-no-files-found: error
+          retention-days: 7
+
+      # Debian packages (x86_64 only — Astra Linux / ALT / Ubuntu are amd64
+      # first; aarch64 users take the offline tarball):
+      #   gigastt_<ver>_amd64.deb        binary + systemd unit + /etc/gigastt
+      #                                  env example, built by cargo-deb from
+      #                                  [package.metadata.deb]
+      #   gigastt-model-int8_<ver>_all.deb  arch-independent model data
+      #                                  (/usr/share/gigastt/models/), built by
+      #                                  scripts/build_model_deb.sh
+      # Both flow into the publish job via the *.deb globs there.
+      - name: Install cargo-deb + dpkg-dev
+        if: matrix.deb
+        shell: bash
+        run: |
+          set -euo pipefail
+          # dpkg-dev provides dpkg-shlibdeps, which cargo-deb needs to resolve
+          # the `$auto` Depends list.
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends dpkg-dev
+          cargo install --locked --version 3.7.0 cargo-deb
+
+      - name: Build deb packages
+        if: matrix.deb
+        id: package_deb
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          # cargo-deb remaps target/release asset paths to the --target dir;
+          # the binary was already produced by the "Build release" step.
+          DEB="gigastt_${VERSION}_amd64.deb"
+          cargo deb --no-build --target "$TARGET" -p gigastt --output "$DEB"
+          sha256sum "$DEB" > "${DEB}.sha256"
+          MODEL_DEB="gigastt-model-int8_${VERSION}_all.deb"
+          scripts/build_model_deb.sh \
+            --version "$VERSION" \
+            --models "${{ runner.temp }}/offline-models" \
+            --output "$MODEL_DEB"
+          sha256sum "$MODEL_DEB" > "${MODEL_DEB}.sha256"
+          echo "deb=$DEB" >> "$GITHUB_OUTPUT"
+          echo "model_deb=$MODEL_DEB" >> "$GITHUB_OUTPUT"
+          ls -la "$DEB" "$MODEL_DEB"
+
+      - name: Upload deb artifacts
+        if: matrix.deb
+        uses: actions/upload-artifact@v4
+        with:
+          name: gigastt-deb-${{ matrix.asset_suffix }}
+          path: |
+            ${{ steps.package_deb.outputs.deb }}
+            ${{ steps.package_deb.outputs.deb }}.sha256
+            ${{ steps.package_deb.outputs.model_deb }}
+            ${{ steps.package_deb.outputs.model_deb }}.sha256
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
     name: Publish GitHub release
     needs: build
@@ -246,7 +349,8 @@ jobs:
         working-directory: dist
         run: |
           : > SHA256SUMS.txt
-          for f in *.tar.gz; do
+          for f in *.tar.gz *.deb; do
+            [ -e "$f" ] || continue
             (sha256sum "$f" 2>/dev/null || shasum -a 256 "$f") >> SHA256SUMS.txt
           done
           cat SHA256SUMS.txt
@@ -282,16 +386,17 @@ jobs:
         with:
           subject-path: |
             dist/*.tar.gz
+            dist/*.deb
             dist/SHA256SUMS.txt
             dist/*.cdx.json
 
-      # minisign signatures for tarballs + SHA256SUMS.txt. The
+      # minisign signatures for tarballs + debs + SHA256SUMS.txt. The
       # signing secret is injected via the `MINISIGN_SECRET_KEY` and
       # `MINISIGN_PASSWORD` repository secrets. When the secret is not
       # configured (forks, preview runs), the step degrades to a warning
       # so we don't break the release pipeline — minisign is added to
-      # the tarball asset list only if signing succeeds.
-      - name: Sign tarballs + SHA256SUMS with minisign
+      # the release asset list only if signing succeeds.
+      - name: Sign artifacts + SHA256SUMS with minisign
         if: env.HAS_MINISIGN_KEY == 'true'
         id: minisign
         shell: bash
@@ -309,7 +414,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends minisign
           printf '%s\n' "$MINISIGN_SECRET_KEY" > minisign.key
           chmod 600 minisign.key
-          for f in *.tar.gz SHA256SUMS.txt *.cdx.json; do
+          for f in *.tar.gz *.deb SHA256SUMS.txt *.cdx.json; do
             [ -f "$f" ] || continue
             # `-S` = sign; `-s` = secret key; `-c` = comment; `-t` = trusted
             # comment (appears in `-Vm` output). Pipe the password so
@@ -341,6 +446,7 @@ jobs:
           files: |
             dist/*.tar.gz
             dist/*.sha256
+            dist/*.deb
             dist/SHA256SUMS.txt
             dist/*.cdx.json
             dist/*.minisig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Air-gapped distribution: offline tarball, Debian packages, systemd unit.** Every
+  release now ships `gigastt-<ver>-offline-<target>.tar.gz` for both Linux targets —
+  binary + pre-quantized INT8 `rnnt` model + punctuation model + hardened systemd unit
+  (`ProtectSystem=strict`, `PrivateTmp`, `NoNewPrivileges`; compatible with systemd 241)
+  + `install.sh` + an offline README — alongside two Debian packages:
+  `gigastt_<ver>_<arch>.deb` (binary, unit, `/etc/gigastt/` config) and
+  `gigastt-model-int8_<ver>_all.deb` (model files under `/usr/share/gigastt/models/`).
+  All are signed like the other release assets (`.sha256`, `SHA256SUMS.txt`, minisign).
+  An installation lands and serves without a single network connection; rpm is
+  intentionally deferred (the tarball covers rpm-based distributions). See
+  `docs/deployment.md`, "Air-gapped / offline installation".
+- **Offline mode: `--offline` / `GIGASTT_OFFLINE=1`.** Every code path that would
+  download a model — `gigastt download`, the punctuation / VAD auto-fetch inside
+  `serve` — fails fast with an error naming the missing file and where to place it,
+  instead of a network timeout. All fetches funnel through a single download function
+  in `gigastt-core`, so the guard covers the model download, the pre-quantized bundle,
+  ANE packages, and the speaker / punctuation / VAD models alike. The shipped systemd
+  unit enables it via `/etc/gigastt/gigastt.env`. The `reqwest` network audit result
+  is recorded in `docs/privacy.md`.
 - **Machine-readable `gigastt download` progress (`--progress=json`).** A new opt-in
   flag (env `GIGASTT_DOWNLOAD_PROGRESS`) switches model download reporting to NDJSON on
   stdout — one JSON event per line and nothing else on stdout (the human `\r`-progress

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -1478,6 +1478,14 @@ async fn download_file(variant: ModelVariant, filename: &str, dir: &Path) -> Res
     stream_to_partial_then_finalize(&url, &final_dest, expected, filename).await
 }
 
+/// Whether air-gapped mode is active: `GIGASTT_OFFLINE` set to anything but
+/// `""` / `"0"`. In this mode every would-be network fetch fails fast with an
+/// instruction naming the missing file instead of a connect timeout.
+#[cfg(feature = "net")]
+fn offline_mode() -> bool {
+    std::env::var_os("GIGASTT_OFFLINE").is_some_and(|v| !v.is_empty() && v != "0")
+}
+
 /// Streaming download with SHA-256 verification and atomic rename.
 ///
 /// Stages the response into `<final_dest>.partial`, verifies the hash (when
@@ -1516,6 +1524,20 @@ async fn stream_to_partial_then_finalize_with_sink(
     label: &str,
     sink: &ProgressSink,
 ) -> Result<()> {
+    // Air-gapped guard: every network fetch in this crate funnels through this
+    // function, so one check here covers the model download, the prequantized
+    // bundle, ANE packages, and the speaker / punctuation / VAD models. Checked
+    // per call (not cached) so the `--offline` CLI flag, which sets the env var
+    // at startup, and an externally exported variable behave identically.
+    if offline_mode() {
+        anyhow::bail!(
+            "offline mode (GIGASTT_OFFLINE=1): refusing to download {label}; \
+             place the file at {} manually (see docs/deployment.md, \
+             \"Air-gapped / offline installation\")",
+            final_dest.display()
+        );
+    }
+
     let partial = partial_path_unique(final_dest);
 
     tracing::info!("Downloading {label}...");
@@ -3144,6 +3166,60 @@ mod tests {
         assert!(
             format!("{err}").contains("not yet published"),
             "unexpected error: {err}"
+        );
+    }
+
+    /// The offline-bundle fetch script duplicates the crate's SHA-256 pins
+    /// (it must run on a machine without gigastt installed). Silent drift —
+    /// e.g. re-quantizing the encoder and bumping only the crate constant —
+    /// would break release builds at tag time; this pins the two sources of
+    /// truth together in PR CI instead.
+    #[test]
+    fn test_fetch_offline_models_script_pins_match_crate_constants() {
+        let script_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../scripts/fetch_offline_models.sh");
+        let script = std::fs::read_to_string(&script_path).expect("read fetch_offline_models.sh");
+
+        assert!(
+            script.contains(PREQUANT_RELEASE_BASE),
+            "script must fetch the model bundle from the release the crate pins ({PREQUANT_RELEASE_BASE})"
+        );
+        assert!(
+            script.contains(PUNCT_HF_REPO),
+            "script must fetch the punctuation model from the repo the crate pins ({PUNCT_HF_REPO})"
+        );
+
+        // Join backslash-continued lines so every `fetch "URL" "DEST" "SHA"`
+        // call is a single parseable line.
+        let joined = script.replace("\\\n", " ");
+        let mut checked = 0usize;
+        for line in joined.lines() {
+            let line = line.trim();
+            if !line.starts_with("fetch ") {
+                continue;
+            }
+            let parts: Vec<&str> = line.split('"').collect();
+            assert!(parts.len() >= 6, "unparseable fetch line: {line}");
+            let (dest, sha) = (parts[3], parts[5]);
+            let file = dest.rsplit('/').next().expect("dest basename");
+            let expected = if file == ModelVariant::Rnnt.encoder_int8_file() {
+                ModelVariant::Rnnt.encoder_int8_checksum()
+            } else if let Some(c) = ModelVariant::Rnnt.checksum(file) {
+                c
+            } else if let Some((_, c)) = PUNCT_FILES.iter().find(|(f, _)| *f == file) {
+                c
+            } else {
+                panic!("script fetches {file}, which the crate has no pin for");
+            };
+            assert_eq!(
+                sha, expected,
+                "SHA-256 pin drift for {file}: script says {sha}, crate says {expected}"
+            );
+            checked += 1;
+        }
+        assert!(
+            checked >= 7,
+            "expected the script to pin at least 7 files, parsed {checked}"
         );
     }
 }

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -17,6 +17,36 @@ name = "gigastt"
 name = "benchmark"
 harness = false
 
+# Debian package built by `cargo deb` (cargo-deb) in the release workflow:
+# `gigastt_<ver>_amd64.deb` with the binary, the systemd unit, and the
+# environment-file example. The companion data package
+# `gigastt-model-int8_<ver>_all.deb` (models in /usr/share/gigastt/models/)
+# is assembled separately by scripts/build_model_deb.sh. See
+# docs/deployment.md, "Air-gapped / offline installation".
+[package.metadata.deb]
+maintainer = "Evgeny Khodzitsky <e@khodzitsky.ru>"
+license-file = ["../../LICENSE", "0"]
+depends = "$auto"
+section = "sound"
+priority = "optional"
+extended-description = """\
+On-device Russian speech-to-text server (WebSocket / REST / SSE on
+127.0.0.1:9876) powered by the GigaAM v3 RNN-T model via ONNX Runtime.
+No cloud APIs, no telemetry.
+.
+The model is not in this package: install the gigastt-model-int8 data
+package (offline), or let gigastt download it from HuggingFace on first
+start. Configuration: /etc/gigastt/gigastt.env; service: gigastt.service
+(not auto-enabled)."""
+assets = [
+    ["target/release/gigastt", "usr/bin/gigastt", "755"],
+    ["../../packaging/systemd/gigastt.service", "lib/systemd/system/gigastt.service", "644"],
+    ["../../packaging/systemd/gigastt.env", "etc/gigastt/gigastt.env", "644"],
+    ["../../README.md", "usr/share/doc/gigastt/README.md", "644"],
+]
+conf-files = ["/etc/gigastt/gigastt.env"]
+maintainer-scripts = "../../packaging/debian/"
+
 [features]
 default = ["diarization"]
 coreml = ["gigastt-core/coreml"]

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -20,6 +20,12 @@ struct Cli {
     #[arg(long, global = true, default_value = "info")]
     log_level: String,
 
+    /// Air-gapped mode: refuse every network fetch (model download, punctuation /
+    /// diarization / VAD auto-fetch) with an instruction naming the missing file
+    /// instead of a connect timeout. Equivalent to GIGASTT_OFFLINE=1.
+    #[arg(long, global = true)]
+    offline: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -991,6 +997,14 @@ fn log_ane_backend(resolved: ModelVariant) {
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    if cli.offline {
+        // Translate the flag into the env var the download guard in
+        // gigastt-core reads, so both spellings behave identically.
+        // Safety: this is the first statement after argument parsing — nothing
+        // has read or written the process environment concurrently yet (the
+        // only env readers live further down this same call path).
+        unsafe { std::env::set_var("GIGASTT_OFFLINE", "1") };
+    }
     // NDJSON download progress owns stdout: in `--progress=json` mode the
     // tracing writer moves to stderr so stdout carries nothing but event
     // lines (the default writer is stdout).

--- a/crates/gigastt/tests/e2e_cli.rs
+++ b/crates/gigastt/tests/e2e_cli.rs
@@ -615,3 +615,58 @@ fn cli_download_json_error_event_and_exit_code_are_consistent() {
         "exit code must match the documented mapping for kind={kind}"
     );
 }
+
+// ─── no-model: air-gapped mode (GIGASTT_OFFLINE / --offline) ────────────────
+
+/// With the env var set and an empty model dir, download must fail fast with
+/// an instruction naming the missing file — not a network timeout. Hermetic:
+/// no model, no network (the guard fires before any connection attempt).
+#[test]
+fn cli_download_offline_env_fails_fast_with_instruction() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = Command::new(bin())
+        .env("GIGASTT_OFFLINE", "1")
+        .args([
+            "download",
+            "--model-dir",
+            tmp.path().to_str().unwrap(),
+            "--model-variant",
+            "rnnt",
+            "--skip-diarization",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "offline download must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("offline mode"),
+        "error must explain offline mode, got: {stderr}"
+    );
+    assert!(
+        stderr.contains(tmp.path().to_str().unwrap()),
+        "error must name where to place the file, got: {stderr}"
+    );
+}
+
+/// The --offline flag is equivalent to GIGASTT_OFFLINE=1.
+#[test]
+fn cli_download_offline_flag_fails_fast() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = Command::new(bin())
+        .args([
+            "download",
+            "--offline",
+            "--model-dir",
+            tmp.path().to_str().unwrap(),
+            "--model-variant",
+            "rnnt",
+            "--skip-diarization",
+        ])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "--offline download must fail");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("offline mode"),
+        "error must explain offline mode"
+    );
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,10 @@ gigastt [OPTIONS] <COMMAND>
 
 Options:
   --log-level <LEVEL>    Log level [default: info]
+  --offline              Air-gapped mode (env: GIGASTT_OFFLINE=1): refuse every
+                         network fetch — model download, punctuation/VAD
+                         auto-fetch — with an error naming the missing file
+                         instead of a connect timeout
 
 Commands:
   serve        Start STT server

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -304,6 +304,43 @@ services:
 
 If you observe clients hanging past the cap or not receiving `Final` on deploy, see `docs/runbook.md` for the rollback escape hatches.
 
+## Air-gapped / offline installation
+
+For hosts with no internet access, every release publishes a self-contained
+tarball per Linux target — `gigastt-<ver>-offline-<target>.tar.gz` (binary +
+INT8 `rnnt` model + punctuation model + systemd unit + `install.sh`) — plus two
+Debian packages: `gigastt_<ver>_<arch>.deb` (binary + unit) and
+`gigastt-model-int8_<ver>_all.deb` (the same model set under
+`/usr/share/gigastt/models/`). All are signed like the other release assets
+(per-asset `.sha256`, `SHA256SUMS.txt`, minisign).
+
+```sh
+# Tarball flow (any distro, incl. rpm-based like RED OS — rpm is deferred):
+tar xf gigastt-<ver>-offline-x86_64-unknown-linux-gnu.tar.gz
+cd gigastt-<ver>-offline && sudo ./install.sh   # binary, model, unit, gigastt user
+sudo systemctl start gigastt
+curl 127.0.0.1:9876/health
+
+# Debian flow:
+sudo dpkg -i gigastt_<ver>_amd64.deb gigastt-model-int8_<ver>_all.deb
+sudo systemctl start gigastt
+```
+
+**Offline mode.** `GIGASTT_OFFLINE=1` (or the `--offline` flag) makes every
+code path that would download a model — `gigastt download`, the punctuation /
+VAD auto-fetch inside `serve` — fail fast with an error naming the file to
+provide and where to put it, instead of a network timeout. The shipped systemd
+unit sets it via `/etc/gigastt/gigastt.env`, so the service never attempts a
+connection. To add optional models later (speaker diarization, other
+recognition heads), fetch them on a connected machine with `gigastt download`
+and copy the files into the model directory; see the bundled
+`README-OFFLINE.md` for exact paths.
+
+Note on builds: the *runtime* needs no network, but building from source does
+(`ort` fetches a prebuilt onnxruntime) — use the prebuilt artifacts above in
+air-gapped contours, or see `docs/embedding-packaging.md` for vendored-ort
+builds.
+
 ## Upgrading from 2.0.x / 2.1.x
 
 **The default recognition head changed.** Fresh installs from 2.2.0+ default to

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -29,6 +29,11 @@ The only outbound network call gigastt makes is the one-time model download:
   `istupakov/gigaam-multilingual-large-ctc-onnx` for the `ml_ctc`/`ml_ctc_large` heads).
 - Each file is SHA-256 verified before use and written atomically to disk.
 - After the initial download, gigastt operates fully offline.
+- Audited: the HTTP client (`reqwest`) is referenced from exactly one module —
+  the model downloader (`gigastt-core/src/model/mod.rs`) — and every fetch in
+  that module funnels through a single download function. No other runtime
+  code path opens outbound connections. `GIGASTT_OFFLINE=1` (or `--offline`)
+  turns even that path into a fast, instructive error for air-gapped hosts.
 
 ## Server binding
 

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,32 @@
+#!/bin/sh
+# postinst for the gigastt deb — create the service account and refresh
+# systemd. The service is intentionally NOT enabled or started here: the
+# model data package (gigastt-model-int8) or an online model download must be
+# in place first, and a 800 MB-resident service should be a deliberate
+# `systemctl enable --now gigastt` decision by the admin.
+set -e
+
+case "$1" in
+    configure)
+        if ! id gigastt >/dev/null 2>&1; then
+            NOLOGIN_SHELL="/usr/sbin/nologin"
+            [ -x "$NOLOGIN_SHELL" ] || NOLOGIN_SHELL="/sbin/nologin"
+            [ -x "$NOLOGIN_SHELL" ] || NOLOGIN_SHELL="/bin/false"
+            useradd --system --no-create-home --shell "$NOLOGIN_SHELL" gigastt || true
+        fi
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl daemon-reload || true
+        fi
+        cat <<'EOF'
+
+gigastt installed. Next steps:
+  1. Install the model data package (offline):  dpkg -i gigastt-model-int8_*_all.deb
+     …or let gigastt download the model on first start (needs network).
+  2. systemctl enable --now gigastt
+  3. curl http://127.0.0.1:9876/health
+
+EOF
+        ;;
+esac
+
+exit 0

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -1,0 +1,16 @@
+#!/bin/sh
+# postrm for the gigastt deb. Deliberately does NOT remove the `gigastt`
+# system user, /etc/gigastt, or /usr/share/gigastt: the user may be shared
+# with the model data package and stale state is harmless — removing accounts
+# or data on package removal is the kind of destructive surprise we avoid.
+set -e
+
+case "$1" in
+    remove|purge)
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl daemon-reload || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/packaging/offline/README-OFFLINE.md
+++ b/packaging/offline/README-OFFLINE.md
@@ -1,0 +1,95 @@
+# gigastt offline bundle
+
+A self-contained, **air-gapped** installation of gigastt — the local Russian
+speech-to-text server (GigaAM v3 RNN-T, INT8). Everything needed to install
+and run is inside this tarball: no HuggingFace, no GitHub, no network at all.
+
+## Contents
+
+```
+bin/gigastt                          the server / CLI binary (statically linked onnxruntime)
+models/v3_rnnt_encoder_int8.onnx     pre-quantized INT8 Conformer encoder (~225 MB)
+models/v3_rnnt_decoder.onnx          LSTM prediction network
+models/v3_rnnt_joint.onnx            RNN-T joiner
+models/v3_vocab.txt                  34-token character vocabulary
+models/punct/                        RUPunct punctuation/casing restorer (INT8 + tokenizer + config)
+systemd/gigastt.service              hardened systemd unit (systemd 241-compatible)
+systemd/gigastt.env                  environment overrides example (all defaults commented)
+install.sh                           offline installer (verifies checksums, installs everything)
+SHA256SUMS.txt                       SHA-256 of every payload file (checked by install.sh)
+LICENSE / README.md / CHANGELOG.md
+```
+
+## Quick start
+
+```sh
+tar xf gigastt-<version>-offline-<target>.tar.gz -C gigastt-offline
+cd gigastt-offline
+sudo ./install.sh
+sudo systemctl enable --now gigastt
+curl http://127.0.0.1:9876/health
+# {"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt",...}
+```
+
+Transcribe a file to verify the full pipeline:
+
+```sh
+gigastt transcribe sample.wav            # add --model-dir /usr/share/gigastt/models if running uninstalled
+```
+
+`install.sh` options: `--prefix`, `--model-root`, `--no-systemd`, `--user`
+(run `./install.sh --help`). Without systemd it prints the manual
+`gigastt serve` command instead of installing a unit.
+
+## Verify before you install
+
+The tarball itself is signed exactly like every other gigastt release
+artifact — verify it **before** unpacking on the target machine
+(see `docs/verifying-releases.md` for the full story):
+
+```sh
+# 1. SHA-256 sidecar published next to the tarball on the release page:
+sha256sum -c gigastt-<version>-offline-<target>.tar.gz.sha256
+
+# 2. minisign signature (protects against a compromised release):
+minisign -Vm gigastt-<version>-offline-<target>.tar.gz -p gigastt.pub
+
+# 3. SLSA build provenance:
+gh attestation verify gigastt-<version>-offline-<target>.tar.gz --repo ekhodzitsky/gigastt
+```
+
+Inside the bundle, `install.sh` re-verifies every payload file against
+`SHA256SUMS.txt` before copying anything (corruption check).
+
+## Installed layout
+
+| What | Path |
+|---|---|
+| Binary | `/usr/local/bin/gigastt` |
+| Models | `/usr/share/gigastt/models/` (+ `models/punct/`) |
+| systemd unit | `/etc/systemd/system/gigastt.service` |
+| Env overrides | `/etc/gigastt/gigastt.env` |
+| Service account | `gigastt` (system user, nologin) |
+
+The unit binds `127.0.0.1:9876` (loopback only), restarts on failure, and
+runs with a systemd 241-compatible hardening set (ProtectSystem=strict,
+PrivateTmp, NoNewPrivileges, …) — works on Astra Linux, RED OS and ALT.
+Model directories are read-only at runtime; logs go to the journal
+(`journalctl -u gigastt -f`).
+
+## What is NOT in the bundle
+
+These optional features download their models on first use and therefore
+still need network access (they fail open with a warning, never block
+transcription):
+
+- `--vad` (Silero VAD, off by default),
+- speaker diarization (`--diarization`, offline by default since 2.11.3),
+- the `e2e_rnnt` / `ml_ctc` / `ml_ctc_large` recognition heads
+  (fetch on a connected machine with `gigastt download --prequantized`,
+  then copy `~/.gigastt/models/` over).
+
+Prefer the `.deb` packages on Debian-family systems: `gigastt_<ver>_amd64.deb`
+(binary + unit) and `gigastt-model-int8_<ver>_all.deb` (this same model set)
+are published next to this tarball. An rpm package is intentionally deferred
+— RED OS and other rpm-based distributions should use this tarball for now.

--- a/packaging/offline/README-OFFLINE.md
+++ b/packaging/offline/README-OFFLINE.md
@@ -79,12 +79,15 @@ Model directories are read-only at runtime; logs go to the journal
 
 ## What is NOT in the bundle
 
-These optional features download their models on first use and therefore
-still need network access (they fail open with a warning, never block
-transcription):
+These optional features need model files that are not part of the bundle.
+The shipped systemd unit runs with `GIGASTT_OFFLINE=1`, so a missing file is
+a fast, instructive error naming the path to fill — never a network attempt
+or a connect timeout:
 
 - `--vad` (Silero VAD, off by default),
-- speaker diarization (`--diarization`, offline by default since 2.11.3),
+- speaker diarization (opt-in per request: `?diarization=true` on REST,
+  `Configure{diarization}` over WebSocket; needs the speaker model fetched by
+  `gigastt download` on a connected machine and copied over),
 - the `e2e_rnnt` / `ml_ctc` / `ml_ctc_large` recognition heads
   (fetch on a connected machine with `gigastt download --prequantized`,
   then copy `~/.gigastt/models/` over).

--- a/packaging/offline/install.sh
+++ b/packaging/offline/install.sh
@@ -114,7 +114,7 @@ if [ "$SYSTEMD" = "yes" ]; then
     install -d /etc/gigastt
     if [ ! -f /etc/gigastt/gigastt.env ]; then
         install -m 0644 "${BUNDLE_DIR}/systemd/gigastt.env" /etc/gigastt/gigastt.env
-        echo "   installed /etc/gigastt/gigastt.env (all defaults commented out)"
+        echo "   installed /etc/gigastt/gigastt.env (offline mode on; other defaults commented out)"
     else
         echo "   kept existing /etc/gigastt/gigastt.env"
     fi

--- a/packaging/offline/install.sh
+++ b/packaging/offline/install.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# install.sh — offline installer shipped inside gigastt-<ver>-offline-<target>.tar.gz.
+#
+# Installs the gigastt binary, the pre-quantized INT8 model, the punctuation
+# model, and (on systemd hosts) the gigastt.service unit — with no network
+# access whatsoever. Everything this script needs is inside the tarball.
+#
+# Usage (from the unpacked tarball directory):
+#   sudo ./install.sh [options]
+#
+# Options:
+#   --prefix DIR      Binary install prefix        (default: /usr/local)
+#   --model-root DIR  Model install root           (default: /usr/share/gigastt)
+#   --systemd         Force-install the systemd unit + gigastt user
+#   --no-systemd      Skip the systemd unit entirely (manual `gigastt serve`)
+#   --user NAME       Service account to create/use (default: gigastt)
+#   -h, --help        Show this help
+#
+# Defaults auto-detect systemd: the unit is installed when systemctl exists.
+
+set -euo pipefail
+
+PREFIX="/usr/local"
+MODEL_ROOT="/usr/share/gigastt"
+SYSTEMD="auto"
+SVC_USER="gigastt"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --prefix) PREFIX="$2"; shift 2 ;;
+        --model-root) MODEL_ROOT="$2"; shift 2 ;;
+        --systemd) SYSTEMD="yes"; shift ;;
+        --no-systemd) SYSTEMD="no"; shift ;;
+        --user) SVC_USER="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,20p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option '$1' (see --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+BUNDLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "error: run as root (sudo ./install.sh) — installing to ${PREFIX} and" >&2
+    echo "       ${MODEL_ROOT} requires elevated privileges" >&2
+    exit 1
+fi
+
+if [ "$SYSTEMD" = "auto" ]; then
+    if command -v systemctl >/dev/null 2>&1 && [ -d /etc/systemd/system ]; then
+        SYSTEMD="yes"
+    else
+        SYSTEMD="no"
+    fi
+fi
+
+# 1. Integrity: verify every payload file against the sums generated at
+#    bundle-build time (covers bin/ and models/). This is a corruption check;
+#    for supply-chain verification check the release-page .minisig signature
+#    first (see README-OFFLINE.md).
+echo ">> verifying bundle integrity (SHA256SUMS.txt)"
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$BUNDLE_DIR" && sha256sum -c SHA256SUMS.txt)
+else
+    (cd "$BUNDLE_DIR" && shasum -a 256 -c SHA256SUMS.txt)
+fi
+
+# 2. Binary.
+echo ">> installing binary to ${PREFIX}/bin/gigastt"
+install -d "${PREFIX}/bin"
+install -m 0755 "${BUNDLE_DIR}/bin/gigastt" "${PREFIX}/bin/gigastt"
+
+# 3. Models (world-readable; the service runs unprivileged and only reads).
+echo ">> installing models to ${MODEL_ROOT}/models"
+install -d "${MODEL_ROOT}/models/punct"
+install -m 0644 \
+    "${BUNDLE_DIR}/models/v3_rnnt_encoder_int8.onnx" \
+    "${BUNDLE_DIR}/models/v3_rnnt_decoder.onnx" \
+    "${BUNDLE_DIR}/models/v3_rnnt_joint.onnx" \
+    "${BUNDLE_DIR}/models/v3_vocab.txt" \
+    "${MODEL_ROOT}/models/"
+install -m 0644 \
+    "${BUNDLE_DIR}/models/punct/rupunct_small_int8.onnx" \
+    "${BUNDLE_DIR}/models/punct/tokenizer.json" \
+    "${BUNDLE_DIR}/models/punct/config.json" \
+    "${MODEL_ROOT}/models/punct/"
+
+# 4. systemd unit + service account.
+if [ "$SYSTEMD" = "yes" ]; then
+    echo ">> installing systemd unit"
+    if ! id "$SVC_USER" >/dev/null 2>&1; then
+        NOLOGIN_SHELL="/usr/sbin/nologin"
+        [ -x "$NOLOGIN_SHELL" ] || NOLOGIN_SHELL="/sbin/nologin"
+        [ -x "$NOLOGIN_SHELL" ] || NOLOGIN_SHELL="/bin/false"
+        useradd --system --no-create-home --shell "$NOLOGIN_SHELL" "$SVC_USER"
+        echo "   created system user '${SVC_USER}'"
+    fi
+
+    # Point the unit at the chosen prefix/model root when they differ from
+    # the deb defaults (/usr/bin, /usr/share/gigastt).
+    sed \
+        -e "s|/usr/bin/gigastt|${PREFIX}/bin/gigastt|" \
+        -e "s|/usr/share/gigastt|${MODEL_ROOT}|g" \
+        -e "s|^User=gigastt$|User=${SVC_USER}|" \
+        -e "s|^Group=gigastt$|Group=${SVC_USER}|" \
+        "${BUNDLE_DIR}/systemd/gigastt.service" > /etc/systemd/system/gigastt.service
+    chmod 0644 /etc/systemd/system/gigastt.service
+
+    install -d /etc/gigastt
+    if [ ! -f /etc/gigastt/gigastt.env ]; then
+        install -m 0644 "${BUNDLE_DIR}/systemd/gigastt.env" /etc/gigastt/gigastt.env
+        echo "   installed /etc/gigastt/gigastt.env (all defaults commented out)"
+    else
+        echo "   kept existing /etc/gigastt/gigastt.env"
+    fi
+
+    # Tolerate systemd being installed but not running (chroot, containers,
+    # debootstrap) — the unit file is in place either way.
+    if ! systemctl daemon-reload 2>/dev/null; then
+        echo "   (systemd not running — skipped daemon-reload)"
+    fi
+fi
+
+cat <<EOF
+
+gigastt installed successfully (fully offline — no downloads needed).
+
+EOF
+if [ "$SYSTEMD" = "yes" ]; then
+    cat <<EOF
+Start the service:
+  systemctl enable --now gigastt
+  systemctl status gigastt
+  curl http://127.0.0.1:9876/health
+
+Logs:  journalctl -u gigastt -f
+EOF
+else
+    cat <<EOF
+Start manually:
+  ${PREFIX}/bin/gigastt serve --model-dir ${MODEL_ROOT}/models --punct-model-dir ${MODEL_ROOT}/models/punct
+  curl http://127.0.0.1:9876/health
+EOF
+fi

--- a/packaging/systemd/gigastt.env
+++ b/packaging/systemd/gigastt.env
@@ -9,6 +9,13 @@
 # Keep the server on 127.0.0.1 and put a TLS-terminating reverse proxy in
 # front for remote access (docs/deployment.md).
 
+# Air-gapped guarantee for the service: any code path that would fetch a
+# model over the network fails fast with an instruction naming the missing
+# file instead. The service never needs the network — models are installed
+# by the offline bundle / model deb. Comment out only if you want `serve`
+# to auto-fetch optional models (punctuation, VAD) on first use.
+GIGASTT_OFFLINE=1
+
 # Log verbosity (tracing env-filter syntax).
 #RUST_LOG=gigastt=info
 

--- a/packaging/systemd/gigastt.env
+++ b/packaging/systemd/gigastt.env
@@ -1,0 +1,35 @@
+# Environment overrides for the gigastt systemd service
+# (/etc/gigastt/gigastt.env, loaded via EnvironmentFile in gigastt.service).
+#
+# Everything is commented out: the shipped defaults are production-safe.
+# Uncomment and adjust only what you need, then `systemctl restart gigastt`.
+#
+# The listen address and port are CLI flags (--host / --port), not env vars —
+# override ExecStart with a drop-in (`systemctl edit gigastt`) to change them.
+# Keep the server on 127.0.0.1 and put a TLS-terminating reverse proxy in
+# front for remote access (docs/deployment.md).
+
+# Log verbosity (tracing env-filter syntax).
+#RUST_LOG=gigastt=info
+
+# Recognition head: rnnt (default), e2e_rnnt, ml_ctc, ml_ctc_large.
+# Usually auto-detected from the installed model files; set only to pin it.
+#GIGASTT_MODEL_VARIANT=rnnt
+
+# Punctuation/casing restoration and inverse text normalization: on|off|auto.
+#GIGASTT_PUNCTUATION=auto
+#GIGASTT_ITN=auto
+
+# Runtime limits (defaults shown).
+#GIGASTT_IDLE_TIMEOUT_SECS=300
+#GIGASTT_MAX_SESSION_SECS=3600
+#GIGASTT_INFERENCE_TIMEOUT_SECS=600
+#GIGASTT_SHUTDOWN_DRAIN_SECS=10
+
+# Per-IP rate limiting (0 = disabled).
+#GIGASTT_RATE_LIMIT_PER_MINUTE=0
+#GIGASTT_RATE_LIMIT_BURST=10
+
+# Prometheus metrics on a separate loopback listener.
+#GIGASTT_METRICS=false
+#GIGASTT_METRICS_LISTEN=127.0.0.1:9090

--- a/packaging/systemd/gigastt.service
+++ b/packaging/systemd/gigastt.service
@@ -1,0 +1,60 @@
+# systemd unit for the gigastt speech-to-text server.
+#
+# Shipped in the `gigastt` deb package and in the offline all-in-one tarball
+# (see packaging/offline/ and docs/deployment.md, "Air-gapped / offline
+# installation").
+#
+# Compatibility: every directive below is available in systemd 241 or older,
+# so the unit works on Astra Linux, RED OS and ALT without modification.
+# Do NOT add directives introduced after 241 (e.g. ProtectProc, ProtectClock,
+# ProtectHostname, RestrictSUIDSGID) — they break on those targets.
+
+[Unit]
+Description=gigastt local speech-to-text server (GigaAM v3, Russian)
+Documentation=https://github.com/ekhodzitsky/gigastt
+After=network.target
+
+[Service]
+Type=simple
+User=gigastt
+Group=gigastt
+
+# Optional environment overrides (RUST_LOG, GIGASTT_* — see the shipped
+# example). The `-` prefix makes a missing file non-fatal.
+EnvironmentFile=-/etc/gigastt/gigastt.env
+
+# Model and punctuation-model directories are passed explicitly: the gigastt
+# user has no $HOME, so the default ~/.gigastt/models lookup would not work.
+# Both directories are read-only at runtime (all models are pre-installed);
+# gigastt never writes to them once the files are present.
+#
+# The server binds 127.0.0.1:9876 by default (loopback only). Do NOT add
+# --bind-all here; expose the API through a reverse proxy instead
+# (docs/deployment.md). To change the port or add flags, create a drop-in
+# with `systemctl edit gigastt` instead of editing this file.
+ExecStart=/usr/bin/gigastt serve \
+    --model-dir /usr/share/gigastt/models \
+    --punct-model-dir /usr/share/gigastt/models/punct
+
+Restart=on-failure
+RestartSec=5
+
+# Hardening. The server needs no capabilities, no writable filesystem (models
+# are pre-installed, logs go to the journal), and no devices/kernel knobs.
+NoNewPrivileges=true
+CapabilityBoundingSet=
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictRealtime=true
+RestrictNamespaces=true
+LockPersonality=true
+# Loopback HTTP only: no DNS, no AF_NETLINK, no packet sockets.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/build_model_deb.sh
+++ b/scripts/build_model_deb.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# build_model_deb.sh — build gigastt-model-int8_<version>_all.deb, the
+# architecture-independent data package holding the pre-quantized INT8 model
+# and the punctuation model under /usr/share/gigastt/models/.
+#
+# Companion to the `gigastt` deb built by cargo-deb (see
+# [package.metadata.deb] in crates/gigastt/Cargo.toml). A data-only package
+# has no cargo involvement, so plain dpkg-deb is used.
+#
+# Model files must be fetched beforehand (SHA-256-verified) by
+# scripts/fetch_offline_models.sh.
+#
+# Usage:
+#   scripts/build_model_deb.sh \
+#       --version 2.12.0 \
+#       --models /path/to/offline-models \
+#       --output gigastt-model-int8_2.12.0_all.deb
+
+set -euo pipefail
+
+PACKAGE="gigastt-model-int8"
+VERSION=""
+MODELS=""
+OUTPUT=""
+
+usage() {
+    sed -n '2,18p' "$0"
+    exit "${1:-2}"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version) VERSION="$2"; shift 2 ;;
+        --models) MODELS="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        -h|--help) usage 0 ;;
+        *) echo "error: unknown option '$1'" >&2; usage ;;
+    esac
+done
+
+[ -n "$VERSION" ] || { echo "error: --version is required" >&2; usage; }
+[ -n "$MODELS" ] || { echo "error: --models is required" >&2; usage; }
+[ -n "$OUTPUT" ] || OUTPUT="${PACKAGE}_${VERSION}_all.deb"
+command -v dpkg-deb >/dev/null 2>&1 || { echo "error: dpkg-deb not found (install dpkg)" >&2; exit 1; }
+
+MODEL_FILES=(v3_rnnt_encoder_int8.onnx v3_rnnt_decoder.onnx v3_rnnt_joint.onnx v3_vocab.txt)
+PUNCT_FILES=(rupunct_small_int8.onnx tokenizer.json config.json)
+for f in "${MODEL_FILES[@]}"; do
+    [ -f "${MODELS}/${f}" ] || { echo "error: missing ${MODELS}/${f} (run scripts/fetch_offline_models.sh first)" >&2; exit 1; }
+done
+for f in "${PUNCT_FILES[@]}"; do
+    [ -f "${MODELS}/punct/${f}" ] || { echo "error: missing ${MODELS}/punct/${f}" >&2; exit 1; }
+done
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+DATA_DIR="${STAGE}/usr/share/gigastt/models"
+mkdir -p "${STAGE}/DEBIAN" "${DATA_DIR}/punct"
+
+for f in "${MODEL_FILES[@]}"; do
+    install -m 0644 "${MODELS}/${f}" "$DATA_DIR/"
+done
+for f in "${PUNCT_FILES[@]}"; do
+    install -m 0644 "${MODELS}/punct/${f}" "${DATA_DIR}/punct/"
+done
+
+INSTALLED_SIZE="$(du -sk "$STAGE" | awk '{print $1}')"
+
+cat > "${STAGE}/DEBIAN/control" <<EOF
+Package: ${PACKAGE}
+Version: ${VERSION}
+Section: sound
+Priority: optional
+Architecture: all
+Installed-Size: ${INSTALLED_SIZE}
+Maintainer: Evgeny Khodzitsky <e@khodzitsky.ru>
+Homepage: https://github.com/ekhodzitsky/gigastt
+Description: GigaAM v3 INT8 speech-recognition model data for gigastt
+ Pre-quantized INT8 model files for the gigastt speech-to-text server:
+ the rnnt head (encoder + decoder + joiner + vocab) plus the RUPunct
+ punctuation/casing model, installed under /usr/share/gigastt/models/.
+ .
+ With this package installed, gigastt starts with no network access —
+ suitable for air-gapped deployments. Ships the same SHA-256-verified
+ files as the offline tarball and \`gigastt download --prequantized\`.
+EOF
+
+# md5sums enable `dpkg --verify` on the installed payload.
+(cd "$STAGE" && find usr -type f | LC_ALL=C sort | xargs md5sum > DEBIAN/md5sums) 2>/dev/null \
+    || (cd "$STAGE" && find usr -type f | LC_ALL=C sort | xargs md5 -r > DEBIAN/md5sums)
+
+dpkg-deb --build --root-owner-group "$STAGE" "$OUTPUT"
+ls -la "$OUTPUT"
+echo "model data deb ready: ${OUTPUT}"

--- a/scripts/build_offline_bundle.sh
+++ b/scripts/build_offline_bundle.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# build_offline_bundle.sh — assemble gigastt-<version>-offline-<suffix>.tar.gz:
+# the air-gapped all-in-one installer (binary + pre-quantized INT8 model +
+# punctuation model + systemd unit + install.sh + README-OFFLINE.md).
+#
+# Run by .github/workflows/release.yml for the Linux targets; also usable
+# locally. Model files must be fetched beforehand (and are SHA-256-verified)
+# by scripts/fetch_offline_models.sh.
+#
+# Usage:
+#   scripts/build_offline_bundle.sh \
+#       --version 2.12.0 \
+#       --suffix x86_64-unknown-linux-gnu \
+#       --binary target/x86_64-unknown-linux-gnu/release/gigastt \
+#       --models /path/to/offline-models \
+#       --output dist
+#
+# Emits <output>/gigastt-<version>-offline-<suffix>.tar.gz plus a .sha256
+# sidecar, mirroring the other release assets.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+VERSION=""
+SUFFIX=""
+BINARY=""
+MODELS=""
+OUTPUT="."
+
+usage() {
+    sed -n '2,22p' "$0"
+    exit "${1:-2}"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version) VERSION="$2"; shift 2 ;;
+        --suffix) SUFFIX="$2"; shift 2 ;;
+        --binary) BINARY="$2"; shift 2 ;;
+        --models) MODELS="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        -h|--help) usage 0 ;;
+        *) echo "error: unknown option '$1'" >&2; usage ;;
+    esac
+done
+
+for var in VERSION SUFFIX BINARY MODELS; do
+    if [ -z "${!var}" ]; then
+        echo "error: --$(echo "$var" | tr '[:upper:]' '[:lower:]') is required" >&2
+        usage
+    fi
+done
+
+[ -f "$BINARY" ] || { echo "error: binary not found: $BINARY" >&2; exit 1; }
+
+MODEL_FILES=(v3_rnnt_encoder_int8.onnx v3_rnnt_decoder.onnx v3_rnnt_joint.onnx v3_vocab.txt)
+PUNCT_FILES=(rupunct_small_int8.onnx tokenizer.json config.json)
+for f in "${MODEL_FILES[@]}"; do
+    [ -f "${MODELS}/${f}" ] || { echo "error: missing model file ${MODELS}/${f} (run scripts/fetch_offline_models.sh first)" >&2; exit 1; }
+done
+for f in "${PUNCT_FILES[@]}"; do
+    [ -f "${MODELS}/punct/${f}" ] || { echo "error: missing model file ${MODELS}/punct/${f}" >&2; exit 1; }
+done
+
+ASSET="gigastt-${VERSION}-offline-${SUFFIX}.tar.gz"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+mkdir -p "${STAGE}/bin" "${STAGE}/models/punct" "${STAGE}/systemd"
+
+install -m 0755 "$BINARY" "${STAGE}/bin/gigastt"
+for f in "${MODEL_FILES[@]}"; do
+    install -m 0644 "${MODELS}/${f}" "${STAGE}/models/"
+done
+for f in "${PUNCT_FILES[@]}"; do
+    install -m 0644 "${MODELS}/punct/${f}" "${STAGE}/models/punct/"
+done
+
+install -m 0644 "${REPO_ROOT}/packaging/systemd/gigastt.service" "${REPO_ROOT}/packaging/systemd/gigastt.env" "${STAGE}/systemd/"
+install -m 0755 "${REPO_ROOT}/packaging/offline/install.sh" "${STAGE}/install.sh"
+install -m 0644 "${REPO_ROOT}/packaging/offline/README-OFFLINE.md" "${STAGE}/README-OFFLINE.md"
+for f in LICENSE README.md CHANGELOG.md; do
+    [ -f "${REPO_ROOT}/${f}" ] && install -m 0644 "${REPO_ROOT}/${f}" "${STAGE}/${f}"
+done
+
+# In-bundle integrity manifest: install.sh verifies this before copying.
+# Covers the executable payload only (bin/ + models/).
+(cd "$STAGE" && find bin models -type f | LC_ALL=C sort | xargs sha256sum > SHA256SUMS.txt)
+
+mkdir -p "$OUTPUT"
+tar -C "$STAGE" -czf "${OUTPUT}/${ASSET}" .
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$OUTPUT" && sha256sum "$ASSET" > "${ASSET}.sha256")
+else
+    (cd "$OUTPUT" && shasum -a 256 "$ASSET" > "${ASSET}.sha256")
+fi
+
+ls -la "${OUTPUT}/${ASSET}" "${OUTPUT}/${ASSET}.sha256"
+echo "offline bundle ready: ${OUTPUT}/${ASSET}"

--- a/scripts/fetch_offline_models.sh
+++ b/scripts/fetch_offline_models.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# fetch_offline_models.sh — download the model files shipped inside the
+# offline all-in-one tarball and the gigastt-model-int8 data deb.
+#
+# Fetches the pre-quantized INT8 `rnnt` bundle from the pinned gigastt model
+# release (the same source `gigastt download --prequantized` uses) plus the
+# RUPunct punctuation model from HuggingFace, and verifies every file against
+# the SHA-256 pinned in crates/gigastt-core/src/model/mod.rs — the constants
+# below MUST mirror RNNT_CHECKSUMS / ModelVariant::encoder_int8_checksum /
+# PUNCT_FILES there; bump both places together when re-quantizing.
+#
+# Usage: scripts/fetch_offline_models.sh <dest-dir>
+#
+# Output layout consumed by build_offline_bundle.sh and build_model_deb.sh:
+#   <dest>/v3_rnnt_encoder_int8.onnx
+#   <dest>/v3_rnnt_decoder.onnx
+#   <dest>/v3_rnnt_joint.onnx
+#   <dest>/v3_vocab.txt
+#   <dest>/punct/rupunct_small_int8.onnx
+#   <dest>/punct/tokenizer.json
+#   <dest>/punct/config.json
+#
+# Idempotent: a file already present with a matching checksum is not
+# re-downloaded.
+
+set -euo pipefail
+
+PREQUANT_BASE="https://github.com/ekhodzitsky/gigastt/releases/download/models-v3-2026-06-22"
+PUNCT_BASE="https://huggingface.co/ekhodzitsky/rupunct-small-onnx/resolve/main"
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <dest-dir>" >&2
+    exit 2
+fi
+DEST="$1"
+mkdir -p "$DEST/punct"
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+download() {
+    local url="$1" out="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fSL --retry 3 --retry-delay 5 -o "$out" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -O "$out" "$url"
+    else
+        echo "error: neither curl nor wget found on PATH" >&2
+        exit 1
+    fi
+}
+
+# fetch <url> <dest-file> <pinned-sha256>
+fetch() {
+    local url="$1" dest="$2" want="$3"
+    if [ -f "$dest" ] && [ "$(sha256_of "$dest")" = "$want" ]; then
+        echo "ok (cached): ${dest}"
+        return 0
+    fi
+    echo "fetching: ${url}"
+    download "$url" "${dest}.partial"
+    local got
+    got="$(sha256_of "${dest}.partial")"
+    if [ "$got" != "$want" ]; then
+        rm -f "${dest}.partial"
+        echo "error: SHA-256 mismatch for ${dest}" >&2
+        echo "  want: ${want}" >&2
+        echo "  got:  ${got}" >&2
+        exit 1
+    fi
+    mv "${dest}.partial" "$dest"
+    echo "ok: ${dest}"
+}
+
+fetch "${PREQUANT_BASE}/v3_rnnt_encoder_int8.onnx" "${DEST}/v3_rnnt_encoder_int8.onnx" \
+    "c52665e9d96c4ca3a153c063d2ee9af6c567fe2975ca50fd038b75bbf2f60e7f"
+fetch "${PREQUANT_BASE}/v3_rnnt_decoder.onnx" "${DEST}/v3_rnnt_decoder.onnx" \
+    "443c3b7bd42b453611618135d6b1e7d9467e5dd97c8a68501da4aa355750c0da"
+fetch "${PREQUANT_BASE}/v3_rnnt_joint.onnx" "${DEST}/v3_rnnt_joint.onnx" \
+    "fd1d02f45c2ad3d6b67cc149811ad794ab4b020ed49a0a9e2790a8619d1cddd8"
+fetch "${PREQUANT_BASE}/v3_vocab.txt" "${DEST}/v3_vocab.txt" \
+    "a9143c30844d3c0bee3e9e927e4084774eb1b9eeaafc473b2c4521e4911a7c07"
+
+fetch "${PUNCT_BASE}/rupunct_small_int8.onnx" "${DEST}/punct/rupunct_small_int8.onnx" \
+    "b105da023474d98aa13ba18953ae67b04b17bd0595034bc06030c17536893933"
+fetch "${PUNCT_BASE}/tokenizer.json" "${DEST}/punct/tokenizer.json" \
+    "7ca617388c2092a3a84272025c52bbf3c6db0aee225c0351186295c0b5d3ddc6"
+fetch "${PUNCT_BASE}/config.json" "${DEST}/punct/config.json" \
+    "6924a8cf41ec2bd3a3aa73a387ae0ccd0aed253ec7cac4d2f53c7d27440891eb"
+
+echo "All offline model files ready in ${DEST}"


### PR DESCRIPTION
## Summary

Air-gapped distribution for closed-contour deployments (the precondition for Astra compatibility and registry work):

- **Offline all-in-one tarball** `gigastt-<ver>-offline-<target>.tar.gz` per Linux target: binary + pre-quantized INT8 `rnnt` model + punctuation model + hardened systemd unit + `install.sh` (re-verifies every payload against `SHA256SUMS.txt`) + README-OFFLINE. Assembled by `release.yml`, signed like every other asset (`.sha256`, `SHA256SUMS.txt`, minisign, SLSA).
- **Debian packages** via cargo-deb: `gigastt_<ver>_<arch>.deb` (binary in `/usr/bin`, unit, `/etc/gigastt/` config) + `gigastt-model-int8_<ver>_all.deb` (models under `/usr/share/gigastt/models/`).
- **systemd unit** with a systemd-241-compatible hardening set (`ProtectSystem=strict`, `PrivateTmp`, `NoNewPrivileges`) for Astra / RED OS / ALT; the shipped unit runs with `GIGASTT_OFFLINE=1` via `/etc/gigastt/gigastt.env`.
- **Offline mode: `--offline` / `GIGASTT_OFFLINE=1`.** Every network fetch in `gigastt-core` funnels through one download function, so a single guard covers the model download, the prequantized bundle, ANE packages, and the speaker/punctuation/VAD models: each would-be fetch fails fast with an error naming the missing file and its destination instead of a connect timeout. No new public API (env-checked inside the crate).
- Docs: `docs/deployment.md` gains the "Air-gapped / offline installation" section (previously dangling-referenced by three shipped files), `docs/privacy.md` records the `reqwest` network-audit result, `docs/cli.md` documents `--offline`. README-OFFLINE's diarization note corrected to the shipped semantics (per-request `?diarization=true` / WS `Configure`; there is no `--diarization` flag).

## Testing

- Hermetic subprocess tests (PR CI, no model, no network): `GIGASTT_OFFLINE=1` and `--offline` both fail fast with the instructive message naming the destination path.
- Unit test pins the offline fetch script's SHA-256 checksums and release/repo URLs to the crate constants — the two sources of truth cannot drift silently (the drift would otherwise surface only at tag time).
- Local smokes on this machine: `build_offline_bundle.sh` assembled a 248 MB bundle from a locally built binary + the local model cache (correct layout, sha256 sidecar); `GIGASTT_OFFLINE=1 gigastt serve` against the installed models boots with punctuation+ITN, transcribes the golos fixture, and logs zero network attempts; `bash -n` clean on all four scripts.
- fmt/clippy/units green post-rebase onto 2.13.0.

Not verifiable before a tag: the `release.yml` additions (offline-bundle + deb steps run only on tag push) and `dpkg -i`/systemd behavior on a real Debian host — the clean-VM acceptance run remains for the next release. rpm is intentionally deferred (the tarball covers rpm-based distributions); noted in docs.