### PR TITLE
fix(server): harden metrics bind consent and Content-Disposition filename

### DIFF
--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -635,6 +635,23 @@ fn ensure_bind_allowed(host: &str, bind_all_flag: bool) -> anyhow::Result<()> {
     )
 }
 
+/// Consent gate for the separate metrics listener. That listener serves
+/// Prometheus `/metrics` with no CORS allowlist or rate limiter, so a
+/// non-loopback `--metrics-listen` requires the same explicit `--bind-all`
+/// (or `GIGASTT_ALLOW_BIND_ANY=1`) opt-in as the primary port — keeps the
+/// loopback-by-default invariant symmetric instead of letting telemetry leak
+/// network-wide silently. No-op when metrics are disabled: nothing is bound.
+fn ensure_metrics_bind_allowed(
+    metrics_enabled: bool,
+    metrics_listen: &std::net::SocketAddr,
+    bind_all_flag: bool,
+) -> anyhow::Result<()> {
+    if !metrics_enabled {
+        return Ok(());
+    }
+    ensure_bind_allowed(&metrics_listen.ip().to_string(), bind_all_flag)
+}
+
 fn is_loopback_host(host: &str) -> bool {
     // Accept the common human forms first.
     let lowered = host.trim().to_ascii_lowercase();
@@ -1085,13 +1102,7 @@ async fn main() -> anyhow::Result<()> {
             )?;
             let metrics_listen =
                 metrics_listen.unwrap_or_else(server::config::default_metrics_listen);
-            // The metrics listener carries no CORS allowlist or rate limiter, so
-            // a non-loopback bind requires the same explicit `--bind-all` opt-in
-            // the primary port does — keeps the loopback-by-default invariant
-            // symmetric instead of letting telemetry leak network-wide silently.
-            if metrics {
-                ensure_bind_allowed(&metrics_listen.ip().to_string(), bind_all)?;
-            }
+            ensure_metrics_bind_allowed(metrics, &metrics_listen, bind_all)?;
             let server_config = build_server_config(
                 port,
                 host,
@@ -1458,6 +1469,51 @@ mod tests {
     #[test]
     fn test_ensure_bind_allowed_explicit_flag_ok() {
         ensure_bind_allowed("0.0.0.0", true).expect("explicit --bind-all must pass");
+    }
+
+    #[test]
+    fn test_ensure_metrics_bind_allowed_disabled_skips_gate() {
+        // Metrics off: no listener is bound, so even a wildcard address needs
+        // no consent.
+        let addr = "0.0.0.0:9090".parse().unwrap();
+        ensure_metrics_bind_allowed(false, &addr, false)
+            .expect("disabled metrics listener must skip the gate");
+    }
+
+    #[test]
+    fn test_ensure_metrics_bind_allowed_loopback_ok() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let addr = "127.0.0.1:9090".parse().unwrap();
+        ensure_metrics_bind_allowed(true, &addr, false)
+            .expect("loopback metrics bind must be allowed");
+    }
+
+    #[test]
+    fn test_ensure_metrics_bind_allowed_non_loopback_requires_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var("GIGASTT_ALLOW_BIND_ANY").ok();
+        unsafe {
+            std::env::remove_var("GIGASTT_ALLOW_BIND_ANY");
+        }
+        let addr = "0.0.0.0:9090".parse().unwrap();
+        let result = ensure_metrics_bind_allowed(true, &addr, false);
+        if let Some(v) = previous {
+            unsafe {
+                std::env::set_var("GIGASTT_ALLOW_BIND_ANY", v);
+            }
+        }
+        assert!(
+            result.is_err(),
+            "0.0.0.0 metrics bind without --bind-all must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_ensure_metrics_bind_allowed_explicit_flag_ok() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let addr = "0.0.0.0:9090".parse().unwrap();
+        ensure_metrics_bind_allowed(true, &addr, true)
+            .expect("explicit --bind-all must allow the metrics bind");
     }
 
     #[test]

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -274,19 +274,19 @@ fn render_export_response(
         } else {
             filename.clone()
         };
-        // The filename is user-controlled (query param), so build the header value
-        // defensively: a filename with control characters would be an invalid
-        // header value and otherwise panic when the response is built below. Fall
-        // back to the safe default name when the requested value isn't valid.
-        let disposition =
-            header::HeaderValue::from_str(&format!("attachment; filename=\"{filename}\""))
-                .unwrap_or_else(|_| {
-                    header::HeaderValue::from_str(&format!(
-                        "attachment; filename=\"transcript.{}\"",
-                        format.extension()
-                    ))
-                    .expect("static content-disposition is always a valid header value")
-                });
+        // The filename is user-controlled (query param), so emit it as an
+        // RFC 6266 value: quotes/semicolons can no longer inject extra header
+        // parameters (filename spoofing) and non-ASCII names survive via
+        // `filename*`. The helper output is pure ASCII, which makes the header
+        // conversion infallible; keep the defensive fallback anyway.
+        let disposition = header::HeaderValue::from_str(&content_disposition_attachment(&filename))
+            .unwrap_or_else(|_| {
+                header::HeaderValue::from_str(&format!(
+                    "attachment; filename=\"transcript.{}\"",
+                    format.extension()
+                ))
+                .expect("static content-disposition is always a valid header value")
+            });
         builder = builder.header(header::CONTENT_DISPOSITION, disposition);
     }
 
@@ -298,6 +298,36 @@ fn render_export_response(
         )
     })?;
     Ok(Some(response))
