### PR TITLE
ci: supply-chain gates, rnnt-default docs drift, orphan .partial cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,12 +472,20 @@ jobs:
       - uses: actions/checkout@v7
       # `rustsec/audit-check` ships a prebuilt cargo-audit, saving the ~90 s
       # `cargo install --locked` rebuild on every PR run.
+      # The ignore list is extracted from deny.toml (the single source of
+      # truth, enforced by the `deny` job) so the two gates cannot drift.
+      # Only quoted IDs in the [advisories] section are taken, so a RUSTSEC
+      # number mentioned in a comment is not picked up.
+      - name: Read advisory ignores from deny.toml
+        id: advisories
+        run: |
+          ignores=$(sed -n '/^\[advisories\]/,/^\[/p' deny.toml \
+            | grep -oE '"RUSTSEC-[0-9]{4}-[0-9]+"' | tr -d '"' | paste -sd, -)
+          echo "ignore=$ignores" >> "$GITHUB_OUTPUT"
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # `paste` is unmaintained (RUSTSEC-2024-0436) and pulled in transitively
-          # via `tokenizers`; no fix available. Mirrors the deny.toml ignore.
-          ignore: RUSTSEC-2024-0436
+          ignore: ${{ steps.advisories.outputs.ignore }}
 
   deny:
     runs-on: ubuntu-latest
@@ -576,7 +584,11 @@ jobs:
         with:
           shared-key: ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo publish --dry-run -p gigastt-core --locked
+      # Both published crates: gigastt-core is the library, gigastt is the
+      # `cargo install gigastt` binary — packaging breakage in either fails CI.
+      - run: |
+          cargo publish --dry-run -p gigastt-core --locked
+          cargo publish --dry-run -p gigastt --locked
 
   msrv:
     runs-on: ubuntu-latest

--- a/crates/gigastt-core/src/inference/decode.rs
+++ b/crates/gigastt-core/src/inference/decode.rs
@@ -1,4 +1,4 @@
-//! RNN-T greedy decoding for GigaAM v3 e2e_rnnt.
+//! RNN-T greedy decoding shared by the GigaAM v3 rnnt and e2e_rnnt heads.
 
 use anyhow::{Context, Result};
 

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -1,4 +1,4 @@
-//! ONNX Runtime inference engine for GigaAM v3 e2e_rnnt.
+//! ONNX Runtime inference engine for GigaAM v3 (rnnt head by default, e2e_rnnt optional).
 //!
 //! Loads encoder, decoder, and joiner ONNX models and runs the RNN-T streaming decode loop.
 

--- a/crates/gigastt-core/src/inference/tokenizer.rs
+++ b/crates/gigastt-core/src/inference/tokenizer.rs
@@ -1,4 +1,5 @@
-//! BPE tokenizer for GigaAM v3 e2e_rnnt.
+//! Tokenizer for the GigaAM v3 RNN-T heads: the plain `rnnt` char vocab and
+//! the `e2e_rnnt` BPE vocab.
 
 use anyhow::{Context, Result, ensure};
 use std::path::Path;

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -1423,6 +1423,39 @@ fn partial_path_unique(final_path: &Path) -> std::path::PathBuf {
     std::path::PathBuf::from(s)
 }
 
