### PR TITLE
feat(cli): add transcribe-batch and watch folder commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,11 +368,16 @@ All CLI flags have corresponding env vars:
 | `GIGASTT_PUNCTUATION` | `--punctuation` | auto |
 | `GIGASTT_PUNCT_MODEL_DIR` | `--punct-model-dir` | `~/.gigastt/models/punct/` |
 | `GIGASTT_ITN` | `--itn` | auto |
-| `GIGASTT_FORMAT` | `transcribe --format` | `txt` |
+| `GIGASTT_FORMAT` | `transcribe --format` | `txt` (`txt,json` for `transcribe-batch` / `watch`) |
 | `GIGASTT_OUTPUT` | `transcribe --output` | — |
 | `GIGASTT_MAX_CHARS_PER_LINE` | `transcribe --max-chars-per-line` | — |
 | `GIGASTT_MAX_WORDS_PER_LINE` | `transcribe --max-words-per-line` | — |
 | `GIGASTT_WORD_TIMESTAMPS` | `transcribe --word-timestamps` | false |
+| `GIGASTT_BATCH_MOVE_TO` | `transcribe-batch / watch --move-to` | — |
+| `GIGASTT_BATCH_DELETE_SOURCE` | `transcribe-batch / watch --delete-source` | false |
+| `GIGASTT_BATCH_RETRIES` | `transcribe-batch / watch --retries` | 0 / 2 |
+| `GIGASTT_WATCH_POLL_INTERVAL_MS` | `watch --poll-interval-ms` | 1000 |
+| `GIGASTT_WATCH_SETTLE_POLLS` | `watch --settle-polls` | 2 |
 | `GIGASTT_STEREO_SPEAKERS` | `--stereo-speakers` | false |
 | `RUST_LOG` | — | `gigastt=info` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.macOS(.v13)` next to `.iOS(.v15)` — macOS apps can embed GigaSTT directly
   instead of shipping the CLI as a sidecar. The release workflow smoke-tests
   the macOS slice before publishing. The xcframework zip grows by ~30 MB.
+- **Batch and watch-folder CLI: `gigastt transcribe-batch` and `gigastt watch`.**
+  First-class folder transcription without shell wrappers: `transcribe-batch
+  <in> <out>` recursively transcribes every WAV / MP3 / M4A / OGG / FLAC file
+  under a directory, writing `<stem>.txt` + `<stem>.json` (configurable via
+  `--format txt,json,md,srt,vtt`) per file with `--pool-size` parallel workers;
+  `watch <in> <out>` polls a folder and transcribes new or changed files once
+  their size+mtime stays stable across `--settle-polls` polls, so
+  partially-copied files are never picked up. Both support `--move-to done/` /
+  `--delete-source` post-success source policies, per-file retries, and
+  graceful Ctrl-C (in-flight files finish; `transcribe-batch` exits 130 like
+  `download`). Files already present when `watch` starts are left for
+  `transcribe-batch`. See [docs/cli.md](docs/cli.md).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ The GigaAM v3 model (~850 MB) auto-downloads on first run and is INT8-quantized 
 $ gigastt transcribe recording.wav
 Привет, как дела?
 
+# Batch-process a whole folder (txt + json per file, 2 workers):
+$ gigastt transcribe-batch samples/ out/
+
+# Or watch a folder and transcribe files as they are dropped in:
+$ gigastt watch inbox/ out/ --move-to inbox/done/
+
 # Or run the server — WebSocket + REST + SSE on one port (loopback only):
 $ gigastt serve
 # WebSocket  ws://127.0.0.1:9876/v1/ws

--- a/crates/gigastt/src/batch.rs
+++ b/crates/gigastt/src/batch.rs
@@ -1,0 +1,937 @@
+//! Batch and watch-folder transcription helpers for the offline CLI.
+//!
+//! Model-free by design: the engine is injected as a [`TranscribeFn`] closure,
+//! so the traversal / rendering / retry / watch state machine is unit-tested
+//! without loading ONNX models.
+
+use anyhow::Context;
+use gigastt_core::export::{ExportFormat, RenderOpts};
+use gigastt_core::inference::TranscribeResult;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Audio extensions accepted by the batch / watch walkers (case-insensitive).
+/// Mirrors the symphonia-backed file support of `Engine::transcribe_file`.
+pub const SUPPORTED_EXTENSIONS: &[&str] = &["wav", "mp3", "m4a", "ogg", "flac"];
+
+/// Injectable transcription step: maps an audio file path to its result. The
+/// production closure checks out a pool triplet and calls
+/// `Engine::transcribe_file`; tests stub it out.
+pub type TranscribeFn = Arc<dyn Fn(PathBuf) -> anyhow::Result<TranscribeResult> + Send + Sync>;
+
+/// Shared knobs for one batch run.
+pub struct BatchOptions {
+    /// Root directory scanned (recursively) for audio files.
+    pub input_dir: PathBuf,
+    /// Directory the rendered outputs are written into (created if absent).
+    pub output_dir: PathBuf,
+    /// Formats rendered per input file (`{stem}.{ext}` per format).
+    pub formats: Vec<ExportFormat>,
+    /// Subtitle / Markdown rendering options.
+    pub render_opts: RenderOpts,
+    /// Optional directory successfully processed sources are moved into.
+    pub move_to: Option<PathBuf>,
+    /// Delete the source file after successful processing.
+    pub delete_source: bool,
+    /// Max files transcribed concurrently (bounded by the engine pool).
+    pub concurrency: usize,
+    /// Extra attempts after the first failure (per file).
+    pub retries: u32,
+}
+
+/// Outcome counters of a [`run_batch`] run.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct BatchSummary {
+    /// Files transcribed and written successfully.
+    pub processed: usize,
+    /// Files that failed after all retries.
+    pub failed: usize,
+    /// Files never started because the run was interrupted.
+    pub skipped: usize,
+    /// Whether the run was cut short by a shutdown request.
+    pub interrupted: bool,
+}
+
+/// Outcome counters of a [`run_watch`] session.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct WatchSummary {
+    /// Files transcribed and written successfully.
+    pub processed: usize,
+    /// Files that failed after all retries.
+    pub failed: usize,
+}
+
+/// Watch-specific knobs on top of [`BatchOptions`].
+pub struct WatchOptions {
+    /// Processing settings shared with one-shot batches.
+    pub batch: BatchOptions,
+    /// Delay between directory scans.
+    pub poll_interval: Duration,
+    /// Consecutive identical observations (size + mtime) required before a
+    /// file is considered fully written and scheduled.
+    pub settle_polls: u32,
+}
+
+/// Whether `path` carries a supported audio extension (case-insensitive).
+pub fn is_audio_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| SUPPORTED_EXTENSIONS.contains(&e.to_ascii_lowercase().as_str()))
+        .unwrap_or(false)
+}
+
+/// Recursively collect supported audio files under `root`, sorted for a
+/// deterministic processing order. Symlinked directories are not followed.
+pub fn collect_audio_files(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    collect_into(root, &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+fn collect_into(dir: &Path, out: &mut Vec<PathBuf>) -> anyhow::Result<()> {
+    let entries = std::fs::read_dir(dir)
+        .with_context(|| format!("failed to read directory {}", dir.display()))?;
+    for entry in entries {
+        let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
+        let path = entry.path();
+        // DirEntry::file_type does not follow symlinks, so a symlinked
+        // directory can never send the walker into a loop.
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_into(&path, out)?;
+        } else if path.is_file() && is_audio_file(&path) {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Output path for one input file and format: `<output_dir>/<stem>.<ext>`.
+pub fn output_path_for(input: &Path, output_dir: &Path, extension: &str) -> PathBuf {
+    let stem = input
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("transcript");
+    output_dir.join(format!("{stem}.{extension}"))
+}
+
+/// Parse a comma-separated format list (`txt,json,md,srt,vtt`) into
+/// [`ExportFormat`]s, de-duplicated, order preserved.
+pub fn parse_formats(s: &str) -> Result<Vec<ExportFormat>, String> {
+    let mut out: Vec<ExportFormat> = Vec::new();
+    for part in s.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+        let fmt = part
+            .parse::<ExportFormat>()
+            .map_err(|_| format!("unsupported export format: {part}"))?;
+        if !out.contains(&fmt) {
+            out.push(fmt);
+        }
+    }
+    if out.is_empty() {
+        return Err("at least one export format is required".to_string());
+    }
+    Ok(out)
+}
+
+/// Move a file, falling back to copy + remove when `rename` cannot cross
+/// filesystems.
+fn move_file(source: &Path, dest: &Path) -> anyhow::Result<()> {
+    if std::fs::rename(source, dest).is_ok() {
+        return Ok(());
+    }
+    std::fs::copy(source, dest)
+        .with_context(|| format!("failed to move {} to {}", source.display(), dest.display()))?;
+    std::fs::remove_file(source)
+        .with_context(|| format!("failed to remove {}", source.display()))?;
+    Ok(())
+}
+
+/// Shared per-run state handed to every processing task.
+struct ProcessCtx {
+    output_dir: PathBuf,
+    formats: Vec<ExportFormat>,
+    render_opts: RenderOpts,
+    move_to: Option<PathBuf>,
+    delete_source: bool,
+    transcribe: TranscribeFn,
+}
+
+/// One attempt: transcribe, render every format, then apply the post-success
+/// source policy (move / delete). Runs on a blocking thread because both the
+/// engine call and the file IO are synchronous.
+async fn process_one_attempt(path: PathBuf, ctx: Arc<ProcessCtx>) -> anyhow::Result<()> {
+    let task_path = path.clone();
+    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        let result = (ctx.transcribe)(task_path.clone())?;
+        for fmt in &ctx.formats {
+            let rendered = fmt.render(&result, &ctx.render_opts);
+            let out = output_path_for(&task_path, &ctx.output_dir, fmt.extension());
+            std::fs::write(&out, rendered)
+                .with_context(|| format!("failed to write {}", out.display()))?;
+        }
+        if let Some(move_to) = &ctx.move_to {
+            let file_name = task_path
+                .file_name()
+                .ok_or_else(|| anyhow::anyhow!("no file name: {}", task_path.display()))?;
+            move_file(&task_path, &move_to.join(file_name))?;
+        } else if ctx.delete_source {
+            std::fs::remove_file(&task_path)
+                .with_context(|| format!("failed to delete {}", task_path.display()))?;
+        }
+        Ok(())
+    })
+    .await
+    .context("batch task panicked")?
+}
+
+/// Retry wrapper around [`process_one_attempt`]: `retries` extra attempts with
+/// a short linear backoff between them.
+async fn process_with_retries(
+    path: PathBuf,
+    ctx: Arc<ProcessCtx>,
+    retries: u32,
+) -> (PathBuf, anyhow::Result<()>) {
+    let mut attempt = 0_u32;
+    loop {
+        match process_one_attempt(path.clone(), ctx.clone()).await {
+            Ok(()) => return (path, Ok(())),
+            Err(e) => {
+                attempt += 1;
+                if attempt > retries {
+                    return (path, Err(e));
+                }
+                tracing::warn!(
+                    attempt,
+                    error = %format!("{e:#}"),
+                    "retrying {}",
+                    path.display()
+                );
+                tokio::time::sleep(Duration::from_millis(200 * u64::from(attempt))).await;
+            }
+        }
+    }
+}
+
+/// Canonicalize the input directory and create the output / move-to
+/// directories. Returns the canonical input root plus the canonical move-to
+/// dir (so files already inside it can be excluded from scans).
+fn prepare_dirs(opts: &BatchOptions) -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
+    let input_root = opts
+        .input_dir
+        .canonicalize()
+        .with_context(|| format!("input directory not found: {}", opts.input_dir.display()))?;
+    std::fs::create_dir_all(&opts.output_dir).with_context(|| {
+        format!(
+            "failed to create output directory {}",
+            opts.output_dir.display()
+        )
+    })?;
+    let move_to = match &opts.move_to {
+        Some(dir) => {
+            std::fs::create_dir_all(dir)
+                .with_context(|| format!("failed to create move-to directory {}", dir.display()))?;
+            Some(dir.canonicalize().unwrap_or_else(|_| dir.clone()))
+        }
+        None => None,
+    };
+    Ok((input_root, move_to))
+}
+
+/// Scan the input root, excluding anything under the move-to directory (files
+/// moved there by earlier runs must not be picked up again).
+fn scan_inputs(input_root: &Path, move_to: Option<&Path>) -> anyhow::Result<Vec<PathBuf>> {
+    let mut files = collect_audio_files(input_root)?;
+    if let Some(excluded) = move_to {
+        files.retain(|p| !p.starts_with(excluded));
+    }
+    Ok(files)
+}
+
+/// Log a warning when two inputs would render to the same output file.
+fn warn_duplicate_outputs(files: &[PathBuf], output_dir: &Path, formats: &[ExportFormat]) {
+    let mut seen = std::collections::HashSet::new();
+    for f in files {
+        for fmt in formats {
+            let out = output_path_for(f, output_dir, fmt.extension());
+            if !seen.insert(out.clone()) {
+                tracing::warn!(
+                    "duplicate output {} — inputs with equal file stems overwrite each other",
+                    out.display()
+                );
+            }
+        }
+    }
+}
+
+/// Process every supported audio file under `input_dir` once, up to
+/// `concurrency` files in flight. On a shutdown request the scheduler stops
+/// starting new files and waits for the in-flight ones to finish.
+pub async fn run_batch(
+    opts: &BatchOptions,
+    transcribe: TranscribeFn,
+    shutdown: tokio_util::sync::CancellationToken,
+) -> anyhow::Result<BatchSummary> {
+    let (input_root, move_to_canonical) = prepare_dirs(opts)?;
+    let files = scan_inputs(&input_root, move_to_canonical.as_deref())?;
+    if files.is_empty() {
+        tracing::info!("no audio files found in {}", input_root.display());
+        return Ok(BatchSummary::default());
+    }
+    warn_duplicate_outputs(&files, &opts.output_dir, &opts.formats);
+    tracing::info!(
+        total = files.len(),
+        concurrency = opts.concurrency,
+        "starting batch transcription"
+    );
+
+    let ctx = Arc::new(ProcessCtx {
+        output_dir: opts.output_dir.clone(),
+        formats: opts.formats.clone(),
+        render_opts: opts.render_opts,
+        move_to: opts.move_to.clone(),
+        delete_source: opts.delete_source,
+        transcribe,
+    });
+
+    let mut summary = BatchSummary::default();
+    let mut set: tokio::task::JoinSet<(PathBuf, anyhow::Result<()>)> = tokio::task::JoinSet::new();
+    let mut iter = files.into_iter();
+    let concurrency = opts.concurrency.max(1);
+
+    loop {
+        // Top up the scheduler unless a shutdown was requested.
+        while !shutdown.is_cancelled() && set.len() < concurrency {
+            match iter.next() {
+                Some(path) => {
+                    set.spawn(process_with_retries(path, ctx.clone(), opts.retries));
+                }
+                None => break,
+            }
+        }
+        if set.is_empty() {
+            break;
+        }
+        let joined = tokio::select! {
+            // Once cancelled, no new files are scheduled (the top-up loop above
+            // is gated), so just drain whatever is still running.
+            () = shutdown.cancelled() => set.join_next().await,
+            r = set.join_next() => r,
+        };
+        let Some(joined) = joined else { break };
+        let (path, result) = joined.context("batch task panicked")?;
+        match result {
+            Ok(()) => {
+                summary.processed += 1;
+                tracing::info!(
+                    processed = summary.processed,
+                    failed = summary.failed,
+                    "done {}",
+                    path.display()
+                );
+            }
+            Err(e) => {
+                summary.failed += 1;
+                tracing::warn!(error = %format!("{e:#}"), "failed {}", path.display());
+            }
+        }
+    }
+
+    summary.skipped = iter.count();
+    summary.interrupted = shutdown.is_cancelled();
+    Ok(summary)
+}
+
+/// A file observation: size and modification time. Identical signatures across
+/// `settle_polls` consecutive scans mean the writer is done.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileSignature {
+    len: u64,
+    mtime: Option<std::time::SystemTime>,
+}
+
+fn signature_of(path: &Path) -> Option<FileSignature> {
+    let meta = std::fs::metadata(path).ok()?;
+    Some(FileSignature {
+        len: meta.len(),
+        mtime: meta.modified().ok(),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WatchStatus {
+    /// Waiting for the signature to settle, then scheduled.
+    Pending,
+    /// Currently being transcribed.
+    InFlight,
+    /// Processed successfully for the current signature.
+    Done,
+    /// Failed all retries for the current signature.
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct WatchEntry {
+    sig: FileSignature,
+    stable_polls: u32,
+    status: WatchStatus,
+    /// The signature changed while the file was InFlight — reprocess on completion.
+    dirty: bool,
+}
+
+/// Watch `input_dir` for new or changed audio files and process them as they
+/// settle. Files already present at startup are registered but not processed —
+/// `transcribe-batch` covers the existing backlog. Returns after a shutdown
+/// request once all in-flight files finish.
+pub async fn run_watch(
+    opts: &WatchOptions,
+    transcribe: TranscribeFn,
+    shutdown: tokio_util::sync::CancellationToken,
+) -> anyhow::Result<WatchSummary> {
+    let (input_root, move_to_canonical) = prepare_dirs(&opts.batch)?;
+    let settle_polls = opts.settle_polls.max(1);
+    let concurrency = opts.batch.concurrency.max(1);
+    let ctx = Arc::new(ProcessCtx {
+        output_dir: opts.batch.output_dir.clone(),
+        formats: opts.batch.formats.clone(),
+        render_opts: opts.batch.render_opts,
+        move_to: opts.batch.move_to.clone(),
+        delete_source: opts.batch.delete_source,
+        transcribe,
+    });
+
+    let mut known: std::collections::HashMap<PathBuf, WatchEntry> =
+        std::collections::HashMap::new();
+    // Register the pre-existing backlog as Done so only genuinely new or
+    // changed files are picked up.
+    for f in scan_inputs(&input_root, move_to_canonical.as_deref())? {
+        if let Some(sig) = signature_of(&f) {
+            known.insert(
+                f,
+                WatchEntry {
+                    sig,
+                    stable_polls: 0,
+                    status: WatchStatus::Done,
+                    dirty: false,
+                },
+            );
+        }
+    }
+    tracing::info!(
+        backlog = known.len(),
+        poll_ms = opts.poll_interval.as_millis() as u64,
+        "watching {}",
+        input_root.display()
+    );
+
+    let mut summary = WatchSummary::default();
+    let mut set: tokio::task::JoinSet<(PathBuf, anyhow::Result<()>)> = tokio::task::JoinSet::new();
+    let mut ticker = tokio::time::interval(opts.poll_interval);
+
+    // Fold a finished task back into the watch state.
+    fn handle_completion(
+        known: &mut std::collections::HashMap<PathBuf, WatchEntry>,
+        summary: &mut WatchSummary,
+        joined: (PathBuf, anyhow::Result<()>),
+    ) {
+        let (path, result) = joined;
+        let Some(entry) = known.get_mut(&path) else {
+            return; // vanished from the directory mid-flight
+        };
+        if entry.status != WatchStatus::InFlight {
+            return;
+        }
+        if entry.dirty {
+            // Changed while processing: re-settle and process the new version.
+            entry.dirty = false;
+            entry.stable_polls = 0;
+            entry.status = WatchStatus::Pending;
+            return;
+        }
+        match result {
+            Ok(()) => {
+                summary.processed += 1;
+                entry.status = WatchStatus::Done;
+                tracing::info!(processed = summary.processed, "done {}", path.display());
+            }
+            Err(e) => {
+                summary.failed += 1;
+                entry.status = WatchStatus::Failed;
+                tracing::warn!(error = %format!("{e:#}"), "failed {}", path.display());
+            }
+        }
+    }
+
+    while !shutdown.is_cancelled() {
+        tokio::select! {
+            () = shutdown.cancelled() => break,
+            _ = ticker.tick() => {}
+            // Guarded: an empty JoinSet resolves join_next immediately, which
+            // would busy-spin the loop and starve the ticker.
+            r = set.join_next(), if !set.is_empty() => {
+                if let Some(joined) = r {
+                    handle_completion(&mut known, &mut summary, joined.context("watch task panicked")?);
+                }
+                continue;
+            }
+        }
+
+        let files = match scan_inputs(&input_root, move_to_canonical.as_deref()) {
+            Ok(files) => files,
+            Err(e) => {
+                tracing::warn!(error = %format!("{e:#}"), "scan failed; retrying next poll");
+                continue;
+            }
+        };
+        // Forget files that disappeared, unless a task is still working on them.
+        let present: std::collections::HashSet<&PathBuf> = files.iter().collect();
+        known.retain(|p, e| e.status == WatchStatus::InFlight || present.contains(p));
+
+        for f in files {
+            let Some(sig) = signature_of(&f) else {
+                continue;
+            };
+            match known.entry(f.clone()) {
+                std::collections::hash_map::Entry::Vacant(v) => {
+                    v.insert(WatchEntry {
+                        sig,
+                        stable_polls: 0,
+                        status: WatchStatus::Pending,
+                        dirty: false,
+                    });
+                }
+                std::collections::hash_map::Entry::Occupied(mut o) => {
+                    let entry = o.get_mut();
+                    if entry.sig != sig {
+                        entry.sig = sig;
+                        entry.stable_polls = 0;
+                        if entry.status == WatchStatus::InFlight {
+                            entry.dirty = true;
+                        } else {
+                            entry.status = WatchStatus::Pending;
+                        }
+                    } else if entry.status == WatchStatus::Pending {
+                        entry.stable_polls += 1;
+                        if entry.stable_polls >= settle_polls && set.len() < concurrency {
+                            entry.status = WatchStatus::InFlight;
+                            set.spawn(process_with_retries(
+                                f.clone(),
+                                ctx.clone(),
+                                opts.batch.retries,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Graceful shutdown: no new work is scheduled from here on; wait for the
+    // files already being transcribed.
+    while let Some(r) = set.join_next().await {
+        handle_completion(&mut known, &mut summary, r.context("watch task panicked")?);
+    }
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gigastt_core::inference::WordInfo;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn sample_result() -> TranscribeResult {
+        TranscribeResult {
+            text: "привет мир".to_string(),
+            words: vec![
+                WordInfo::new("привет", 0.0, 0.5, 0.98, None),
+                WordInfo::new("мир", 0.6, 1.0, 0.97, None),
+            ],
+            duration_s: 1.0,
+        }
+    }
+
+    fn ok_transcribe() -> TranscribeFn {
+        Arc::new(|_| Ok(sample_result()))
+    }
+
+    fn test_opts(input: &Path, output: &Path) -> BatchOptions {
+        BatchOptions {
+            input_dir: input.to_path_buf(),
+            output_dir: output.to_path_buf(),
+            formats: vec![ExportFormat::Txt, ExportFormat::Json],
+            render_opts: RenderOpts::default(),
+            move_to: None,
+            delete_source: false,
+            concurrency: 2,
+            retries: 0,
+        }
+    }
+
+    /// Write a minimal PCM16 WAV file (silence) — enough for the walker; the
+    /// stubbed transcribe closure never decodes it.
+    fn write_wav(path: &Path) {
+        let samples = [0_i16; 160];
+        let data_len = (samples.len() * 2) as u32;
+        let mut buf = Vec::with_capacity(44 + data_len as usize);
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&(36 + data_len).to_le_bytes());
+        buf.extend_from_slice(b"WAVEfmt ");
+        buf.extend_from_slice(&16_u32.to_le_bytes());
+        buf.extend_from_slice(&1_u16.to_le_bytes()); // PCM
+        buf.extend_from_slice(&1_u16.to_le_bytes()); // mono
+        buf.extend_from_slice(&16000_u32.to_le_bytes());
+        buf.extend_from_slice(&32000_u32.to_le_bytes());
+        buf.extend_from_slice(&2_u16.to_le_bytes());
+        buf.extend_from_slice(&16_u16.to_le_bytes());
+        buf.extend_from_slice(b"data");
+        buf.extend_from_slice(&data_len.to_le_bytes());
+        for s in samples {
+            buf.extend_from_slice(&s.to_le_bytes());
+        }
+        std::fs::write(path, buf).unwrap();
+    }
+
+    #[test]
+    fn test_is_audio_file_accepts_supported_case_insensitive() {
+        assert!(is_audio_file(Path::new("a.wav")));
+        assert!(is_audio_file(Path::new("a.MP3")));
+        assert!(is_audio_file(Path::new("a.m4a")));
+        assert!(is_audio_file(Path::new("a.OGG")));
+        assert!(is_audio_file(Path::new("a.flac")));
+    }
+
+    #[test]
+    fn test_is_audio_file_rejects_other_extensions() {
+        assert!(!is_audio_file(Path::new("a.txt")));
+        assert!(!is_audio_file(Path::new("a.json")));
+        assert!(!is_audio_file(Path::new("a")));
+        assert!(!is_audio_file(Path::new(".wav")));
+    }
+
+    #[test]
+    fn test_collect_audio_files_recurses_and_sorts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write_wav(&root.join("b.wav"));
+        write_wav(&root.join("a.mp3"));
+        std::fs::write(root.join("notes.txt"), b"x").unwrap();
+        std::fs::create_dir(root.join("sub")).unwrap();
+        write_wav(&root.join("sub").join("c.flac"));
+
+        let files = collect_audio_files(root).unwrap();
+        let names: Vec<_> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap().to_string())
+            .collect();
+        assert_eq!(names, vec!["a.mp3", "b.wav", "c.flac"]);
+    }
+
+    #[test]
+    fn test_collect_audio_files_missing_dir_errors() {
+        let result = collect_audio_files(Path::new("/nonexistent/dir"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_output_path_for_uses_stem_and_extension() {
+        let out = output_path_for(Path::new("/in/sub/rec.wav"), Path::new("/out"), "json");
+        assert_eq!(out, PathBuf::from("/out/rec.json"));
+    }
+
+    #[test]
+    fn test_output_path_for_dotfile_keeps_full_name() {
+        // `.hidden` has no extension; the whole name is the stem.
+        let out = output_path_for(Path::new("/in/.hidden"), Path::new("/out"), "txt");
+        assert_eq!(out, PathBuf::from("/out/.hidden.txt"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_output_path_for_non_utf8_stem_falls_back() {
+        use std::os::unix::ffi::OsStrExt;
+        let path = PathBuf::from(std::ffi::OsStr::from_bytes(b"/in/\xff\xfe.wav"));
+        let out = output_path_for(&path, Path::new("/out"), "txt");
+        assert_eq!(out, PathBuf::from("/out/transcript.txt"));
+    }
+
+    #[test]
+    fn test_parse_formats_csv_dedup_and_order() {
+        let formats = parse_formats("txt, json ,txt,md").unwrap();
+        assert_eq!(
+            formats,
+            vec![ExportFormat::Txt, ExportFormat::Json, ExportFormat::Md]
+        );
+    }
+
+    #[test]
+    fn test_parse_formats_rejects_unknown_and_empty() {
+        assert!(parse_formats("txt,docx").is_err());
+        assert!(parse_formats(" , ").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_writes_all_formats() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("in");
+        let output = tmp.path().join("out");
+        std::fs::create_dir(&input).unwrap();
+        write_wav(&input.join("one.wav"));
+        write_wav(&input.join("two.mp3"));
+
+        let summary = run_batch(
+            &test_opts(&input, &output),
+            ok_transcribe(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(summary.processed, 2);
+        assert_eq!(summary.failed, 0);
+        assert!(!summary.interrupted);
+        for stem in ["one", "two"] {
+            let txt = std::fs::read_to_string(output.join(format!("{stem}.txt"))).unwrap();
+            assert_eq!(txt, "привет мир");
+            let json = std::fs::read_to_string(output.join(format!("{stem}.json"))).unwrap();
+            assert!(json.contains("привет мир"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_continues_after_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("in");
+        let output = tmp.path().join("out");
+        std::fs::create_dir(&input).unwrap();
+        write_wav(&input.join("good.wav"));
+        write_wav(&input.join("bad.wav"));
+
+        let transcribe: TranscribeFn = Arc::new(|path| {
+            if path.file_stem().unwrap() == "bad" {
+                anyhow::bail!("decode exploded");
+            }
+            Ok(sample_result())
+        });
+        let summary = run_batch(
+            &test_opts(&input, &output),
+            transcribe,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(summary.processed, 1);
+        assert_eq!(summary.failed, 1);
+        assert!(output.join("good.txt").exists());
+        assert!(!output.join("bad.txt").exists());
+        // A failed source is left in place for inspection.
+        assert!(input.join("bad.wav").exists());
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_move_to_moves_source_after_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("in");
+        let output = tmp.path().join("out");
+        let done = input.join("done");
+        std::fs::create_dir(&input).unwrap();
+        write_wav(&input.join("a.wav"));
+        // A backlog file already inside done/ must not be reprocessed.
+        std::fs::create_dir(&done).unwrap();
+        write_wav(&done.join("old.wav"));
+
+        let mut opts = test_opts(&input, &output);
+        opts.move_to = Some(done.clone());
+        let summary = run_batch(
+            &opts,
+            ok_transcribe(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(summary.processed, 1);
+        assert!(!input.join("a.wav").exists());
+        assert!(done.join("a.wav").exists());
+        assert!(output.join("a.txt").exists());
+        assert!(!output.join("old.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_delete_source_removes_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("in");
+        let output = tmp.path().join("out");
+        std::fs::create_dir(&input).unwrap();
+        write_wav(&input.join("a.wav"));
+
+        let mut opts = test_opts(&input, &output);
+        opts.delete_source = true;
+        let summary = run_batch(
+            &opts,
+            ok_transcribe(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(summary.processed, 1);
+        assert!(!input.join("a.wav").exists());
+        assert!(output.join("a.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_retries_transient_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("in");
+        let output = tmp.path().join("out");
+        std::fs::create_dir(&input).unwrap();
+        write_wav(&input.join("a.wav"));
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let transcribe: TranscribeFn = Arc::new(move |_| {
+            if calls2.fetch_add(1, Ordering::SeqCst) == 0 {
+                anyhow::bail!("transient");
+            }
+            Ok(sample_result())
+        });
+        let mut opts = test_opts(&input, &output);
+        opts.retries = 2;
+        let summary = run_batch(
+            &opts,
+            transcribe,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(summary.processed, 1);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_cancelled_before_start_processes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("in");
+        let output = tmp.path().join("out");
+        std::fs::create_dir(&input).unwrap();
+        write_wav(&input.join("a.wav"));
+        write_wav(&input.join("b.wav"));
+
+        let token = tokio_util::sync::CancellationToken::new();
+        token.cancel();
+        let summary = run_batch(&test_opts(&input, &output), ok_transcribe(), token)
+            .await
+            .unwrap();
+
+        assert_eq!(summary.processed, 0);
+        assert_eq!(summary.skipped, 2);
+        assert!(summary.interrupted);
+    }
+
+    #[tokio::test]
+    async fn test_run_batch_empty_dir_is_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("in");
+        std::fs::create_dir(&input).unwrap();
+        let summary = run_batch(
+            &test_opts(&input, &tmp.path().join("out")),
+            ok_transcribe(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(summary, BatchSummary::default());
+    }
+
+    #[tokio::test]
+    async fn test_watch_processes_new_file_and_shuts_down() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("in");
+        let output = tmp.path().join("out");
+        std::fs::create_dir(&input).unwrap();
+        // Pre-existing backlog file: watch must leave it alone.
+        write_wav(&input.join("old.wav"));
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let opts = WatchOptions {
+            batch: BatchOptions {
+                concurrency: 1,
+                ..test_opts(&input, &output)
+            },
+            poll_interval: Duration::from_millis(10),
+            settle_polls: 2,
+        };
+        // Drive the scenario from a separate task: drop a new file, wait for
+        // its outputs, then shut the watch down.
+        let driver = tokio::spawn({
+            let input = input.clone();
+            let output = output.clone();
+            let token = token.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                write_wav(&input.join("new.wav"));
+                let deadline = std::time::Instant::now() + Duration::from_secs(10);
+                while !output.join("new.txt").exists() {
+                    assert!(std::time::Instant::now() < deadline, "watch timed out");
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                token.cancel();
+            }
+        });
+        let summary = run_watch(&opts, ok_transcribe(), token).await.unwrap();
+        driver.await.unwrap();
+
+        assert_eq!(summary.processed, 1);
+        assert_eq!(summary.failed, 0);
+        assert!(!output.join("old.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_watch_skips_move_to_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("in");
+        let output = tmp.path().join("out");
+        let done = input.join("done");
+        std::fs::create_dir(&input).unwrap();
+        std::fs::create_dir(&done).unwrap();
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let opts = WatchOptions {
+            batch: BatchOptions {
+                move_to: Some(done.clone()),
+                concurrency: 1,
+                ..test_opts(&input, &output)
+            },
+            poll_interval: Duration::from_millis(10),
+            settle_polls: 1,
+        };
+        let driver = tokio::spawn({
+            let input = input.clone();
+            let done = done.clone();
+            let token = token.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(30)).await;
+                write_wav(&input.join("a.wav"));
+                let deadline = std::time::Instant::now() + Duration::from_secs(10);
+                while !done.join("a.wav").exists() {
+                    assert!(std::time::Instant::now() < deadline, "watch timed out");
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                // Let a few extra polls run: the moved file must not be
+                // re-processed.
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                token.cancel();
+            }
+        });
+        let summary = run_watch(&opts, ok_transcribe(), token).await.unwrap();
+        driver.await.unwrap();
+
+        assert_eq!(summary.processed, 1);
+        assert!(output.join("a.txt").exists());
+    }
+}

--- a/crates/gigastt/src/lib.rs
+++ b/crates/gigastt/src/lib.rs
@@ -1,2 +1,3 @@
 pub use gigastt_core::*;
+pub mod batch;
 pub mod server;

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
+use gigastt::batch;
 use gigastt::server;
 use gigastt::server::{OriginPolicy, RuntimeLimits, ServerConfig};
 use gigastt_core::export::{ExportFormat, RenderOpts};
@@ -28,6 +29,136 @@ struct Cli {
 
     #[command(subcommand)]
     command: Commands,
+}
+
+/// Engine / post-processing flags shared by the offline directory commands
+/// (`transcribe-batch`, `watch`). Mirrors the corresponding `transcribe` flags.
+#[derive(Args)]
+struct OfflineEngineArgs {
+    /// Model directory
+    #[arg(long, default_value_t = model::default_model_dir())]
+    model_dir: String,
+
+    /// Recognition head to use. Omit to auto-detect from the model directory.
+    /// Env: GIGASTT_MODEL_VARIANT.
+    #[arg(
+        long,
+        env = "GIGASTT_MODEL_VARIANT",
+        value_parser = parse_model_variant
+    )]
+    model_variant: Option<ModelVariant>,
+
+    /// Punctuation + capitalization restoration: `on`, `off`, or `auto`.
+    /// Env: GIGASTT_PUNCTUATION.
+    #[arg(
+        long,
+        env = "GIGASTT_PUNCTUATION",
+        default_value = "auto",
+        value_parser = parse_punctuation_mode
+    )]
+    punctuation: PunctuationMode,
+
+    /// Directory holding the optional punctuation model.
+    /// Env: GIGASTT_PUNCT_MODEL_DIR.
+    #[arg(
+        long,
+        env = "GIGASTT_PUNCT_MODEL_DIR",
+        default_value_t = model::default_punct_model_dir()
+    )]
+    punct_model_dir: String,
+
+    /// Inverse text normalization (Russian number-words → digits):
+    /// `on`, `off`, or `auto`. Env: GIGASTT_ITN.
+    #[arg(
+        long,
+        env = "GIGASTT_ITN",
+        default_value = "auto",
+        value_parser = parse_itn_mode
+    )]
+    itn: ItnMode,
+
+    /// Contextual hotword biasing: path to a file of phrases to boost (one
+    /// phrase per line, optional `\t<weight>` suffix). Env: GIGASTT_HOTWORDS_FILE.
+    #[arg(long, env = "GIGASTT_HOTWORDS_FILE")]
+    hotwords_file: Option<String>,
+
+    /// Also bias the built-in Russian brand/acronym lexicon.
+    /// Env: GIGASTT_HOTWORDS_DEFAULT.
+    #[arg(long, env = "GIGASTT_HOTWORDS_DEFAULT", default_value_t = false)]
+    hotwords_default: bool,
+
+    /// Additive logit boost applied to hotword continuation tokens [default: 5.0].
+    /// Env: GIGASTT_HOTWORDS_BOOST.
+    #[arg(long, env = "GIGASTT_HOTWORDS_BOOST")]
+    hotwords_boost: Option<f32>,
+
+    /// Voice activity detection: skip silence before decoding. Env: GIGASTT_VAD.
+    #[arg(long, env = "GIGASTT_VAD", default_value_t = false)]
+    vad: bool,
+
+    /// VAD speech-probability threshold in [0,1] [default: 0.5].
+    /// Env: GIGASTT_VAD_THRESHOLD.
+    #[arg(long, env = "GIGASTT_VAD_THRESHOLD")]
+    vad_threshold: Option<f32>,
+
+    /// Minimum trailing silence (ms) to close a speech region [default: 500].
+    /// Env: GIGASTT_VAD_MIN_SILENCE_MS.
+    #[arg(long, env = "GIGASTT_VAD_MIN_SILENCE_MS")]
+    vad_min_silence_ms: Option<u32>,
+
+    /// Directory holding the Silero VAD model (`silero_vad.onnx`).
+    /// Env: GIGASTT_VAD_MODEL_DIR.
+    #[arg(long, env = "GIGASTT_VAD_MODEL_DIR", default_value_t = model::default_vad_model_dir())]
+    vad_model_dir: String,
+
+    /// Intra-op thread count for the encoder session on the CPU build. When
+    /// unset, defaults to the logical CPU count divided across the pool.
+    /// Env: GIGASTT_ENCODER_INTRA_THREADS.
+    #[arg(long, env = "GIGASTT_ENCODER_INTRA_THREADS")]
+    encoder_intra_threads: Option<usize>,
+
+    /// Number of concurrent transcription workers (engine session pool). Each
+    /// session loads its own encoder copy (~0.4 GB resident for the INT8
+    /// encoder), so the default is 2 to bound the memory footprint.
+    #[arg(long, default_value_t = 2)]
+    pool_size: usize,
+}
+
+/// Output / source-policy flags shared by `transcribe-batch` and `watch`.
+#[derive(Args)]
+struct BatchOutputArgs {
+    /// Export formats, comma-separated: txt, json, md, srt, vtt.
+    /// One `<stem>.<ext>` file is written per format. Env: GIGASTT_FORMAT.
+    #[arg(short, long, env = "GIGASTT_FORMAT", default_value = "txt,json")]
+    format: String,
+
+    /// Move each successfully transcribed source file into this directory
+    /// (e.g. `--move-to done/`). Mutually exclusive with `--delete-source`.
+    /// Env: GIGASTT_BATCH_MOVE_TO.
+    #[arg(long, env = "GIGASTT_BATCH_MOVE_TO", conflicts_with = "delete_source")]
+    move_to: Option<String>,
+
+    /// Delete each successfully transcribed source file. Failed files are
+    /// always left in place. Env: GIGASTT_BATCH_DELETE_SOURCE.
+    #[arg(long, env = "GIGASTT_BATCH_DELETE_SOURCE", default_value_t = false)]
+    delete_source: bool,
+
+    /// Extra attempts per file after a failure, with a short backoff
+    /// [default: 0 for transcribe-batch, 2 for watch]. Env: GIGASTT_BATCH_RETRIES.
+    #[arg(long, env = "GIGASTT_BATCH_RETRIES")]
+    retries: Option<u32>,
+
+    /// Maximum characters per subtitle/caption line (SRT/VTT) [default: 80]
+    #[arg(long, env = "GIGASTT_MAX_CHARS_PER_LINE")]
+    max_chars_per_line: Option<usize>,
+
+    /// Maximum words per subtitle/caption line (SRT/VTT) [default: 14]
+    #[arg(long, env = "GIGASTT_MAX_WORDS_PER_LINE")]
+    max_words_per_line: Option<usize>,
+
+    /// Include per-word timestamps in Markdown output
+    #[arg(long, env = "GIGASTT_WORD_TIMESTAMPS", default_value_t = false)]
+    word_timestamps: bool,
 }
 
 // `Serve` carries many optional CLI flags, so it is much larger than the other
@@ -487,6 +618,49 @@ enum Commands {
         /// files, and files with more than two channels. Env: GIGASTT_STEREO_SPEAKERS.
         #[arg(long, env = "GIGASTT_STEREO_SPEAKERS", default_value_t = false)]
         stereo_speakers: bool,
+    },
+
+    /// Transcribe every audio file in a directory (offline, one-shot)
+    TranscribeBatch {
+        /// Directory scanned recursively for audio files (WAV, MP3, M4A, OGG, FLAC)
+        input_dir: String,
+
+        /// Directory the `<stem>.<ext>` transcripts are written into
+        output_dir: String,
+
+        #[command(flatten)]
+        engine: OfflineEngineArgs,
+
+        #[command(flatten)]
+        output: BatchOutputArgs,
+    },
+
+    /// Watch a directory and transcribe new/changed audio files as they appear
+    Watch {
+        /// Directory polled for audio files (WAV, MP3, M4A, OGG, FLAC). Files
+        /// already present at startup are registered but not transcribed.
+        input_dir: String,
+
+        /// Directory the `<stem>.<ext>` transcripts are written into
+        output_dir: String,
+
+        #[command(flatten)]
+        engine: OfflineEngineArgs,
+
+        #[command(flatten)]
+        output: BatchOutputArgs,
+
+        /// Poll interval in milliseconds [default: 1000]. Polling with a
+        /// stability check keeps the watcher dependency-free and handles
+        /// files still being copied into the directory.
+        /// Env: GIGASTT_WATCH_POLL_INTERVAL_MS.
+        #[arg(long, env = "GIGASTT_WATCH_POLL_INTERVAL_MS", default_value_t = 1000)]
+        poll_interval_ms: u64,
+
+        /// Consecutive polls with an identical size+mtime required before a
+        /// file is scheduled [default: 2]. Env: GIGASTT_WATCH_SETTLE_POLLS.
+        #[arg(long, env = "GIGASTT_WATCH_SETTLE_POLLS", default_value_t = 2)]
+        settle_polls: u32,
     },
 }
 
@@ -984,6 +1158,115 @@ fn ensure_int8_encoder(variant: ModelVariant, model_dir: &str, skip: bool) -> an
     Ok(())
 }
 
+/// Load the offline CLI engine (`transcribe`, `transcribe-batch`, `watch`):
+/// ensure the model, attach the punctuation / ITN / VAD / hotword chain, and
+/// size the session pool to `pool_size`. Kept as one helper so every offline
+/// command builds a byte-for-byte identical engine.
+#[allow(clippy::too_many_arguments)]
+async fn load_offline_engine(
+    model_dir: &str,
+    model_variant: Option<ModelVariant>,
+    punctuation: PunctuationMode,
+    punct_model_dir: &str,
+    itn: ItnMode,
+    hotwords_file: Option<&str>,
+    hotwords_default: bool,
+    hotwords_boost: Option<f32>,
+    vad: bool,
+    vad_threshold: Option<f32>,
+    vad_min_silence_ms: Option<u32>,
+    vad_model_dir: &str,
+    encoder_intra_threads: Option<usize>,
+    pool_size: usize,
+) -> anyhow::Result<inference::Engine> {
+    let resolved = model::ensure_model_variant(model_variant, model_dir).await?;
+    maybe_download_punct_model(punctuation, punct_model_dir, resolved).await;
+    maybe_download_vad_model(vad, vad_model_dir).await;
+    let punctuator = maybe_load_punctuator(punctuation, punct_model_dir, resolved);
+    let hotwords = resolve_hotwords(hotwords_file, hotwords_default);
+    let resolved_intra_threads = resolve_encoder_intra_threads(
+        encoder_intra_threads,
+        pool_size,
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1),
+    );
+    let mut engine = inference::Engine::load_with_pools_threads_variant(
+        model_dir,
+        Some(resolved),
+        pool_size,
+        1,
+        0,
+        resolved_intra_threads,
+    )?
+    .with_punctuator(punctuator)
+    .with_itn(resolve_itn(itn, resolved))
+    .with_vad(
+        maybe_load_vad(vad, vad_model_dir),
+        build_vad_config(vad_threshold, vad_min_silence_ms),
+    );
+    if let Some(pairs) = hotwords {
+        engine = engine.with_hotwords(&pairs, hotwords_boost.unwrap_or(DEFAULT_HOTWORDS_BOOST));
+    }
+    log_rss();
+    Ok(engine)
+}
+
+/// Build the synchronous transcribe closure injected into the batch / watch
+/// runners: check out a pool triplet (blocking — the runner calls it from a
+/// blocking thread) and transcribe one file.
+fn make_transcribe_fn(engine: std::sync::Arc<inference::Engine>) -> batch::TranscribeFn {
+    std::sync::Arc::new(move |path: std::path::PathBuf| {
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("non-UTF-8 path: {}", path.display()))?;
+        let mut guard = engine
+            .pool
+            .checkout_blocking()
+            .map_err(|e| anyhow::anyhow!("session pool closed: {e}"))?;
+        Ok(engine.transcribe_file(path_str, &mut guard)?)
+    })
+}
+
+/// Cancellation token fired on SIGINT, shared by the batch / watch runners for
+/// graceful shutdown (finish in-flight files, stop scheduling new ones).
+fn ctrl_c_token() -> tokio_util::sync::CancellationToken {
+    let token = tokio_util::sync::CancellationToken::new();
+    let inner = token.clone();
+    tokio::spawn(async move {
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => inner.cancel(),
+            Err(e) => tracing::warn!("Failed to listen for Ctrl-C: {e}"),
+        }
+    });
+    token
+}
+
+/// Build the [`batch::BatchOptions`] shared by `transcribe-batch` and `watch`
+/// from the parsed CLI flags.
+fn build_batch_options(
+    input_dir: &str,
+    output_dir: &str,
+    pool_size: usize,
+    retries: u32,
+    out: &BatchOutputArgs,
+) -> anyhow::Result<batch::BatchOptions> {
+    Ok(batch::BatchOptions {
+        input_dir: std::path::PathBuf::from(input_dir),
+        output_dir: std::path::PathBuf::from(output_dir),
+        formats: batch::parse_formats(&out.format).map_err(|e| anyhow::anyhow!("{e}"))?,
+        render_opts: RenderOpts {
+            max_chars_per_line: out.max_chars_per_line.unwrap_or(80),
+            max_words_per_line: out.max_words_per_line.unwrap_or(14),
+            include_word_timestamps: out.word_timestamps,
+        },
+        move_to: out.move_to.as_deref().map(std::path::PathBuf::from),
+        delete_source: out.delete_source,
+        concurrency: pool_size,
+        retries,
+    })
+}
+
 /// Log a concise summary of the active ANE (Core ML / Apple Neural Engine)
 /// encoder backend at startup. No-op outside `--features ane`.
 ///
@@ -1341,40 +1624,26 @@ async fn main() -> anyhow::Result<()> {
             word_timestamps,
             stereo_speakers,
         } => {
-            let resolved = model::ensure_model_variant(model_variant, &model_dir).await?;
-            maybe_download_punct_model(punctuation, &punct_model_dir, resolved).await;
-            maybe_download_vad_model(vad, &vad_model_dir).await;
-            let punctuator = maybe_load_punctuator(punctuation, &punct_model_dir, resolved);
-            let hotwords = resolve_hotwords(hotwords_file.as_deref(), hotwords_default);
             // Single-triplet pool for offline file transcription; when the
             // thread count is unset it defaults to every logical CPU (one
             // running triplet), else the explicit value is used as-is.
-            let resolved_intra_threads = resolve_encoder_intra_threads(
+            let engine = load_offline_engine(
+                &model_dir,
+                model_variant,
+                punctuation,
+                &punct_model_dir,
+                itn,
+                hotwords_file.as_deref(),
+                hotwords_default,
+                hotwords_boost,
+                vad,
+                vad_threshold,
+                vad_min_silence_ms,
+                &vad_model_dir,
                 encoder_intra_threads,
                 1,
-                std::thread::available_parallelism()
-                    .map(|n| n.get())
-                    .unwrap_or(1),
-            );
-            let mut engine = inference::Engine::load_with_pools_threads_variant(
-                &model_dir,
-                Some(resolved),
-                1,
-                1,
-                0,
-                resolved_intra_threads,
-            )?
-            .with_punctuator(punctuator)
-            .with_itn(resolve_itn(itn, resolved))
-            .with_vad(
-                maybe_load_vad(vad, &vad_model_dir),
-                build_vad_config(vad_threshold, vad_min_silence_ms),
-            );
-            if let Some(pairs) = hotwords {
-                engine =
-                    engine.with_hotwords(&pairs, hotwords_boost.unwrap_or(DEFAULT_HOTWORDS_BOOST));
-            }
-            log_rss();
+            )
+            .await?;
             let mut guard = engine.pool.checkout().await?;
             let result = if stereo_speakers {
                 let channels = inference::audio::load_audio_channels(&file)?;
@@ -1414,6 +1683,107 @@ async fn main() -> anyhow::Result<()> {
                     tracing::info!("Wrote {} export to {path}", format);
                 }
                 None => println!("{rendered}"),
+            }
+        }
+        Commands::TranscribeBatch {
+            input_dir,
+            output_dir,
+            engine: eng,
+            output: out,
+        } => {
+            let engine = load_offline_engine(
+                &eng.model_dir,
+                eng.model_variant,
+                eng.punctuation,
+                &eng.punct_model_dir,
+                eng.itn,
+                eng.hotwords_file.as_deref(),
+                eng.hotwords_default,
+                eng.hotwords_boost,
+                eng.vad,
+                eng.vad_threshold,
+                eng.vad_min_silence_ms,
+                &eng.vad_model_dir,
+                eng.encoder_intra_threads,
+                eng.pool_size,
+            )
+            .await?;
+            let opts = build_batch_options(
+                &input_dir,
+                &output_dir,
+                eng.pool_size,
+                out.retries.unwrap_or(0),
+                &out,
+            )?;
+            let summary = batch::run_batch(
+                &opts,
+                make_transcribe_fn(std::sync::Arc::new(engine)),
+                ctrl_c_token(),
+            )
+            .await?;
+            tracing::info!(
+                processed = summary.processed,
+                failed = summary.failed,
+                skipped = summary.skipped,
+                "batch finished"
+            );
+            if summary.interrupted {
+                // Same contract as `download`: SIGINT exits 130.
+                std::process::exit(130);
+            }
+            if summary.failed > 0 {
+                std::process::exit(1);
+            }
+        }
+        Commands::Watch {
+            input_dir,
+            output_dir,
+            engine: eng,
+            output: out,
+            poll_interval_ms,
+            settle_polls,
+        } => {
+            let engine = load_offline_engine(
+                &eng.model_dir,
+                eng.model_variant,
+                eng.punctuation,
+                &eng.punct_model_dir,
+                eng.itn,
+                eng.hotwords_file.as_deref(),
+                eng.hotwords_default,
+                eng.hotwords_boost,
+                eng.vad,
+                eng.vad_threshold,
+                eng.vad_min_silence_ms,
+                &eng.vad_model_dir,
+                eng.encoder_intra_threads,
+                eng.pool_size,
+            )
+            .await?;
+            let opts = batch::WatchOptions {
+                batch: build_batch_options(
+                    &input_dir,
+                    &output_dir,
+                    eng.pool_size,
+                    out.retries.unwrap_or(2),
+                    &out,
+                )?,
+                poll_interval: std::time::Duration::from_millis(poll_interval_ms),
+                settle_polls,
+            };
+            let summary = batch::run_watch(
+                &opts,
+                make_transcribe_fn(std::sync::Arc::new(engine)),
+                ctrl_c_token(),
+            )
+            .await?;
+            tracing::info!(
+                processed = summary.processed,
+                failed = summary.failed,
+                "watch stopped"
+            );
+            if summary.failed > 0 {
+                std::process::exit(1);
             }
         }
     }
@@ -2923,5 +3293,148 @@ mod tests {
     fn test_cli_serve_rejects_bad_itn_value() {
         let res = Cli::try_parse_from(["gigastt", "serve", "--itn", "sometimes"]);
         assert!(res.is_err(), "invalid itn mode must be rejected");
+    }
+
+    #[test]
+    fn test_cli_transcribe_batch_defaults() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let restores: Vec<EnvRestore> = ["GIGASTT_FORMAT", "GIGASTT_BATCH_RETRIES"]
+            .iter()
+            .map(|k| {
+                let r = EnvRestore(k, std::env::var(k).ok());
+                unsafe {
+                    std::env::remove_var(k);
+                }
+                r
+            })
+            .collect();
+        let cli = Cli::parse_from(["gigastt", "transcribe-batch", "samples/", "out/"]);
+        match cli.command {
+            Commands::TranscribeBatch {
+                input_dir,
+                output_dir,
+                engine,
+                output,
+            } => {
+                assert_eq!(input_dir, "samples/");
+                assert_eq!(output_dir, "out/");
+                assert_eq!(engine.pool_size, 2);
+                assert_eq!(engine.model_variant, None);
+                assert_eq!(output.format, "txt,json");
+                assert_eq!(output.move_to, None);
+                assert!(!output.delete_source);
+                assert_eq!(output.retries, None);
+            }
+            _ => panic!("expected TranscribeBatch"),
+        }
+        drop(restores);
+    }
+
+    #[test]
+    fn test_cli_transcribe_batch_flags() {
+        let cli = Cli::parse_from([
+            "gigastt",
+            "transcribe-batch",
+            "in/",
+            "out/",
+            "--format",
+            "md,srt",
+            "--move-to",
+            "in/done",
+            "--pool-size",
+            "4",
+            "--retries",
+            "1",
+        ]);
+        match cli.command {
+            Commands::TranscribeBatch { engine, output, .. } => {
+                assert_eq!(engine.pool_size, 4);
+                assert_eq!(output.format, "md,srt");
+                assert_eq!(output.move_to, Some("in/done".to_string()));
+                assert_eq!(output.retries, Some(1));
+            }
+            _ => panic!("expected TranscribeBatch"),
+        }
+    }
+
+    #[test]
+    fn test_cli_transcribe_batch_move_to_conflicts_with_delete_source() {
+        let res = Cli::try_parse_from([
+            "gigastt",
+            "transcribe-batch",
+            "in/",
+            "out/",
+            "--move-to",
+            "done/",
+            "--delete-source",
+        ]);
+        assert!(res.is_err(), "--move-to and --delete-source must conflict");
+    }
+
+    #[test]
+    fn test_cli_watch_defaults() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let restores: Vec<EnvRestore> = [
+            "GIGASTT_WATCH_POLL_INTERVAL_MS",
+            "GIGASTT_WATCH_SETTLE_POLLS",
+            "GIGASTT_FORMAT",
+        ]
+        .iter()
+        .map(|k| {
+            let r = EnvRestore(k, std::env::var(k).ok());
+            unsafe {
+                std::env::remove_var(k);
+            }
+            r
+        })
+        .collect();
+        let cli = Cli::parse_from(["gigastt", "watch", "in/", "out/"]);
+        match cli.command {
+            Commands::Watch {
+                input_dir,
+                output_dir,
+                poll_interval_ms,
+                settle_polls,
+                engine,
+                output,
+            } => {
+                assert_eq!(input_dir, "in/");
+                assert_eq!(output_dir, "out/");
+                assert_eq!(poll_interval_ms, 1000);
+                assert_eq!(settle_polls, 2);
+                assert_eq!(engine.pool_size, 2);
+                assert_eq!(output.format, "txt,json");
+            }
+            _ => panic!("expected Watch"),
+        }
+        drop(restores);
+    }
+
+    #[test]
+    fn test_cli_watch_flags() {
+        let cli = Cli::parse_from([
+            "gigastt",
+            "watch",
+            "in/",
+            "out/",
+            "--poll-interval-ms",
+            "250",
+            "--settle-polls",
+            "4",
+            "--delete-source",
+        ]);
+        match cli.command {
+            Commands::Watch {
+                poll_interval_ms,
+                settle_polls,
+                output,
+                ..
+            } => {
+                assert_eq!(poll_interval_ms, 250);
+                assert_eq!(settle_polls, 4);
+                assert!(output.delete_source);
+            }
+            _ => panic!("expected Watch"),
+        }
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,8 @@ Commands:
   serve        Start STT server
   download     Download model (~850 MB) and auto-generate INT8 encoder
   transcribe   Transcribe audio file (offline)
+  transcribe-batch  Transcribe every audio file in a directory (offline)
+  watch        Watch a directory and transcribe new/changed audio files
   quantize     Quantize encoder to INT8 (always available since v0.9.0)
 
 gigastt serve [OPTIONS]
@@ -146,6 +148,57 @@ gigastt transcribe [OPTIONS] <FILE>
     gigastt transcribe recording.wav
     gigastt transcribe recording.wav -f srt -o recording.srt
     gigastt transcribe recording.wav -f md --word-timestamps -o notes.md
+
+gigastt transcribe-batch [OPTIONS] <INPUT_DIR> <OUTPUT_DIR>
+  Recursively transcribe every audio file (WAV, MP3, M4A, OGG, FLAC) under
+  INPUT_DIR, writing one `<stem>.<ext>` file per format into OUTPUT_DIR.
+  Files are processed in parallel (--pool-size workers). Files already inside
+  a --move-to directory are excluded from the scan.
+  --model-dir <DIR>           Model directory [default: ~/.gigastt/models]
+  --model-variant <V>         Recognition head: rnnt | e2e_rnnt | ml_ctc | ml_ctc_large.
+                              Omit to auto-detect. Env: GIGASTT_MODEL_VARIANT.
+  --punctuation <MODE>        Restore punctuation/casing: auto | on | off.
+                              Env: GIGASTT_PUNCTUATION.
+  --punct-model-dir <DIR>     Punctuation model directory. Env: GIGASTT_PUNCT_MODEL_DIR.
+  --itn <MODE>                Inverse text normalization: auto | on | off. Env: GIGASTT_ITN.
+  -f, --format <LIST>         Export formats, comma-separated: txt, json, md, srt, vtt
+                              [default: txt,json]. Env: GIGASTT_FORMAT.
+  --pool-size <N>             Concurrent transcription workers [default: 2]
+  --retries <N>               Extra attempts per file after a failure [default: 0].
+                              Env: GIGASTT_BATCH_RETRIES.
+  --move-to <DIR>             Move each successfully transcribed source into DIR
+                              (e.g. --move-to done/). Env: GIGASTT_BATCH_MOVE_TO.
+  --delete-source             Delete each successfully transcribed source
+                              (exclusive with --move-to). Env: GIGASTT_BATCH_DELETE_SOURCE.
+  --max-chars-per-line <N>    Max chars per subtitle line (SRT/VTT) [default: 80]
+  --max-words-per-line <N>    Max words per subtitle line (SRT/VTT) [default: 14]
+  --word-timestamps           Include per-word timestamps in Markdown output
+  Exit codes: 0 = all files done · 1 = at least one file failed · 130 = interrupted
+  (Ctrl-C finishes in-flight files, skips the rest).
+
+  Examples:
+    gigastt transcribe-batch samples/ out/
+    gigastt transcribe-batch samples/ out/ --format txt,json,srt --pool-size 4
+    gigastt transcribe-batch inbox/ out/ --move-to inbox/done/
+
+gigastt watch [OPTIONS] <INPUT_DIR> <OUTPUT_DIR>
+  Poll INPUT_DIR and transcribe new/changed audio files as they appear. A file
+  is scheduled only after its size+mtime is unchanged for --settle-polls
+  consecutive polls, so partially-copied files are never picked up. Files
+  already present at startup are registered but NOT transcribed (use
+  transcribe-batch for the backlog). Ctrl-C stops polling and waits for
+  in-flight files before exiting.
+  Same options as transcribe-batch, plus:
+  --poll-interval-ms <MS>     Poll interval [default: 1000].
+                              Env: GIGASTT_WATCH_POLL_INTERVAL_MS.
+  --settle-polls <N>          Identical polls required before scheduling a file
+                              [default: 2]. Env: GIGASTT_WATCH_SETTLE_POLLS.
+  --retries <N>               Extra attempts per file after a failure [default: 2].
+                              Env: GIGASTT_BATCH_RETRIES.
+
+  Examples:
+    gigastt watch inbox/ out/ --move-to inbox/done/
+    gigastt watch inbox/ out/ --format txt --delete-source
 
 gigastt quantize [OPTIONS]          # always available since v0.9.0
   --model-dir <DIR>      Model directory [default: ~/.gigastt/models]


### PR DESCRIPTION
## Summary

Adds first-class batch folder transcription to the CLI, replacing the shell/incron/FFmpeg wrappers users currently build around `gigastt`:

- **`gigastt transcribe-batch <in> <out>`** — recursively transcribes every WAV/MP3/M4A/OGG/FLAC file under a directory, writing `<stem>.txt` + `<stem>.json` per file (formats configurable via `--format txt,json,md,srt,vtt`), with `--pool-size` parallel workers on the engine session pool. Supports `--move-to done/` / `--delete-source` post-success source policies, per-file `--retries`, and graceful Ctrl-C (in-flight files finish, the rest is skipped, exit 130 like `download`; exit 1 when any file failed).
- **`gigastt watch <in> <out>`** — polls the folder (`--poll-interval-ms`, default 1 s) and transcribes new/changed files only after their size+mtime stays identical across `--settle-polls` polls (default 2), so partially-copied files are never picked up. Polling keeps the watcher dependency-free (no `notify` crate). Files present at startup are registered but not processed — the backlog belongs to `transcribe-batch`. In-flight files are never double-scheduled (in-memory state), failures retry with backoff, and SIGINT stops polling then drains in-flight work.
- New model-free module `crates/gigastt/src/batch.rs` — the engine is injected as a closure, so traversal/render/retry/watch logic is fully unit-tested without ONNX. The shared offline-engine setup used by `transcribe` is extracted into one helper reused by all three offline commands (no behavior change for `transcribe`).
- Docs: `docs/cli.md` sections, README quickstart examples, CHANGELOG entry, AGENTS.md env-var table (`GIGASTT_BATCH_MOVE_TO`, `GIGASTT_BATCH_DELETE_SOURCE`, `GIGASTT_BATCH_RETRIES`, `GIGASTT_WATCH_POLL_INTERVAL_MS`, `GIGASTT_WATCH_SETTLE_POLLS`).

## Verification

- `cargo clippy -p gigastt --all-targets` — zero warnings.
- `cargo test -p gigastt --lib --bins` — green, including 13 new `batch.rs` unit tests (walker, formats parse, batch run, move/delete, retries, cancel, watch pickup/shutdown, move-to exclusion) and 5 new CLI parsing tests.
- `cargo fmt --check` clean on changed files.
- Shared `CARGO_TARGET_DIR` cross-worktree poisoning observed during local runs (another worktree's `gigastt-core` rlib being linked); worked around by touching all sources of both crates before the run — the full gate runs in PR CI from a clean checkout.

No e2e (`--ignored`) tests run locally (multi-GB model); CI covers them.
