### PR TITLE
docs(core): drop stale ort_err references after runtime abstraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,7 @@ The `e2e_rnnt` head (`--model-variant e2e_rnnt`) uses the parallel `v3_e2e_rnnt_
 - `tracing` for logging (never `println!` in library code)
 - **No `unwrap()` in production paths** — use `?`, `.context()`, or `unwrap_or_else`
 - Shared constants live in `inference/mod.rs`, referenced by sub-modules
-- `ort` errors wrapped via `ort_err()` helper (Send/Sync workaround for ort 2.0-rc)
+- `ort` errors are converted to typed `RuntimeError` at the `runtime/ort` seam (no `anyhow` wrapping)
 - Execution provider selection uses `#[cfg(feature = "coreml")]` / `#[cfg(feature = "cuda")]` blocks
 - **No internal task-tracker IDs in code/docs.** Never write tracker indices (`V1-NN`, `SUS-NN`, `TODO-NN`, etc.) into source comments, `CHANGELOG.md`, `docs/`, CI files, or any artifact — they mean nothing to a reader without the tracker. Comments should say *what* and *why*; the link from a fix to a tracked item lives only in `specs/prod-readiness-v1.0.md`, not in the code.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Three-tier test architecture:
 - `anyhow` for error handling, `tracing` for logging
 - No `unwrap()` in production paths (use `?`, `context()`, or `unwrap_or_else`)
 - Shared constants in `crates/gigastt-core/src/inference/mod.rs`, referenced by sub-modules
-- `ort` errors wrapped via `ort_err()` helper (Send/Sync workaround)
+- `ort` errors are converted to typed `RuntimeError` at the `runtime/ort` seam (no `anyhow` wrapping)
 - Execution provider selection uses `#[cfg(feature = "coreml")]` / `#[cfg(feature = "cuda")]` blocks in `crates/gigastt-core/src/inference/mod.rs`; default falls through to CPU EP
 - **No internal task-tracker IDs in code/docs.** Never write tracker indices (`V1-NN`, `SUS-NN`, `TODO-NN`, etc.) into source comments, `CHANGELOG.md`, `docs/`, CI files, or any artifact — they are noise to anyone without the tracker. Describe *what* the code does and *why*; if a fix maps to a tracked item, that linkage lives only in `specs/prod-readiness-v1.0.md` (the tracker), not in the code.
 

--- a/crates/gigastt-core/src/punctuation.rs
+++ b/crates/gigastt-core/src/punctuation.rs
@@ -488,8 +488,8 @@ mod tests {
     }
 
     /// config + tokenizer both load, but the ONNX model file is absent: `load`
-    /// must fail at `Session::commit_from_file` (the `ort_err` + context branch),
-    /// never panic. This is the last gate the caller turns into "punct disabled".
+    /// must fail inside `OrtRuntime::load_session` (the `RuntimeError::LoadFailed`
+    /// branch), never panic. This is the last gate the caller turns into "punct disabled".
     // Skipped under Miri: this is the one punctuation-load test that drives
     // past the config + tokenizer gates into `OrtRuntime::load_session`, which
     // calls the onnxruntime C API — a foreign function Miri cannot interpret.


### PR DESCRIPTION
## Summary

The roadmap item called for removing the `ort_err()` wrapper once `ort` allowed it. Investigation found the work is already done in code: `ort_err()` was removed wholesale by the v2.4.0 runtime abstraction (PR #115) — ort errors now cross the `runtime/ort` seam as typed `RuntimeError` (`LoadFailed`/`InferenceFailed`). crates.io still has no stable ort 2.0 (newest is 2.0.0-rc.12, same as pinned), but that no longer matters: the wrapper is gone and the code contains no `ort_err`.

This PR sweeps the three stale references left behind:

- `crates/gigastt-core/src/punctuation.rs` — test doc comment referenced "the `ort_err` + context branch"; now names the actual failure path (`OrtRuntime::load_session` → `RuntimeError::LoadFailed`).
- `AGENTS.md` / `CLAUDE.md` — code-style bullet still described the removed `ort_err()` Send/Sync workaround; now describes the typed `RuntimeError` seam.

Historical mentions in `CHANGELOG.md` (release history) and `specs/` (tracker docs that already mark the item obsolete) are intentionally left untouched.

## Verified (scoped)

- `cargo fmt --check -p gigastt-core` — clean
- `cargo clippy -p gigastt-core --all-targets` — zero warnings
- `cargo test -p gigastt-core` — exit 0 (unit tests green; model-dependent tests ignored as expected)

The full workspace gate (fmt/clippy/unit tests across all crates) runs in PR CI.