### PR TITLE
docs: document confidence fields, ready session caps, and CLI codec flags

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -44,7 +44,9 @@ Sent immediately after the WebSocket handshake, before any audio is accepted.
   "sample_rate": 48000,
   "version": "1.0",
   "supported_rates": [8000, 16000, 24000, 44100, 48000],
-  "diarization": false
+  "diarization": false,
+  "max_session_secs": 3600,
+  "idle_timeout_secs": 300
 }
 ```
 
@@ -56,6 +58,8 @@ Sent immediately after the WebSocket handshake, before any audio is accepted.
 | `supported_rates` | integer[] | Accepted input sample rates in Hz; omitted if empty. Use it instead of hardcoding a rate list |
 | `diarization` | boolean | `true` when the speaker-encoder model is loaded and diarization can be enabled per session; omitted when `false` |
 | `min_protocol_version` | string | Oldest protocol version the server accepts; omitted when equal to `version` (only one version supported) |
+| `max_session_secs` | integer | Wall-clock session cap (`--max-session-secs`); `0` means disabled. Always sent — plan long recordings around it instead of discovering it via close 1008 |
+| `idle_timeout_secs` | integer | Idle timeout (`--idle-timeout-secs`): close 1001 after this many seconds without frames. Always sent |
 
 #### `partial` / `final`
 
@@ -68,6 +72,7 @@ complete (endpointing detected, or the stream was flushed by `stop`/shutdown).
   "text": "Привет, как дела?",
   "timestamp": 1712700001.456,
   "is_final": true,
+  "confidence": 0.95,
   "words": [
     {"word": "привет", "start": 0.0, "end": 0.4, "confidence": 0.97},
     {"word": "как", "start": 0.5, "end": 0.7, "confidence": 0.93},
@@ -81,6 +86,7 @@ complete (endpointing detected, or the stream was flushed by `stop`/shutdown).
 | `text` | string | Joined transcript text (see post-processing below) |
 | `timestamp` | number | Unix time (seconds) when the segment was produced |
 | `is_final` | boolean | Mirrors the `type` discriminator (`true` in `final`) |
+| `confidence` | number | Segment-level confidence: the duration-weighted mean of `words[].confidence` (plain mean when all word durations are zero). Omitted when the segment has no words. It is an average of per-word softmax scores — not a calibrated probability |
 | `words[]` | object[] | Per-word detail; may be empty on flushed/empty finals |
 
 Each `words[]` entry:
@@ -258,14 +264,19 @@ progress); the onnxruntime linking trade-offs are in
 # Full JSON
 curl -X POST http://127.0.0.1:9876/v1/transcribe \
   -H "Content-Type: application/octet-stream" --data-binary @recording.wav
-# {"text":"Привет, как дела?","words":[{"word":"Привет,","start":0.5,"end":0.9,"confidence":0.97}, ...],"duration":3.5}
+# {"text":"Привет, как дела?","words":[{"word":"Привет,","start":0.5,"end":0.9,"confidence":0.97}, ...],"confidence":0.94,"duration":3.5}
 
 # SSE streaming
 curl -X POST http://127.0.0.1:9876/v1/transcribe/stream \
   -H "Content-Type: application/octet-stream" --data-binary @recording.wav
 # data: {"type":"partial","text":"привет как"}
-# data: {"type":"final","text":"Привет, как дела?"}
+# data: {"type":"final","text":"Привет, как дела?","confidence":0.94}
 ```
+
+The full-JSON response, SSE `final` events, and job results also carry an
+optional top-level `confidence` — the duration-weighted mean of
+`words[].confidence` (an average of per-word softmax scores, not a calibrated
+probability; omitted when there are no words).
 
 ## Asynchronous jobs
 

--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -7,6 +7,12 @@ info:
     Real-time speech-to-text WebSocket API powered by GigaAM v3 (rnnt head by default).
     On-device Russian speech recognition via ONNX Runtime.
 
+    This document is the machine-readable schema. The human-readable protocol
+    reference (field tables, error codes, close codes, examples) lives in
+    [docs/api.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/api.md);
+    troubleshooting for common integration failures is in
+    [docs/troubleshooting.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/troubleshooting.md).
+
     ## Connection Flow
 
     1. Client connects to `ws://{host}:{port}/v1/ws` (default: `ws://127.0.0.1:9876/v1/ws`).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,12 +142,19 @@ gigastt transcribe [OPTIONS] <FILE>
   --max-chars-per-line <N>    Max chars per subtitle line (SRT/VTT) [default: 80]
   --max-words-per-line <N>    Max words per subtitle line (SRT/VTT) [default: 14]
   --word-timestamps           Include per-word timestamps in Markdown output
-  Supports: WAV, M4A, MP3, OGG, FLAC (mono or auto-mixed)
+  --codec <CODEC>             Decode a headerless raw stream instead of a container:
+                              pcmu | pcma | g722 (aliases: ulaw, alaw). Requires
+                              --sample-rate. Env: GIGASTT_CODEC.
+  --sample-rate <HZ>          Sample rate of a raw --codec stream (8000 or 16000
+                              for g722). Env: GIGASTT_SAMPLE_RATE.
+  Supports: WAV (incl. G.711 A-law/μ-law and G.722 payloads), M4A, MP3, OGG,
+            FLAC (mono or auto-mixed); raw .ulaw/.alaw/.g722 via --codec
 
   Examples:
     gigastt transcribe recording.wav
     gigastt transcribe recording.wav -f srt -o recording.srt
     gigastt transcribe recording.wav -f md --word-timestamps -o notes.md
+    gigastt transcribe call.ulaw --codec pcmu --sample-rate 8000
 
 gigastt transcribe-batch [OPTIONS] <INPUT_DIR> <OUTPUT_DIR>
   Recursively transcribe every audio file (WAV, MP3, M4A, OGG, FLAC) under


### PR DESCRIPTION
## Summary

Docs follow-up to #186 (segment confidence + ready limits) and #188 (telephony codecs) — closes the hooks they left:

- `docs/api.md`: `ready` reference gains the always-sent `max_session_secs` / `idle_timeout_secs` fields (so clients plan long recordings instead of discovering cap via close 1008); `partial`/`final` tables and the REST/SSE examples gain the segment-level `confidence` (duration-weighted mean of `words[].confidence`, documented as an average of per-word softmax scores, not a calibrated probability; omitted when there are no words).
- `docs/cli.md`: `--codec` / `--sample-rate` for `gigastt transcribe` (raw `.ulaw`/`.alaw`/`.g722` streams, aliases `ulaw`/`alaw`) and the updated "Supports:" line (G.711/G.722 WAV payloads).
- `docs/asyncapi.yaml`: back-link to the human-readable `docs/api.md` and `docs/troubleshooting.md` (one-directional link gap noted in #184).

## Verification

- All JSON examples in api.md parse; `asyncapi.yaml` parses (ruby psych); `typos` clean on all three files.
- Flag names/env vars/codec aliases checked against the merged code (`main.rs`, `audio.rs`).
- Docs-only; no code changed.
