### PR TITLE
docs: full WebSocket protocol reference and integrator troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **WebSocket protocol fully documented for integrators.** The `docs/api.md`
+  WebSocket section is now a complete human-readable reference — every `ready`,
+  `partial`/`final` (including per-word `start`/`end`/`confidence`/`speaker`),
+  and `error` field, the `configure`/`stop` semantics (`stop` flushes trailing
+  audio and emits a last `final` — the explicit end-of-stream marker), the full
+  error-code and close-code tables, keepalive behavior, `/health` vs `/ready`
+  lifecycle (including the bootstrap responder and the `version` field for
+  version gates without exec-ing the binary), and session/frame limits with
+  guidance for >1 h sessions. `docs/troubleshooting.md` gains the matching
+  failure scenarios: port-already-in-use and orphaned sidecars, the one-hour
+  session cap, raw lowercase WS finals, slow first run, pre-2.0.14 CoreML
+  builds, a capture/startup/config triage checklist, and log-sharing hygiene.
 - **File-transcription duration cap lowered from 2 hours to 30 minutes.** The cap
   bounds the fully decoded PCM buffer of an upload; 30 minutes ≈ the largest
   uncompressed PCM16@16kHz file the default 50 MiB body limit admits and bounds

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,21 +7,90 @@ Machine-readable specs: [`docs/asyncapi.yaml`](asyncapi.yaml) (WebSocket) and
 ## WebSocket — real-time streaming
 
 Connect to `ws://127.0.0.1:9876/v1/ws`, send PCM16 audio frames, receive transcription
-in real time.
+in real time. This section is the human-readable protocol reference; the
+machine-readable schema (same fields, same error codes) lives in
+[`docs/asyncapi.yaml`](asyncapi.yaml). Field-level source of truth:
+`crates/gigastt-core/src/protocol/mod.rs`.
 
 ```
 Client                            Server
   |-------- connect --------------> |
-  | <------- ready ----------------- |  {type:"ready", version:"1.0"}
+  | <------- ready ----------------- |  {type:"ready", model, version, supported_rates, ...}
   |------- configure (optional) --> |  {type:"configure", sample_rate:16000}
   |-------- binary PCM16 ---------> |
-  | <------- partial --------------- |  {type:"partial", text:"привет"}
-  | <------- final ----------------- |  {type:"final", text:"Привет, как дела?"}
+  | <------- partial --------------- |  {type:"partial", text, words[], ...}
+  |-------- binary PCM16 ---------> |
+  | <------- final ----------------- |  {type:"final", text, words[], ...}
+  |--------- stop ----------------> |  {type:"stop"}
+  | <------- final ----------------- |  trailing words flushed, then the client closes
 ```
 
