### PR TITLE
feat(spm): macOS arm64 slice in the xcframework package

### DIFF
--- a/.github/workflows/ios-xcframework.yml
+++ b/.github/workflows/ios-xcframework.yml
@@ -1,6 +1,7 @@
 name: iOS xcframework
 
-# Builds GigasttFFI.xcframework (device arm64 + simulator arm64/x86_64),
+# Builds GigasttFFI.xcframework (iOS device arm64 + simulator arm64/x86_64 +
+# macOS arm64),
 # attaches the zip to a GitHub release, then rewrites the SwiftPM binaryTarget
 # url + checksum in packaging/swift/Package.swift and commits that to main
 # (only when dispatched from main). A follow-up job verifies the published
@@ -70,7 +71,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,aarch64-apple-darwin
 
       - name: Install protoc
         run: brew install protobuf
@@ -110,6 +111,14 @@ jobs:
           ORT_LIB_LOCATION="$RUNNER_TEMP/ort-x64-stub" \
             cargo rustc --release -p gigastt-ffi --target x86_64-apple-ios --crate-type staticlib
 
+      # macOS arm64 (Apple Silicon): the pyke prebuilt for aarch64-apple-darwin
+      # is a static libonnxruntime.a exactly like the iOS ones, so the slice is
+      # self-contained — no vendored dylib, no extra link flags. There is no
+      # x86_64-apple-darwin prebuilt upstream, so the macOS slice stays
+      # arm64-only (no universal lipo step).
+      - name: Build staticlib (macOS arm64)
+        run: cargo build --release -p gigastt-ffi --target aarch64-apple-darwin
+
       # Regenerate the C header from the FFI crate, then stage a Headers/ dir
       # (gigastt.h + module.modulemap) shared by every xcframework slice.
       - name: Generate header + stage Headers/
@@ -145,8 +154,59 @@ jobs:
             -headers build/Headers \
             -library build/sim/libgigastt_ffi.a \
             -headers build/Headers \
+            -library target/aarch64-apple-darwin/release/libgigastt_ffi.a \
+            -headers build/Headers \
             -output GigasttFFI.xcframework
           plutil -p GigasttFFI.xcframework/Info.plist
+
+      # Smoke-test the macOS slice before publishing: a scratch executable
+      # package consumes the just-built xcframework by path (the documented
+      # local-development mode) and calls into the C ABI through the Swift
+      # wrapper. Engine creation against a missing model dir must fail cleanly
+      # with NULL — reaching that error path proves the statically linked
+      # archive loads and runs on macOS. Fails the build if the macOS slice is
+      # missing or broken, so a bad zip never reaches the release.
+      - name: Smoke-test macOS slice
+        shell: bash
+        run: |
+          set -euo pipefail
+          SMOKE="$RUNNER_TEMP/gigastt-smoke"
+          mkdir -p "$SMOKE/Sources/smoke"
+          cp -R GigasttFFI.xcframework "$SMOKE/"
+          cp -R packaging/swift/Sources/GigaSTT "$SMOKE/Sources/GigaSTT"
+          cat > "$SMOKE/Package.swift" <<'EOF'
+          // swift-tools-version:5.9
+          import PackageDescription
+          // Mirrors packaging/swift/Package.swift (path binaryTarget instead of
+          // the released url) plus an executable target that calls into the C ABI.
+          let package = Package(
+              name: "smoke",
+              platforms: [.macOS(.v13)],
+              targets: [
+                  .binaryTarget(name: "GigasttFFI", path: "GigasttFFI.xcframework"),
+                  .target(
+                      name: "GigaSTT",
+                      dependencies: ["GigasttFFI"],
+                      linkerSettings: [
+                          .linkedLibrary("c++")
+                      ]
+                  ),
+                  .executableTarget(name: "smoke", dependencies: ["GigaSTT"])
+              ]
+          )
+          EOF
+          cat > "$SMOKE/Sources/smoke/main.swift" <<'EOF'
+          import GigaSTT
+
+          do {
+              _ = try Engine(modelDir: "/nonexistent-model-dir")
+              fatalError("expected engineLoadFailed for a missing model dir")
+          } catch {
+              print("macOS smoke OK: C ABI linked, missing model dir rejected (\(error))")
+          }
+          EOF
+          swift build --package-path "$SMOKE"
+          swift run --package-path "$SMOKE" smoke
 
       - name: Zip xcframework
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **macOS support in the Swift package.** `GigasttFFI.xcframework` now ships a
+  macOS arm64 slice alongside the iOS ones (ONNX Runtime statically linked into
+  the slice, no separate runtime to bundle), and the package declares
+  `.macOS(.v13)` next to `.iOS(.v15)` — macOS apps can embed GigaSTT directly
+  instead of shipping the CLI as a sidecar. The release workflow smoke-tests
+  the macOS slice before publishing. The xcframework zip grows by ~30 MB.
+
 ### Changed
 
 - **File-transcription duration cap lowered from 2 hours to 30 minutes.** The cap

--- a/packaging/swift/Package.swift
+++ b/packaging/swift/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "GigaSTT",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v15),
+        .macOS(.v13)
     ],
     products: [
         .library(name: "GigaSTT", targets: ["GigaSTT"])
@@ -33,7 +34,15 @@ let package = Package(
         // -----------------------------------------------------------------------
         .target(
             name: "GigaSTT",
-            dependencies: ["GigasttFFI"]
+            dependencies: ["GigasttFFI"],
+            // ONNX Runtime inside the static archive is C++; its `-lc++` link
+            // directive is emitted by cargo for the Rust link only and does not
+            // propagate through the xcframework, so the consumer link must add
+            // libc++ explicitly or the final app fails with undefined
+            // `std::__1::*` symbols.
+            linkerSettings: [
+                .linkedLibrary("c++")
+            ]
         )
     ]
 )

