### PR TITLE
fix(server): bound upload-driven memory growth in decode, jobs, and SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **File-transcription duration cap lowered from 2 hours to 30 minutes.** The cap
+  bounds the fully decoded PCM buffer of an upload; 30 minutes ≈ the largest
+  uncompressed PCM16@16kHz file the default 50 MiB body limit admits and bounds
+  the decoded f32 buffer at ~346 MB per concurrent decode (down from ~1.4 GB),
+  closing a >27× memory-amplification vector on compressed uploads. Chunked
+  long-form decoding is unaffected below the cap.
+
+### Fixed
+
+- **Finished jobs no longer pin their upload in RAM.** A `Done`/`Failed` job used
+  to keep its raw audio body for the full `--jobs-ttl-secs` (up to
+  `--jobs-max` × body-limit of dead audio); the body is now released as soon as
+  execution ends (retries keep it for the next attempt).
+- **Per-job SSE subscriber list is bounded.** `GET /v1/jobs/{id}/events` now
+  prunes closed channels on subscribe and caps listeners at 32 per job (oldest
+  evicted), so a connect/disconnect flood can no longer accumulate senders
+  between broadcasts.
+
 ## [2.13.0] - 2026-07-20
 
 ### Added

--- a/crates/gigastt-core/src/inference/audio.rs
+++ b/crates/gigastt-core/src/inference/audio.rs
@@ -21,11 +21,13 @@ use super::{HOP_LENGTH, N_FFT};
 const MAX_BUFFER_SAMPLES: usize = 16000 * 5; // 5 seconds at 16kHz
 /// Hard upper bound on file-transcription audio length (seconds). Long-form
 /// inputs are decoded in bounded overlapping chunks (see
-/// `Engine::transcribe_samples_chunked`), so peak memory is O(chunk) regardless
-/// of file length; this cap now only fences off genuinely absurd / adversarial
-/// uploads rather than the old 10-minute encoder-memory limit. Raised to 2h.
+/// `Engine::transcribe_samples_chunked`), so peak encoder memory is O(chunk)
+/// regardless of file length; this cap bounds the fully decoded PCM buffer
+/// instead. 30 minutes ≈ the largest uncompressed PCM16@16kHz upload the
+/// default 50 MiB body limit admits (~27 min), and bounds the decoded f32
+/// buffer at 30 min × 48 kHz × 4 B ≈ 346 MB per concurrent decode.
 #[cfg(feature = "file-decode")]
-const MAX_DURATION_S: f64 = 7200.0; // 2 hours
+const MAX_DURATION_S: f64 = 1800.0; // 30 minutes
 /// Upper bound on a header-declared sample rate. Legal rates (8k–48k) stay well
 /// below this; anything above is a malformed/adversarial header and is rejected
 /// before it can scale the duration cap or the capacity hint.
@@ -1281,19 +1283,17 @@ mod tests {
 
     #[test]
     fn test_decode_duration_cap_pure() {
-        // Pure cap math (testable without realizing a multi-hour PCM buffer):
-        // the sample budget scales with the clamped rate and the raised cap.
-        // A >10-minute file is now under budget (chunked long-form decode bounds
-        // memory); only genuinely absurd lengths trip the cap.
+        // Pure cap math (testable without realizing a multi-minute PCM buffer):
+        // the sample budget scales with the clamped rate and the duration cap.
         let budget_16k = max_decode_samples(16000);
-        // 2h cap at 16kHz => 7200 * 16000 samples.
-        assert_eq!(budget_16k, 7200 * 16000);
-        // 12 minutes (the old reject point) is now comfortably under budget.
-        assert!(12 * 60 * 16000 < budget_16k, "12-minute file must pass now");
-        // >2h is over budget and would be rejected.
+        // 30-min cap at 16kHz => 1800 * 16000 samples.
+        assert_eq!(budget_16k, 1800 * 16000);
+        // 12 minutes (the old reject point) is comfortably under budget.
+        assert!(12 * 60 * 16000 < budget_16k, "12-minute file must pass");
+        // >30 min is over budget and would be rejected.
         assert!(
-            (2 * 3600 + 1) * 16000 > budget_16k,
-            ">2h must exceed budget"
+            (30 * 60 + 1) * 16000 > budget_16k,
+            ">30min must exceed budget"
         );
         // Header rate is clamped: a crafted 192kHz header can't inflate the
         // budget past the 48kHz ceiling.

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -1338,7 +1338,7 @@ pub async fn job_events(
             .update(
                 &id,
                 Box::new(move |j| {
-                    j.event_channels.push(tx);
+                    j.subscribe(tx);
                 }),
             )
             .await;

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -130,6 +130,12 @@ pub struct Job {
     pub event_channels: Vec<tokio::sync::mpsc::UnboundedSender<JobEvent>>,
 }
 
+/// Upper bound on simultaneous SSE listeners per job. Dead channels are
+/// pruned on subscribe and on broadcast, but broadcasts can be ≥500 ms apart
+/// (and rarer for a queued job), so a connect/disconnect flood could otherwise
+/// accumulate `UnboundedSender`s faster than they get cleaned up.
+pub(crate) const MAX_JOB_EVENT_SUBSCRIBERS: usize = 32;
+
 impl Job {
     /// Create a new queued job.
     pub fn queued(body: Bytes, params: ExportParams) -> Self {
@@ -148,6 +154,17 @@ impl Job {
             error: None,
             event_channels: Vec::new(),
         }
+    }
+
+    /// Register an SSE listener, pruning closed channels first. When the
+    /// subscriber cap is reached, the oldest listener is evicted (its stream
+    /// ends) so a connect/disconnect flood cannot grow the list without bound.
+    pub(crate) fn subscribe(&mut self, tx: tokio::sync::mpsc::UnboundedSender<JobEvent>) {
+        self.event_channels.retain(|tx| !tx.is_closed());
+        if self.event_channels.len() >= MAX_JOB_EVENT_SUBSCRIBERS {
+            self.event_channels.remove(0);
+        }
+        self.event_channels.push(tx);
     }
 }
 
@@ -458,6 +475,11 @@ impl<E: JobExecution + 'static> JobWorker<E> {
                                 j.status = JobStatus::Done;
                                 j.result = Some(res);
                                 j.processed_seconds = total;
+                                // Release the upload: a terminal job never needs
+                                // its body again, and holding it for the full TTL
+                                // would keep up to jobs_max × body-limit of dead
+                                // audio in RAM.
+                                j.body = Bytes::new();
                             }),
                         )
                         .await;
