### PR TITLE
docs(workbook): chapter desktop & embedded — Swift/SPM, sidecar, Electron, UniFFI (en+ru)

### DIFF
--- a/docs/workbook/en/src/05-desktop-embedded.md
+++ b/docs/workbook/en/src/05-desktop-embedded.md
@@ -1,0 +1,443 @@
+# Desktop & embedded: Swift/SPM, sidecar, Electron, UniFFI
+
+## Scenario
+
+You are building a desktop or mobile app with on-device Russian speech-to-text:
+a macOS dictation app in Swift, an Electron meeting recorder, or a Kotlin /
+Python tool. The model must run locally (no cloud), and you have two ways to
+ship the engine — embed it **in-process** via a native binding, or run
+`gigastt serve` as a **sidecar** subprocess and talk to it over the loopback
+HTTP/WS API. This chapter helps you choose, then walks each path to the first
+transcript.
+
+## Choosing a path: embedded vs sidecar
+
+| | Embedded (in-process) | Sidecar (`gigastt serve` + client) |
+|---|---|---|
+| How | Engine linked into your app: SwiftPM `GigaSTT`, npm `gigastt`, PyPI `gigastt`, UniFFI bindings | Engine runs as a child process; your app talks WS/REST over a loopback port |
+| Interface | Native calls; typed errors (`throws` / exceptions / rejected promises) | Wire protocol (`/v1/ws`, REST `/v1/transcribe`, SSE) |
+| Deployment | One package install; no process supervision | Binary discovery on the user's machine, spawn, supervision, port selection |
+| Memory | Model + pool live inside your app (~350–400 MB RSS per pool session) | Model lives in the separate server process |
+| Concurrency | One engine/pool instance per app process | One server shared by several apps/clients |
+| Failure isolation | An engine crash takes the app down (and vice versa) | Server crashes are isolated; the app survives and can restart it |
+| Upgrades | Redeploy the app with the new engine | Upgrade the server binary independently of any client |
+| Versioning | App and engine are one artifact | App must gate on the discovered server's version (`/health` → `version`) |
+
+Rules of thumb:
+
+- **Embedded** when your app owns its whole audio pipeline (a dictation tool,
+  a recorder) and is the only consumer. On iOS it is the *only* option — apps
+  cannot spawn subprocesses.
+- **Sidecar** when one engine is shared by several clients, when the app must
+  survive an engine crash, or when you want to upgrade the engine without
+  redeploying the app. Both confirmed external desktop integrations use this
+  pattern.
+
+## Prerequisites
+
+- **A model directory** — every path below assumes one. Fetch the
+  pre-quantized INT8 bundle once (~215 MB, no FP32 download, no on-device
+  quantization):
+
+  ```sh
+  gigastt download --prequantized          # -> ~/.gigastt/models
+  ```
+
+- **Embedded**: the toolchain for your binding — Xcode 15+ (Swift), Node.js
+  (npm package), Python 3 (wheel), or an Android SDK/NDK (Kotlin).
+- **Sidecar**: the `gigastt` binary — bundled inside your app's resources, or
+  installed (`brew tap ekhodzitsky/gigastt https://github.com/ekhodzitsky/gigastt && brew install gigastt`,
+  release tarball, or `cargo install gigastt`) — plus `curl` for probing.
+
+## Recipe — Swift/SPM (iOS + macOS)
+
+The `GigaSTT` Swift package wraps the C ABI in a safe Swift interface. The
+native code ships as a prebuilt `GigasttFFI.xcframework` (iOS device `arm64`,
+simulator `arm64`/`x86_64`, macOS `arm64`) with ONNX Runtime statically
+linked — there is no separate runtime to bundle. Requires iOS 15 / macOS 13
+(Apple Silicon only — there is no Intel macOS slice) and Xcode 15+.
+
+1. **Add the package.** Xcode → File → Add Package Dependencies… → enter the
+   mirror repository URL `https://github.com/ekhodzitsky/gigastt-swift` and add
+   the `GigaSTT` product to your target. The mirror is the canonical remote
+   source (SwiftPM needs `Package.swift` at the repository root, so the
+   monorepo subdirectory `packaging/swift` cannot be consumed via URL — use it
+   only as a local path dependency for development).
+2. **Bundle the model.** Copy `~/.gigastt/models` into your app target as a
+   **folder reference** (the blue folder — it preserves the directory layout;
+   a yellow "group" flattens the files and the engine will not find them).
+   Alternatively download the model on first launch and cache it.
+3. **Load the engine and transcribe:**
+
+   ```swift
+   import GigaSTT
+
+   guard let modelDir = Bundle.main.url(
+       forResource: "models", withExtension: nil
+   )?.path else {
+       fatalError("bundle the model directory as a folder reference")
+   }
+
+   // poolSize: 1 keeps RAM around ~350 MB, recommended on device.
+   let engine = try Engine(modelDir: modelDir, poolSize: 1)
+
+   // Path is relative to the current working directory; absolute paths and
+   // ".." are rejected by the engine.
+   let text = try engine.transcribeFile(path: "audio.wav")
+   print(text)
+   ```
+
+4. **Stream** little-endian mono PCM16 chunks at your capture rate (resampled
+   to 16 kHz internally):
+
+   ```swift
+   let stream = try Stream(engine: engine)
+
+   // pcm16: Data of little-endian Int16 mono samples at 48 kHz.
+   for segment in try stream.processChunk(pcm16, sampleRate: 48000) {
+       print(segment.text, segment.isFinal)
+   }
+
+   // Drain the tail at end-of-stream.
+   for segment in try stream.flush() {
+       print(segment.text)
+   }
+   ```
+
+   `processChunk` and `flush` return `[TranscriptSegment]`; each segment
+   carries `text`, `words` (per-word `word`/`start`/`end`/`confidence` and an
+   optional `speaker`), `isFinal`, and a `timestamp`.
+
+5. **Handle errors.** The wrapper throws `GigasttError`:
+   `engineLoadFailed(modelDir:)` (missing/unreadable model directory),
+   `streamCreationFailed` (pool checkout failed), `inferenceFailed`, and
+   `decodingFailed(underlying:)`. The C ABI signals failure with `NULL`
+   returns, so a case tells you *where* it failed rather than carrying an
+   engine-side message.
+
+Verify: run the app, transcribe a known WAV, and confirm the expected text is
+printed. If the engine throws `engineLoadFailed` at boot, the model directory
+is not where `Bundle.main.url(forResource: "models", withExtension: nil)`
+points — see Common pitfalls.
+
+## Recipe — sidecar server (macOS / Electron)
+
+Run `gigastt serve` as a managed child process. The full lifecycle: discover
+the binary, pre-stage the model, spawn, gate on readiness, transcribe, stop
+gracefully.
+
+1. **Discover the binary**, in order: an env override (e.g. `MYAPP_GIGASTT_BIN`)
+   → a copy bundled in your app's resources → `/opt/homebrew/bin/gigastt` →
+   `/usr/local/bin/gigastt` → `PATH`. Record which one you picked for logging.
+2. **Pre-stage the model** at install time or first launch, with
+   machine-readable progress for your UI:
+
+   ```sh
+   gigastt download --prequantized --progress json
+   ```
+
+   stdout carries one NDJSON event per line
+   (`{"phase":"download","file":...,"bytes_done":N,"bytes_total":M}`, then
+   `verify`, then `done`) and exit codes distinguish network/disk/checksum
+   failures — see [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md).
+   `--prequantized` skips the ~2-minute on-device INT8 pass, so the first
+   `serve` starts in seconds, not minutes.
+3. **Pick a port.** Today: a fixed high port (e.g. `49876`). Ephemeral
+   auto-selection (`--port 0` with a machine-readable `LISTENING` line),
+   `--die-with-parent`, and `--log-file` are planned server additions — they
+   require a gigastt version that ships them, so do not rely on their syntax
+   yet; use a fixed port and the lifecycle below.
+4. **Spawn and capture logs.** Never send the sidecar's output to `/dev/null` —
+   pipe stdout/stderr to a log file (if you connect pipes instead, keep
+   draining them: a full pipe buffer can deadlock the child). Example in an
+   Electron main process / Node:
+
+   ```js
+   import { spawn } from 'node:child_process';
+   import fs from 'node:fs';
+
+   const PORT = 49876;
+   const BASE = `http://127.0.0.1:${PORT}`;
+
+   const log = fs.createWriteStream('gigastt-sidecar.log', { flags: 'a' });
+   const server = spawn(gigasttBin, [
+     'serve',
+     '--port', String(PORT),
+     '--pool-size', '1',
+     '--model-dir', modelDir,
+   ], { stdio: ['ignore', log, log] });
+
+   async function waitForReady(timeoutMs = 120_000) {
+     const deadline = Date.now() + timeoutMs;
+     for (;;) {
+       try {
+         const res = await fetch(`${BASE}/ready`);
+         // 200 {"status":"ready","pool_available":N,"pool_total":M}
+         if (res.ok) return;
+         // 503 {"status":"not_ready","reason":"initializing"} — keep waiting.
+       } catch {
+         // Connection refused: the listener is not up (yet) — or the process
+         // is gone. Distinguish by the child exit code, not by killing it.
+         if (server.exitCode !== null) {
+           throw new Error(`gigastt exited with code ${server.exitCode}`);
+         }
+       }
+       if (Date.now() > deadline) throw new Error('readiness timeout');
+       await new Promise((resolve) => setTimeout(resolve, 500));
+     }
+   }
+   ```
+
+5. **Gate on `/ready`, not on TCP connect.** The server binds the port
+   immediately and answers probes from a bootstrap responder while the model
+   loads, so "port listening" does not mean "ready". Poll `GET /ready` until
+   it returns 200; a 503 body carries
+   `{"status":"not_ready","reason":"initializing"|"pool_exhausted"|"shutting_down"}`.
+   Connection-refused means the process is dead or not yet spawned — not that
+   it is stuck.
+6. **Version handshake over HTTP.** `GET /health` returns 200 in *both*
+   phases — `{"status":"ok","model":"loading","version":"2.13.0"}` during
+   bootstrap, then `{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.13.0","punctuation":true,"itn":true}`.
+   Gate your minimum engine version on the `version` field instead of running
+   `gigastt --version` in a subprocess.
+7. **Transcribe.** For live partial results open a WebSocket session on
+   `/v1/ws` (patterns in [Streaming](03-streaming.md)); for whole files POST to
+   `/v1/transcribe` (recipes in [Server integration](05-server-integration.md)).
+   On pool saturation the server answers 503 + `Retry-After` (REST) or an
+   error with `retry_after_ms` (WS) — honor it instead of inventing a backoff.
+   Before closing a WS session, send `{"type":"stop"}` so the server flushes
+   trailing words into a final segment.
+8. **Stop gracefully.** Send SIGTERM: the server drains in-flight sessions
+   for up to `--shutdown-drain-secs` (default 10), flushing a `final` and
+   closing WS clients with code 1001. Escalate to SIGKILL only after the drain
+   window. Track the child pid and terminate it when your app exits — an
+   orphaned sidecar holds ~1 GB RSS and the port.
+
+Verify:
+
+```sh
+gigastt serve --port 49876 --pool-size 1 &
+curl -s http://127.0.0.1:49876/ready    # -> {"status":"ready","pool_available":1,"pool_total":1}
+curl -s http://127.0.0.1:49876/health   # -> {"status":"ok","model":"gigaam-v3-rnnt",...,"version":"..."}
+kill %1                                  # SIGTERM — process exits within the drain window
+```
+
+## Recipe — Node/Electron in-process
+
+The `gigastt` npm package (napi-rs) embeds the engine inside your Node/Electron
+process — no sidecar, no port, no version gate. Inference runs on a libuv
+worker thread, so calls return Promises and never block the event loop;
+onnxruntime is statically linked, so the `.node` addon is self-contained.
+
+1. **Install:** `npm install gigastt`. The postinstall downloads exactly one
+   prebuilt binary (`gigastt.<platform>.node`, ~47 MB) for the install platform
+   from the GitHub release. Prebuilt platforms: `darwin-arm64`,
+   `linux-x64-gnu`, `linux-arm64-gnu`, `win32-x64-msvc` (no Intel macOS).
+2. **Side-load the model** — it is not bundled: `gigastt download --prequantized`
+   → `~/.gigastt/models`, or set `GIGASTT_MODEL_DIR`.
+3. **Use it:**
+
+   ```js
+   const { Engine, Stream } = require('gigastt');
+
+   const engine = new Engine('/path/to/gigastt/models'); // new Engine(modelDir, poolSize?)
+   const t = await engine.transcribeFile('recording.wav');
+   console.log(t.text, t.durationS);
+   for (const w of t.words) console.log(w.text, w.startS, w.endS, w.confidence);
+
+   // streaming — await each chunk before sending the next to keep order
+   const s = new Stream(engine);
+   for (const seg of await s.processChunk(pcm16, 16000)) console.log(seg.text);
+   console.log((await s.flush()).map((seg) => seg.text));
+
+   // errors are thrown JS Errors whose message starts with a stable code
+   try { new Engine('/no/such/dir'); } catch (e) { /* e.message starts "ModelNotFound:" */ }
+   ```
+
+4. **Electron layout:** construct the `Engine` in the **main process** (never
+   in a renderer) and keep one `Stream` per audio channel (e.g. mic + system).
+   Each `Stream` holds one pool session for its lifetime, so `poolSize` must
+   cover the number of live streams — a third `Stream` on a pool of 2 throws
+   `PoolExhausted`. The full dual-channel pattern with IPC handlers is in
+   [examples/electron_main.mjs](https://github.com/ekhodzitsky/gigastt/blob/main/examples/electron_main.mjs).
+5. **Size the thread pool.** Inference runs on libuv's worker pool (default 4
+   threads, shared with `fs`/`crypto`). For `N` channels transcribing
+   simultaneously, start with `UV_THREADPOOL_SIZE >= N`
+   (e.g. `UV_THREADPOOL_SIZE=4 electron .`) and a matching `poolSize`.
+6. **Packaging (asar):** keep the model directory *and* the native `.node`
+   addon **out of the asar archive** — native code memory-maps the weights and
+   `dlopen`s the addon, neither of which works from asar's virtual filesystem.
+   With electron-builder, use `asarUnpack` for `**/*.node` and ship the model
+   via `extraResources`.
+
+Verify: in a checkout, `GIGASTT_MODEL_DIR=~/.gigastt/models npm run smoke`
+(from `crates/gigastt-node`) transcribes a test fixture; in your app, await
+`engine.transcribeFile` on a known WAV and check the text.
+
+## Recipe — Kotlin and Python (UniFFI)
+
+`crates/gigastt-uniffi` generates idiomatic Swift, Kotlin, and Python bindings
+from one Rust source with UniFFI. They wrap the synchronous lean core (models
+side-loaded, no tokio runtime), surface typed `GigasttFfiError` errors
+(`ModelNotFound`, `InvalidAudio`, `PoolExhausted`, `Inference`,
+`InvalidArgument`), and manage objects by reference counting.
+
+Shared surface (casing follows each language's idiom):
+
+- `Engine(model_dir)` / `Engine.new_with_pool_size(model_dir, pool_size)` ·
+  `transcribe_file(path) -> Transcript { text, words, duration_s }`
+- `Stream(engine)` · `process_chunk(pcm16, sample_rate) -> [TranscriptSegment]` ·
+  `flush() -> [TranscriptSegment]`
+- `TranscriptSegment { text, words, is_final }` ·
+  `Word { text, start_s, end_s, confidence, speaker }`
+
+**Python — published.** `pip install gigastt` installs a self-contained
+prebuilt wheel (`py3-none-<platform>`; onnxruntime statically linked):
+
+```python
+import gigastt_uniffi as g
+
+engine = g.Engine("/path/to/gigastt/models")        # side-loaded model dir
+t = engine.transcribe_file("recording.wav")
+print(t.text)
+for w in t.words:
+    print(w.text, w.start_s, w.end_s, w.confidence)
+
+# streaming
+s = g.Stream(engine)
+for seg in s.process_chunk(pcm16_bytes, 16000):
+    print(seg.text)
+print([seg.text for seg in s.flush()])
+
+# typed errors
+try:
+    g.Engine("/no/such/dir")
+except g.GigasttFfiError.ModelNotFound as e:
+    ...
+```
+
+**Kotlin — experimental AAR.** The Rust cross-build is proven (CI
+cross-compiles `libgigastt_uniffi.so` per ABI via cargo-ndk), but the
+Gradle/Maven AAR assembly and publish have not been validated end-to-end yet.
+To build locally:
+
+```sh
+# native libs per ABI
+cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 \
+  -o packaging/android/gigastt/src/main/jniLibs build --release -p gigastt-uniffi
+# Kotlin bindings (from a host build of the cdylib; metadata is arch-independent)
+cargo build --release -p gigastt-uniffi
+cargo run --release -p gigastt-uniffi --bin uniffi-bindgen -- generate \
+  --library target/release/libgigastt_uniffi.* --language kotlin \
+  --out-dir packaging/android/gigastt/src/main/kotlin
+# assemble
+cd packaging/android && gradle :gigastt:assembleRelease
+```
+
+**Swift (UniFFI):** the bindings generate (`--language swift`), but the shipped
+SwiftPM package uses the handwritten C-ABI wrapper from the Swift recipe above
+— prefer it for app development.
+
+To regenerate any binding from a checkout:
+
+```sh
+cargo build -p gigastt-uniffi
+LIB=target/debug/libgigastt_uniffi.dylib   # .so on Linux
+
+cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate --library "$LIB" --language python --out-dir bindings/python
+cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate --library "$LIB" --language swift  --out-dir bindings/swift
+cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate --library "$LIB" --language kotlin --out-dir bindings/kotlin
+```
+
+Generated bindings are build artifacts (`bindings/` is git-ignored). Status and
+packaging details:
+[crates/gigastt-uniffi/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/crates/gigastt-uniffi/README.md),
+[packaging/android/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/android/README.md).
+
+Verify: the Python snippet above prints the transcript of a known file; for
+Kotlin, assemble the AAR and transcribe from an instrumented test or a debug
+screen.
+
+## Verifying the result
+
+End-to-end checklist, whichever path you took:
+
+- **First transcript**: your app prints the expected text for a known WAV
+  (any Russian speech file, e.g. a Golos sample).
+- **Model on disk**: `ls ~/.gigastt/models` shows `v3_rnnt_*` files (the
+  `--prequantized` bundle includes `v3_rnnt_encoder_int8.onnx`).
+- **Memory**: RSS stays in the expected band — roughly 350–400 MB per pool
+  session; a `poolSize`/`pool-size` of 1 is the right default on-device.
+- **Sidecar health**: `curl -s http://127.0.0.1:<port>/ready` returns
+  `{"status":"ready",...}` and `/health` reports the `version` you gate on;
+  SIGTERM shuts the process down within the drain window with a clean log
+  tail.
+- **Streaming order**: partial segments (`isFinal == false`) may be revised;
+  persist only finals, and call `flush()` (or send `{"type":"stop"}` on WS)
+  before tearing down a session so the tail is not lost.
+
+## Common pitfalls
+
+- **Model not bundled as a folder reference (Swift).** Added as a yellow
+  "group", Xcode flattens the directory and the engine fails at boot with
+  `engineLoadFailed`. Fix: add `models` as a folder reference (blue folder)
+  and assert `Bundle.main.url(forResource: "models", withExtension: nil)` is
+  non-nil in a debug run.
+- **Undefined `std::__1::*` symbols at link time (Swift).** ONNX Runtime is
+  C++; the current package already declares `.linkedLibrary("c++")` — this
+  error means you are consuming an old or hand-rolled xcframework. Use the
+  released package from the mirror (or current `packaging/swift`).
+- **Blocking call on the UI thread.** `Engine`/`Stream` calls are synchronous
+  and the handles are not thread-safe. Run all engine work on a dedicated
+  background queue/actor (Swift) and serialize access; never transcribe on the
+  main thread. In Node the calls already run on the libuv pool — just `await`
+  them.
+- **Readiness timeouts on the first run (sidecar).** A plain
+  `gigastt download` leaves a ~2-minute on-device INT8 quantization pass to the
+  first `serve`, and the punctuation model fetches lazily on first start — a
+  client with a 10–30 s boot timeout gives up too early. Fix: pre-stage with
+  `gigastt download --prequantized`, keep the readiness timeout generous, and
+  branch on the `/ready` `reason` instead of killing the process.
+- **Killing the server on 503.** During model load the port is bound by the
+  bootstrap responder and every API answers 503 `initializing` — that is
+  progress, not a hang. Only connection-refused plus a dead child process
+  means failure.
+- **Hardcoded port collision.** A fixed port already in use (often by an
+  orphaned gigastt from a previous run) surfaces as a silent timeout. Check
+  `/health` → `version` to learn whether the listener is *your* server, and
+  terminate your child on app exit (a `--die-with-parent` flag is planned).
+- **Sidecar logs to `/dev/null`.** You will need them the first time the model
+  directory is corrupt. Pipe stdout/stderr to a file — and if you use pipes,
+  keep draining them to avoid a pipe-buffer deadlock.
+- **`require('gigastt')` fails after `npm install --ignore-scripts`.** The
+  postinstall that downloads the native binary was skipped; run `node
+  install.js` inside the package.
+- **Model or addon inside asar (Electron).** Native code memory-maps the
+  weights and `dlopen`s the `.node` — both need real files. `asarUnpack` the
+  addon and ship the model via `extraResources`.
+- **Absolute path to `transcribeFile` (Swift).** The C ABI accepts only
+  relative paths inside the working directory — point the working directory at
+  the file's location first (or copy the file there).
+
+## Links
+
+In this book:
+
+- [Getting started](01-getting-started.md) — install and model download
+- [Streaming](03-streaming.md) — WebSocket protocol patterns for the sidecar
+- [Server integration](05-server-integration.md) — REST / SSE / jobs recipes
+
+Reference material (do not duplicate — read here):
+
+- [packaging/swift/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/swift/README.md) — Swift package API reference
+- [crates/gigastt-node/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/crates/gigastt-node/README.md) — npm package API + in-process vs sidecar trade-offs
+- [crates/gigastt-uniffi/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/crates/gigastt-uniffi/README.md) — UniFFI bindings and generation
+- [packaging/android/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/android/README.md) — Kotlin/AAR build status
+- [examples/electron_main.mjs](https://github.com/ekhodzitsky/gigastt/blob/main/examples/electron_main.mjs) — full Electron main-process pattern
+- [docs/quickstarts.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/quickstarts.md) — per-binding quickstarts and availability table
+- [docs/embedding-packaging.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/embedding-packaging.md) — onnxruntime static vs dynamic linking
+- [docs/api.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/api.md) — `/health`, `/ready`, REST/WS/SSE reference
+- [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md) — `serve` and `download` flags (lifecycle knobs used above)
+
+A dedicated embedding & distribution guide (`docs/embedding.md`, covering
+topics like macOS notarization) is in progress.

--- a/docs/workbook/ru/src/05-desktop-embedded.md
+++ b/docs/workbook/ru/src/05-desktop-embedded.md
@@ -1,0 +1,453 @@
+# Десктоп и встраивание: Swift/SPM, sidecar, Electron, UniFFI
+
+## Сценарий
+
+Вы пишете десктопное или мобильное приложение с локальным распознаванием
+русской речи: диктофон на Swift под macOS, записывающее приложение для встреч
+на Electron или инструмент на Kotlin / Python. Модель должна работать локально
+(без облака), и движок можно поставить двумя способами — встроить **в процесс**
+через нативный биндинг или запустить `gigastt serve` как **sidecar**-подпроцесс
+и общаться с ним по loopback HTTP/WS API. Эта глава помогает выбрать путь и
+проводит по каждому до первого транскрипта.
+
+## Какой путь выбрать: embedded или sidecar
+
+| | Embedded (в процессе) | Sidecar (`gigastt serve` + клиент) |
+|---|---|---|
+| Как | Движок слинкован с приложением: SwiftPM `GigaSTT`, npm `gigastt`, PyPI `gigastt`, UniFFI-биндинги | Движок работает дочерним процессом; приложение общается по WS/REST через loopback-порт |
+| Интерфейс | Нативные вызовы; типизированные ошибки (`throws` / исключения / rejected promises) | Сетевой протокол (`/v1/ws`, REST `/v1/transcribe`, SSE) |
+| Деплой | Одна установка пакета; без супервизии процессов | Поиск бинаря на машине пользователя, spawn, супервизия, выбор порта |
+| Память | Модель и пул живут внутри вашего приложения (~350–400 МБ RSS на сессию пула) | Модель живёт в отдельном серверном процессе |
+| Конкурентность | Один движок/пул на процесс приложения | Один сервер на несколько приложений/клиентов |
+| Изоляция падений | Падение движка роняет приложение (и наоборот) | Падение сервера изолировано; приложение выживает и может его перезапустить |
+| Обновления | Передеплой приложения с новым движком | Бинарь сервера обновляется независимо от клиентов |
+| Версионирование | Приложение и движок — один артефакт | Приложение должно гейтоваться на версию найденного сервера (`/health` → `version`) |
+
+Правила выбора:
+
+- **Embedded**, когда приложение владеет всем аудио-конвейером (диктофон,
+  рекордер) и является единственным потребителем. На iOS это *единственный*
+  вариант — приложения не могут запускать подпроцессы.
+- **Sidecar**, когда один движок делят несколько клиентов, когда приложение
+  должно переживать падение движка или когда движок нужно обновлять без
+  передеплоя приложения. Оба подтверждённых внешних десктоп-интегратора
+  используют именно этот паттерн.
+
+## Предпосылки
+
+- **Директория с моделью** — все рецепты ниже её предполагают. Один раз
+  скачайте преквантизованный INT8-бандл (~215 МБ, без скачивания FP32 и без
+  квантизации на устройстве):
+
+  ```sh
+  gigastt download --prequantized          # -> ~/.gigastt/models
+  ```
+
+- **Embedded**: тулчейн вашего биндинга — Xcode 15+ (Swift), Node.js
+  (npm-пакет), Python 3 (wheel) или Android SDK/NDK (Kotlin).
+- **Sidecar**: бинарь `gigastt` — забандленный в ресурсы приложения или
+  установленный (`brew tap ekhodzitsky/gigastt https://github.com/ekhodzitsky/gigastt && brew install gigastt`,
+  тарбол релиза или `cargo install gigastt`) — плюс `curl` для проб.
+
+## Рецепт — Swift/SPM (iOS + macOS)
+
+Swift-пакет `GigaSTT` оборачивает C ABI в безопасный Swift-интерфейс. Нативный
+код поставляется готовым `GigasttFFI.xcframework` (iOS device `arm64`,
+симулятор `arm64`/`x86_64`, macOS `arm64`) со статически слинкованным ONNX
+Runtime — отдельный рантайм бандлить не нужно. Требования: iOS 15 / macOS 13
+(только Apple Silicon — слайса для Intel macOS нет) и Xcode 15+.
+
+1. **Добавьте пакет.** Xcode → File → Add Package Dependencies… → введите URL
+   зеркала `https://github.com/ekhodzitsky/gigastt-swift` и добавьте продукт
+   `GigaSTT` к вашему таргету. Зеркало — каноничный удалённый источник (SwiftPM
+   требует `Package.swift` в корне репозитория, поэтому поддиректорию монорепо
+   `packaging/swift` нельзя подключить по URL — используйте её только как
+   локальную path-зависимость для разработки).
+2. **Забандлите модель.** Скопируйте `~/.gigastt/models` в таргет приложения
+   как **folder reference** (синяя папка — сохраняет структуру директорий;
+   жёлтая «group» плющит файлы, и движок их не найдёт). Альтернатива —
+   скачать модель при первом запуске и закешировать.
+3. **Загрузите движок и транскрибируйте:**
+
+   ```swift
+   import GigaSTT
+
+   guard let modelDir = Bundle.main.url(
+       forResource: "models", withExtension: nil
+   )?.path else {
+       fatalError("bundle the model directory as a folder reference")
+   }
+
+   // poolSize: 1 keeps RAM around ~350 MB, recommended on device.
+   let engine = try Engine(modelDir: modelDir, poolSize: 1)
+
+   // Path is relative to the current working directory; absolute paths and
+   // ".." are rejected by the engine.
+   let text = try engine.transcribeFile(path: "audio.wav")
+   print(text)
+   ```
+
+4. **Стриминг** — чанки little-endian mono PCM16 на частоте захвата (внутри
+   ресемплируется в 16 кГц):
+
+   ```swift
+   let stream = try Stream(engine: engine)
+
+   // pcm16: Data of little-endian Int16 mono samples at 48 kHz.
+   for segment in try stream.processChunk(pcm16, sampleRate: 48000) {
+       print(segment.text, segment.isFinal)
+   }
+
+   // Drain the tail at end-of-stream.
+   for segment in try stream.flush() {
+       print(segment.text)
+   }
+   ```
+
+   `processChunk` и `flush` возвращают `[TranscriptSegment]`; каждый сегмент
+   несёт `text`, `words` (по каждому слову `word`/`start`/`end`/`confidence` и
+   опциональный `speaker`), `isFinal` и `timestamp`.
+
+5. **Обрабатывайте ошибки.** Обёртка бросает `GigasttError`:
+   `engineLoadFailed(modelDir:)` (директория модели отсутствует/нечитаема),
+   `streamCreationFailed` (не удалось занять сессию пула), `inferenceFailed` и
+   `decodingFailed(underlying:)`. C ABI сигналит об ошибке `NULL`-возвратом,
+   поэтому кейс говорит, *где* произошёл сбой, а не несёт сообщение движка.
+
+Проверка: запустите приложение, транскрибируйте заведомо известный WAV и
+убедитесь, что напечатан ожидаемый текст. Если движок бросает
+`engineLoadFailed` при старте — директории модели нет там, куда указывает
+`Bundle.main.url(forResource: "models", withExtension: nil)`; см. «Частые
+ошибки».
+
+## Рецепт — sidecar-сервер (macOS / Electron)
+
+Запускаем `gigastt serve` как управляемый дочерний процесс. Полный жизненный
+цикл: найти бинарь, предустановить модель, запустить, дождаться готовности,
+транскрибировать, корректно остановить.
+
+1. **Найдите бинарь** в порядке приоритета: env-override (например,
+   `MYAPP_GIGASTT_BIN`) → копия в ресурсах приложения →
+   `/opt/homebrew/bin/gigastt` → `/usr/local/bin/gigastt` → `PATH`.
+   Залогируйте, какой вариант выбран.
+2. **Предустановите модель** при установке или первом запуске, с
+   машиночитаемым прогрессом для UI:
+
+   ```sh
+   gigastt download --prequantized --progress json
+   ```
+
+   stdout несёт по одному NDJSON-событию на строку
+   (`{"phase":"download","file":...,"bytes_done":N,"bytes_total":M}`, затем
+   `verify`, затем `done`), а коды выхода различают сетевые/дисковые/контрольные
+   ошибки — см. [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md).
+   `--prequantized` пропускает ~2-минутный проход INT8-квантизации на
+   устройстве, поэтому первый `serve` стартует за секунды, а не минуты.
+3. **Выберите порт.** Сегодня: фиксированный высокий порт (например, `49876`).
+   Автовыбор эфемерного порта (`--port 0` с машиночитаемой строкой
+   `LISTENING`), а также `--die-with-parent` и `--log-file` — планируемые
+   дополнения сервера: они требуют версии gigastt, где эти флаги есть, поэтому
+   пока не полагайтесь на их синтаксис; используйте фиксированный порт и
+   жизненный цикл ниже.
+4. **Запустите и собирайте логи.** Никогда не отправляйте вывод sidecar'я в
+   `/dev/null` — перенаправьте stdout/stderr в лог-файл (если подключаете
+   пайпы вместо файла, непрерывно их читайте: полный буфер пайпа может
+   заблокировать дочерний процесс). Пример для главного процесса Electron /
+   Node:
+
+   ```js
+   import { spawn } from 'node:child_process';
+   import fs from 'node:fs';
+
+   const PORT = 49876;
+   const BASE = `http://127.0.0.1:${PORT}`;
+
+   const log = fs.createWriteStream('gigastt-sidecar.log', { flags: 'a' });
+   const server = spawn(gigasttBin, [
+     'serve',
+     '--port', String(PORT),
+     '--pool-size', '1',
+     '--model-dir', modelDir,
+   ], { stdio: ['ignore', log, log] });
+
+   async function waitForReady(timeoutMs = 120_000) {
+     const deadline = Date.now() + timeoutMs;
+     for (;;) {
+       try {
+         const res = await fetch(`${BASE}/ready`);
+         // 200 {"status":"ready","pool_available":N,"pool_total":M}
+         if (res.ok) return;
+         // 503 {"status":"not_ready","reason":"initializing"} — keep waiting.
+       } catch {
+         // Connection refused: the listener is not up (yet) — or the process
+         // is gone. Distinguish by the child exit code, not by killing it.
+         if (server.exitCode !== null) {
+           throw new Error(`gigastt exited with code ${server.exitCode}`);
+         }
+       }
+       if (Date.now() > deadline) throw new Error('readiness timeout');
+       await new Promise((resolve) => setTimeout(resolve, 500));
+     }
+   }
+   ```
+
+5. **Гейт по `/ready`, а не по TCP-connect.** Сервер биндит порт сразу и
+   отвечает на пробы из bootstrap-ответчика, пока модель грузится, поэтому
+   «порт слушается» не значит «готов». Поллите `GET /ready` до 200; тело 503
+   несёт
+   `{"status":"not_ready","reason":"initializing"|"pool_exhausted"|"shutting_down"}`.
+   Connection-refused означает, что процесс мёртв или ещё не запущен, — а не
+   что он завис.
+6. **Версионное рукопожатие по HTTP.** `GET /health` возвращает 200 в *обеих*
+   фазах — `{"status":"ok","model":"loading","version":"2.13.0"}` во время
+   bootstrap, затем `{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.13.0","punctuation":true,"itn":true}`.
+   Гейт минимальной версии движка делайте по полю `version`, а не запуском
+   `gigastt --version` подпроцессом.
+7. **Транскрибация.** Для live-частичных результатов откройте
+   WebSocket-сессию на `/v1/ws` (паттерны — в главе
+   [Стриминг](03-streaming.md)); для целых файлов — POST на `/v1/transcribe`
+   (рецепты — в главе [Серверная интеграция](05-server-integration.md)). При
+   насыщении пула сервер отвечает 503 + `Retry-After` (REST) или ошибкой с
+   `retry_after_ms` (WS) — соблюдайте подсказку вместо выдумывания своего
+   backoff'а. Перед закрытием WS-сессии отправьте `{"type":"stop"}`, чтобы
+   сервер дописал хвост в финальный сегмент.
+8. **Корректная остановка.** Пошлите SIGTERM: сервер дожидается завершения
+   активных сессий до `--shutdown-drain-secs` (по умолчанию 10), шлёт `final` и
+   закрывает WS-клиентов кодом 1001. Эскалируйте до SIGKILL только после окна
+   drain. Отслеживайте pid дочернего процесса и завершайте его при выходе
+   приложения — осиротевший sidecar держит ~1 ГБ RSS и порт.
+
+Проверка:
+
+```sh
+gigastt serve --port 49876 --pool-size 1 &
+curl -s http://127.0.0.1:49876/ready    # -> {"status":"ready","pool_available":1,"pool_total":1}
+curl -s http://127.0.0.1:49876/health   # -> {"status":"ok","model":"gigaam-v3-rnnt",...,"version":"..."}
+kill %1                                  # SIGTERM — process exits within the drain window
+```
+
+## Рецепт — Node/Electron в процессе
+
+npm-пакет `gigastt` (napi-rs) встраивает движок внутрь вашего Node/Electron
+процесса — без sidecar'я, порта и версионного гейта. Инференс идёт на рабочем
+потоке libuv, поэтому вызовы возвращают Promise и не блокируют event loop;
+onnxruntime слинкован статически, поэтому `.node`-аддон самодостаточен.
+
+1. **Установка:** `npm install gigastt`. postinstall скачивает ровно один
+   готовый бинарь (`gigastt.<platform>.node`, ~47 МБ) под платформу установки
+   из GitHub-релиза. Готовые платформы: `darwin-arm64`, `linux-x64-gnu`,
+   `linux-arm64-gnu`, `win32-x64-msvc` (Intel macOS нет).
+2. **Загрузите модель** — она не забандлена: `gigastt download --prequantized`
+   → `~/.gigastt/models`, либо задайте `GIGASTT_MODEL_DIR`.
+3. **Использование:**
+
+   ```js
+   const { Engine, Stream } = require('gigastt');
+
+   const engine = new Engine('/path/to/gigastt/models'); // new Engine(modelDir, poolSize?)
+   const t = await engine.transcribeFile('recording.wav');
+   console.log(t.text, t.durationS);
+   for (const w of t.words) console.log(w.text, w.startS, w.endS, w.confidence);
+
+   // streaming — await each chunk before sending the next to keep order
+   const s = new Stream(engine);
+   for (const seg of await s.processChunk(pcm16, 16000)) console.log(seg.text);
+   console.log((await s.flush()).map((seg) => seg.text));
+
+   // errors are thrown JS Errors whose message starts with a stable code
+   try { new Engine('/no/such/dir'); } catch (e) { /* e.message starts "ModelNotFound:" */ }
+   ```
+
+4. **Схема для Electron:** создавайте `Engine` в **главном процессе** (никогда
+   в renderer'е) и держите по одному `Stream` на аудиоканал (например, mic +
+   system). Каждый `Stream` держит одну сессию пула всё своё время жизни,
+   поэтому `poolSize` должен покрывать число живых стримов — третий `Stream`
+   на пуле из 2 бросит `PoolExhausted`. Полный двухканальный паттерн с
+   IPC-обработчиками — в
+   [examples/electron_main.mjs](https://github.com/ekhodzitsky/gigastt/blob/main/examples/electron_main.mjs).
+5. **Размер thread-пула.** Инференс идёт на рабочем пуле libuv (по умолчанию 4
+   потока, общие с `fs`/`crypto`). Для `N` одновременно транскрибирующих
+   каналов запускайте с `UV_THREADPOOL_SIZE >= N`
+   (например, `UV_THREADPOOL_SIZE=4 electron .`) и соответствующим `poolSize`.
+6. **Упаковка (asar):** держите директорию модели *и* нативный `.node`-аддон
+   **вне asar-архива** — нативный код мапит веса в память и делает `dlopen`
+   аддона, а оба этих действия невозможны из виртуальной ФС asar. В
+   electron-builder используйте `asarUnpack` для `**/*.node` и поставляйте
+   модель через `extraResources`.
+
+Проверка: в чекауте репозитория `GIGASTT_MODEL_DIR=~/.gigastt/models npm run smoke`
+(из `crates/gigastt-node`) транскрибирует тестовую фикстуру; в вашем
+приложении — дождитесь `engine.transcribeFile` на заведомо известном WAV и
+проверьте текст.
+
+## Рецепт — Kotlin и Python (UniFFI)
+
+`crates/gigastt-uniffi` генерирует идиоматичные биндинги для Swift, Kotlin и
+Python из одного Rust-источника через UniFFI. Они оборачивают синхронное
+урезанное ядро (модели подгружаются с диска, без tokio-рантайма), дают
+типизированные ошибки `GigasttFfiError` (`ModelNotFound`, `InvalidAudio`,
+`PoolExhausted`, `Inference`, `InvalidArgument`) и управляют объектами по
+счётчику ссылок.
+
+Общая поверхность (регистр имён следует идиомам языка):
+
+- `Engine(model_dir)` / `Engine.new_with_pool_size(model_dir, pool_size)` ·
+  `transcribe_file(path) -> Transcript { text, words, duration_s }`
+- `Stream(engine)` · `process_chunk(pcm16, sample_rate) -> [TranscriptSegment]` ·
+  `flush() -> [TranscriptSegment]`
+- `TranscriptSegment { text, words, is_final }` ·
+  `Word { text, start_s, end_s, confidence, speaker }`
+
+**Python — опубликован.** `pip install gigastt` ставит самодостаточный готовый
+wheel (`py3-none-<platform>`; onnxruntime слинкован статически):
+
+```python
+import gigastt_uniffi as g
+
+engine = g.Engine("/path/to/gigastt/models")        # side-loaded model dir
+t = engine.transcribe_file("recording.wav")
+print(t.text)
+for w in t.words:
+    print(w.text, w.start_s, w.end_s, w.confidence)
+
+# streaming
+s = g.Stream(engine)
+for seg in s.process_chunk(pcm16_bytes, 16000):
+    print(seg.text)
+print([seg.text for seg in s.flush()])
+
+# typed errors
+try:
+    g.Engine("/no/such/dir")
+except g.GigasttFfiError.ModelNotFound as e:
+    ...
+```
+
+**Kotlin — экспериментальный AAR.** Кросс-сборка Rust доказана (CI
+кросс-компилирует `libgigastt_uniffi.so` под каждый ABI через cargo-ndk), но
+сборка и публикация Gradle/Maven AAR ещё не проверены end-to-end. Локальная
+сборка:
+
+```sh
+# native libs per ABI
+cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 \
+  -o packaging/android/gigastt/src/main/jniLibs build --release -p gigastt-uniffi
+# Kotlin bindings (from a host build of the cdylib; metadata is arch-independent)
+cargo build --release -p gigastt-uniffi
+cargo run --release -p gigastt-uniffi --bin uniffi-bindgen -- generate \
+  --library target/release/libgigastt_uniffi.* --language kotlin \
+  --out-dir packaging/android/gigastt/src/main/kotlin
+# assemble
+cd packaging/android && gradle :gigastt:assembleRelease
+```
+
+**Swift (UniFFI):** биндинги генерируются (`--language swift`), но поставляемый
+SwiftPM-пакет использует рукописную обёртку над C ABI из Swift-рецепта выше —
+для разработки приложений берите её.
+
+Перегенерация любого биндинга из чекаута:
+
+```sh
+cargo build -p gigastt-uniffi
+LIB=target/debug/libgigastt_uniffi.dylib   # .so on Linux
+
+cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate --library "$LIB" --language python --out-dir bindings/python
+cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate --library "$LIB" --language swift  --out-dir bindings/swift
+cargo run -p gigastt-uniffi --bin uniffi-bindgen -- generate --library "$LIB" --language kotlin --out-dir bindings/kotlin
+```
+
+Сгенерированные биндинги — артефакты сборки (`bindings/` в git-игноре). Статус
+и детали упаковки:
+[crates/gigastt-uniffi/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/crates/gigastt-uniffi/README.md),
+[packaging/android/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/android/README.md).
+
+Проверка: Python-сниппет выше печатает транскрипт заведомо известного файла;
+для Kotlin — соберите AAR и транскрибируйте из instrumented-теста или
+отладочного экрана.
+
+## Проверка результата
+
+Сквозной чек-лист для любого из путей:
+
+- **Первый транскрипт**: приложение печатает ожидаемый текст для известного
+  WAV (любой файл с русской речью, например сэмпл Golos).
+- **Модель на диске**: `ls ~/.gigastt/models` показывает файлы `v3_rnnt_*`
+  (бандл `--prequantized` включает `v3_rnnt_encoder_int8.onnx`).
+- **Память**: RSS в ожидаемых пределах — примерно 350–400 МБ на сессию пула;
+  `poolSize`/`pool-size` 1 — правильный дефолт для устройства.
+- **Здоровье sidecar'я**: `curl -s http://127.0.0.1:<port>/ready` возвращает
+  `{"status":"ready",...}`, а `/health` показывает `version`, на которую вы
+  гейтованы; SIGTERM завершает процесс в пределах окна drain с чистым хвостом
+  лога.
+- **Порядок в стриминге**: частичные сегменты (`isFinal == false`) могут
+  пересматриваться; сохраняйте только финальные, а перед завершением сессии
+  вызывайте `flush()` (или шлите `{"type":"stop"}` по WS), чтобы не потерять
+  хвост.
+
+## Частые ошибки
+
+- **Модель забандлена не как folder reference (Swift).** Добавленная жёлтой
+  «group», Xcode плющит директорию, и движок падает при старте с
+  `engineLoadFailed`. Исправление: добавьте `models` как folder reference
+  (синяя папка) и в отладочном запуске проверьте, что
+  `Bundle.main.url(forResource: "models", withExtension: nil)` не nil.
+- **Неопределённые символы `std::__1::*` при линковке (Swift).** ONNX Runtime —
+  это C++; актуальный пакет уже объявляет `.linkedLibrary("c++")` — такая
+  ошибка означает, что вы используете старый или самосборный xcframework.
+  Берите релизный пакет из зеркала (или актуальный `packaging/swift`).
+- **Блокирующий вызов в UI-потоке.** Вызовы `Engine`/`Stream` синхронны, а
+  хендлы не thread-safe. Выполняйте всю работу движка на выделенной фоновой
+  очереди/акторе (Swift) и сериализуйте доступ; никогда не транскрибируйте на
+  главном потоке. В Node вызовы уже идут на пуле libuv — просто делайте
+  `await`.
+- **Таймауты готовности при первом запуске (sidecar).** Обычный
+  `gigastt download` оставляет ~2-минутный проход INT8-квантизации на первый
+  `serve`, а модель пунктуации подгружается лениво при первом старте — клиент
+  с таймаутом загрузки 10–30 с сдаётся слишком рано. Исправление:
+  предустановка через `gigastt download --prequantized`, щедрый таймаут
+  готовности и ветвление по `reason` из `/ready` вместо убийства процесса.
+- **Убийство сервера на 503.** Пока модель грузится, порт занят
+  bootstrap-ответчиком и каждый API отвечает 503 `initializing` — это
+  прогресс, а не зависание. Признак сбоя — только connection-refused вместе с
+  мёртвым дочерним процессом.
+- **Коллизия захардкоженного порта.** Занятый фиксированный порт (часто —
+  осиротевшим gigastt от прошлого запуска) проявляется как молчаливый таймаут.
+  Проверяйте `/health` → `version`, чтобы понять, ваш ли это сервер, и
+  завершайте дочерний процесс при выходе приложения (флаг `--die-with-parent`
+  в планах).
+- **Логи sidecar'я в `/dev/null`.** Они понадобятся в первый же раз, когда
+  директория модели окажется битой. Перенаправляйте stdout/stderr в файл — а
+  если используете пайпы, непрерывно их читайте во избежание дедлока на буфере
+  пайпа.
+- **`require('gigastt')` падает после `npm install --ignore-scripts`.**
+  postinstall, скачивающий нативный бинарь, был пропущен; запустите `node
+  install.js` внутри пакета.
+- **Модель или аддон внутри asar (Electron).** Нативный код мапит веса в
+  память и делает `dlopen` для `.node` — обоим нужны реальные файлы.
+  `asarUnpack` для аддона и поставка модели через `extraResources`.
+- **Абсолютный путь в `transcribeFile` (Swift).** C ABI принимает только
+  относительные пути внутри рабочей директории — сначала направьте рабочую
+  директорию на расположение файла (или скопируйте файл туда).
+
+## Ссылки
+
+В этой книге:
+
+- [Начало работы](01-getting-started.md) — установка и скачивание модели
+- [Стриминг](03-streaming.md) — паттерны WebSocket-протокола для sidecar'я
+- [Серверная интеграция](05-server-integration.md) — рецепты REST / SSE / jobs
+
+Справочные материалы (не дублируем — читайте здесь):
+
+- [packaging/swift/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/swift/README.md) — справочник API Swift-пакета
+- [crates/gigastt-node/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/crates/gigastt-node/README.md) — API npm-пакета + trade-offs in-process vs sidecar
+- [crates/gigastt-uniffi/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/crates/gigastt-uniffi/README.md) — UniFFI-биндинги и генерация
+- [packaging/android/README.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/android/README.md) — статус сборки Kotlin/AAR
+- [examples/electron_main.mjs](https://github.com/ekhodzitsky/gigastt/blob/main/examples/electron_main.mjs) — полный паттерн главного процесса Electron
+- [docs/quickstarts.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/quickstarts.md) — квикстарты по биндингам и таблица доступности
+- [docs/embedding-packaging.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/embedding-packaging.md) — статическая vs динамическая линковка onnxruntime
+- [docs/api.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/api.md) — справочник `/health`, `/ready`, REST/WS/SSE
+- [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md) — флаги `serve` и `download` (использованные выше ручки жизненного цикла)
+
+Отдельный гайд по встраиванию и дистрибуции (`docs/embedding.md`, включая
+темы вроде нотаризации macOS) находится в работе.


### PR DESCRIPTION
## What this PR adds

The **Desktop & embedded** workbook chapter, in both languages:

- `docs/workbook/en/src/05-desktop-embedded.md` (canonical, EN)
- `docs/workbook/ru/src/05-desktop-embedded.md` (RU, identical heading skeleton, code/commands/JSON untranslated)

Chapter contents (template structure: scenario → decision guide → prerequisites → recipes → verifying the result → common pitfalls → links):

- **Embedded vs sidecar decision guide** — comparison table (interface, deployment, memory, concurrency, failure isolation, upgrades, versioning) plus rules of thumb.
- **Recipe: Swift/SPM** — add package from the `gigastt-swift` mirror, bundle the model as a folder reference, `Engine(modelDir:poolSize:)`, file + streaming transcription, `GigasttError` cases, macOS/iOS slice notes.
- **Recipe: sidecar server (macOS / Electron)** — binary discovery, model pre-staging with `download --prequantized --progress json`, fixed port (with a clearly-marked note that `--port 0` + `LISTENING` / `--die-with-parent` / `--log-file` are planned and require a version that ships them — no invented syntax), spawn + log capture with a Node/Electron code sketch, `/ready` gating with `reason` codes, `/health` `version` handshake, SIGTERM graceful stop.
- **Recipe: Node/Electron in-process** — `npm install gigastt`, prebuilt-platform list, main-process `Engine` + one `Stream` per channel, `UV_THREADPOOL_SIZE` sizing, asar unpacking, stable error-code prefixes.
- **Recipe: Kotlin & Python (UniFFI)** — shared API surface, published Python wheel quickstart, experimental Kotlin AAR build steps, binding regeneration commands, current status per binding.
- **Common pitfalls** — folder-reference vs group, `std::__1::*` (c++) linkage (already solved by the shipped package), blocking calls on the UI thread, first-run readiness timeouts (quantization), killing on 503 `initializing`, port collisions/orphans, `/dev/null` logs, `--ignore-scripts`, asar, Swift relative-path restriction.
- **Links** — relative intra-book links (getting started / streaming / server integration) and absolute GitHub URLs to the canonical references; no reference tables duplicated.

## Sources verified against

- `packaging/swift/README.md` + `packaging/swift/Sources/GigaSTT/GigaSTT.swift` + `packaging/swift/Package.swift` (API signatures, `GigasttError` cases, `Word`/`TranscriptSegment` fields, platforms, `.linkedLibrary("c++")`)
- `crates/gigastt-uniffi/README.md` + `crates/gigastt-uniffi/src/lib.rs` (`GigasttFfiError` variants, record fields, generation commands)
- `crates/gigastt-node/README.md` + `examples/electron_main.mjs` (npm packaging, thread-pool note, asar caveat, error codes)
- `docs/embedding-packaging.md` (static vs load-dynamic linking)
- `docs/api.md` (`/health` two-phase payload incl. `version`, `/ready` 200/503 bodies and `reason` values, bootstrap responder, close codes, `{"type":"stop"}`)
- `docs/cli.md` (serve/download flags: `--prequantized`, `--progress json`, `--shutdown-drain-secs`, `--pool-size`)
- `packaging/android/README.md` (Kotlin AAR status: experimental)

## Verification performed

- `mdbook build docs/workbook/en` and `docs/workbook/ru` — both exit 0, no errors.
- Heading parity: identical heading count and level sequence across EN/RU; all 10 fenced code blocks byte-identical between versions.
- Snippet syntax checks: 5 shell blocks (`bash -n`), 2 JS blocks (`node --check`, ESM + CJS), 1 Python block (`py_compile`), 2 Swift blocks (`swiftc -parse`), all inline JSON (`python3 -m json.tool`) — all pass.
- `typos` clean on both files.
- All 10 relative intra-book links resolve; all absolute links point to `github.com/ekhodzitsky/gigastt/blob/main/...`.
- No roadmap/task references in the chapter.

## Notes / coordination

- **File name vs SUMMARY.md:** the chapter file is `05-desktop-embedded.md` per the wave plan, while the merged skeleton's SUMMARY.md currently lists `05-server-integration.md` (a different chapter stub, untouched here). This chapter therefore builds cleanly but is not yet in the TOC — a follow-up TOC reconciliation across the parallel chapter PRs should either add it to SUMMARY.md or settle final file names.
- `docs/embedding.md` (embedding & notarization guide) is referenced in prose as "in progress", matching the note already present in `docs/api.md`; no link to it (it does not exist yet).
- While verifying the Swift API I noticed the Swift snippet in `docs/quickstarts.md` does not match the shipped wrapper in `Sources/GigaSTT` (`transcribeFile` returns `String`, and `Word` fields are `word/start/end`, not `text/startS/endS` — the quickstart shows the UniFFI shape). This chapter follows the actual source; a fix to `docs/quickstarts.md` is left to a separate change.
