### PR TITLE
feat(server): segment confidence and session limits in ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     convention, or `16000` and always decodes to its native 16 kHz). A raw
     stream posted without `codec` is still rejected with `422 invalid_audio`.
   - CLI parity: `gigastt transcribe call.ulaw --codec pcmu --sample-rate 8000`.
+- **Segment-level confidence on every transcript surface.** `final`/`partial`
+  WebSocket messages, SSE stream events, and the REST `/v1/transcribe` JSON
+  response now carry an optional `confidence` field: the duration-weighted
+  average of the segment's per-word softmax scores (plain average when every
+  word has zero duration; omitted when the segment has no words). It is an
+  average of word scores, not a calibrated segment probability. Additive and
+  omitted-when-absent, so existing clients are unaffected.
+- **Session limits advertised in the WebSocket `ready` message.** The payload
+  now always includes `max_session_secs` and `idle_timeout_secs` from the
+  server configuration, so clients can plan a reconnect before the server
+  closes the socket with `max_session_duration_exceeded` or an idle timeout
+  instead of discovering the caps by getting cut off. Additive; protocol
+  version stays `1.0`.
 
 ### Changed
 

--- a/crates/gigastt-core/src/export.rs
+++ b/crates/gigastt-core/src/export.rs
@@ -538,6 +538,7 @@ mod tests {
             text: "привет как дела".to_string(),
             words: sample_words(),
             duration_s: 1.4,
+            confidence: None,
         }
     }
 
@@ -718,6 +719,7 @@ mod tests {
                 speaker: None,
             }],
             duration_s: 0.3,
+            confidence: None,
         };
         let md = to_md(&result, true);
         assert!(md.contains("speakers: 0"));
@@ -731,6 +733,7 @@ mod tests {
             text: String::new(),
             words: Vec::new(),
             duration_s: 0.0,
+            confidence: None,
         };
         let md = to_md(&result, true);
         // Empty word list means the appendix table is omitted entirely.
@@ -750,6 +753,7 @@ mod tests {
                 speaker: Some(2),
             }],
             duration_s: 0.5,
+            confidence: None,
         };
         let md = to_md(&result, true);
         // Pipe in the word must be escaped to avoid breaking the table column.
@@ -872,6 +876,7 @@ mod tests {
             text: String::new(),
             words: Vec::new(),
             duration_s: 0.0,
+            confidence: None,
         };
         let md = to_md_segments(&result, 80, 14);
         // No words means no section headers, but the frontmatter still renders.

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -632,6 +632,31 @@ impl WordInfo {
     }
 }
 
+/// Aggregate per-word confidences into a single segment-level score:
+/// a duration-weighted mean of `words[].confidence` (longer words count
+/// more). Falls back to a plain mean when every word has zero duration, and
+/// returns `None` for an empty word list. The result is an average of
+/// per-word softmax scores — **not** a calibrated probability that the
+/// segment is correct.
+fn aggregate_confidence(words: &[WordInfo]) -> Option<f32> {
+    if words.is_empty() {
+        return None;
+    }
+    let mut weighted_sum = 0.0_f64;
+    let mut total_weight = 0.0_f64;
+    for w in words {
+        let weight = (w.end - w.start).max(0.0);
+        weighted_sum += f64::from(w.confidence) * weight;
+        total_weight += weight;
+    }
+    let mean = if total_weight > 0.0 {
+        weighted_sum / total_weight
+    } else {
+        words.iter().map(|w| f64::from(w.confidence)).sum::<f64>() / words.len() as f64
+    };
+    Some(mean as f32)
+}
+
 /// Per-connection streaming state that persists across audio chunks.
 ///
 /// Created via [`Engine::create_state`]. Holds the decoder LSTM state, an audio
@@ -782,11 +807,13 @@ impl TranscriptAssembler {
 
     /// Build a **final** segment and reset internal accumulation.
     pub fn finalize(&mut self, timestamp: f64) -> TranscriptSegment {
+        let confidence = aggregate_confidence(&self.words);
         TranscriptSegment {
             text: std::mem::take(&mut self.text),
             words: std::mem::take(&mut self.words),
             is_final: true,
             timestamp,
+            confidence,
         }
     }
 
@@ -797,6 +824,7 @@ impl TranscriptAssembler {
             words: self.words.clone(),
             is_final: false,
             timestamp,
+            confidence: aggregate_confidence(&self.words),
         }
     }
 