-**Supported sample rates:** 8, 16, 24, 44.1, 48 kHz (default 48 kHz, resampled to
-16 kHz internally). Protocol messages are versioned via the `type` field; new fields
-are additive only.
+**Versioning.** Protocol messages are discriminated by the `type` field; the
+current version is `1.0`, reported in `ready.version`. New fields are additive
+only — never removed or renamed — so clients must ignore fields they do not
+know. A client may announce its version via `configure.protocol_version`; an
+unsupported value is rejected with `unsupported_protocol_version`.
+
+### Server → Client messages
+
+#### `ready`
+
+Sent immediately after the WebSocket handshake, before any audio is accepted.
+
+```json
+{
+  "type": "ready",
+  "model": "gigaam-v3-rnnt",
+  "sample_rate": 48000,
+  "version": "1.0",
+  "supported_rates": [8000, 16000, 24000, 44100, 48000],
+  "diarization": false
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `model` | string | Loaded head: `gigaam-v3-rnnt`, `gigaam-v3-e2e-rnnt`, `gigaam-multilingual-ctc`, or `gigaam-multilingual-large-ctc` |
+| `sample_rate` | integer | Default input rate in Hz (48000 for backward compatibility) — used when no `configure` overrides it |
+| `version` | string | WebSocket protocol version (semver-lite `major.minor`) |
+| `supported_rates` | integer[] | Accepted input sample rates in Hz; omitted if empty. Use it instead of hardcoding a rate list |
+| `diarization` | boolean | `true` when the speaker-encoder model is loaded and diarization can be enabled per session; omitted when `false` |
+| `min_protocol_version` | string | Oldest protocol version the server accepts; omitted when equal to `version` (only one version supported) |
+
+#### `partial` / `final`
+
+Both carry the same `TranscriptSegment` payload; `final` means the utterance is
+complete (endpointing detected, or the stream was flushed by `stop`/shutdown).
+
+```json
+{
+  "type": "final",
+  "text": "Привет, как дела?",
+  "timestamp": 1712700001.456,
+  "is_final": true,
+  "words": [
+    {"word": "привет", "start": 0.0, "end": 0.4, "confidence": 0.97},
+    {"word": "как", "start": 0.5, "end": 0.7, "confidence": 0.93},
+    {"word": "дела", "start": 0.8, "end": 1.1, "confidence": 0.95}
+  ]
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `text` | string | Joined transcript text (see post-processing below) |
+| `timestamp` | number | Unix time (seconds) when the segment was produced |
+| `is_final` | boolean | Mirrors the `type` discriminator (`true` in `final`) |
+| `words[]` | object[] | Per-word detail; may be empty on flushed/empty finals |
+
+Each `words[]` entry:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `word` | string | Recognized word (BPE tokens joined, raw decoder casing) |
+| `start` / `end` | number | Word boundaries in seconds from the start of the stream |
+| `confidence` | number | Mean softmax confidence over the word's BPE tokens, 0.0–1.0. Real decoder output — use it instead of a hardcoded constant |
+| `speaker` | integer | Zero-based speaker label; present only when diarization is active |
 
 **Transcript post-processing.** `partial` messages are always the raw decoder
 hypothesis (lowercase, no punctuation) and may change with more audio. `final`
@@ -33,17 +102,140 @@ for the bare `rnnt` head, off for `e2e_rnnt` which is already punctuated). The
 is rewritten. The same applies to SSE `final` events on `/v1/transcribe/stream`
 (server defaults; there are no per-request parameters there yet).
 
