### PR TITLE
ci(spm): fail fast on invalid SWIFT_PACKAGE_TOKEN

### DIFF
--- a/.github/workflows/ios-xcframework.yml
+++ b/.github/workflows/ios-xcframework.yml
@@ -42,6 +42,32 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Fail fast: a bad SWIFT_PACKAGE_TOKEN is otherwise discovered only on
+      # the mirror push, after a ~40-minute build (public-repo clones accept
+      # any token, so the clone itself is NOT a validation). Check auth +
+      # Contents:write on the mirror repo before doing any expensive work.
+      - name: Validate SWIFT_PACKAGE_TOKEN
+        if: github.ref == 'refs/heads/main' && env.HAS_SWIFT_PACKAGE_TOKEN == 'true'
+        shell: bash
+        env:
+          SWIFT_PACKAGE_TOKEN: ${{ secrets.SWIFT_PACKAGE_TOKEN }}
+        run: |
+          set -euo pipefail
+          BODY="$RUNNER_TEMP/gigastt-swift-repo.json"
+          CODE="$(curl -sS -o "$BODY" -w '%{http_code}' \
+            -H "Authorization: Bearer ${SWIFT_PACKAGE_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/ekhodzitsky/gigastt-swift)"
+          if [ "$CODE" != "200" ]; then
+            echo "::error ::SWIFT_PACKAGE_TOKEN was rejected by the GitHub API (HTTP $CODE). Recreate the secret with a valid fine-grained PAT (Contents: write on ekhodzitsky/gigastt-swift)."
+            exit 1
+          fi
+          if [ "$(jq -r '.permissions.push // false' "$BODY")" != "true" ]; then
+            echo "::error ::SWIFT_PACKAGE_TOKEN is valid but lacks Contents:write on ekhodzitsky/gigastt-swift."
+            exit 1
+          fi
+          echo "SWIFT_PACKAGE_TOKEN validated (auth + Contents:write on gigastt-swift)."
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios


### PR DESCRIPTION
## Summary

Follow-up to #176: the first live run of the mirror step (v2.13.0) failed on `git push` because `SWIFT_PACKAGE_TOKEN` was rejected — and this was only discovered after a ~40-minute xcframework build. The clone inside the mirror step cannot catch this: public-repo fetches are anonymous and accept any token (verified: a garbage-token clone succeeds).

This PR adds a **Validate SWIFT_PACKAGE_TOKEN** step at the start of `build-xcframework` (only on `main` dispatches with the secret configured): it calls the GitHub API for `ekhodzitsky/gigastt-swift` and fails in seconds with an actionable `::error` when the token is rejected (HTTP ≠ 200) or lacks `Contents: write` (`permissions.push != true`).

## Verification

- Happy path: script run locally with a valid token → HTTP 200, `permissions.push == true`, exit 0.
- Failure path: garbage token → HTTP 401, clear `::error` message, exit 1.
- Workflow YAML structure validated by a parser.
- Pre-commit hook: fmt + clippy + workspace unit tests.

No behaviour change when the secret is absent (mirror step already degrades to a warning).