@@ -2029,6 +2057,7 @@ impl Engine {
                 text: String::new(),
                 words: Vec::new(),
                 duration_s: 0.0,
+                confidence: None,
             });
         }
 
@@ -2038,6 +2067,7 @@ impl Engine {
             let words = self.decode_words_for_samples(channel_samples, triplet, &overrides)?;
             let duration_s = channel_samples.len() as f64 / 16000.0;
             per_channel.push(TranscribeResult {
+                confidence: aggregate_confidence(&words),
                 text: String::new(),
                 words,
                 duration_s,
@@ -2329,6 +2359,7 @@ impl Engine {
 
         TranscribeResult {
             text,
+            confidence: aggregate_confidence(&words),
             words,
             duration_s,
         }
@@ -2558,6 +2589,13 @@ pub struct TranscribeResult {
     pub words: Vec<WordInfo>,
     /// Duration of the decoded audio in seconds.
     pub duration_s: f64,
+    /// Mean confidence across all words (duration-weighted average of
+    /// `words[].confidence`; plain average when every word has zero
+    /// duration). An average of per-word softmax scores — **not** a
+    /// calibrated probability that the transcript is correct. `None` when no
+    /// words were decoded; omitted from JSON in that case.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f32>,
 }
 
 /// Per-request overrides for the recognition post-processing knobs, letting a
@@ -2659,6 +2697,7 @@ pub fn merge_channel_results(per_channel: Vec<TranscribeResult>) -> TranscribeRe
         .join(" ");
 
     TranscribeResult {
+        confidence: aggregate_confidence(&all_words),
         text,
         words: all_words,
         duration_s,
@@ -2679,6 +2718,13 @@ pub struct TranscriptSegment {
     pub is_final: bool,
     /// Unix timestamp (seconds since epoch) when this segment was produced.
     pub timestamp: f64,
+    /// Mean confidence across the segment's words (duration-weighted average
+    /// of `words[].confidence`; plain average when every word has zero
+    /// duration). An average of per-word softmax scores — **not** a
+    /// calibrated probability that the segment is correct. `None` when the
+    /// segment has no words; omitted from JSON in that case.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f32>,
 }
 
 impl TranscriptSegment {
@@ -2688,6 +2734,7 @@ impl TranscriptSegment {
             words: vec![],
             is_final: true,
             timestamp: now_timestamp(),
+            confidence: None,
         }
     }
 }
@@ -2894,11 +2941,13 @@ mod tests {
                 text: String::new(),
                 words: vec![],
                 duration_s: 0.0,
+                confidence: None,
             },
             TranscribeResult {
                 text: String::new(),
                 words: vec![],
                 duration_s: 0.0,
+                confidence: None,
             },
         ]);
         assert!(merged.words.is_empty());
@@ -2914,11 +2963,13 @@ mod tests {
                 sample_word("как", 1.0, 1.3, None),
             ],
             duration_s: 1.5,
+            confidence: None,
         };
         let ch1 = TranscribeResult {
             text: String::new(),
             words: vec![sample_word("да", 0.5, 0.8, None)],
             duration_s: 1.5,
+            confidence: None,
         };
         let merged = merge_channel_results(vec![ch0, ch1]);
         assert_eq!(merged.words.len(), 3);
@@ -2936,11 +2987,13 @@ mod tests {
             text: String::new(),
             words: vec![sample_word("а", 0.5, 0.7, None)],
             duration_s: 1.0,
+            confidence: None,
         };
         let ch1 = TranscribeResult {
             text: String::new(),
             words: vec![sample_word("б", 0.5, 0.7, None)],
             duration_s: 1.0,
+            confidence: None,
         };
         let merged = merge_channel_results(vec![ch0, ch1]);
         assert_eq!(merged.words[0].word, "а");
@@ -2963,11 +3016,13 @@ mod tests {
             text: String::new(),
             words: vec![sample_word("a", 0.0, 0.5, None)],
             duration_s: 5.0,
+            confidence: None,
         };
         let ch1 = TranscribeResult {
             text: String::new(),
             words: vec![sample_word("b", 0.5, 1.0, None)],
             duration_s: 12.0,
+            confidence: None,
         };
         let merged = merge_channel_results(vec![ch0, ch1]);
         assert_eq!(merged.duration_s, 12.0);
@@ -3576,6 +3631,80 @@ mod tests {
         assert!(!seg.is_final);
         // partial must not reset the assembler.
         assert!(!asm.is_empty());
+    }
+
+    #[test]
+    fn test_aggregate_confidence_duration_weighted() {
+        // The longer word dominates: (0.9*1.0 + 0.5*3.0) / 4.0 = 0.6.
+        let words = vec![
+            WordInfo::new("short", 0.0, 1.0, 0.9, None),
+            WordInfo::new("long", 1.0, 4.0, 0.5, None),
+        ];
+        let c = aggregate_confidence(&words).expect("non-empty words give a score");
+        assert!((c - 0.6).abs() < 1e-6, "duration-weighted mean, got {c}");
+    }
+
+    #[test]
+    fn test_aggregate_confidence_zero_duration_plain_mean() {
+        // Zero-duration words carry no weight; fall back to the plain mean
+        // (0.8 + 0.6) / 2 = 0.7 instead of a 0/0 divide.
+        let words = vec![
+            WordInfo::new("a", 1.0, 1.0, 0.8, None),
+            WordInfo::new("b", 2.0, 2.0, 0.6, None),
+        ];
+        let c = aggregate_confidence(&words).expect("non-empty words give a score");
+        assert!((c - 0.7).abs() < 1e-6, "plain mean, got {c}");
+    }
+
+    #[test]
+    fn test_aggregate_confidence_empty_words_none() {
+        assert_eq!(aggregate_confidence(&[]), None);
+    }
+
+    #[test]
+    fn test_assembler_fills_segment_confidence() {
+        let mut asm = TranscriptAssembler::new();
+        asm.append(vec![
+            WordInfo::new("hello", 0.0, 0.5, 0.9, None),
+            WordInfo::new("world", 0.5, 1.0, 0.8, None),
+        ]);
+        let partial = asm.partial(0.5);
+        let c = partial.confidence.expect("partial carries the aggregate");
+        assert!(
+            (c - 0.85).abs() < 1e-6,
+            "equal durations → plain mean, got {c}"
+        );
+        let final_seg = asm.finalize(1.0);
+        let c = final_seg.confidence.expect("final carries the aggregate");
+        assert!((c - 0.85).abs() < 1e-6, "got {c}");
+        // An empty assembler yields an empty segment with no score.
+        let empty = asm.finalize(1.0);
+        assert_eq!(empty.confidence, None);
+    }
+
+    #[test]
+    fn test_segment_confidence_omitted_from_json_when_none() {
+        // Backward-compatible payload: a segment without words must serialize
+        // exactly like before the field existed — no `confidence` key at all.
+        let seg = TranscriptSegment::empty_final();
+        let v = serde_json::to_value(&seg).unwrap();
+        assert!(v.get("confidence").is_none());
+    }
+
+    #[test]
+    fn test_segment_old_json_without_confidence_still_deserializes() {
+        // Client-side view of the wire contract: payloads written before the
+        // `confidence` field existed (no key) must keep parsing into a typed
+        // client that knows the field — it simply defaults to `None`. The
+        // core segment type is Serialize-only; this mirrors a typed SDK.
+        #[derive(serde::Deserialize)]
+        struct ClientSegmentView {
+            #[serde(default)]
+            confidence: Option<f32>,
+        }
+        let old_json = r#"{"text":"привет","words":[],"is_final":true,"timestamp":1.0}"#;
+        let view: ClientSegmentView = serde_json::from_str(old_json).unwrap();
+        assert_eq!(view.confidence, None);
     }
 
     #[test]

--- a/crates/gigastt-core/src/protocol/mod.rs
+++ b/crates/gigastt-core/src/protocol/mod.rs
@@ -29,6 +29,15 @@ pub enum ServerMessage {
         /// to `version` (i.e. only one version is supported) for backward compat.
         #[serde(skip_serializing_if = "Option::is_none")]
         min_protocol_version: Option<String>,
+        /// Maximum wall-clock session duration in seconds (server
+        /// `--max-session-secs`; `0` = no cap). Always sent so clients can
+        /// plan a reconnect before the server closes the socket with
+        /// `max_session_duration_exceeded`. Additive; older clients ignore it.
+        max_session_secs: u64,
+        /// Idle timeout in seconds (server `--idle-timeout-secs`): the server
+        /// closes the session when no frame arrives within this window.
+        /// Always sent; additive, older clients ignore it.
+        idle_timeout_secs: u64,
     },
 
     /// Partial (interim) transcript — may change with more audio.
@@ -111,6 +120,8 @@ mod tests {
             supported_rates: vec![],
             diarization: false,
             min_protocol_version: Some(PROTOCOL_VERSION.into()),
+            max_session_secs: 3600,
+            idle_timeout_secs: 300,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -122,12 +133,34 @@ mod tests {
     }
 
     #[test]
+    fn test_ready_session_limits_always_serialized() {
+        // The session caps are plain `u64` fields (no skip attr): they must be
+        // present in every ready payload so clients can plan around them
+        // before hitting a close frame. A zero cap serializes as `0`, not null
+        // or an omitted key.
+        let msg = ServerMessage::Ready {
+            model: "test".into(),
+            sample_rate: 48000,
+            version: "1.0".into(),
+            supported_rates: vec![],
+            diarization: false,
+            min_protocol_version: None,
+            max_session_secs: 0,
+            idle_timeout_secs: 42,
+        };
+        let v = serde_json::to_value(&msg).unwrap();
+        assert_eq!(v["max_session_secs"], 0);
+        assert_eq!(v["idle_timeout_secs"], 42);
+    }
+
+    #[test]
     fn test_partial_serialization_no_version() {
         let msg = ServerMessage::Partial(crate::inference::TranscriptSegment {
             text: "hello".into(),
             timestamp: 1.0,
             words: vec![],
             is_final: false,
+            confidence: None,
         });
         let json = serde_json::to_string(&msg).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -142,6 +175,7 @@ mod tests {
             timestamp: 1.0,
             words: vec![],
             is_final: true,
+            confidence: None,
         });
         let json = serde_json::to_string(&msg).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -206,6 +240,8 @@ mod tests {
             supported_rates: vec![8000, 16000, 24000, 44100, 48000],
             diarization: false,
             min_protocol_version: None,
+            max_session_secs: 3600,
+            idle_timeout_secs: 300,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -221,6 +257,8 @@ mod tests {
             supported_rates: vec![],
             diarization: false,
             min_protocol_version: None,
+            max_session_secs: 3600,
+            idle_timeout_secs: 300,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -347,6 +385,8 @@ mod tests {
             supported_rates: vec![],
             diarization: false,
             min_protocol_version: None,
+            max_session_secs: 3600,
+            idle_timeout_secs: 300,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -362,6 +402,8 @@ mod tests {
             supported_rates: vec![],
             diarization: false,
             min_protocol_version: None,
+            max_session_secs: 3600,
+            idle_timeout_secs: 300,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/crates/gigastt/src/batch.rs
+++ b/crates/gigastt/src/batch.rs
@@ -548,6 +548,7 @@ mod tests {
                 WordInfo::new("привет", 0.0, 0.5, 0.98, None),
                 WordInfo::new("мир", 0.6, 1.0, 0.97, None),
             ],
+            confidence: Some(0.975),
             duration_s: 1.0,
         }
     }

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -163,6 +163,12 @@ pub struct TranscribeResponse {
     pub words: Vec<gigastt_core::inference::WordInfo>,
     /// Duration of the submitted audio in seconds.
     pub duration: f64,
+    /// Mean confidence across all words (duration-weighted average of
+    /// `words[].confidence`): an average of per-word softmax scores, not a
+    /// calibrated transcript probability. Additive; omitted when no words
+    /// were decoded so the pre-field response shape is preserved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f32>,
     /// Transcript segments grouped from word timestamps, present only when the
     /// caller passed `?segments=true`. Additive: absent from the default response,
     /// so existing clients that read `text` / `words` / `duration` are unaffected.
@@ -523,13 +529,18 @@ fn sse_data_payload(
     match result {
         Ok(seg) => {
             let ty = if seg.is_final { "final" } else { "partial" };
-            serde_json::json!({
+            let mut payload = serde_json::json!({
                 "type": ty,
                 "text": seg.text,
                 "timestamp": seg.timestamp,
                 "words": seg.words,
-            })
-            .to_string()
+            });
+            // Same omission contract as the WS segment payload: no words →
+            // no `confidence` key at all.
+            if let Some(confidence) = seg.confidence {
+                payload["confidence"] = confidence.into();
+            }
+            payload.to_string()
         }
         Err(err) => serde_json::json!({
             "type": "error",
@@ -887,6 +898,7 @@ pub async fn transcribe(
                     text: result.text,
                     words: result.words,
                     duration: result.duration_s,
+                    confidence: result.confidence,
                     segments,
                 })
                 .into_response())
@@ -1383,6 +1395,7 @@ pub async fn get_job_result(
             text: result.text,
             words: result.words,
             duration: result.duration_s,
+            confidence: result.confidence,
             segments,
         })
         .into_response())
@@ -1492,6 +1505,7 @@ mod tests {
             words: vec![],
 
             duration: 1.5,
+            confidence: None,
             segments: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
@@ -1779,6 +1793,23 @@ mod tests {
         let partial_payload = sse_data_payload(&Ok(partial));
         let v: serde_json::Value = serde_json::from_str(&partial_payload).unwrap();
         assert_eq!(v["type"], "partial");
+    }
+
+    #[test]
+    fn test_sse_data_payload_confidence_present_only_when_some() {
+        // A segment with words carries the aggregate; an empty one omits the
+        // key entirely, matching the WS payload contract.
+        let mut seg = gigastt_core::inference::TranscriptSegment::empty_final();
+        seg.confidence = Some(0.85);
+        let payload = sse_data_payload(&Ok(seg));
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        let c = v["confidence"].as_f64().expect("numeric confidence");
+        assert!((c - 0.85).abs() < 1e-6, "got {c}");
+
+        let empty = gigastt_core::inference::TranscriptSegment::empty_final();
+        let payload = sse_data_payload(&Ok(empty));
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert!(v.get("confidence").is_none());
     }
 
     #[tokio::test]
@@ -2110,6 +2141,7 @@ mod tests {
                 WordInfo::new("мир", 0.6, 1.0, 0.97, Some(0)),
             ],
             duration_s: 1.0,
+            confidence: None,
         }
     }
 
@@ -2450,12 +2482,40 @@ mod tests {
             text: "hello".into(),
             words: vec![],
             duration: 1.5,
+            confidence: None,
             segments: None,
         };
         let v = serde_json::to_value(&resp).unwrap();
         assert!(v.get("segments").is_none());
         assert_eq!(v["text"], "hello");
         assert_eq!(v["duration"], 1.5);
+    }
+
+    #[test]
+    fn test_transcribe_response_confidence_present_only_when_some() {
+        // With words decoded, the aggregate rides the top-level response;
+        // without words the key is omitted so the response shape matches the
+        // pre-field contract exactly.
+        let with = TranscribeResponse {
+            text: "hello".into(),
+            words: vec![],
+            duration: 1.5,
+            confidence: Some(0.87),
+            segments: None,
+        };
+        let v = serde_json::to_value(&with).unwrap();
+        let c = v["confidence"].as_f64().expect("numeric confidence");
+        assert!((c - 0.87).abs() < 1e-6, "got {c}");
+
+        let without = TranscribeResponse {
+            text: String::new(),
+            words: vec![],
+            duration: 0.0,
+            confidence: None,
+            segments: None,
+        };
+        let v = serde_json::to_value(&without).unwrap();
+        assert!(v.get("confidence").is_none());
     }
 
     #[test]
@@ -2470,6 +2530,7 @@ mod tests {
             text: "привет мир".into(),
             words: words.clone(),
             duration: 1.0,
+            confidence: None,
             segments: Some(to_segments(&words, 80, 14)),
         };
         let v = serde_json::to_value(&resp).unwrap();

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -983,6 +983,7 @@ mod tests {
             text: "ok".into(),
             words: vec![],
             duration_s: 1.0,
+            confidence: None,
         })
     }
 

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -785,6 +785,8 @@ mod tests {
             supported_rates: vec![16000],
             diarization: false,
             min_protocol_version: None,
+            max_session_secs: 3600,
+            idle_timeout_secs: 300,
         };
         let json = json_text(&msg);
         assert!(json.contains("\"type\":\"ready\""));

--- a/crates/gigastt/src/server/ws.rs
+++ b/crates/gigastt/src/server/ws.rs
@@ -573,6 +573,8 @@ async fn handle_ws_inner(
         supported_rates: SUPPORTED_RATES.to_vec(),
         diarization: diarization_available,
         min_protocol_version: None,
+        max_session_secs: limits.max_session_secs,
+        idle_timeout_secs: limits.idle_timeout_secs,
     };
     send_server_message(&mut sink, &ready).await?;
 

--- a/crates/gigastt/tests/e2e_ws.rs
+++ b/crates/gigastt/tests/e2e_ws.rs
@@ -46,6 +46,11 @@ async fn test_ws_connect_receives_ready() {
         rates.contains(&serde_json::json!(48000)),
         "supported_rates should contain 48000"
     );
+
+    // Session caps are always advertised (server defaults: 3600s session,
+    // 300s idle) so clients can plan reconnects before a close frame.
+    assert_eq!(ready["max_session_secs"], 3600);
+    assert_eq!(ready["idle_timeout_secs"], 300);
 }
 
 // ---------------------------------------------------------------------------