+/// RAII guard that removes a staged `.partial` file when the download path
+/// returns early (stream error, write failure, finalize failure). Armed when
+/// the staging path is chosen and disarmed only after the partial has been
+/// renamed into its final location, so a flaky network cannot accumulate
+/// orphaned `.partial` files.
+#[cfg(feature = "net")]
+struct PartialFileGuard(Option<std::path::PathBuf>);
+
+#[cfg(feature = "net")]
+impl PartialFileGuard {
+    fn new(path: std::path::PathBuf) -> Self {
+        Self(Some(path))
+    }
+
+    /// Disarm after the partial was renamed into place: the file no longer
+    /// exists at the staging path, so there is nothing left to clean up.
+    fn disarm(mut self) {
+        self.0 = None;
+    }
+}
+
+#[cfg(feature = "net")]
+impl Drop for PartialFileGuard {
+    fn drop(&mut self) {
+        if let Some(path) = self.0.take() {
+            // Best-effort: a missing file (already cleaned up, or never
+            // created because the request failed before staging) is fine,
+            // and a removal failure must not mask the original error.
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
 /// Compute SHA-256 for a file synchronously, returning the lowercase hex digest.
 #[cfg(feature = "net")]
 fn sha256_file(path: &Path) -> Result<String> {
@@ -1539,6 +1572,9 @@ async fn stream_to_partial_then_finalize_with_sink(
     }
 
     let partial = partial_path_unique(final_dest);
+    // Remove the staged partial on any early return below; disarmed after the
+    // successful rename at the end of this function.
+    let cleanup = PartialFileGuard::new(partial.clone());
 
     tracing::info!("Downloading {label}...");
 
@@ -1590,6 +1626,7 @@ async fn stream_to_partial_then_finalize_with_sink(
         });
     }
     finalize_download(&partial, final_dest, expected_sha256, label)?;
+    cleanup.disarm();
     tracing::info!("Saved {label}");
 
     Ok(())
@@ -2207,6 +2244,74 @@ mod tests {
             msg.contains("SHA-256 mismatch"),
             "error should mention mismatch: {msg}"
         );
+    }
+
+    /// The RAII guard removes the staged partial on drop (early return) but
+    /// leaves it alone once disarmed (successful rename).
+    #[test]
+    fn test_partial_file_guard_drop_removes_staged_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let partial = tmp.path().join("model.onnx.partial");
+        std::fs::write(&partial, b"half-written junk").expect("write partial");
+
+        drop(PartialFileGuard::new(partial.clone()));
+        assert!(!partial.exists(), "guard drop must remove the partial");
+
+        std::fs::write(&partial, b"half-written junk").expect("write partial");
+        PartialFileGuard::new(partial.clone()).disarm();
+        assert!(partial.exists(), "disarmed guard must keep the partial");
+    }
+
+    /// A connection cut mid-stream leaves no orphan `.partial` behind: the
+    /// guard cleans up the staged bytes so a retry starts clean.
+    #[tokio::test]
+    #[cfg_attr(miri, ignore = "tokio runtime is unsupported under Miri")]
+    async fn test_stream_to_partial_then_finalize_stream_error_removes_partial() {
+        use tokio::io::AsyncReadExt as _;
+
+        // Hand-rolled stub: hyper (and therefore wiremock) refuses to send a
+        // body shorter than the declared content-length, so speak raw HTTP/1.1
+        // instead — send the headers, a fraction of the promised body, then
+        // close the socket to cut the stream.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stub server");
+        let addr = listener.local_addr().expect("local addr");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            // Drain the tiny GET request so the response does not race it.
+            let mut buf = [0u8; 1024];
+            let _ = socket.read(&mut buf).await;
+            let head = "HTTP/1.1 200 OK\r\ncontent-length: 4096\r\nconnection: close\r\n\r\n";
+            socket.write_all(head.as_bytes()).await.expect("write head");
+            socket
+                .write_all(b"half of the model")
+                .await
+                .expect("write body");
+            // The socket closes on drop, truncating the promised body.
+        });
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let final_path = tmp.path().join("model.onnx");
+        let url = format!("http://{addr}/model.onnx");
+
+        let err = stream_to_partial_then_finalize(&url, &final_path, None, "model.onnx")
+            .await
+            .expect_err("truncated body should fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Download stream error"),
+            "error should come from the stream read: {msg}"
+        );
+        server.await.expect("stub server task");
+
+        assert!(!final_path.exists(), "final must not appear on failure");
+        let orphans: Vec<_> = std::fs::read_dir(tmp.path())
+            .expect("read dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".partial"))
+            .collect();
+        assert!(orphans.is_empty(), "no orphan .partial files: {orphans:?}");
     }
 
     /// End-to-end NDJSON contract on a local HTTP stub: the download of one

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme = "../../README.md"
-description = "Local STT server powered by GigaAM v3 e2e_rnnt — on-device Russian speech recognition via ONNX Runtime"
+description = "Local STT server powered by GigaAM v3 (rnnt head by default, e2e_rnnt optional) — on-device Russian speech recognition via ONNX Runtime"
 keywords = ["stt", "speech-recognition", "gigaam", "onnx", "russian"]
 categories = ["multimedia::audio", "command-line-utilities"]
 


### PR DESCRIPTION
## Summary

Four small mechanical fixes in one PR:

- **CI publish dry-run for the `gigastt` binary crate.** The `publish-dry-run` job only ran `cargo publish --dry-run -p gigastt-core`, leaving the crate people actually `cargo install` ungated. The job now dry-runs both published crates.
- **Single source of truth for advisory ignores.** The `audit` job's hardcoded `ignore: RUSTSEC-2024-0436` had drifted from `deny.toml` (which also ignores `RUSTSEC-2025-0141`), so the two security gates gave different signals. The audit job now extracts the quoted RUSTSEC IDs from the `[advisories]` ignore list in `deny.toml` and passes them to `rustsec/audit-check`.
- **Docs drift: `rnnt` is the default head.** The `gigastt` crate description advertised `e2e_rnnt`, and the module docs of `inference/mod.rs`, `decode.rs`, `tokenizer.rs` said "GigaAM v3 e2e_rnnt" for what is the shared/default `rnnt` path. All now state both heads with `rnnt` as default (matches `#[default] Rnnt` in `model/mod.rs`).
- **Orphan `.partial` on interrupted downloads.** `stream_to_partial_then_finalize_with_sink` only cleaned the staged `.partial.{pid}.{stamp}` file on checksum-mismatch / rename-fail paths; a stream error or write failure left it behind. A small `PartialFileGuard` RAII guard now removes the staged file on any early return and is disarmed only after the successful rename.

## Verification (scoped)

- `cargo fmt --check -p gigastt-core` — clean.
- `cargo clippy -p gigastt-core --all-targets` and `cargo clippy -p gigastt --all-targets` — zero warnings.
- `cargo test -p gigastt-core --lib` — 433 passed, 0 failed (after forcing a rebuild from this worktree's sources; the shared target dir initially served a stale test binary). New tests: `test_partial_file_guard_drop_removes_staged_file`, `test_stream_to_partial_then_finalize_stream_error_removes_partial` (raw-TCP stub that truncates the body mid-stream; wiremock/hyper refuse to send a body shorter than the declared content-length).
- `cargo test -p gigastt --lib --bins` — 84 passed, 0 failed.
- `.github/workflows/ci.yml` validated with `yq`; the deny.toml extraction pipeline was run locally and yields exactly `RUSTSEC-2024-0436,RUSTSEC-2025-0141`.

The full workspace gate runs in CI on this PR.