-Per session, the client can override the server policy with additive `configure`
-fields (sent before the first audio frame):
+#### `error`
+
+```json
+{"type": "error", "message": "Server busy, try again later", "code": "timeout", "retry_after_ms": 30000}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `message` | string | Generic user-facing description (internal details are never leaked) |
+| `code` | string | Machine-readable code — branch on this, not on `message` (table below) |
+| `retry_after_ms` | integer | Suggested backoff in milliseconds; present only for transient backpressure (`timeout` on pool saturation). Honor it instead of guessing a retry delay |
+
+### Client → Server messages
+
+#### `configure`
+
+Optional; must be sent **before the first audio frame** (otherwise the server
+replies with `configure_too_late` and keeps the previous settings).
 
 ```json
 {"type": "configure", "sample_rate": 16000, "punctuation": false, "itn": false}
 ```
 
-Omitting a field keeps the server default; repeated `configure` messages compose
-(an absent field leaves the previous value). Asking for `punctuation: true` on a
-server without a punctuation model is a graceful no-op — finals stay raw, no
-error is emitted.
+| Field | Type | Meaning |
+|---|---|---|
+| `sample_rate` | integer | Input rate in Hz; must be one of `ready.supported_rates`, else `invalid_sample_rate` (the session continues at the previous rate) |
+| `diarization` | boolean | Enable speaker diarization for this session (requires `ready.diarization: true`) |
+| `protocol_version` | string | Version the client wants to speak; unsupported values are rejected with `unsupported_protocol_version` and the server ends the session |
+| `punctuation` | boolean | Per-session punctuation/casing override for `final` segments only. `true` on a server without a punctuation model is a graceful no-op — finals stay raw, no error |
+| `itn` | boolean | Per-session inverse text normalization override (`final` segments only) |
+
+All fields are optional. Omitting a field keeps the server default; repeated
+`configure` messages compose (an absent field leaves the previous value).
+
+#### `stop`
+
+```json
+{"type": "stop"}
+```
+
+Asks the server to **finalize the session**: it decodes any audio still buffered
+since the last partial (trailing words are not lost), emits one last `final`
+message — possibly with empty `text` if nothing was pending — and only then is
+the session over. The correct end-of-stream pattern is: send `stop`, wait for
+the `final`, then close the socket. Do **not** close immediately after the last
+audio frame or insert a fixed drain delay — the `final` after `stop` is the
+explicit, lossless end marker.
+
+#### Binary audio frames
+
+Raw PCM16 signed little-endian, mono, at the negotiated rate (default 48 kHz;
+resampled to 16 kHz internally). Frame size up to `--ws-frame-max-bytes`
+(default 512 KiB ≈ 16 s at 16 kHz). Odd-length frames are fine — the trailing
+byte is carried into the next frame. Empty frames are tolerated up to a
+per-session cap (1000) and then closed with `policy_violation` + close code
+1008.
+
+### Keepalive
+
+The server sends a WebSocket **ping every 30 s** and closes the connection after
+**2 consecutive pings** with no inbound frame in between (≈ 90 s detection of a
+half-open peer). Any inbound frame — pong, binary audio, or text — counts as
+liveness and resets the counter. Standard WS clients answer pings automatically;
+you do not need to send your own pings.
+
+### Error codes
+
+Codes emitted on the WebSocket (`error` message, sometimes followed by a close
+frame). The same enum is declared in [`docs/asyncapi.yaml`](asyncapi.yaml).
+
+| Code | Session after | Meaning |
+|---|---|---|
+| `timeout` | ends (never opened) | Pool saturation: no inference slot freed within the checkout window (default 30 s). `retry_after_ms` is set — wait and reconnect |
+| `pool_closed` | ends | Server is shutting down, pool closed to new sessions |
+| `idle_timeout` | ends (close 1001) | No frames for `--idle-timeout-secs` (default 300 s) |
+| `max_session_duration_exceeded` | ends (close 1008) | Wall-clock session cap `--max-session-secs` (default 3600 s) hit; a `final` is flushed before the close |
+| `policy_violation` | ends (close 1008) | Empty-frame spam (over 1000 empty binary frames) |
+| `inference_timeout` | ends | One inference run exceeded `--inference-timeout-secs` (default 600 s) |
+| `inference_error` | continues | Inference failed on the last chunk (bad audio format, etc.); the session state is intact |
+| `inference_panic` | continues, state reset | Inference panicked; the decoder state was reset, so earlier audio context is lost — already-received `final`s remain valid |
+| `configure_too_late` | continues | `configure` arrived after the first audio frame; previous settings kept |
+| `invalid_sample_rate` | continues | Rate not in `supported_rates`; previous rate kept |
+| `unsupported_protocol_version` | ends | Client requested a protocol version the server does not speak |
+| `payload_too_large` | — | REST/SSE surface (body over `--body-limit-bytes`). On WS, an oversized frame is rejected by the transport with close code 1009 instead |
+
+### Close codes
+
+| Code | When |
+|---|---|
+| 1001 Going Away | Graceful shutdown drain (SIGTERM), `idle_timeout`, or keepalive ping timeout. A `final` is flushed first on shutdown |
+| 1008 Policy Violation | `max_session_duration_exceeded`, `policy_violation` |
+| 1009 Message Too Big | A frame exceeded `--ws-frame-max-bytes` |
+| 1006 Abnormal Closure | Never sent by the server — the client observes it when an established socket drops with no close frame (process killed, crash, middlebox). Do not confuse it with an *upgrade refusal*: while the model is still loading, `/v1/ws` answers HTTP 503 `{"code":"initializing"}` before any socket exists — poll `/ready` and retry later instead of killing the process. If the port listens but even `/health` fails, suspect an orphaned process holding the port — see [troubleshooting](troubleshooting.md) |
+
+### Session lifecycle: `/health` vs `/ready`
+
+Use the HTTP probes to drive client-side state machines — do not spawn
+`gigastt --version` or guess from TCP connectability:
+
+- `GET /health` — **liveness**. Returns 200 as soon as the listener is up,
+  including during first-run model download/quantization, when it is served by a
+  minimal bootstrap responder:
+  `{"status":"ok","model":"loading","version":"2.13.0"}`. Once the engine is up:
+  `{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.13.0","punctuation":true,"itn":true}`.
+  The `version` field is present in **both** phases — use it for version gates
+  instead of executing the binary.
+- `GET /ready` — **readiness**. 200 `{"status":"ready","pool_available":N,"pool_total":M}`
+  when at least one inference slot is free; 503 with
+  `{"status":"not_ready","reason":"initializing"}` while the model loads,
+  `"pool_exhausted"` when all slots are busy, or `"shutting_down"` during drain.
+  Gate first audio on `/ready`, gate process liveness on `/health`.
+
+### Session and frame limits
+
+Defaults; every limit is a CLI flag with a matching `GIGASTT_*` env var
+(see `gigastt serve --help`):
+
+| Limit | Default | Behavior at the limit |
+|---|---|---|
+| `--pool-size` | 2 | Concurrent inference sessions; the next connect waits up to 30 s, then `timeout` + `retry_after_ms` (WS) or 503 + `Retry-After` (REST) |
+| `--idle-timeout-secs` | 300 | No frames for 5 min → `idle_timeout` + close 1001. Streaming silence (quiet PCM) keeps the session alive — silence is still audio |
+| `--max-session-secs` | 3600 | Wall-clock cap → `max_session_duration_exceeded` + flushed `final` + close 1008. `0` disables |
+| `--ws-frame-max-bytes` | 512 KiB | Larger frame → close 1009 |
+| `--inference-timeout-secs` | 600 | One hung inference run → `inference_timeout`, session ends |
+
+**Long sessions (interviews over an hour):** the 1-hour cap is the default, not
+a hard limit — raise `--max-session-secs` (or set `0`) and keep frames flowing
+so the idle timeout never trips. Reconnecting on the cap is also safe: the
+server flushes a `final` before closing, so nothing recognized is lost. See
+[troubleshooting](troubleshooting.md) for the failure scenarios these limits
+produce. Embedding the binary as a managed sidecar (spawn, readiness probing,
+version gating) is covered by the embedding guide (`docs/embedding.md`, in
+progress); the onnxruntime linking trade-offs are in
+[embedding-packaging](embedding-packaging.md).
 
 ## REST
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,8 +9,58 @@
 | CoreML not used on macOS | Built without `--features coreml` | Re-build: `cargo build --release --features coreml` |
 | `falling back to CPU execution provider` in logs | CoreML failed to compile/execute on this macOS/model combo | Transcription still works on CPU; clear `~/.gigastt/models/coreml_cache/` and retry, or file an issue with the warning text |
 | CUDA not available on Linux | Built without `--features cuda` or missing CUDA 12+ | Re-build: `cargo build --release --features cuda`; verify `nvidia-smi` |
-| WebSocket closes with 1008 | Session exceeded `--max-session-secs` | Increase `--max-session-secs` or send shorter streams |
+| WebSocket closes with 1008 | Session exceeded `--max-session-secs` (default 3600 — a stream dying *exactly at the 1-hour mark* is this cap, not a crash). The server sends `max_session_duration_exceeded`, flushes a `final`, then closes | Raise `--max-session-secs` (0 disables), or reconnect on the close — the flushed `final` means nothing recognized is lost |
+| WebSocket closes with 1001 after ~5 min of silence | No frames for `--idle-timeout-secs` (default 300) — pauses in speech count as idle if the client stops sending | Keep streaming PCM silence while the mic is open (silence is still audio), or raise `--idle-timeout-secs` |
+| `Address already in use` on startup, port 9876 | Another process holds the port — often an orphaned gigastt from a previous run | Find it: `lsof -nP -tiTCP:9876 -sTCP:LISTEN`; confirm it is ours before killing: `ps -p <pid> -o command=` should show `gigastt serve`. Then `kill <pid>` (SIGTERM drains sessions cleanly), or start on a different `--port` |
+| gigastt keeps running after the parent app was force-killed | SIGKILL gives the parent no chance to forward SIGTERM, so a managed sidecar is orphaned and keeps the port and ~800 MB of RAM | Same `lsof`/`ps` recipe as above to find and stop it. Long-term: supervise with launchd/systemd, or have the parent poll its own PID liveness and SIGTERM the child on exit paths that do run |
+| WS `final` text arrives bare lowercase, no punctuation | The punctuation model is not attached (check `GET /health` → `punctuation:false`), or policy is off for this server/session. `e2e_rnnt` punctuates by itself; the bare `rnnt` head needs the punct model | Enable server-wide with `--punctuation on` (model auto-downloads to `~/.gigastt/models/punct/`), per WS session with `{"type":"configure","punctuation":true}`, or per REST request with `?punctuation=true`. `words[]` always stay raw by design — only the joined `text` is rewritten |
+| First `serve` takes minutes before `/ready` turns green | One-time setup: ~850 MB model download + INT8 quantization of the encoder. `/health` answers 200 `{"model":"loading"}` meanwhile — the server is not hung | Pre-seed during install: `gigastt download` (or `gigastt download --prequantized` to fetch the ~215 MB pre-quantized INT8 bundle and skip local quantization entirely). Gate clients on `/ready`, never on the process being alive |
+| Every inference fails on a Homebrew install (CoreML) | Builds earlier than 2.0.14 shipped a broken CoreML runtime; the brew tarball is compiled `--features coreml` | Check the version without exec-ing the binary: `GET /health` → `version`. Upgrade: `brew update && brew upgrade gigastt`. Integrations should gate on **≥ 2.0.14** |
+| WS upgrade fails with HTTP 503 `{"code":"initializing"}` but the port is listening | The model is still loading (bootstrap responder) — this is the healthy first-run state, not a stuck server | Poll `GET /ready` until 200, then connect. Killing and restarting only restarts the download/quantization |
 | 429 Too Many Requests | Rate limiter enabled and bucket exhausted | Wait for `Retry-After`, or disable with `--rate-limit-per-minute 0` |
 | Empty transcription for noisy audio | Input too quiet or wrong format | Ensure 16-bit PCM; normalize level; check supported formats |
 | Diarization returns no speaker labels; logs show `Got: 2 Expected: 3` | Pre-2.11.2 bug — the WeSpeaker encoder was fed rank-2 waveform instead of rank-3 fbank features | Upgrade to **2.11.2+** (fixed); ensure `wespeaker_resnet34.onnx` is present in `~/.gigastt/models/` |
 | `--model-variant` ignored when the model dir holds more than one head | Pre-2.11.1 bug — the engine re-detected the head from disk (`rnnt` precedence) and dropped the requested variant | Upgrade to **2.11.1+** (the resolved variant is now honored); or keep each head in its own `--model-dir` |
+
+## No transcript: audio capture vs STT startup vs language config
+
+"No text comes out" has three independent failure domains. Triage them in this
+order — each step isolates one:
+
+1. **STT startup** — is the server actually ready?
+   `curl -s localhost:9876/ready` must return 200 with `"status":"ready"`.
+   A 503 `initializing` means the model is still downloading/quantizing (wait);
+   `pool_exhausted` means all inference slots are busy (retry with backoff —
+   WS clients get `retry_after_ms`). A WS client that connected must have
+   received the `ready` message before any audio counts.
+2. **Audio capture** — is audio actually reaching the server?
+   Log frame sizes client-side: a stream of zero-length or silent frames
+   produces empty partials. Confirm the negotiated rate
+   (`ready.supported_rates`, your `configure.sample_rate`) matches what the
+   capture pipeline emits, PCM16 little-endian mono. On macOS, check the host
+   app's microphone permission (System Settings → Privacy & Security →
+   Microphone). To cut the server out of the loop entirely, POST a known-good
+   WAV to `/v1/transcribe` — if REST returns text, startup and the model are
+   fine and the bug is in capture or the streaming client.
+3. **Language / model config** — is the loaded head the one you think?
+   gigastt has no per-request language switch: language is a property of the
+   loaded model head. Check `ready.model` (WS) or `/health` → `model`: `rnnt`
+   and `e2e_rnnt` are Russian-only; use `--model-variant ml_ctc` /
+   `ml_ctc_large` for multilingual (ru/en/kk/ky/uz) speech. Client-side
+   "recognition language" settings have no effect on the server.
+
+## Sharing logs safely
+
+Error payloads the server sends to clients are already sanitized (generic
+messages, no internal paths or model details). **Log files are not**: tracing
+output can contain local filesystem paths (including your username via
+`$HOME`), hostnames, and peer IP addresses. Recognized transcript text is never
+logged, and error `code`s, version numbers, timings, and pool/limits
+configuration are always safe to paste publicly. Before attaching a log to an
+issue, skim it once for paths, hostnames, and IPs and redact those.
+
+## See also
+
+- [API reference](api.md) — the full WebSocket protocol (messages, error
+  codes, close codes, session limits) these fixes refer to.
+- [`asyncapi.yaml`](asyncapi.yaml) — the machine-readable WebSocket schema.