@@ -1466,5 +1471,61 @@ async fn test_ws_punctuation_override_survives_diarization_reconfigure() {
     assert_eq!(
         text, raw,
         "punctuation=false must survive the diarization state recreation: {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Session limits in `ready` + segment-level confidence
+// ---------------------------------------------------------------------------
+
+/// The `ready` message advertises the server's session caps verbatim so a
+/// client can plan a reconnect before hitting `max_session_duration_exceeded`
+/// or an idle close. Distinctive non-default values prove the payload is
+/// wired to the live config, not hardcoded.
+#[ignore]
+#[tokio::test]
+async fn test_ws_ready_reports_configured_session_limits() {
+    let model_dir = common::model_dir();
+    let limits = gigastt::server::RuntimeLimits {
+        max_session_secs: 4567,
+        idle_timeout_secs: 123,
+        ..Default::default()
+    };
+    let (port, _shutdown) = common::start_server_with_limits(&model_dir, limits).await;
+
+    let (_sink, _stream, ready) = common::ws_connect(port).await;
+
+    assert_eq!(ready["max_session_secs"], 4567);
+    assert_eq!(ready["idle_timeout_secs"], 123);
+}
+
+/// A final segment decoded from real speech carries a segment-level
+/// `confidence` aggregate in [0, 1] alongside the per-word scores.
+#[ignore]
+#[tokio::test]
+async fn test_ws_final_carries_segment_confidence() {
+    let model_dir = common::model_dir();
+    let (port, _shutdown) = common::start_server(&model_dir).await;
+
+    let (mut sink, mut stream, _ready) = common::ws_connect(port).await;
+    sink.send(Message::Text(
+        serde_json::to_string(&serde_json::json!({"type": "configure", "sample_rate": 16000}))
+            .unwrap()
+            .into(),
+    ))
+    .await
+    .unwrap();
+
+    let (_partials, final_seg) = stream_golos_and_collect(&mut sink, &mut stream).await;
+    assert!(
+        !joined_words(&final_seg).is_empty(),
+        "speech fixture must decode to words"
+    );
+    let confidence = final_seg["confidence"]
+        .as_f64()
+        .expect("final with words must carry a numeric confidence");
+    assert!(
+        (0.0..=1.0).contains(&confidence),
+        "segment confidence must lie in [0, 1], got {confidence}"
     );
 }

--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -11,7 +11,8 @@ info:
 
     1. Client connects to `ws://{host}:{port}/v1/ws` (default: `ws://127.0.0.1:9876/v1/ws`).
        - Server binds `127.0.0.1` by default; use `--bind-all` (or `GIGASTT_ALLOW_BIND_ANY=1`) plus `--host 0.0.0.0` for Docker.
-    2. Server sends `ready` message with model info, protocol version, `supported_rates`, and `diarization` capability
+    2. Server sends `ready` message with model info, protocol version, `supported_rates`, `diarization`
+       capability, and the configured session caps (`max_session_secs`, `idle_timeout_secs`)
     3. (Optional) Client sends `configure` to pick a non-default `sample_rate`, enable `diarization`,
        and/or override the post-processing policy (`punctuation`, `itn`)
     4. Client streams raw PCM16 audio as binary frames (default 48 kHz mono, or the negotiated rate)
@@ -255,6 +256,20 @@ components:
           type: boolean
           example: false
           description: Whether speaker diarization is available
+        max_session_secs:
+          type: integer
+          example: 3600
+          description: >-
+            Wall-clock session cap in seconds (server `--max-session-secs`;
+            `0` = no cap). Always sent so clients can plan a reconnect before
+            the server closes the socket with `max_session_duration_exceeded`.
+        idle_timeout_secs:
+          type: integer
+          example: 300
+          description: >-
+            Idle timeout in seconds (server `--idle-timeout-secs`): the server
+            closes the session when no frame arrives within this window.
+            Always sent.
 
     PartialMessage:
       type: object
@@ -284,6 +299,18 @@ components:
           items:
             $ref: "#/components/schemas/WordInfo"
           description: Word-level transcription with timestamps
+        confidence:
+          type: number
+          format: float
+          minimum: 0.0
+          maximum: 1.0
+          example: 0.93
+          description: >-
+            Mean confidence across the segment's words (duration-weighted
+            average of `words[].confidence`; plain average when every word has
+            zero duration). An average of per-word softmax scores — not a
+            calibrated probability that the segment is correct. Omitted when
+            the segment has no words.
 
     FinalMessage:
       type: object
@@ -314,6 +341,18 @@ components:
           items:
             $ref: "#/components/schemas/WordInfo"
           description: Word-level transcription with timestamps
+        confidence:
+          type: number
+          format: float
+          minimum: 0.0
+          maximum: 1.0
+          example: 0.95
+          description: >-
+            Mean confidence across the segment's words (duration-weighted
+            average of `words[].confidence`; plain average when every word has
+            zero duration). An average of per-word softmax scores — not a
+            calibrated probability that the segment is correct. Omitted when
+            the segment has no words.
 
     ErrorMessage:
       type: object