@@ -474,6 +496,9 @@ impl<E: JobExecution + 'static> JobWorker<E> {
                         .unwrap_or(0);
                     let retryable = is_retryable_error(&e) && attempts <= self.max_retries;
                     if retryable {
+                        // Keep the body: the requeued job needs it for the
+                        // next attempt. It is released when the job reaches a
+                        // terminal state.
                         let _ = self
                             .store
                             .update(
@@ -504,6 +529,10 @@ impl<E: JobExecution + 'static> JobWorker<E> {
                                     move |j| {
                                         j.status = JobStatus::Failed;
                                         j.error = Some(sanitized);
+                                        // Same release as the Done path: a
+                                        // failed job is terminal and no longer
+                                        // needs its upload.
+                                        j.body = Bytes::new();
                                     }
                                 }),
                             )
@@ -1330,5 +1359,140 @@ mod tests {
         let resp = job_status_response(&job);
         assert_eq!(resp.percent, 35);
         assert_eq!(resp.processed_seconds, 3.5);
+    }
+
+    #[tokio::test]
+    async fn test_queue_done_job_releases_body() {
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(test_limits()));
+        let executor = MockExecutor {
+            results: Arc::new(Mutex::new(vec![ok_result()])),
+            delay_ms: 0,
+        };
+        let queue = JobQueue::new(
+            store.clone(),
+            1,
+            0,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        queue.spawn(executor);
+
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"audio-bytes"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        for _ in 0..50 {
+            let job = store.get(&id).await.unwrap().unwrap();
+            if matches!(job.status, JobStatus::Done) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Done));
+        assert!(job.body.is_empty());
+    }
+
+    /// Records the body length seen by each attempt so tests can verify the
+    /// upload survives retries and is only released at a terminal state.
+    #[derive(Clone)]
+    struct BodyLenRecorder {
+        lens: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl JobExecution for BodyLenRecorder {
+        async fn execute(
+            &self,
+            _id: &str,
+            _store: Arc<dyn JobStore>,
+            body: Bytes,
+            _params: ExportParams,
+        ) -> anyhow::Result<gigastt_core::inference::TranscribeResult> {
+            self.lens.lock().push(body.len());
+            Err(anyhow::anyhow!("inference_timeout"))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_queue_failed_job_releases_body_after_retries() {
+        // max_retries=1 → two attempts, then terminal Failed.
+        let limits = RuntimeLimits {
+            jobs_retry: 1,
+            ..test_limits()
+        };
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(limits));
+        let lens = Arc::new(Mutex::new(Vec::new()));
+        let executor = BodyLenRecorder { lens: lens.clone() };
+        let queue = JobQueue::new(
+            store.clone(),
+            1,
+            1,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        queue.spawn(executor);
+
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"audio-bytes"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        for _ in 0..50 {
+            let job = store.get(&id).await.unwrap().unwrap();
+            if matches!(job.status, JobStatus::Failed) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Failed));
+        // Both attempts received the full upload; the body is released only
+        // once the job reaches a terminal state.
+        assert_eq!(*lens.lock(), vec![11, 11]);
+        assert!(job.body.is_empty());
+    }
+
+    #[test]
+    fn test_subscribe_prunes_closed_channels() {
+        let mut job = Job::queued(Bytes::new(), ExportParams::default());
+        let (dead_tx, dead_rx) = tokio::sync::mpsc::unbounded_channel::<JobEvent>();
+        job.event_channels.push(dead_tx);
+        drop(dead_rx);
+
+        let (live_tx, _live_rx) = tokio::sync::mpsc::unbounded_channel::<JobEvent>();
+        job.subscribe(live_tx);
+
+        assert_eq!(job.event_channels.len(), 1);
+    }
+
+    #[test]
+    fn test_subscribe_evicts_oldest_at_cap() {
+        let mut job = Job::queued(Bytes::new(), ExportParams::default());
+        let mut rxs = Vec::new();
+        for _ in 0..MAX_JOB_EVENT_SUBSCRIBERS {
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<JobEvent>();
+            job.subscribe(tx);
+            rxs.push(rx);
+        }
+        assert_eq!(job.event_channels.len(), MAX_JOB_EVENT_SUBSCRIBERS);
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<JobEvent>();
+        job.subscribe(tx);
+        rxs.push(rx);
+
+        // The list stays capped; the oldest listener was evicted, so its
+        // stream is disconnected.
+        assert_eq!(job.event_channels.len(), MAX_JOB_EVENT_SUBSCRIBERS);
+        assert!(matches!(
+            rxs[0].try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
     }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -185,7 +185,7 @@ paths:
         `txt` / `srt` / `vtt` ignore `segments` (already flat / cue-based).
 
         The entire file is processed in a single inference session.
-        Max audio duration: 10 minutes.
+        Max audio duration: 30 minutes.
       operationId: transcribeFile
       parameters:
         - name: format


### PR DESCRIPTION
## Summary

Three independent bounded-memory hardening fixes for network-facing paths (all already limit-mitigated or opt-in; this tightens the actual peak-RAM envelope):

- **Duration cap aligned with the body limit** (`crates/gigastt-core/src/inference/audio.rs`): `MAX_DURATION_S` lowered from 7200 (2h) to 1800 (30 min). The cap bounds the fully decoded PCM buffer of an upload — 30 min ≈ the largest uncompressed PCM16@16kHz file the default 50 MiB body limit admits (~27 min), capping the decoded f32 buffer at ~346 MB per concurrent decode (was ~1.4 GB, i.e. a >27× memory amplification on compressed uploads). Chunked long-form decoding (peak encoder memory O(chunk)) is unaffected below the cap. The stale `docs/openapi.yaml` "Max audio duration" line was updated to match.
- **Jobs release the upload after execution** (`crates/gigastt/src/server/jobs.rs`): `job.body` is cleared in the worker's `Done` and terminal-`Failed` updates instead of being held for the full `--jobs-ttl-secs` (previously up to `--jobs-max` × body-limit ≈ 5 GiB of dead audio; `--enable-jobs` only). Retry/requeue keeps the body for the next attempt.
- **Per-job SSE subscriber list bounded** (`crates/gigastt/src/server/jobs.rs`, `crates/gigastt/src/server/http.rs`): `Job::subscribe` prunes closed channels on subscribe and caps listeners at 32 per job (oldest evicted, its stream ends). Previously the list grew unbounded between broadcasts (≥500 ms apart, rarer for queued jobs) under connect/disconnect flapping.

New unit tests: body released on Done, body released on terminal Failed with both retry attempts still receiving the full upload, subscribe prunes closed channels, subscribe evicts oldest at cap, and the pure cap-math test updated for the 30-min budget. CHANGELOG updated under Unreleased.

## Verification (scoped)

- `cargo fmt --check -p gigastt-core -p gigastt` — clean.
- `cargo clippy -p gigastt-core -p gigastt --all-targets` — zero warnings (compiled from this branch's sources).
- `cargo test -p gigastt-core -p gigastt --lib --bins` — **green**: 120 + 84 + 431 passed, 0 failed (binaries rebuilt from this branch's sources after detecting cross-worktree binary staleness in the shared `CARGO_TARGET_DIR`).
- `cargo test -p gigastt --test benchmark -- --self-test` — ok (model-free gate).
- `docs/openapi.yaml` re-validated with a YAML parser.
- `--ignored` e2e tests not run locally (multi-GB model download); the full gate (fmt, clippy, unit + e2e on main) runs in CI.

Note: `model::tests::test_stream_to_partial_then_finalize_stream_error_removes_partial` fails identically on a clean checkout of the base commit (hyper content-length panic in the local test server) — pre-existing and unrelated to this change; it does not compile into this branch's default feature set.

Follow-up candidate (out of scope here): jobs cancelled while queued/processing also keep their body until TTL; clearing it on the cancel paths would close the residual vector.