### PR DESCRIPTION
## Summary

Turns the ~20-line WebSocket section of `docs/api.md` into a complete
human-readable protocol reference, and extends `docs/troubleshooting.md` with
the failure scenarios integrators actually hit. Docs-only change; field-level
source of truth is `crates/gigastt-core/src/protocol/mod.rs`,
`TranscriptSegment`/`WordInfo` in `inference/mod.rs`, `server/ws.rs`, and
`docs/asyncapi.yaml` (which is not duplicated — linked as the machine-readable
schema).

`docs/api.md` WS section now covers:

- Server→Client messages: `ready` (`model`, `sample_rate`, `version`,
  `supported_rates`, `diarization`, `min_protocol_version`), `partial`/`final`
  as `TranscriptSegment` (`text`, `words[]` = `{word, start, end, confidence,
  speaker?}`, `is_final`, `timestamp`), `error` (`message`, `code`,
  `retry_after_ms`).
- Client→Server: `configure` (all fields, compose semantics,
  `configure_too_late`), `stop` as the explicit finalize: flush of buffered
  trailing audio + one last `final` before close — replacing drain-delay
  workarounds; binary PCM16 frame format, odd-byte carry, empty-frame cap.
- Keepalive: server ping every 30 s, close after 2 unanswered (≈90 s).
- Error-code table (identical set to the `asyncapi.yaml` enum, verified
  programmatically) + close codes 1001/1008/1009 and a 1006 diagnostic note
  (upgrade-refused 503 `initializing` vs. dropped socket vs. orphaned process).