--- a/packaging/swift/README.md
+++ b/packaging/swift/README.md
@@ -1,12 +1,12 @@
 # GigaSTT for Swift
 
-On-device Russian speech-to-text for iOS, powered by GigaAM v3 and ONNX Runtime.
-No cloud APIs, no network calls at inference time, full privacy.
+On-device Russian speech-to-text for iOS and macOS, powered by GigaAM v3 and
+ONNX Runtime. No cloud APIs, no network calls at inference time, full privacy.
 
 This package wraps the gigastt C ABI in a safe Swift interface. The native code
-ships as a prebuilt `GigasttFFI.xcframework` (device `arm64` + simulator
-`arm64`/`x86_64`), with ONNX Runtime statically linked into each slice — there is no
-separate runtime to bundle.
+ships as a prebuilt `GigasttFFI.xcframework` (iOS device `arm64` + simulator
+`arm64`/`x86_64` + macOS `arm64`), with ONNX Runtime statically linked into
+each slice — there is no separate runtime to bundle.
 
 The package is published in two places: in the engine monorepo
 (`packaging/swift`, for local path dependencies and development) and in the
@@ -17,7 +17,7 @@ subdirectory cannot be consumed via URL).
 
 ## Requirements
 
-- iOS 15 or later
+- iOS 15 or later, or macOS 13 or later (Apple Silicon)
 - Xcode 15 or later (Swift 5.9 tools)
 
 ## Installation


### PR DESCRIPTION
## Summary

Adds a macOS slice to `GigasttFFI.xcframework` and declares macOS support in the Swift package, so macOS apps (e.g. sotto) can embed GigaSTT directly instead of shipping the CLI as a sidecar.

- **`.github/workflows/ios-xcframework.yml`** — builds `gigastt-ffi` for `aarch64-apple-darwin` and adds the resulting `.a` to `xcodebuild -create-xcframework`. The pyke prebuilt for that triple is a static `libonnxruntime.a` (verified in the ort-sys dist manifest and the local build), so the slice is self-contained exactly like the iOS ones — no vendored dylib. A new **Smoke-test macOS slice** step runs before the zip is published: a scratch macOS executable package consumes the just-built xcframework by path, links it, and calls into the C ABI through the Swift wrapper (engine creation against a missing model dir must fail cleanly with NULL → proves the archive loads and runs). A missing/broken slice now fails the workflow instead of shipping.
- **`packaging/swift/Package.swift`** — `platforms: [.iOS(.v15), .macOS(.v13)]`, and the `GigaSTT` wrapper target gains `linkerSettings: [.linkedLibrary("c++")]`. This is **required**, not cosmetic: ONNX Runtime's C++ objects need libc++ at the consumer link, cargo's `-lc++` directive does not propagate through a static archive, and SPM does not add it for a C-module binary target — without it the consumer link fails with undefined `std::__1::*` symbols (reproduced locally). This also fixes the same latent gap for pure-Swift iOS consumers.
- **`packaging/swift/README.md`** — Requirements now list iOS 15+ / macOS 13+ (Apple Silicon); intro updated.
- **`CHANGELOG.md`** — additive Unreleased entry, including the ~30 MB zip growth.

No source changes in `Sources/GigaSTT/` — the wrapper was already platform-neutral (Foundation only), no `#if os(macOS)` needed.

## Verified locally (macOS arm64, this machine)

- `cargo build -p gigastt-ffi --target aarch64-apple-darwin` — clean; resulting `libgigastt_ffi.a` is arm64 with ONNX Runtime statically embedded (~65k ORT symbols, no dylib dependency).
- Full xcframework rehearsal: built all three iOS staticlibs, lipo'd the fat simulator archive, ran the exact `xcodebuild -create-xcframework` command from the updated workflow → 3-slice xcframework (`ios-arm64`, `ios-arm64_x86_64-simulator`, `macos-arm64`).
- The exact smoke-step flow (scratch package, path binaryTarget, `swift build` + `swift run`) — builds and prints `macOS smoke OK: ... engineLoadFailed(...)`.
- `otool -L` on the smoke binary: only system libraries (libc++, libSystem, Foundation/CoreFoundation, CoreML, libobjc, swift runtime) — no third-party dylib, nothing sandbox-hostile. Final binary minos 13.0 as declared.
- `swift package dump-package` — manifest compiles; platforms serialize as iOS 15.0 + macOS 13.0 with the `c++` linker setting on `GigaSTT`.
- Workflow YAML parses (ruby psych); step order verified.
- No Rust sources changed, so fmt/clippy/test are not implicated; the full pre-commit gate runs in PR CI. The full iOS matrix and release attach flow run in the dispatched workflow.

## Notes / deviations

- **No `x86_64-apple-darwin` (universal) slice**: ort's pyke prebuilt manifest has no entry for that triple, so a universal macOS library is not cheap — arm64-only for now. Relevant for the universal2 CLI work in the desktop distribution track.
- **Deployment-target nuance**: the pyke macOS prebuilt objects carry `minos 13.4`; the package declares `.macOS(.v13)` per spec. Consumers targeting 13.0–13.3 get a benign ld warning ("built for newer version"), link and run fine (verified: smoke binary minos 13.0).
- The committed `Package.swift` keeps pointing at the v2.13.0 zip (iOS-only) until the next xcframework release runs — the url/checksum auto-update on dispatch handles the swap, as designed.