### PR DESCRIPTION
## Summary

- **Segment-level confidence on every transcript surface.** `TranscriptSegment` (WS `partial`/`final`), SSE stream events, and REST `/v1/transcribe` (`TranscribeResult` → `TranscribeResponse`) now carry an optional `confidence` field: the duration-weighted average of `words[].confidence` (plain average when every word has zero duration; `None` — key omitted — when the segment has no words). Doc comments fix the semantics: an average of per-word softmax scores, **not** a calibrated segment probability.
- **Session limits in `ready`.** The WebSocket `ready` message now always includes `max_session_secs` and `idle_timeout_secs` from the live server config, so clients can plan a reconnect before a `max_session_duration_exceeded` / idle close instead of discovering the caps by getting cut off (the OpenOffer >1h interview case).
- Both changes are strictly additive; `PROTOCOL_VERSION` stays `1.0`. Old payloads (no `confidence` key) still deserialize into confidence-aware clients (pinned by a unit test).

## Implementation notes

- Aggregate lives in `crates/gigastt-core/src/inference/mod.rs` (`aggregate_confidence`), filled by `TranscriptAssembler::partial`/`finalize` (streaming), `finish_transcribe_result` (file path), and `merge_channel_results` (stereo split).
- SSE `final` did **not** get the field for free — `sse_data_payload` builds its JSON by hand, so the confidence key is added there explicitly with the same omit-when-`None` contract as the WS payload.
- `TranscribeResult` literals in `export.rs` / `jobs.rs` tests and `http.rs` helpers gained `confidence: None` (compile-forced, no behavior change).

