### PR TITLE
docs(node): surface the npm/Electron in-process path, backfill 2.4.0 changelog artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (indistinguishable from a crash) while the model loads. A shutdown signal
   during loading exits cleanly without serving. The heavy load work runs on a
   blocking thread so the bootstrap responder stays responsive.
+- **Node.js binding: the `gigastt` npm package (napi-rs).** `crates/gigastt-node`
+  wraps the engine in an idiomatic JS API — `new Engine(modelDir, poolSize?)`,
+  `engine.transcribeFile(path)`, `stream.processChunk(pcm16, sampleRate)` /
+  `stream.flush()` — running inference on a libuv worker thread via napi's
+  `AsyncTask` (Promises, never blocking the event loop), with failures thrown as
+  JS `Error`s prefixed by a stable code (`ModelNotFound`, `InvalidAudio`,
+  `PoolExhausted`, `Inference`) matching the C-ABI / UniFFI contract across
+  bindings. It is a single JS-only package: the postinstall downloads exactly one
+  prebuilt `gigastt.<platform>.node` — onnxruntime statically linked, so the addon
+  is self-contained — from the `node-v<version>` GitHub release. Prebuilt
+  platforms: `darwin-arm64`, `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc`
+  (Intel macOS omitted — ort ships no onnxruntime for it), built per native runner
+  by the Node Prebuilds workflow. Desktop JS (Electron) gets an in-process engine
+  with no sidecar to spawn. See `crates/gigastt-node/README.md`.
+- **Pre-quantized INT8 model bundle: `gigastt download --prequantized`.**
+  Integrators can now skip the ~844 MB FP32 encoder download, the ~2-minute
+  on-device INT8 quantization pass, and the `protoc` build dependency by fetching
+  a pre-quantized bundle (INT8 encoder + decoder + joiner + vocab) directly from a
+  pinned GitHub Release; the engine prefers the INT8 encoder and runs from this
+  set alone (verified: an INT8-only model directory loads and transcribes). The
+  bundle is quantized for both heads, SHA-256 pinned, minisign-signed, and
+  published by the `release-model` workflow. Intended for embedding and
+  air-gapped installs.
+- **Android AAR packaging pipeline (experimental).** `packaging/android/` is a
+  Gradle library module (JNA + UniFFI-generated Kotlin, `jniLibs` source sets,
+  consumer ProGuard rules), and the `android-aar` workflow cross-builds
+  `libgigastt_uniffi.so` for `arm64-v8a` / `armeabi-v7a` / `x86_64` with
+  cargo-ndk, generates the Kotlin bindings, and assembles the AAR (Maven
+  publication gated on credentials). The same release also ships FFI tarballs —
+  `gigastt-ffi` cdylib + staticlib + the cbindgen C header, onnxruntime
+  statically linked — for `x86_64` and `aarch64` Linux, a drop-in embedding
+  artifact for ARM servers and Raspberry Pi.
+- **iOS xcframework + SwiftPM package.** `packaging/swift/` ships a SwiftPM
+  package (swift-tools 5.9, iOS 15+) whose binary target wraps
+  `GigasttFFI.xcframework` — the `gigastt-ffi` static library with onnxruntime
+  statically linked, so each slice is self-contained — plus a safe Swift wrapper
+  over the C ABI: `Engine` (`transcribeFile`) and `Stream` (`processChunk` /
+  `flush`) with RAII handle management, typed `GigasttError`, and Codable structs
+  matching the streaming JSON. The release workflow builds the xcframework and
+  pins its URL/checksum into `Package.swift`.
 
 ### Changed
 

