### PR TITLE
docs(workbook): chapter 01 getting started (en+ru)

### DIFF
--- a/docs/workbook/en/src/01-getting-started.md
+++ b/docs/workbook/en/src/01-getting-started.md
@@ -1,31 +1,305 @@
 # Getting started
 
-> **Stub** — this chapter is a skeleton; the full recipe lands in a follow-up
-> change. Structure follows [`_template.md`](_template.md).
-
 ## Scenario
 
-You have never run gigastt and want a working local transcription in minutes:
-install the binary, download the GigaAM v3 model, transcribe a first file.
+You have never run gigastt and want a working local transcription in about five
+minutes: install the binary, download the GigaAM v3 model, transcribe a first
+audio file — on macOS, Linux, or in Docker. This chapter is the whole path;
+you should not need any other document to get here.
 
 ## Prerequisites
 
-_To be written._
+- **Disk:** ~1.5 GB free (model + tools). The lean `--prequantized` path needs
+  only ~250 MB during setup.
+- **RAM:** ~800 MB free at the default `--pool-size 2` (~400 MB per session).
+- **Network** (unless you follow the air-gapped recipe): reach either
+  `huggingface.co` (full model) or `github.com` (pre-quantized bundle).
+- **An audio file to transcribe** — WAV, M4A, MP3, OGG, or FLAC. Any short
+  recording of Russian speech works.
+- Only for `cargo install` (build from source): Rust 1.88+ and `protoc` on
+  `PATH` (`brew install protobuf` / `apt install protobuf-compiler`).
 