## Verified locally

- `cargo test -p gigastt-core --lib` — 440 passed (new: aggregate weighting, zero-duration fallback, empty → `None`, assembler fill, JSON omission, old-JSON deserializes)
- `cargo test -p gigastt --lib --bins` — 125 + 88 passed (new: SSE payload confidence present/omitted, `TranscribeResponse` confidence present/omitted, `ready` limits always serialized incl. zero cap)
- `cargo clippy -p gigastt-core -p gigastt --all-targets` — zero warnings; `cargo fmt --check` clean
- `cargo test -p gigastt --test e2e_ws --no-run` — new e2e tests compile (`test_ws_ready_reports_configured_session_limits`, `test_ws_final_carries_segment_confidence`, plus default-limit assertions in the existing ready test)
- `cargo check -p gigastt-ffi -p gigastt-uniffi -p gigastt-node` — dependent crates unaffected
- `docs/asyncapi.yaml` parses (ruby YAML + `yq`); `ReadyMessage`, `PartialMessage`, `FinalMessage` schemas updated
- Not run locally: `--ignored` e2e (needs the multi-GB model) and the WER harness — the full gate runs in CI.

## Deviations / cross-task notes

- `docs/api.md` intentionally untouched per the roadmap split — **hook for the docs task**: document the new additive fields there (`ready.max_session_secs` / `ready.idle_timeout_secs`, WS `partial`/`final` `confidence`, REST `confidence`, SSE `confidence`).
- Shared-file touches (additive, tightly scoped): `server/http.rs` (response field + SSE payload + tests), `server/jobs.rs` (one mock literal), `export.rs` (test literals only), `server/mod.rs` (one test literal).