--- a/crates/gigastt-node/README.md
+++ b/crates/gigastt-node/README.md
@@ -4,6 +4,28 @@ Node.js binding for [gigastt](https://github.com/ekhodzitsky/gigastt) — on-dev
 
 Wraps the synchronous `gigastt-core` engine: models are **side-loaded** (no HTTP download) and inference runs on a libuv worker thread via napi's `AsyncTask`, so calls return **Promises** and never block the event loop. Errors are thrown JS `Error`s and objects are garbage-collected (no manual free). onnxruntime is statically linked, so the `.node` addon is self-contained.
 
+## In-process (this package) vs sidecar server
+
+This package embeds the engine **inside your Node/Electron process** — desktop JS
+with no sidecar. The alternative is shipping `gigastt serve` next to your app and
+talking to it over WebSocket/REST. Pick consciously:
+
+| | In-process (`npm install gigastt`) | Sidecar (`gigastt serve` + WS/REST client) |
+|---|---|---|
+| Deployment | Single `npm install` — one prebuilt binary fetched by postinstall | Binary discovery on the user's machine, spawn, supervision, port selection |
+| Interface | Plain JS calls; errors are thrown `Error`s | Wire protocol over a loopback port (`/v1/ws`, REST, SSE) |
+| Versioning | App and engine are one artifact, shipped together | App must gate on the discovered server's version |
+| Memory | Model + pool live in your app's process (budget ~400 MB RSS per pool session) | Model lives in the separate server process |
+| Concurrency | One engine/pool instance per app process | One server shared by several apps/clients |
+| Failure isolation | An engine crash takes the app down (and vice versa) | Server crashes are isolated; the app survives and can restart it |
+| Upgrades | Redeploy the app | Upgrade the server independently of any client |
+
+Rule of thumb: a desktop app that owns its whole audio pipeline (an Electron
+recorder, a dictation tool) is simplest in-process; a setup shared by several
+clients, or one that must survive engine crashes, belongs behind the sidecar.
+For Electron, construct the `Engine` in the **main process** and keep one
+`Stream` per audio channel — see [`examples/electron_main.mjs`](../../examples/electron_main.mjs).
+
 ## API
 
 | Type | Members |

--- a/crates/gigastt-node/__test__/smoke.cjs
+++ b/crates/gigastt-node/__test__/smoke.cjs
@@ -1,7 +1,10 @@
 // Local smoke test: build the addon (`npm run build`) then `npm run smoke`.
 // Requires a side-loaded model dir (default ~/.gigastt/models) and the
-// committed golos_00.wav fixture. Asserts a non-empty Russian transcript with
-// word timings, and that a missing model throws a typed JS error.
+// committed golos_00.wav fixture (16 kHz mono PCM16). Asserts a non-empty
+// Russian transcript with word timings from `transcribeFile`, a non-empty final
+// transcript from a `Stream` fed the fixture's PCM, and that a missing model
+// throws a typed JS error.
+const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { Engine, Stream } = require('../loader.js');
@@ -41,10 +44,31 @@ function fail(msg) {
   }
   if (!threw) fail('expected a throw for a missing model dir');
 
-  // 3. streaming: feed the fixture's PCM as one 16 kHz chunk via Stream
-  if (typeof Stream === 'function') {
-    console.log('Stream export present');
+  // 3. streaming: feed the fixture's PCM through a Stream in 0.5 s chunks
+  // (little-endian mono PCM16 @ 16 kHz), then flush what remains buffered.
+  // Segments finalize mid-stream at endpoint boundaries, so finals arrive from
+  // both processChunk and flush — collect them from each.
+  const wav = fs.readFileSync(fixture);
+  const dataOff = wav.indexOf('data', 12); // data chunk descriptor
+  if (dataOff < 0) fail('fixture has no data chunk');
+  const dataSize = wav.readUInt32LE(dataOff + 4);
+  const pcm = wav.subarray(dataOff + 8, dataOff + 8 + dataSize);
+  const stream = new Stream(engine);
+  const CHUNK = 16000; // 0.5 s of 16 kHz mono PCM16 (8000 samples * 2 bytes)
+  const finals = [];
+  let partials = 0;
+  for (let off = 0; off < pcm.length; off += CHUNK) {
+    // Await each chunk before sending the next to preserve ordering.
+    for (const s of await stream.processChunk(pcm.subarray(off, off + CHUNK), 16000)) {
+      s.isFinal ? finals.push(s) : partials++;
+    }
   }
+  for (const s of await stream.flush()) {
+    s.isFinal ? finals.push(s) : partials++;
+  }
+  const streamed = finals.map((s) => s.text).join(' ').trim();
+  if (!streamed) fail('stream transcription empty');
+  console.log('streamed:', JSON.stringify(streamed), '| partial segs:', partials);
 
   console.log('SMOKE OK');
 })().catch((e) => fail(e && e.stack ? e.stack : String(e)));

--- a/crates/gigastt-node/package.json
+++ b/crates/gigastt-node/package.json
@@ -3,7 +3,21 @@
   "version": "2.11.3",
   "description": "On-device Russian speech-to-text (GigaAM v3) — Node.js binding",
   "license": "MIT",