+}
+
+/// Build a `Content-Disposition: attachment` value for a user-controlled
+/// filename per RFC 6266. The legacy quoted `filename=` parameter carries an
+/// ASCII fallback (`"` / `\` / control / non-ASCII characters replaced by
+/// `_`), and the full name travels percent-encoded in `filename*=UTF-8''…`
+/// (RFC 5987 attr-char set emitted verbatim, everything else as `%XX` UTF-8
+/// bytes). Without the fallback sanitization a name like `x"; filename*=…`
+/// would splice extra parameters into the header — `HeaderValue` only rejects
+/// control characters, not quotes or semicolons — letting an attacker spoof
+/// the download filename seen by the client. The output is always printable
+/// ASCII, so `HeaderValue::from_str` accepts it unconditionally.
+fn content_disposition_attachment(filename: &str) -> String {
+    let mut fallback = String::with_capacity(filename.len());
+    for c in filename.chars() {
+        match c {
+            '"' | '\\' => fallback.push('_'),
+            c if c.is_ascii() && !c.is_ascii_control() => fallback.push(c),
+            _ => fallback.push('_'),
+        }
+    }
+    let mut encoded = String::with_capacity(filename.len());
+    for &b in filename.as_bytes() {
+        if b.is_ascii_alphanumeric() || b"!#$&+-.^_`|~".contains(&b) {
+            encoded.push(char::from(b));
+        } else {
+            encoded.push_str(&format!("%{b:02X}"));
+        }
+    }
+    format!("attachment; filename=\"{fallback}\"; filename*=UTF-8''{encoded}")
 }
 
 /// Error response produced by the REST handlers. Using `Response` directly