-## Recipe
+Pick **one** recipe below — macOS, Linux, Docker, or air-gapped — then read
+[Choosing the recognition head](#choosing-the-recognition-head) and
+[The expensive first run](#the-expensive-first-run) once.
 
-_To be written._
+## Recipe: macOS (Homebrew)
+
+Homebrew is the fastest path on Apple Silicon (the tap ships a CoreML-enabled
+binary). On an Intel Mac use `cargo install gigastt` instead — see the Linux
+recipe for the protoc prerequisite.
+
+```sh
+brew tap ekhodzitsky/gigastt https://github.com/ekhodzitsky/gigastt
+brew install gigastt
+
+# Fetch the model (~850 MB FP32 from HuggingFace, then a one-time ~2 min
+# INT8 quantization pass — see "The expensive first run" below):
+gigastt download
+
+# Transcribe your first file:
+gigastt transcribe recording.wav
+```
+
+**Verify:** the last command prints the recognized text on stdout, e.g.
+
+```text
+$ gigastt transcribe recording.wav
+Привет, как дела?
+```
+
+and `ls ~/.gigastt/models/` shows `v3_rnnt_encoder_int8.onnx`,
+`v3_rnnt_decoder.onnx`, `v3_rnnt_joint.onnx`, and `v3_vocab.txt`.
+
+## Recipe: Linux (prebuilt binary or cargo)
+
+**Option A — prebuilt binary** (no Rust toolchain, no protoc). Each release
+publishes tarballs for `x86_64-unknown-linux-gnu` and
+`aarch64-unknown-linux-gnu`:
+
+```sh
+# Resolve the latest release tag (or set TAG=v2.13.0 by hand):
+TAG=$(curl -fsSL https://api.github.com/repos/ekhodzitsky/gigastt/releases/latest \
+      | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+VER=${TAG#v}
+
+curl -fLO "https://github.com/ekhodzitsky/gigastt/releases/download/${TAG}/gigastt-${VER}-x86_64-unknown-linux-gnu.tar.gz"
+curl -fLO "https://github.com/ekhodzitsky/gigastt/releases/download/${TAG}/gigastt-${VER}-x86_64-unknown-linux-gnu.tar.gz.sha256"
+sha256sum -c "gigastt-${VER}-x86_64-unknown-linux-gnu.tar.gz.sha256"
+
+tar xf "gigastt-${VER}-x86_64-unknown-linux-gnu.tar.gz"
+sudo install -m 0755 gigastt /usr/local/bin/gigastt
+```
+
+(On ARM64 replace `x86_64-unknown-linux-gnu` with
+`aarch64-unknown-linux-gnu`. Homebrew on Linux x86_64 — `brew install
+gigastt` after the tap from the macOS recipe — works too.)
+
+**Option B — cargo** (any platform, needs Rust 1.88+ and `protoc`):
+
+```sh
+sudo apt install protobuf-compiler   # Debian/Ubuntu; skip if protoc exists
+cargo install gigastt
+```
+
+Then fetch the model — the lean way, a ~225 MB pre-quantized INT8 bundle from
+the pinned GitHub Release (no ~850 MB FP32 download, no ~2-minute on-device
+quantization; also handy when HuggingFace is unreachable but GitHub is not):
+
+```sh
+gigastt download --prequantized
+gigastt transcribe recording.wav
+```
+
+**Verify:** `gigastt transcribe recording.wav` prints the recognized text on
+stdout, and `ls ~/.gigastt/models/` shows the `v3_rnnt_*` model files.
+
+## Recipe: Docker
+
+Prebuilt multi-arch images (amd64 + arm64) are published to GHCR for every
+release; `-cuda` tags carry the CUDA variant:
+
+```sh
+docker pull ghcr.io/ekhodzitsky/gigastt:latest   # pin :<version> in production
+
+docker run -d --name gigastt \
+  -p 127.0.0.1:9876:9876 \
+  -v gigastt-models:/home/gigastt/.gigastt/models \
+  ghcr.io/ekhodzitsky/gigastt:latest
+```
+
+The named volume keeps the model across container restarts; without it the
+container re-downloads ~850 MB on every recreation. On first start the
+container downloads the model and quantizes it — the port binds immediately,
+but inference is only up when `/ready` turns green:
+
+```sh
+# Wait until the model is loaded (503 while initializing):
+until curl -sf http://127.0.0.1:9876/ready > /dev/null; do sleep 5; done
+
+curl http://127.0.0.1:9876/health
+```
+
+Then transcribe a file from the host (the file path is on the host — `curl`
+reads it, not the container):
+
+```sh
+curl -F file=@recording.wav http://127.0.0.1:9876/v1/transcribe
+```
+
+**Verify:** `/health` returns
+
+```json
+{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.13.0","punctuation":true,"itn":true}
+```
+
+(the `version` field reflects the image you pulled), and the POST returns a
+JSON transcript:
+
+```json
+{"text":"Привет, как дела?","words":[{"word":"привет","start":0.0,"end":0.4,"confidence":0.99}],"duration":1.2}
+```
+
+## Recipe: air-gapped (offline bundle)
+
+For hosts with no internet access, every release publishes a self-contained
+offline bundle per Linux target — binary + pre-quantized INT8 `rnnt` model +
+punctuation model + systemd unit + installer — plus two Debian packages with
+the same content. Download them on a **connected** machine, carry them over,
+install.
+
+Tarball flow (any distro):
+
+```sh
+# On a connected machine (see the Linux recipe for resolving TAG/VER):
+curl -fLO "https://github.com/ekhodzitsky/gigastt/releases/download/${TAG}/gigastt-${VER}-offline-x86_64-unknown-linux-gnu.tar.gz"
+curl -fLO "https://github.com/ekhodzitsky/gigastt/releases/download/${TAG}/gigastt-${VER}-offline-x86_64-unknown-linux-gnu.tar.gz.sha256"
+sha256sum -c "gigastt-${VER}-offline-x86_64-unknown-linux-gnu.tar.gz.sha256"
+
+# On the target machine:
+tar xf "gigastt-${VER}-offline-x86_64-unknown-linux-gnu.tar.gz"
+cd "gigastt-${VER}-offline-x86_64-unknown-linux-gnu"
+sudo ./install.sh                      # verifies SHA256SUMS, installs binary + model + unit
+sudo systemctl enable --now gigastt
+```
+
+Debian flow: install `gigastt_<ver>_amd64.deb` (binary + unit) together with
+`gigastt-model-int8_<ver>_all.deb` (the same model set), then
+`sudo systemctl enable --now gigastt`.
+
+The bundle deliberately omits optional pieces — speaker diarization and the
+`e2e_rnnt` / `ml_ctc` heads. The installed unit runs with `GIGASTT_OFFLINE=1`,
+so a missing optional model is a fast, instructive error naming the exact path
+to fill (fetch it on a connected machine with `gigastt download` and copy the
+file over), never a network timeout. The full contents list and signature
+verification are in
+[packaging/offline/README-OFFLINE.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/offline/README-OFFLINE.md).
+
+**Verify:** `curl http://127.0.0.1:9876/health` returns `{"status":"ok",...}`
+with `"model":"gigaam-v3-rnnt"`, and
+`gigastt transcribe sample.wav --model-dir /usr/share/gigastt/models` prints
+text (the flag is only needed when running uninstalled — the systemd unit
+already points at the installed model).
+
+## Choosing the recognition head
+
+gigastt ships four recognition heads; `--model-variant` picks one at
+`download` / `serve` / `transcribe` time. When you omit the flag, an existing
+model directory is used as-is (auto-detect), and a fresh install defaults to
+`rnnt`.
+
+| Head | Languages | Output style | Pick it when |
+|---|---|---|---|
+| `rnnt` (default) | Russian | Bare lowercase from the acoustic model; casing + punctuation restored by an auto-downloaded RuPunct pass, digits by ITN | Default: lowest WER on Russian speech |
+| `e2e_rnnt` | Russian | Punctuation / casing / ITN baked into the acoustic model | You want one self-contained model with no post-processing passes |
+| `ml_ctc` | ru/en/kk/ky/uz | Bare lowercase, no restoration passes | Mixed Russian/English (or kk/ky/uz) speech; lighter 220M encoder |
+| `ml_ctc_large` | ru/en/kk/ky/uz | Bare lowercase, no restoration passes | Multilingual speech where accuracy matters more than footprint (600M encoder) |
+
+The `ml_ctc*` heads download pre-quantized INT8 directly, so there is no
+quantization step for them. Switching heads after install:
+
+```sh
+gigastt download --model-variant e2e_rnnt   # fetch another head
+gigastt serve --model-variant e2e_rnnt      # and serve it explicitly
+```
+
+WER/RTF numbers per head are in
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md);
+the deeper model/backend tour is in [Models and backends](04-models-and-backends.md).
+
+## The expensive first run
+
+The very first `gigastt download` (or first `gigastt serve`, which
+auto-downloads a missing model) does two one-time things:
+
+1. **Downloads ~850 MB** of FP32 ONNX files from HuggingFace
+   (SHA-256-verified, staged to `.partial`, atomically renamed).
+2. **Quantizes the encoder to INT8** (~2 minutes, one-time), producing the
+   ~225 MB encoder the engine actually loads. Later runs reuse it.
+
+Three levers change what you pay:
+
+- `gigastt download --prequantized` — the recommended shortcut: fetch the
+  ~225 MB pre-quantized INT8 bundle from the pinned GitHub Release. No FP32
+  download, no local quantization, no `protoc`. Note it pulls from
+  `github.com`, not `huggingface.co` — useful when one of the two is blocked.
+- `gigastt download --skip-quantize` (or `GIGASTT_SKIP_QUANTIZE=1` on
+  `serve`) — keep the FP32 encoder and skip quantization. The engine then
+  loads FP32: slower inference and ~4× the model RAM. Only for debugging.
+- Nothing — just let the first `serve` do it. The port binds immediately;
+  `/health` answers `200` with `"model":"loading"` and `/ready` returns
+  `503 {"reason":"initializing"}` until the model is usable, so clients should
+  gate on `/ready`, never on the process being alive.
 
 ## Verifying the result
 
-_To be written._
+End-to-end checklist that works after any of the recipes above:
+
+```sh
+# 1. Model files are in place:
+ls ~/.gigastt/models/
+#   v3_rnnt_encoder_int8.onnx  v3_rnnt_decoder.onnx  v3_rnnt_joint.onnx  v3_vocab.txt  ...
+
+# 2. Offline transcription works (no server needed):
+gigastt transcribe recording.wav
+#   → prints the recognized text on stdout
+
+# 3. The server comes up and reports the loaded head:
+gigastt serve &                      # Ctrl-C to stop; default http://127.0.0.1:9876
+curl http://127.0.0.1:9876/ready     # 200 once the model is loaded
+curl http://127.0.0.1:9876/health
+#   {"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"...","punctuation":true,"itn":true}
+
+# 4. REST transcription works:
+curl -F file=@recording.wav http://127.0.0.1:9876/v1/transcribe
+#   → {"text":"...","words":[...],"duration":N}
+```
 
 ## Common pitfalls
 
-_To be written._
+- **`protoc` not found** during `cargo install` or a source build — install
+  the Protocol Buffers compiler (`brew install protobuf` /
+  `apt install protobuf-compiler`), or skip the toolchain entirely with the
+  prebuilt binary / Homebrew.
+- **First `serve` sits there for minutes** — that is the one-time model
+  download + INT8 quantization, not a hang: `/health` returns
+  `{"model":"loading"}` meanwhile. Pre-seed with `gigastt download
+  --prequantized` and gate clients on `/ready`.
+- **`Address already in use` on port 9876** — find the holder with
+  `lsof -nP -tiTCP:9876 -sTCP:LISTEN`; confirm it is gigastt
+  (`ps -p <pid> -o command=`), then `kill <pid>` (SIGTERM drains cleanly), or
+  start on another port with `--port`.
+- **Model download fails or hangs** (proxy, firewall, HuggingFace
+  unreachable) — retry `gigastt download`; the resume-safe staging file makes
+  it idempotent, and exit codes distinguish causes (65 = checksum, 69 =
+  network, 74 = disk). If `huggingface.co` is blocked but `github.com` is
+  not, use `gigastt download --prequantized`; in a fully closed contour use
+  the air-gapped bundle. Check `~/.gigastt/models/` permissions on disk
+  errors.
+- **OOM or heavy swap on startup** — each pool session loads its own encoder
+  copy (~400 MB resident with INT8); the default `--pool-size 2` peaks around
+  790 MB. On small machines run with `--pool-size 1`.
+
+The full symptom → cause → fix table lives in
+[docs/troubleshooting.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/troubleshooting.md).
 
 ## Links
 
-- [Project README](../../../../README.md) — install options and quick start
-- [docs/cli.md](../../../cli.md) — `download` / `transcribe` / `serve` commands
-- [docs/troubleshooting.md](../../../troubleshooting.md) — setup problems
+- [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md) —
+  canonical CLI reference (every flag and env var)
+- [docs/api.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/api.md) —
+  REST / SSE / WebSocket API reference
+- [docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md) —
+  per-head WER / RTF numbers
+- [docs/troubleshooting.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/troubleshooting.md) —
+  symptom → cause → fix
+- [docs/deployment.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/deployment.md) —
+  Docker details, reverse proxy, systemd, offline installs
+- [docs/verifying-releases.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/verifying-releases.md) —
+  checksums, minisign, SLSA provenance for release artifacts
+- [packaging/offline/README-OFFLINE.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/offline/README-OFFLINE.md) —
+  offline bundle contents and installer options
+- [File transcription](02-file-transcription.md) — the next chapter: batch,
+  watch mode, export formats
+- [Models and backends](04-models-and-backends.md) — heads, quantization,
+  execution providers in depth

--- a/docs/workbook/ru/src/01-getting-started.md
+++ b/docs/workbook/ru/src/01-getting-started.md
@@ -1,32 +1,310 @@
 # Начало работы
 
-> **Заглушка** — глава представляет собой скелет; полный рецепт появится в
-> следующем изменении. Структура следует [`_template.md`](_template.md).
-
 ## Сценарий
 
 Вы никогда не запускали gigastt и хотите получить рабочую локальную
-транскрибацию за считаные минуты: установить бинарник, скачать модель
-GigaAM v3, транскрибировать первый файл.
+транскрибацию примерно за пять минут: установить бинарник, скачать модель
+GigaAM v3, транскрибировать первый аудиофайл — на macOS, Linux или в Docker.
+Эта глава покрывает весь путь; другие документы для этого не понадобятся.
 
 ## Предпосылки
 
-_Будет написано._
+- **Диск:** ~1,5 ГБ свободно (модель + инструменты). «Лёгкий» путь с
+  `--prequantized` требует при установке всего ~250 МБ.
+- **RAM:** ~800 МБ свободно при дефолтном `--pool-size 2` (~400 МБ на сессию).
+- **Сеть** (если вы не идёте по рецепту для замкнутого контура): доступ к
+  `huggingface.co` (полная модель) или `github.com` (предквантизованный бандл).
+- **Аудиофайл для транскрибации** — WAV, M4A, MP3, OGG или FLAC. Подойдёт
+  любая короткая запись русской речи.
+- Только для `cargo install` (сборка из исходников): Rust 1.88+ и `protoc` в
+  `PATH` (`brew install protobuf` / `apt install protobuf-compiler`).
 
-## Рецепт
+Выберите **один** рецепт ниже — macOS, Linux, Docker или замкнутый контур, —
+затем один раз прочитайте [Выбор головы распознавания](#выбор-головы-распознавания)
+и [Дорогой первый запуск](#дорогой-первый-запуск).
 
-_Будет написано._
+## Рецепт: macOS (Homebrew)
+
+Homebrew — самый быстрый путь на Apple Silicon (tap содержит бинарник с
+CoreML). На Intel Mac используйте `cargo install gigastt` — см. требование
+про protoc в рецепте для Linux.
+
+```sh
+brew tap ekhodzitsky/gigastt https://github.com/ekhodzitsky/gigastt
+brew install gigastt
+
+# Скачать модель (~850 МБ FP32 с HuggingFace, затем разовая ~2-минутная
+# INT8-квантизация — см. «Дорогой первый запуск» ниже):
+gigastt download
+
+# Транскрибировать первый файл:
+gigastt transcribe recording.wav
+```
+
+**Проверка:** последняя команда печатает распознанный текст в stdout, например:
+
+```text
+$ gigastt transcribe recording.wav
+Привет, как дела?
+```
+
+а `ls ~/.gigastt/models/` показывает `v3_rnnt_encoder_int8.onnx`,
+`v3_rnnt_decoder.onnx`, `v3_rnnt_joint.onnx` и `v3_vocab.txt`.
+
+## Рецепт: Linux (готовый бинарник или cargo)
+
+**Вариант A — готовый бинарник** (без Rust-инструментария и protoc). Каждый
+релиз публикует tarball'ы для `x86_64-unknown-linux-gnu` и
+`aarch64-unknown-linux-gnu`:
+
+```sh
+# Определить тег последнего релиза (или задайте TAG=v2.13.0 вручную):
+TAG=$(curl -fsSL https://api.github.com/repos/ekhodzitsky/gigastt/releases/latest \
+      | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+VER=${TAG#v}
+
+curl -fLO "https://github.com/ekhodzitsky/gigastt/releases/download/${TAG}/gigastt-${VER}-x86_64-unknown-linux-gnu.tar.gz"
+curl -fLO "https://github.com/ekhodzitsky/gigastt/releases/download/${TAG}/gigastt-${VER}-x86_64-unknown-linux-gnu.tar.gz.sha256"
+sha256sum -c "gigastt-${VER}-x86_64-unknown-linux-gnu.tar.gz.sha256"
+
+tar xf "gigastt-${VER}-x86_64-unknown-linux-gnu.tar.gz"
+sudo install -m 0755 gigastt /usr/local/bin/gigastt
+```
+
+(На ARM64 замените `x86_64-unknown-linux-gnu` на
+`aarch64-unknown-linux-gnu`. Homebrew на Linux x86_64 — `brew install
+gigastt` после tap из рецепта для macOS — тоже работает.)
+
+**Вариант B — cargo** (любая платформа, нужны Rust 1.88+ и `protoc`):
+
+```sh
+sudo apt install protobuf-compiler   # Debian/Ubuntu; пропустите, если protoc есть
+cargo install gigastt
+```
+
+Затем скачайте модель «лёгким» способом — предквантизованный INT8-бандл
+~225 МБ из закреплённого GitHub Release (без ~850 МБ FP32-загрузки и без
+~2-минутной квантизации на устройстве; удобно и тогда, когда HuggingFace
+недоступен, а GitHub — нет):
+
+```sh
+gigastt download --prequantized
+gigastt transcribe recording.wav
+```
+
+**Проверка:** `gigastt transcribe recording.wav` печатает распознанный текст в
+stdout, а `ls ~/.gigastt/models/` показывает файлы модели `v3_rnnt_*`.
+
+## Рецепт: Docker
+
+Готовые мультиархитектурные образы (amd64 + arm64) публикуются в GHCR для
+каждого релиза; теги `-cuda` содержат CUDA-вариант:
+
+```sh
+docker pull ghcr.io/ekhodzitsky/gigastt:latest   # в продакшене зафиксируйте :<version>
+
+docker run -d --name gigastt \
+  -p 127.0.0.1:9876:9876 \
+  -v gigastt-models:/home/gigastt/.gigastt/models \
+  ghcr.io/ekhodzitsky/gigastt:latest
+```
+
+Именованный volume сохраняет модель между перезапусками контейнера; без него
+контейнер будет заново скачивать ~850 МБ при каждом пересоздании. При первом
+старте контейнер скачивает модель и квантизует её — порт поднимается сразу,
+но инференс доступен, только когда `/ready` становится «зелёным»:
+
+```sh
+# Дождаться загрузки модели (503, пока идёт инициализация):
+until curl -sf http://127.0.0.1:9876/ready > /dev/null; do sleep 5; done
+
+curl http://127.0.0.1:9876/health
+```
+
+Затем транскрибируйте файл с хоста (путь к файлу — на хосте: его читает
+`curl`, а не контейнер):
+
+```sh
+curl -F file=@recording.wav http://127.0.0.1:9876/v1/transcribe
+```
+
+**Проверка:** `/health` возвращает
+
+```json
+{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.13.0","punctuation":true,"itn":true}
+```
+
+(поле `version` отражает скачанный образ), а POST возвращает JSON с
+транскриптом:
+
+```json
+{"text":"Привет, как дела?","words":[{"word":"привет","start":0.0,"end":0.4,"confidence":0.99}],"duration":1.2}
+```
+
+## Рецепт: замкнутый контур (offline bundle)
+
+Для машин без доступа в интернет каждый релиз публикует самодостаточный
+офлайн-бандл для каждой Linux-цели — бинарник + предквантизованная INT8-модель
+`rnnt` + модель пунктуации + systemd unit + установщик, — а также два
+Debian-пакета с тем же содержимым. Скачайте их на **подключённой** машине,
+перенесите и установите.
+
+Поток с tarball'ом (любой дистрибутив):
+
+```sh
+# На подключённой машине (TAG/VER — см. рецепт для Linux):
+curl -fLO "https://github.com/ekhodzitsky/gigastt/releases/download/${TAG}/gigastt-${VER}-offline-x86_64-unknown-linux-gnu.tar.gz"
+curl -fLO "https://github.com/ekhodzitsky/gigastt/releases/download/${TAG}/gigastt-${VER}-offline-x86_64-unknown-linux-gnu.tar.gz.sha256"
+sha256sum -c "gigastt-${VER}-offline-x86_64-unknown-linux-gnu.tar.gz.sha256"
+
+# На целевой машине:
+tar xf "gigastt-${VER}-offline-x86_64-unknown-linux-gnu.tar.gz"
+cd "gigastt-${VER}-offline-x86_64-unknown-linux-gnu"
+sudo ./install.sh                      # проверяет SHA256SUMS, ставит бинарник + модель + unit
+sudo systemctl enable --now gigastt
+```
+
+Поток с Debian-пакетами: установите `gigastt_<ver>_amd64.deb` (бинарник +
+unit) вместе с `gigastt-model-int8_<ver>_all.deb` (тот же набор моделей),
+затем `sudo systemctl enable --now gigastt`.
+
+В бандл намеренно не входят опциональные части — диаризация спикеров и головы
+`e2e_rnnt` / `ml_ctc`. Установленный unit работает с `GIGASTT_OFFLINE=1`,
+поэтому отсутствующая опциональная модель — это быстрая, понятная ошибка с
+точным путём, куда положить файл (скачайте его на подключённой машине командой
+`gigastt download` и скопируйте), а не сетевой таймаут. Полный список
+содержимого и проверка подписей — в
+[packaging/offline/README-OFFLINE.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/offline/README-OFFLINE.md).
+
+**Проверка:** `curl http://127.0.0.1:9876/health` возвращает
+`{"status":"ok",...}` с `"model":"gigaam-v3-rnnt"`, а
+`gigastt transcribe sample.wav --model-dir /usr/share/gigastt/models` печатает
+текст (флаг нужен только при запуске без установки — systemd unit уже
+указывает на установленную модель).
+
+## Выбор головы распознавания
+
+gigastt поставляется с четырьмя головами распознавания; `--model-variant`
+выбирает одну из них при `download` / `serve` / `transcribe`. Если флаг не
+указан, существующая директория модели используется как есть
+(автоопределение), а свежая установка по умолчанию получает `rnnt`.
+
+| Голова | Языки | Стиль вывода | Когда выбирать |
+|---|---|---|---|
+| `rnnt` (по умолчанию) | русский | «Голый» lowercase из акустической модели; регистр + пунктуация восстанавливаются автоскачиваемым проходом RuPunct, цифры — ITN | По умолчанию: минимальный WER на русской речи |
+| `e2e_rnnt` | русский | Пунктуация / регистр / ITN «зашиты» в акустическую модель | Нужна одна самодостаточная модель без постобработки |
+| `ml_ctc` | ru/en/kk/ky/uz | «Голый» lowercase, без восстановления | Смешанная русско-английская (или kk/ky/uz) речь; лёгкий энкодер 220M |
+| `ml_ctc_large` | ru/en/kk/ky/uz | «Голый» lowercase, без восстановления | Мультиязычная речь, где точность важнее размера (энкодер 600M) |
+
+Головы `ml_ctc*` скачиваются сразу в предквантизованном INT8, поэтому шага
+квантизации у них нет. Смена головы после установки:
+
+```sh
+gigastt download --model-variant e2e_rnnt   # скачать другую голову
+gigastt serve --model-variant e2e_rnnt      # и явно подать её
+```
+
+Цифры WER/RTF по каждой голове — в
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md);
+более глубокий обзор моделей и бэкендов — в главе
+[Модели и бэкенды](04-models-and-backends.md).
+
+## Дорогой первый запуск
+
+Самый первый `gigastt download` (или первый `gigastt serve`, который
+автоматически скачивает отсутствующую модель) делает две разовые вещи:
+
+1. **Скачивает ~850 МБ** FP32 ONNX-файлов с HuggingFace (с проверкой SHA-256,
+  через промежуточный `.partial` и атомарное переименование).
+2. **Квантизует энкодер в INT8** (~2 минуты, один раз), создавая энкодер
+   ~225 МБ, который движок реально загружает. Следующие запуски используют его
+   повторно.
+
+Три рычага меняют цену:
+
+- `gigastt download --prequantized` — рекомендуемый короткий путь: скачать
+  предквантизованный INT8-бандл ~225 МБ из закреплённого GitHub Release. Без
+  FP32-загрузки, без локальной квантизации, без `protoc`. Обратите внимание:
+  файлы берутся с `github.com`, а не с `huggingface.co` — полезно, когда один
+  из двух хостов заблокирован.
+- `gigastt download --skip-quantize` (или `GIGASTT_SKIP_QUANTIZE=1` у
+  `serve`) — оставить FP32-энкодер и пропустить квантизацию. Движок тогда
+  загружает FP32: инференс медленнее, а модель занимает в ~4 раза больше RAM.
+  Только для отладки.
+- Ничего — просто позволить первому `serve` сделать всё самому. Порт
+  поднимается сразу; `/health` отвечает `200` с `"model":"loading"`, а
+  `/ready` возвращает `503 {"reason":"initializing"}`, пока модель не готова,
+  поэтому клиенты должны ждать `/ready`, а не сам факт запущенного процесса.
 
 ## Проверка результата
 
-_Будет написано._
+Сквозной чек-лист, работающий после любого из рецептов выше:
+
+```sh
+# 1. Файлы модели на месте:
+ls ~/.gigastt/models/
+#   v3_rnnt_encoder_int8.onnx  v3_rnnt_decoder.onnx  v3_rnnt_joint.onnx  v3_vocab.txt  ...
+
+# 2. Офлайн-транскрибация работает (сервер не нужен):
+gigastt transcribe recording.wav
+#   → печатает распознанный текст в stdout
+
+# 3. Сервер поднимается и сообщает загруженную голову:
+gigastt serve &                      # Ctrl-C для остановки; по умолчанию http://127.0.0.1:9876
+curl http://127.0.0.1:9876/ready     # 200, когда модель загружена
+curl http://127.0.0.1:9876/health
+#   {"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"...","punctuation":true,"itn":true}
+
+# 4. REST-транскрибация работает:
+curl -F file=@recording.wav http://127.0.0.1:9876/v1/transcribe
+#   → {"text":"...","words":[...],"duration":N}
+```
 
 ## Частые ошибки
 
-_Будет написано._
+- **`protoc` не найден** при `cargo install` или сборке из исходников —
+  установите компилятор Protocol Buffers (`brew install protobuf` /
+  `apt install protobuf-compiler`) или вовсе обойдитесь без инструментария,
+  взяв готовый бинарник / Homebrew.
+- **Первый `serve` «висит» несколько минут** — это разовая загрузка модели +
+  INT8-квантизация, а не зависание: `/health` в это время возвращает
+  `{"model":"loading"}`. Подготовьте модель заранее командой `gigastt download
+  --prequantized` и настройте клиентов на ожидание `/ready`.
+- **`Address already in use` на порту 9876** — найдите, кто держит порт:
+  `lsof -nP -tiTCP:9876 -sTCP:LISTEN`; убедитесь, что это gigastt
+  (`ps -p <pid> -o command=`), затем `kill <pid>` (SIGTERM корректно завершает
+  сессии) или запустите на другом порту с `--port`.
+- **Скачивание модели падает или виснет** (прокси, файрвол, HuggingFace
+  недоступен) — повторите `gigastt download`; промежуточный `.partial`-файл
+  делает повтор безопасным, а коды выхода различают причины (65 = контрольная
+  сумма, 69 = сеть, 74 = диск). Если `huggingface.co` заблокирован, а
+  `github.com` — нет, используйте `gigastt download --prequantized`; в полностью
+  замкнутом контуре — офлайн-бандл. При ошибках диска проверьте права на
+  `~/.gigastt/models/`.
+- **OOM или активный swap при старте** — каждая сессия пула загружает свою
+  копию энкодера (~400 МБ резидентно с INT8); дефолтный `--pool-size 2`
+  достигает ~790 МБ. На слабых машинах запускайте с `--pool-size 1`.
+
+Полная таблица «симптом → причина → исправление» — в
+[docs/troubleshooting.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/troubleshooting.md).
 
 ## Ссылки
 
-- [README проекта](../../../../README_RU.md) — варианты установки и быстрый старт
-- [docs/cli.md](../../../cli.md) — команды `download` / `transcribe` / `serve`
-- [docs/troubleshooting.md](../../../troubleshooting.md) — проблемы установки
+- [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md) —
+  канонический справочник CLI (все флаги и переменные окружения)
+- [docs/api.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/api.md) —
+  справочник REST / SSE / WebSocket API
+- [docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md) —
+  цифры WER / RTF по каждой голове
+- [docs/troubleshooting.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/troubleshooting.md) —
+  симптом → причина → исправление
+- [docs/deployment.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/deployment.md) —
+  детали Docker, reverse proxy, systemd, офлайн-установка
+- [docs/verifying-releases.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/verifying-releases.md) —
+  контрольные суммы, minisign, SLSA provenance для артефактов релизов
+- [packaging/offline/README-OFFLINE.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/offline/README-OFFLINE.md) —
+  состав офлайн-бандла и опции установщика
+- [Транскрибация файлов](02-file-transcription.md) — следующая глава: пакетная
+  обработка, режим watch, форматы экспорта
+- [Модели и бэкенды](04-models-and-backends.md) — головы, квантизация,
+  execution providers в деталях


### PR DESCRIPTION
## Workbook chapter 01: Getting started (EN + RU)

Replaces the stubs in `docs/workbook/{en,ru}/src/01-getting-started.md` with the full chapter, following `docs/workbook/src/_template.md` (scenario → prerequisites → recipe → verifying the result → common pitfalls → links).

### What the chapter covers

- **Recipe: macOS (Homebrew)** — `brew tap` + `brew install gigastt` → `gigastt download` → `gigastt transcribe recording.wav`, with a verify check (stdout text + `ls ~/.gigastt/models/`).
- **Recipe: Linux (prebuilt binary or cargo)** — release tarball with SHA-256 sidecar verification (tag auto-resolved via the GitHub API), or `cargo install gigastt` with the `protoc` prerequisite; model fetched via the lean `gigastt download --prequantized` (~225 MB, no FP32, no on-device quantize).
- **Recipe: Docker** — `docker pull ghcr.io/ekhodzitsky/gigastt:latest`, named volume on `/home/gigastt/.gigastt/models` (path read from the Dockerfile), `/ready` gating, `curl -F file=@... /v1/transcribe` from the host, expected `/health` and transcript JSON.
- **Recipe: air-gapped (offline bundle)** — tarball + `.deb` flows from `docs/deployment.md` / `packaging/offline/README-OFFLINE.md`, `install.sh` + systemd, what is deliberately not in the bundle, `GIGASTT_OFFLINE=1` behavior.
- **Choosing the recognition head** — `rnnt` (default) vs `e2e_rnnt` vs `ml_ctc` / `ml_ctc_large`: a when-to-pick table without duplicating benchmark numbers (links to `docs/benchmarks.md` and chapter 04).
- **The expensive first run** — ~850 MB FP32 download + one-time ~2 min INT8 quantization, and the three levers: `--prequantized`, `--skip-quantize` (FP32 engine fallback, per `ensure_int8_encoder` in `main.rs`), and letting first `serve` do it (`/health` = `model:loading`, `/ready` = 503 meanwhile).
- **Common pitfalls** — `protoc` missing, slow first run, port 9876 busy (`lsof` recipe), download failures through proxy/firewall (exit codes 65/69/74, `--prequantized` as the GitHub-hosted fallback), OOM with `--pool-size > 1`.
- Every recipe ends with a **verify-the-result** check; a final end-to-end checklist section ties them together.

### quickstarts.md consolidation decision

The chapter fully absorbs the "install → download → first transcript" path that used to be scattered. `docs/quickstarts.md` stays untouched: per the workbook's own documentation map it is the *in-process embedding* quickstart (FFI bindings / client SDKs), a different audience from this chapter, so no redirect is needed. (This PR is scoped to the two chapter files only.)

### Sources verified against

- `crates/gigastt/src/main.rs` — `download` flags (`--prequantized`, `--skip-quantize`, `--model-variant`, `--skip-diarization`, `--progress`), `serve`/`transcribe` flags, `ensure_int8_encoder` skip behavior, download exit codes.
- `docs/cli.md`, `docs/deployment.md`, `docs/quickstarts.md`, `README.md` — commands, health JSON shape, GHCR image names.
- `Dockerfile` — container user, model path `/home/gigastt/.gigastt/models`, `--bind-all` CMD.
- `.github/workflows/release.yml` + live release page — asset names (`gigastt-<ver>-{x86_64,aarch64}-*.tar.gz`, `-offline-`, `.deb`); all four URLs used in the chapter return HTTP 200 for v2.13.0.
- `Formula/gigastt.rb` — brew tap/install commands, Apple-Silicon-only caveat.
- `packaging/offline/README-OFFLINE.md` + `install.sh` — bundle contents, installer flags.
- Recipes run end-to-end locally with the installed model: `gigastt transcribe` (printed text), `gigastt serve` + `curl /ready` + `curl /health` + `curl -F file=@... /v1/transcribe` (real JSON output used as the shape for the examples).

### Checks

- `mdbook build docs/workbook/en` and `.../ru` — zero errors/warnings.
- Heading parity EN↔RU: 27 heading lines each, identical level sequences (drift-gate safe).
- All 10 shell snippets per file pass `bash -n`; both JSON snippets parse.
- `typos` clean on both files.
- Intra-book relative links (`02-file-transcription.md`, `04-models-and-backends.md`) resolve in the rendered HTML; section anchors (incl. Cyrillic slugs) verified in output.
- Book→repo links use absolute `github.com/ekhodzitsky/gigastt/blob/main/...` URLs (relative ones 404 on the published Pages site); every linked repo path exists. Note: this deviates from the "relative `.md` links only" line in the workbook intro README — followed the chapter spec instead, since absolute URLs are what works on GitHub Pages.