- Lifecycle: `/health` vs `/ready`, bootstrap responder during model load,
  reason codes `initializing`/`pool_exhausted`/`shutting_down`,
  `pool_available/pool_total`, and version gating via `/health` → `version`
  instead of exec-ing `gigastt --version`.
- Session/frame limits (`--pool-size`, `--idle-timeout-secs`,
  `--max-session-secs`, `--ws-frame-max-bytes`, `--inference-timeout-secs`),
  pool-saturation backpressure (`timeout` + `retry_after_ms`, REST 503 +
  `Retry-After`), and guidance for >1 h sessions.

`docs/troubleshooting.md` gains: port 9876 already in use (find/verify the
process before killing), orphaned sidecar after a parent SIGKILL, stream dying
exactly at one hour (session cap) and idle-timeout closes, WS finals without
punctuation, slow first run + `download --prequantized`, pre-2.0.14 CoreML
builds (version gate + `brew upgrade`), WS upgrade refused with 503
`initializing`, a capture-vs-startup-vs-config triage checklist, and
log-sharing hygiene (client payloads are sanitized; log files can contain
paths/hostnames/IPs — transcript text is never logged).

## Verification

Docs-only — no Rust code touched, so the test suite is unaffected (full gate
runs in CI anyway). Checked locally:

- All fenced JSON examples in `docs/api.md` and inline JSON in
  `docs/troubleshooting.md` parse (`python3 json.loads`).
- All relative Markdown links in both files resolve to existing files.
- The error-code table matches the `asyncapi.yaml` `ErrorMessage.code` enum
  exactly (set comparison scripted: 12 codes, identical).
- `typos` (the CI spell-check) passes on all three changed files.

## Deviations / notes

- `docs/embedding.md` (the upcoming sidecar embedding guide) does not exist
  yet, so it is referenced in prose (`docs/embedding.md`, in progress) rather
  than as a Markdown link to keep the "no broken links" criterion;
  `embedding-packaging.md` is linked for the linking/trade-off content.
- Mutual linking is done from both of my files; adding a back-link inside
  `docs/asyncapi.yaml` is left to its owner (parallel task) to avoid
  cross-task edits.
- Fields announced by the parallel segment-confidence work (segment-level
  confidence, limits echoed in `ready`) are not documented here since they do
  not exist in the protocol yet; the new `ready`/`error` tables are structured
  so those rows slot in when it lands.