@@ -1932,14 +1962,15 @@ mod tests {
         let resp = render_export_response(&result, &params).unwrap().unwrap();
         assert_eq!(
             resp.headers().get(header::CONTENT_DISPOSITION).unwrap(),
-            "attachment; filename=\"recording.vtt\""
+            "attachment; filename=\"recording.vtt\"; filename*=UTF-8''recording.vtt"
         );
     }
 
     #[tokio::test]
     async fn test_render_export_download_filename_with_control_char_does_not_panic() {
-        // The download filename is user-controlled; a control character must not
-        // produce an invalid header value / panic — it falls back to the default.
+        // The download filename is user-controlled; control characters must not
+        // produce an invalid header value / panic — they are sanitized out of
+        // the quoted fallback and percent-encoded in `filename*`.
         let result = sample_export_result();
         let params = ExportParams {
             format: Some("srt".into()),
@@ -1950,7 +1981,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(
             resp.headers().get(header::CONTENT_DISPOSITION).unwrap(),
-            "attachment; filename=\"transcript.srt\""
+            "attachment; filename=\"evil__Injected: x\"; filename*=UTF-8''evil%0D%0AInjected%3A%20x"
         );
     }
 
@@ -2024,8 +2055,71 @@ mod tests {
         let resp = render_export_response(&result, &params).unwrap().unwrap();
         assert_eq!(
             resp.headers().get(header::CONTENT_DISPOSITION).unwrap(),
-            "attachment; filename=\"transcript.vtt\""
+            "attachment; filename=\"transcript.vtt\"; filename*=UTF-8''transcript.vtt"
         );
+    }
+
+    #[tokio::test]
+    async fn test_render_export_download_filename_injection_neutralized() {
+        // A crafted `download` value trying to splice a second `filename*`
+        // parameter must survive only as inert data: the quote becomes `_` in
+        // the fallback, and the `filename*` bytes are percent-encoded, so the
+        // spoofed `spoofed.exe` never appears as a real header parameter.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("srt".into()),
+            download: Some("evil\"; filename*=UTF-8''spoofed.exe".into()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(
+            resp.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            "attachment; filename=\"evil_; filename*=UTF-8''spoofed.exe\"; \
+             filename*=UTF-8''evil%22%3B%20filename%2A%3DUTF-8%27%27spoofed.exe"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_render_export_download_filename_unicode_percent_encoded() {
+        // Non-ASCII names get an ASCII-safe fallback for legacy clients and
+        // keep the full UTF-8 name percent-encoded in `filename*` (RFC 6266).
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("txt".into()),
+            download: Some("é.txt".into()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        assert_eq!(
+            resp.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            "attachment; filename=\"_.txt\"; filename*=UTF-8''%C3%A9.txt"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_render_export_download_filename_cyrillic_percent_encoded() {
+        // Cyrillic input must not leak raw non-ASCII bytes into the header:
+        // the fallback replaces each non-ASCII character, `filename*` carries
+        // the percent-encoded UTF-8, and the whole value stays ASCII.
+        let result = sample_export_result();
+        let params = ExportParams {
+            format: Some("srt".into()),
+            download: Some("отчёт.srt".into()),
+            ..ExportParams::default()
+        };
+        let resp = render_export_response(&result, &params).unwrap().unwrap();
+        let value = resp
+            .headers()
+            .get(header::CONTENT_DISPOSITION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let encoded_name = format!("{}.srt", "%d0%be%d1%82%d1%87%d1%91%d1%82".to_uppercase());
+        assert_eq!(
+            value,
+            format!("attachment; filename=\"_____.srt\"; filename*=UTF-8''{encoded_name}")
+        );
+        assert!(value.is_ascii());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Two low-severity operator-exposure hardening fixes:

- **Metrics listener bind consent (`--metrics-listen`)**: the primary port refuses non-loopback binds unless the operator opts in via `--bind-all` / `GIGASTT_ALLOW_BIND_ANY=1`, and the metrics listener must follow the same rule. The gate existed only as an inline, untested block in the serve arm; it is now extracted into `ensure_metrics_bind_allowed()` with unit tests for all four paths: metrics disabled (no-op), loopback (allowed), non-loopback without consent (rejected), non-loopback with `--bind-all` (allowed).
- **`Content-Disposition` filename injection**: the `download` query parameter on export endpoints was interpolated verbatim into the header. `HeaderValue` blocks control characters (no response splitting), but a value like `x"; filename*=UTF-8''evil.exe` could splice extra parameters into the header and spoof the download filename. The header is now built per RFC 6266: an ASCII-sanitized quoted `filename=` fallback (`"`, `\`, control and non-ASCII chars become `_`) plus the full name percent-encoded as `filename*=UTF-8''...` (RFC 5987 attr-char set verbatim, everything else `%XX`). Injected quotes/semicolons survive only as inert data, and non-ASCII names are preserved for modern clients.

## Files changed

- `crates/gigastt/src/main.rs` — extract `ensure_metrics_bind_allowed()`, wire it in the serve arm, add 4 unit tests.
- `crates/gigastt/src/server/http.rs` — add `content_disposition_attachment()` (RFC 6266), use it for the `download` header, update 3 existing tests to the new header shape, add 3 new tests (parameter-injection, `é`, Cyrillic).

## Verification (scoped)

- `cargo fmt -p gigastt -- --check` — clean
- `cargo clippy -p gigastt --all-targets` — zero warnings
- `cargo test -p gigastt --lib --bins` — 119 lib + 88 bin tests pass, 0 failed (17 model-dependent unit tests skipped as ignored). Note: `cargo test -p gigastt` unscoped also runs the custom-harness WER benchmark target against the full local Golos corpus (~10k files), which is intentionally not part of this check; e2e `--ignored` tests (multi-GB model) not run.

The full fmt/clippy/unit-test gate runs in PR CI.