-  "repository": "https://github.com/ekhodzitsky/gigastt",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ekhodzitsky/gigastt.git",
+    "directory": "crates/gigastt-node"
+  },
+  "homepage": "https://github.com/ekhodzitsky/gigastt#readme",
+  "keywords": [
+    "russian",
+    "speech-to-text",
+    "stt",
+    "gigaam",
+    "speech-recognition",
+    "transcription",
+    "offline"
+  ],
   "main": "loader.js",
   "types": "gigastt.d.ts",
   "files": [

--- a/docs/quickstarts.md
+++ b/docs/quickstarts.md
@@ -42,7 +42,7 @@ except g.GigasttError.ModelNotFound:
     ...
 ```
 
-## Node — `npm install gigastt`
+## Node / Electron — `npm install gigastt`
 
 ```js
 const { Engine, Stream } = require('gigastt');
@@ -60,6 +60,14 @@ console.log((await s.flush()).map((seg) => seg.text));
 // errors are thrown JS Errors (message prefixed with a stable code)
 try { new Engine('/no/such/dir'); } catch (e) { /* e.message starts "ModelNotFound:" */ }
 ```
+
+The engine runs **in-process** — no sidecar server, port, or version gate — which
+makes it the shortest path for desktop JS. In an Electron app, construct the
+`Engine` in the main process and keep one `Stream` per audio channel (e.g. mic +
+system): [examples/electron_main.mjs](../examples/electron_main.mjs). If you need
+crash isolation or one engine shared by several apps instead, run `gigastt serve`
+and use a client SDK (below); the trade-offs are tabulated in
+[crates/gigastt-node/README.md](../crates/gigastt-node/README.md).
 
 ## Swift — SwiftPM
 

--- a/examples/electron_main.mjs
+++ b/examples/electron_main.mjs
@@ -1,0 +1,97 @@
+// Electron main-process integration: in-process Russian speech-to-text via the
+// `gigastt` npm package — no sidecar server, no loopback port, no version gate,
+// no process supervision. The engine lives inside the main process.
+//
+// Pattern: one shared `Engine` (main process only — never in a renderer), one
+// `Stream` per audio channel. The dual-channel recorder case below keeps a mic
+// stream and a system-audio stream side by side; each holds one pool session
+// for its lifetime, so the pool size must cover the number of live streams.
+//
+// Prerequisites:
+//   npm install gigastt electron
+//   gigastt download --prequantized   # INT8 bundle -> ~/.gigastt/models
+//
+// This is a teaching file, not a runnable app: renderer-side audio capture is
+// sketched in comments at the bottom. The same Engine/Stream calls are exercised
+// against a real model by crates/gigastt-node/__test__/smoke.cjs (`npm run smoke`).
+
+import os from 'node:os';
+import path from 'node:path';
+import { app, BrowserWindow, ipcMain } from 'electron';
+import gigastt from 'gigastt';
+
+const { Engine, Stream } = gigastt;
+
+// The model directory is side-loaded, not bundled: fetch the pre-quantized
+// INT8 bundle once (`gigastt download --prequantized`, ~215 MB) or ship the
+// directory inside your installer. Keep it OUT of the asar archive — native
+// code memory-maps the weights, which asar's virtual filesystem does not support.
+const modelDir =
+  process.env.GIGASTT_MODEL_DIR || path.join(os.homedir(), '.gigastt', 'models');
+
+// Errors surface as thrown JS `Error`s whose message starts with a stable code
+// (`ModelNotFound`, `InvalidAudio`, `PoolExhausted`, `Inference`) — branch on
+// the prefix, show the rest to the user. A bad model path throws here, at boot,
+// instead of on the first transcription attempt.
+const engine = new Engine(modelDir, 2); // pool of 2: one session per channel
+
+// One Stream per channel: mic (local speaker) and system (remote speaker).
+// Each Stream holds one pool session until it is garbage-collected; creating a
+// third Stream on a pool of 2 throws `PoolExhausted`.
+const streams = {
+  mic: new Stream(engine),
+  system: new Stream(engine),
+};
+
+// Audio contract: little-endian mono PCM16 (`Int16Array` bytes) at 16 kHz.
+// Capture at 16 kHz mono if you can — `processChunk` resamples 8/24/44.1/48 kHz
+// internally, but feeding 16 kHz skips that work entirely.
+ipcMain.handle('stt:chunk', async (_event, channel, pcm16) => {
+  const stream = streams[channel];
+  if (!stream) throw new Error(`unknown channel: ${channel}`);
+  // Await each chunk before feeding the next one: chunks are decoded in order,
+  // and concurrent calls on one Stream would interleave audio.
+  const segments = await stream.processChunk(new Uint8Array(pcm16), 16000);
+  // Segments arrive as interim hypotheses (isFinal === false) — render them as
+  // pending text, they can still be revised — and as finals (isFinal === true)
+  // when an endpoint is detected mid-stream; finals are safe to persist.
+  return segments;
+});
+
+ipcMain.handle('stt:flush', async (_event, channel) => {
+  const stream = streams[channel];
+  if (!stream) throw new Error(`unknown channel: ${channel}`);
+  // Flush on recording stop: drains the buffered tail into the last segment(s).
+  // It may legitimately return an empty array when every segment already
+  // finalized via processChunk.
+  return stream.flush();
+});
+
+// Inference runs on libuv's worker pool (default 4 threads, shared with
+// fs/crypto). For N channels transcribing simultaneously, start Electron with
+// UV_THREADPOOL_SIZE >= N, e.g. `UV_THREADPOOL_SIZE=4 electron .`
+
+function createWindow() {
+  const win = new BrowserWindow({ width: 900, height: 600 });
+  win.loadFile('index.html'); // renderer: capture + IPC forwarding (see below)
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+// --- renderer sketch (index.html) -------------------------------------------
+// Mic channel: getUserMedia({ audio: { channelCount: 1, sampleRate: 16000 } })
+// into an AudioContext + AudioWorklet; the worklet posts Float32 frames, the
+// renderer converts to little-endian Int16 (`Math.max(-1, Math.min(1, s)) *
+// 0x7fff`) and forwards via `ipcRenderer.invoke('stt:chunk', 'mic', bytes)`.
+// System channel: same pipeline fed from `desktopCapturer` /
+// `getDisplayMedia({ audio: true })` with channel 'system'.
+// On stop: `ipcRenderer.invoke('stt:flush', channel)` and persist the finals.


### PR DESCRIPTION
## Summary

Makes the npm in-process path discoverable for Electron/JS integrators and backfills shipped-but-unlisted artifacts in the changelog.

- **`crates/gigastt-node/README.md`** — new "In-process vs sidecar server" section: a decision table (no port / external process / version gate in-process vs crash isolation, multi-app sharing, independent upgrades behind `gigastt serve`) plus an Electron pointer (Engine in the main process, one Stream per channel).
- **`examples/electron_main.mjs`** (new) — Electron main-process teaching example in the dual-channel recorder pattern: one shared `Engine(modelDir, 2)`, `mic` + `system` Streams, `processChunk(pcm16, 16000)` returning interim **and** endpoint-finalized segments, `flush()` draining the tail (may legitimately return `[]`), typed JS errors, 16 kHz mono PCM16 input contract, asar and `UV_THREADPOOL_SIZE` caveats, renderer capture sketched in comments. Not a runnable app and not a CI target, per scope.
- **`docs/quickstarts.md`** — Node section extended to Node/Electron with a link to the example and to the sidecar trade-off table.
- **`CHANGELOG.md`** — backfills four shipped artifacts into the **2.4.0** section: the `gigastt` npm package + cross-platform prebuilds, `gigastt download --prequantized`, the Android AAR pipeline (+ ARM64/RPi FFI tarballs), and the iOS xcframework/SwiftPM package.
- **`crates/gigastt-node/package.json`** — adds `keywords` (russian, speech-to-text, stt, gigaam, speech-recognition, transcription, offline) so the package is findable by "russian stt" on npmjs, `homepage`, and `repository.directory` so the npm card links to the binding subtree. Verified the live registry card with `npm view gigastt`: description/repository were already present, keywords were missing (now fixed for the next publish).
- **`crates/gigastt-node/__test__/smoke.cjs`** — the streaming section now actually transcribes the golos fixture through a `Stream` (0.5 s PCM16 chunks → `processChunk` → `flush`) and asserts a non-empty final transcript, instead of only checking the export exists.

## Deviation from the task note

The task suggested the npm package / `--prequantized` belonged to 2.10.0. Git facts say otherwise: PRs #103–#108 are all first contained in tag **v2.4.0** (`git tag --contains <sha>`), and npmjs shows the first published npm version is 2.3.0. The changelog entries were therefore placed in the 2.4.0 section, which the acceptance criterion ("correct version sections") supports.

## Verification (scoped)

- **Smoke against the real model** (`~/.gigastt/models`, prebuilt `gigastt.darwin-arm64.node` from the `node-v2.11.0` release):
  ```sh
  cd crates/gigastt-node
  GIGASTT_NODE_TAG=node-v2.11.0 node install.js   # one-time binary fetch
  npm run smoke
  ```
  Output: `transcript: "шестьдесят тысяч тенге сколько будет стоить" | words: 6`, error path `ModelNotFound`, `streamed: "шестьдесят тысяч тенге сколь будет стоить" | partial segs: 2`, **SMOKE OK**. (The streamed text ends up slightly different from the file transcript — "сколь" vs "сколько" — because endpointing finalizes segments mid-stream; expected behavior, unchanged by this PR.)
- `node --check examples/electron_main.mjs` and `node --check crates/gigastt-node/__test__/smoke.cjs` — clean.
- `package.json` parses; `typos` clean on all changed files.
- No Rust sources changed, so cargo clippy/test have nothing to check here (docs/JS/JSON only, per the docs-only clause). The full gate (fmt/clippy/unit tests) runs in PR CI.