### PR TITLE
docs(workbook): chapter 02 CLI & batch processing (en+ru)

### DIFF
--- a/docs/workbook/en/src/02-cli-batch.md
+++ b/docs/workbook/en/src/02-cli-batch.md
@@ -1,0 +1,469 @@
+# CLI and batch processing
+
+Turn a folder of recordings into transcripts: one-off sweeps with
+`transcribe-batch`, a continuously watched drop folder with `watch`, and an
+asynchronous queue with the jobs API. Every recipe is copy-paste runnable and
+ends with a check that it worked.
+
+## Scenario
+
+You have a directory of audio — call-center recordings, podcast episodes, an
+archive of voice notes — and you want text files out the other side. Sometimes
+it is a one-time archive conversion; sometimes new recordings keep arriving
+and the pipeline must run unattended, retry failures, and never get stuck on
+a half-copied file.
+
+## Prerequisites
+
+- gigastt installed and the model downloaded (`gigastt download`) — see
+  [Getting started](01-getting-started.md).
+- A folder of audio files: WAV, MP3, M4A, OGG, FLAC (subfolders are scanned
+  recursively).
+- Nothing else: `transcribe`, `transcribe-batch`, and `watch` are offline
+  commands — no server, no network.
+
+One thing to know before scripting: **every CLI invocation loads the model**
+(~1–2 s warm). `transcribe-batch` amortizes that cost across the whole
+folder, so prefer it over a shell `for` loop around single-file `transcribe`
+calls.
+
+## Recipe: one-off folder run — `transcribe-batch`
+
+The workhorse. Point it at an input directory and an output directory:
+
+```sh
+gigastt transcribe-batch calls/ transcripts/
+```
+
+It scans `calls/` recursively, transcribes every supported audio file with
+`--pool-size` workers (default 2), and writes `transcripts/<name>.txt` and
+`transcripts/<name>.json` per input (default `--format txt,json`).
+
+A production-shaped run — more formats, more workers, and a source policy:
+
+```sh
+gigastt transcribe-batch calls/ transcripts/ \
+  --format txt,json,srt \
+  --pool-size 4 \
+  --retries 2 \
+  --move-to calls/done/
+```
+
+- `--format` — comma-separated list of `txt,json,md,srt,vtt`; one output file
+  per format per input.
+- `--pool-size` — parallel workers; each costs ~0.4 GB RAM (INT8 encoder), so
+  scale with memory, not just cores (see the throughput recipe below).
+- `--retries` — extra attempts per file with a short backoff (200 ms, 400 ms,
+  …). Default 0 for batch, 2 for watch.
+- `--move-to` — move each *successfully* transcribed source into the given
+  directory. Failed files are always left in place. The move-to directory is
+  excluded from the scan, so putting it inside the input folder
+  (`calls/done/`) is safe and is the recommended layout.
+- `--delete-source` — alternative to `--move-to`: delete sources after
+  success. Mutually exclusive with `--move-to`.
+
+Reading the run report. Each file logs a line, and the run ends with a
+summary:
+
+```text
+INFO gigastt::batch: done /calls/alpha.wav processed=1 failed=0
+WARN gigastt::batch: failed /calls/broken.mp3 error=invalid audio: Unsupported audio format: ...
+INFO gigastt: batch finished processed=12 failed=1 skipped=0
+```
+
+Exit codes (script on these, not on the log text):
+
+| Code | Meaning |
+|---|---|
+| `0` | every file transcribed |
+| `1` | at least one file failed after all retries |
+| `130` | interrupted with Ctrl-C — in-flight files finish, the rest are skipped (`skipped=N` in the summary) |
+
+An empty input folder is not an error: it logs `no audio files found` and
+exits 0.
+
+### Verify the result
+
+```sh
+gigastt transcribe-batch calls/ transcripts/ --move-to calls/done/
+echo "exit code: $?"        # 0 = clean sweep, 1 = some files failed
+ls transcripts/             # one <name>.txt + <name>.json per source
+ls calls/done/              # sources that succeeded
+ls calls/*.wav 2>/dev/null  # anything still here failed — check the WARN lines
+```
+
+## Recipe: a live folder — `watch`
+
+`watch` polls a directory and transcribes files as they arrive:
+
+```sh
+gigastt watch inbox/ transcripts/ --format txt,json --move-to inbox/done/
+```
+
+How it differs from `transcribe-batch`:
+
+- **Backlog is skipped.** Files already present at startup are registered but
+  *not* transcribed (`watching /inbox backlog=3 poll_ms=1000`). Sweep the
+  existing pile with `transcribe-batch` first (see the wrapper recipe), then
+  let `watch` handle new arrivals.
+- **Settle protection.** A file is scheduled only after its size + mtime are
+  unchanged for `--settle-polls` consecutive polls (default 2) spaced
+  `--poll-interval-ms` apart (default 1000 ms). A recording still being copied
+  or written is never picked up half-finished. Slow network mounts → raise
+  both.
+- **Changes are picked up.** Overwriting a file resets the settle counter and
+  the new version is transcribed (a change mid-transcription re-queues it
+  after the current run finishes).
+- **Failures are sticky.** A file that exhausts its retries (default 2 for
+  watch) is marked failed and left alone until its content changes.
+- **Graceful stop.** Ctrl-C stops scheduling new files, waits for the ones in
+  flight, prints `watch stopped processed=N failed=M`, and exits 0 (1 if
+  anything failed).
+
+### Verify the result
+
+```sh
+# terminal 1
+gigastt watch inbox/ transcripts/ --move-to inbox/done/
+
+# terminal 2
+cp ~/recordings/sample.wav inbox/
+# wait settle-polls x poll-interval plus transcription time, then:
+ls transcripts/sample.txt        # appeared
+ls inbox/done/sample.wav         # source archived
+# back in terminal 1: Ctrl-C → "watch stopped processed=1 failed=0"
+```
+
+## Recipe: inbox pipeline wrapper (shell)
+
+The standard "drop folder" service: audio lands in `inbox/`, transcripts come
+out, successes are archived to `done/`, failures are collected in `failed/`
+and automatically retried on the next sweep. Save as `transcribe-inbox.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Usage: transcribe-inbox.sh [INBOX] [OUT]
+set -uo pipefail
+
+INBOX="${1:-inbox}"
+OUT="${2:-transcripts}"
+DONE="$INBOX/done"
+FAILED="$INBOX/failed"
+mkdir -p "$OUT" "$DONE" "$FAILED"
+
+# Requeue previous failures for another attempt.
+find "$FAILED" -maxdepth 1 -type f \
+  \( -name '*.wav' -o -name '*.mp3' -o -name '*.m4a' -o -name '*.ogg' -o -name '*.flac' \) \
+  -exec mv -n {} "$INBOX/" \;
+
+gigastt transcribe-batch "$INBOX" "$OUT" --format txt,json --move-to "$DONE"
+rc=$?
+
+# Successes were moved to done/; whatever audio remains at the inbox top
+# level failed all retries — collect it for inspection and future requeue.
+if [ "$rc" -eq 1 ]; then
+  find "$INBOX" -maxdepth 1 -type f \
+    \( -name '*.wav' -o -name '*.mp3' -o -name '*.m4a' -o -name '*.ogg' -o -name '*.flac' \) \
+    -exec mv -n {} "$FAILED/" \;
+  echo "some files failed — collected in $FAILED" >&2
+fi
+exit "$rc"
+```
+
+Run it on a schedule. A cron entry is enough for most inboxes:
+
+```cron
+*/15 * * * * /usr/local/bin/transcribe-inbox.sh /srv/stt/inbox /srv/stt/transcripts >> /var/log/stt-batch.log 2>&1
+```
+
+For a systemd timer + service unit instead of cron, see
+[Deployment & ops](06-deployment-ops.md).
+
+**Watch + batch catch-up.** The two commands compose into an always-on
+pipeline: `watch` handles trickling arrivals with low latency, a periodic
+`transcribe-batch` drains the startup backlog and anything the watcher
+marked failed. Both honor the same `--move-to` exclusion, so they do not
+double-process the backlog. One caveat: a catch-up sweep started *while* the
+watcher is live can pick up a file the watcher has just scheduled but not yet
+moved — schedule sweeps for quiet hours, or accept that a file is
+occasionally transcribed twice (its outputs are simply overwritten).
+
+```sh
+# once, and then periodically (quiet hours): drain backlog + retry failures
+./transcribe-inbox.sh /srv/stt/inbox /srv/stt/transcripts
+
+# always on: new arrivals
+gigastt watch /srv/stt/inbox /srv/stt/transcripts \
+  --format txt,json --move-to /srv/stt/inbox/done/
+```
+
+### Verify the result
+
+```sh
+chmod +x transcribe-inbox.sh
+cp ~/recordings/*.wav inbox/ && printf 'junk' > inbox/broken.mp3
+./transcribe-inbox.sh inbox transcripts; echo "exit: $?"   # 1 — broken.mp3 failed
+ls transcripts/   # transcripts for the good files
+ls inbox/done/    # good sources archived
+ls inbox/failed/  # broken.mp3 collected here
+./transcribe-inbox.sh inbox transcripts   # re-runs the failure, exits 1 again
+```
+
+## Recipe: queued pipeline — the jobs API
+
+`watch` covers one machine with a shared folder. Switch to the **jobs API**
+when producers are on other machines, when files are long enough that holding
+a synchronous HTTP request is awkward, or when you need progress reporting
+and cancellation. It is the same engine, fronted by an in-memory FIFO queue
+inside `gigastt serve`.
+
+Jobs are off by default. Enable them (and reserve inference slots so queued
+work cannot starve WebSocket/REST streaming):
+
+```sh
+gigastt serve --enable-jobs --batch-pool-size 1
+```
+
+Submit → poll → fetch:
+
+```sh
+# submit (accepts the same query params as /v1/transcribe, e.g. ?format=srt)
+curl -s -X POST http://127.0.0.1:9876/v1/jobs \
+  --data-binary @episode.wav
+# {"job_id":"019f858a-...","status":"queued","created_at":1784651881.9}
+
+# poll status
+curl -s http://127.0.0.1:9876/v1/jobs/019f858a-...
+# {"job_id":"...","status":"processing","processed_seconds":12.5,"percent":42}
+
+# fetch the result once status is "done"
+curl -s http://127.0.0.1:9876/v1/jobs/019f858a-.../result
+# {"text":"...","words":[...],"duration":3512.4}
+```
+
+`status` walks `queued` → `processing` → `done` | `failed` | `cancelled`.
+Fetching `/result` before `done` returns `409 job_not_finished`. Other
+endpoints: `DELETE /v1/jobs/{id}` cancels a queued/processing job (`204`),
+and `GET /v1/jobs/{id}/events` streams SSE progress
+(`data: {"type":"progress","percent":42,...}` then `done`/`failed`).
+
+A minimal driver script:
+
+```bash
+#!/usr/bin/env bash
+# submit-and-wait.sh AUDIO_FILE — submit a job and print its transcript.
+set -euo pipefail
+BASE="${GIGASTT_BASE:-http://127.0.0.1:9876}"
+
+job=$(curl -sf -X POST "$BASE/v1/jobs" --data-binary "@$1" \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin)["job_id"])')
+echo "job: $job" >&2
+
+while true; do
+  status=$(curl -sf "$BASE/v1/jobs/$job" \
+           | python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')
+  case "$status" in
+    done)               break ;;
+    failed|cancelled)   echo "job $status" >&2; exit 1 ;;
+  esac
+  sleep 2
+done
+
+curl -sf "$BASE/v1/jobs/$job/result" | python3 -c 'import json,sys; print(json.load(sys.stdin)["text"])'
+```
+
+Queue behavior to plan around:
+
+- `--jobs-retry` (default 3) — retries only *transient* failures: inference
+  timeouts and worker panics. A file that cannot be decoded fails immediately,
+  no retries.
+- `--jobs-max` (default 100) — when the store is full, submit returns
+  `429 queue_full` with `Retry-After`. Back off and resubmit.
+- `--jobs-ttl-secs` (default 3600) — finished/failed/cancelled jobs are
+  evicted after the TTL. **Fetch and persist results promptly** — the store
+  is in-memory, so a server restart drops queued jobs and unfetched results.
+
+### Verify the result
+
+```sh
+curl -s http://127.0.0.1:9876/ready     # {"status":"ready",...} before submitting
+./submit-and-wait.sh episode.wav        # prints the transcript text
+# disabled API check: without --enable-jobs every /v1/jobs call returns 404
+```
+
+## Recipe: choosing output formats
+
+Five formats, one file per format per input. Pick by the consumer:
+
+| Format | Use it for | Notes |
+|---|---|---|
+| `txt` | humans, grep, downstream text tools | transcript text only |
+| `json` | machines | `{"text", "words": [{"word","start","end","confidence"}], "duration"}` — per-word timings and confidence |
+| `srt` | video editors, YouTube upload | SubRip cues grouped from word timings |
+| `vtt` | web players | WebVTT variant of the same cues |
+| `md` | notes, archives | YAML frontmatter (`duration`, `language`, `speakers`) + transcript |
+
+```sh
+gigastt transcribe-batch episodes/ out/ --format txt,json        # default pair
+gigastt transcribe recording.wav -f srt -o recording.srt         # single file
+```
+
+Subtitle shaping (SRT/VTT): `--max-chars-per-line` (default 80) and
+`--max-words-per-line` (default 14) control cue grouping; `0` disables the
+limit. Broadcast-style captions usually want shorter lines:
+
+```sh
+gigastt transcribe recording.wav -f vtt --max-chars-per-line 42 -o recording.vtt
+```
+
+Markdown extras: `--word-timestamps` appends a per-word table with timings
+and confidence — handy for manual review, noisy for archives.
+
+Scripting caveat for single-file `transcribe`: logs go to **stdout** at the
+default `info` level, mixed with the transcript. Use `-o` to write the
+transcript to a file, or silence the logs with the global flag placed before
+the subcommand:
+
+```sh
+gigastt --log-level error transcribe recording.wav          # stdout = transcript only
+```
+
+Extracting text from a folder of JSON results:
+
+```sh
+jq -r '.text' transcripts/*.json
+```
+
+### Verify the result
+
+```sh
+gigastt transcribe recording.wav -f srt -o /tmp/check.srt
+head -4 /tmp/check.srt
+# 1
+# 00:00:00,480 --> 00:00:02,160
+# Привет, как дела?
+jq -r '.duration' transcripts/episode.json    # JSON parses and has fields
+```
+
+## Recipe: unusual inputs — telephony WAV, Opus, raw streams
+
+**G.711 / G.722 inside WAV — just works.** A-law/μ-law (8 kHz telephony
+exports) and G.722 ADPCM (Asterisk/Cisco/Teams, format tags `0x0064`/`0x028F`)
+are decoded automatically; the batch walker picks them up like any other
+`.wav`.
+
+**OGG/Opus and `.opus` (Telegram voice notes, browser MediaRecorder).** The
+container is sniffed from content, so single-file transcription works as-is:
+
+```sh
+gigastt transcribe voice.opus
+```
+
+But the batch/watch walkers scan by extension (`wav,mp3,m4a,ogg,flac`) and
+**do not pick up `.opus` files**. Rename them to `.ogg` before sweeping —
+the content is already an OGG container, so a plain rename suffices:
+
+```sh
+for f in inbox/*.opus; do mv "$f" "${f%.opus}.ogg"; done
+gigastt transcribe-batch inbox/ transcripts/
+```
+
+**Raw headerless streams** (RTP dumps, Asterisk Monitor raw) carry no
+container to sniff — declare the codec and rate explicitly:
+
+```sh
+gigastt transcribe call.ulaw --codec pcmu --sample-rate 8000
+gigastt transcribe call.alaw --codec pcma --sample-rate 8000
+gigastt transcribe call.g722 --codec g722 --sample-rate 8000   # 16000 also accepted
+```
+
+`--codec` accepts `pcmu` (alias `ulaw`), `pcma` (alias `alaw`), `g722`, and
+requires `--sample-rate`. Anything else — WebM, AMR, MP4 video, a corrupt
+file — fails with `invalid audio: Unsupported audio format: ...` (REST:
+`422 invalid_audio`).
+
+### Verify the result
+
+```sh
+file recording.wav                 # confirms the container type
+gigastt --log-level error transcribe call.ulaw --codec pcmu --sample-rate 8000
+echo "exit: $?"                    # 0 = decoded and transcribed
+gigastt transcribe call.ulaw --codec pcmu 2>&1 | head -2
+# error: the following required arguments were not provided: --sample-rate
+```
+
+## Recipe: throughput and memory
+
+The `rnnt` head on INT8 runs at **RTF ≈ 0.10** on an M1 CPU — one worker
+processes an hour of audio in about 6 minutes. A 100-hour archive at
+`--pool-size 4` finishes in roughly `100 h × 0.10 / 4 ≈ 2.5 h` of wall time.
+Full measurements, other hardware, and WER numbers:
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md).
+
+Budget memory before raising `--pool-size`:
+
+- Each worker loads its own encoder copy: **~0.4 GB resident** with the
+  default INT8 encoder, **~1.7 GB** with FP32. Default pool of 2 ≈ 790 MB RSS.
+- The engine refuses to let the pool eat more than half of total RAM: an
+  oversized `--pool-size` is **clamped with a warning** at load, so check the
+  log instead of assuming you got the parallelism you asked for.
+- Stay on INT8 (the default after the first-run auto-quantization): the
+  encoder shrinks 844 MB → 215 MB on disk with ~0% WER degradation, and FP32
+  quadruples the per-worker memory cost for no batch-speed win.
+- On CPU builds, `--encoder-intra-threads` defaults to logical CPUs divided
+  across the pool — the right value for a dedicated batch box; tune only for
+  shared machines.
+
+### Verify the result
+
+```sh
+# clamp warning, if any, appears at load time:
+gigastt transcribe-batch calls/ transcripts/ --pool-size 8 2>&1 | grep -i "pool" | head -3
+# per-file throughput in the log: "transcribe complete audio_s=... wall_s=... rtf=0.129"
+time gigastt transcribe-batch calls/ transcripts/ --pool-size 4 --move-to calls/done/
+```
+
+## Common pitfalls
+
+- **Half-copied files.** `transcribe-batch` transcribes whatever is in the
+  folder *now*, including a file still being copied — you get a decode failure
+  or a truncated transcript. Producers should write to a temp name and
+  `mv` into the inbox (rename is atomic on the same filesystem). `watch`
+  protects itself with settle polls; batch relies on a quiet folder.
+- **Accidental reprocessing.** Without `--move-to`/`--delete-source`, every
+  rerun redoes the whole folder. Always set a source policy for repeated
+  sweeps. Related: `--move-to` flattens subdirectories — `a/week1/call.wav`
+  and `a/week2/call.wav` collide as one `done/call.wav` (and the run warns
+  `duplicate output ... inputs with equal file stems overwrite each other`
+  for the transcripts). Keep source filenames unique.
+- **Expecting parallelism you did not get.** `--pool-size 16` on 8 GB RAM is
+  silently clamped at load (warning logged). Check the startup log, and
+  remember FP32 quadruples per-worker memory.
+- **`invalid audio` / 422 on an unsupported container.** WebM, AMR, MP4 video,
+  or a corrupt upload fails decoding. Convert first
+  (`ffmpeg -i in.webm -ar 16000 -ac 1 out.wav`) or, for raw telephony streams,
+  declare `--codec` + `--sample-rate`. A `.opus` file is decodable but
+  invisible to batch/watch — rename to `.ogg`.
+- **Watch "forgets" failures.** A file that failed all retries is not retried
+  until its content changes, and restarting the watcher registers it as
+  backlog (never processed). Fix or replace the file, or point
+  `transcribe-batch` at it — that is what the catch-up sweep in the wrapper
+  recipe is for.
+- **Job results evaporate.** The jobs store is in-memory with a 1 h TTL on
+  terminal jobs: a restart loses queued jobs, and unfetched results are
+  evicted. Persist results client-side; treat `429 queue_full` as
+  backpressure, not an error worth alerting on.
+
+## Links
+
+- [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md) —
+  full flag reference for `transcribe`, `transcribe-batch`, `watch`
+- [docs/api.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/api.md) —
+  jobs API endpoints, query parameters, error codes
+- [docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md) —
+  RTF, memory, and WER measurements
+- [docs/troubleshooting.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/troubleshooting.md) —
+  decode and format error catalog
+- [Getting started](01-getting-started.md) — install and model download
+- [Deployment & ops](06-deployment-ops.md) — systemd units and timers for
+  always-on pipelines

--- a/docs/workbook/ru/src/02-cli-batch.md
+++ b/docs/workbook/ru/src/02-cli-batch.md
@@ -1,0 +1,480 @@
+# CLI и пакетная обработка
+
+Превращаем папку с записями в транскрипты: разовые прогоны через
+`transcribe-batch`, постоянно наблюдаемая папка-сброс через `watch` и
+асинхронная очередь через jobs API. Каждый рецепт можно скопировать и
+запустить как есть, и каждый заканчивается проверкой результата.
+
+## Сценарий
+
+У вас есть каталог с аудио — записи колл-центра, выпуски подкастов, архив
+голосовых заметок — и на выходе нужны текстовые файлы. Иногда это разовая
+конвертация архива; иногда записи продолжают поступать, и конвейер должен
+работать без присмотра, повторять неудачные попытки и не спотыкаться о
+недокопированные файлы.
+
+## Предварительные требования
+
+- Установленный gigastt и скачанная модель (`gigastt download`) — см.
+  [Начало работы](01-getting-started.md).
+- Папка с аудиофайлами: WAV, MP3, M4A, OGG, FLAC (вложенные папки
+  сканируются рекурсивно).
+- Больше ничего: `transcribe`, `transcribe-batch` и `watch` — офлайн-команды,
+  без сервера и сети.
+
+Что важно знать до написания скриптов: **каждый запуск CLI загружает модель**
+(~1–2 с в тёплом состоянии). `transcribe-batch` амортизирует эту стоимость
+на всю папку, поэтому предпочитайте его shell-циклу `for` вокруг одиночных
+вызовов `transcribe`.
+
+## Рецепт: разовый прогон папки — `transcribe-batch`
+
+Основной рабочий инструмент. Укажите входной и выходной каталоги:
+
+```sh
+gigastt transcribe-batch calls/ transcripts/
+```
+
+Команда рекурсивно сканирует `calls/`, транскрибирует каждый поддерживаемый
+аудиофайл в `--pool-size` воркеров (по умолчанию 2) и пишет
+`transcripts/<имя>.txt` и `transcripts/<имя>.json` на каждый входной файл
+(по умолчанию `--format txt,json`).
+
+Прогон «как в продакшене» — больше форматов, больше воркеров и политика
+исходников:
+
+```sh
+gigastt transcribe-batch calls/ transcripts/ \
+  --format txt,json,srt \
+  --pool-size 4 \
+  --retries 2 \
+  --move-to calls/done/
+```
+
+- `--format` — список через запятую из `txt,json,md,srt,vtt`; по одному
+  выходному файлу на формат на входной файл.
+- `--pool-size` — параллельные воркеры; каждый стоит ~0,4 ГБ RAM (INT8-
+  энкодер), поэтому масштабируйтесь по памяти, а не только по ядрам (см.
+  рецепт про производительность ниже).
+- `--retries` — дополнительные попытки на файл с коротким бэкоффом
+  (200 мс, 400 мс, …). По умолчанию 0 для batch и 2 для watch.
+- `--move-to` — перемещать каждый *успешно* транскрибированный исходник в
+  указанный каталог. Файлы с ошибкой всегда остаются на месте. Каталог
+  move-to исключается из сканирования, поэтому размещение его внутри входной
+  папки (`calls/done/`) безопасно и является рекомендуемой раскладкой.
+- `--delete-source` — альтернатива `--move-to`: удалять исходники после
+  успеха. Несовместимо с `--move-to`.
+
+Как читать отчёт о прогоне. Каждый файл оставляет строку в логе, а прогон
+завершается сводкой:
+
+```text
+INFO gigastt::batch: done /calls/alpha.wav processed=1 failed=0
+WARN gigastt::batch: failed /calls/broken.mp3 error=invalid audio: Unsupported audio format: ...
+INFO gigastt: batch finished processed=12 failed=1 skipped=0
+```
+
+Коды выхода (скриптуйте по ним, а не по тексту лога):
+
+| Код | Значение |
+|---|---|
+| `0` | все файлы транскрибированы |
+| `1` | хотя бы один файл завершился ошибкой после всех попыток |
+| `130` | прервано Ctrl-C — файлы в работе завершаются, остальные пропускаются (`skipped=N` в сводке) |
+
+Пустая входная папка — не ошибка: логируется `no audio files found`, код
+выхода 0.
+
+### Проверка результата
+
+```sh
+gigastt transcribe-batch calls/ transcripts/ --move-to calls/done/
+echo "exit code: $?"        # 0 = чистый прогон, 1 = были ошибки
+ls transcripts/             # по <имя>.txt + <имя>.json на каждый исходник
+ls calls/done/              # успешно обработанные исходники
+ls calls/*.wav 2>/dev/null  # всё, что осталось, завершилось ошибкой — см. строки WARN
+```
+
+## Рецепт: живая папка — `watch`
+
+`watch` опрашивает каталог и транскрибирует файлы по мере их появления:
+
+```sh
+gigastt watch inbox/ transcripts/ --format txt,json --move-to inbox/done/
+```
+
+Чем отличается от `transcribe-batch`:
+
+- **Бэклог пропускается.** Файлы, уже лежащие в папке на момент запуска,
+  регистрируются, но *не* транскрибируются (`watching /inbox backlog=3
+  poll_ms=1000`). Существующую гору сначала разгребите `transcribe-batch`
+  (см. рецепт с обёрткой), а `watch` оставьте для новых поступлений.
+- **Settle-защита.** Файл ставится в работу только после того, как его
+  размер + mtime не менялись на протяжении `--settle-polls` подряд опросов
+  (по умолчанию 2) с интервалом `--poll-interval-ms` (по умолчанию 1000 мс).
+  Запись, которую ещё копируют или пишут, никогда не будет подхвачена
+  наполовину. Медленные сетевые шары → увеличьте оба параметра.
+- **Изменения подхватываются.** Перезапись файла сбрасывает settle-счётчик,
+  и новая версия транскрибируется (изменение посреди транскрибации ставит
+  файл в очередь повторно после завершения текущего прогона).
+- **Ошибки «липкие».** Файл, исчерпавший попытки (по умолчанию 2 для watch),
+  помечается failed и не трогается, пока не изменится его содержимое.
+- **Мягкая остановка.** Ctrl-C прекращает постановку новых файлов, ждёт
+  завершения текущих, печатает `watch stopped processed=N failed=M` и
+  выходит с кодом 0 (1, если были ошибки).
+
+### Проверка результата
+
+```sh
+# терминал 1
+gigastt watch inbox/ transcripts/ --move-to inbox/done/
+
+# терминал 2
+cp ~/recordings/sample.wav inbox/
+# подождите settle-polls x poll-interval плюс время транскрибации, затем:
+ls transcripts/sample.txt        # появился
+ls inbox/done/sample.wav         # исходник заархивирован
+# в терминале 1: Ctrl-C → "watch stopped processed=1 failed=0"
+```
+
+## Рецепт: конвейер-обёртка для inbox (shell)
+
+Стандартный сервис «папка-сброс»: аудио падает в `inbox/`, наружу выходят
+транскрипты, успехи архивируются в `done/`, ошибки собираются в `failed/` и
+автоматически повторяются при следующем прогоне. Сохраните как
+`transcribe-inbox.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Usage: transcribe-inbox.sh [INBOX] [OUT]
+set -uo pipefail
+
+INBOX="${1:-inbox}"
+OUT="${2:-transcripts}"
+DONE="$INBOX/done"
+FAILED="$INBOX/failed"
+mkdir -p "$OUT" "$DONE" "$FAILED"
+
+# Requeue previous failures for another attempt.
+find "$FAILED" -maxdepth 1 -type f \
+  \( -name '*.wav' -o -name '*.mp3' -o -name '*.m4a' -o -name '*.ogg' -o -name '*.flac' \) \
+  -exec mv -n {} "$INBOX/" \;
+
+gigastt transcribe-batch "$INBOX" "$OUT" --format txt,json --move-to "$DONE"
+rc=$?
+
+# Successes were moved to done/; whatever audio remains at the inbox top
+# level failed all retries — collect it for inspection and future requeue.
+if [ "$rc" -eq 1 ]; then
+  find "$INBOX" -maxdepth 1 -type f \
+    \( -name '*.wav' -o -name '*.mp3' -o -name '*.m4a' -o -name '*.ogg' -o -name '*.flac' \) \
+    -exec mv -n {} "$FAILED/" \;
+  echo "some files failed — collected in $FAILED" >&2
+fi
+exit "$rc"
+```
+
+Запуск по расписанию. Для большинства инбоксов достаточно cron:
+
+```cron
+*/15 * * * * /usr/local/bin/transcribe-inbox.sh /srv/stt/inbox /srv/stt/transcripts >> /var/log/stt-batch.log 2>&1
+```
+
+Вариант с systemd timer + service-юнитом вместо cron — см.
+[Развёртывание и эксплуатация](06-deployment-ops.md).
+
+**Watch + догоняющий batch.** Обе команды складываются в постоянно работающий
+конвейер: `watch` обрабатывает поступающие файлы с малой задержкой, а
+периодический `transcribe-batch` разгребает стартовый бэклог и всё, что
+наблюдатель пометил failed. Обе команды учитывают одно и то же исключение
+`--move-to`, поэтому бэклог не обрабатывается дважды. Одна оговорка:
+догоняющий прогон, запущенный *пока* наблюдатель работает, может подхватить
+файл, который наблюдатель только что поставил в работу, но ещё не переместил —
+планируйте прогоны на тихие часы или примите, что файл изредка будет
+транскрибирован дважды (его выходные файлы просто перезапишутся).
+
+```sh
+# один раз и далее периодически (тихие часы): разобрать бэклог + повторить ошибки
+./transcribe-inbox.sh /srv/stt/inbox /srv/stt/transcripts
+
+# постоянно: новые поступления
+gigastt watch /srv/stt/inbox /srv/stt/transcripts \
+  --format txt,json --move-to /srv/stt/inbox/done/
+```
+
+### Проверка результата
+
+```sh
+chmod +x transcribe-inbox.sh
+cp ~/recordings/*.wav inbox/ && printf 'junk' > inbox/broken.mp3
+./transcribe-inbox.sh inbox transcripts; echo "exit: $?"   # 1 — broken.mp3 failed
+ls transcripts/   # транскрипты для хороших файлов
+ls inbox/done/    # хорошие исходники заархивированы
+ls inbox/failed/  # broken.mp3 собран здесь
+./transcribe-inbox.sh inbox transcripts   # повторяет ошибочный, снова выходит с 1
+```
+
+## Рецепт: конвейер с очередью — jobs API
+
+`watch` покрывает одну машину с общей папкой. Переходите на **jobs API**,
+когда производители на других машинах, когда файлы настолько длинные, что
+держать синхронный HTTP-запрос неудобно, или когда нужны прогресс и
+отмена. Это тот же движок за in-memory FIFO-очередью внутри `gigastt serve`.
+
+Jobs по умолчанию выключены. Включите их (и зарезервируйте инференс-слоты,
+чтобы очередь не душила WebSocket/REST-стриминг):
+
+```sh
+gigastt serve --enable-jobs --batch-pool-size 1
+```
+
+Отправка → опрос → получение:
+
+```sh
+# submit (принимает те же query-параметры, что и /v1/transcribe, напр. ?format=srt)
+curl -s -X POST http://127.0.0.1:9876/v1/jobs \
+  --data-binary @episode.wav
+# {"job_id":"019f858a-...","status":"queued","created_at":1784651881.9}
+
+# poll status
+curl -s http://127.0.0.1:9876/v1/jobs/019f858a-...
+# {"job_id":"...","status":"processing","processed_seconds":12.5,"percent":42}
+
+# fetch the result once status is "done"
+curl -s http://127.0.0.1:9876/v1/jobs/019f858a-.../result
+# {"text":"...","words":[...],"duration":3512.4}
+```
+
+`status` проходит путь `queued` → `processing` → `done` | `failed` |
+`cancelled`. Запрос `/result` до `done` возвращает `409 job_not_finished`.
+Другие эндпоинты: `DELETE /v1/jobs/{id}` отменяет queued/processing-задачу
+(`204`), а `GET /v1/jobs/{id}/events` стримит SSE-прогресс
+(`data: {"type":"progress","percent":42,...}`, затем `done`/`failed`).
+
+Минимальный скрипт-драйвер:
+
+```bash
+#!/usr/bin/env bash
+# submit-and-wait.sh AUDIO_FILE — submit a job and print its transcript.
+set -euo pipefail
+BASE="${GIGASTT_BASE:-http://127.0.0.1:9876}"
+
+job=$(curl -sf -X POST "$BASE/v1/jobs" --data-binary "@$1" \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin)["job_id"])')
+echo "job: $job" >&2
+
+while true; do
+  status=$(curl -sf "$BASE/v1/jobs/$job" \
+           | python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')
+  case "$status" in
+    done)               break ;;
+    failed|cancelled)   echo "job $status" >&2; exit 1 ;;
+  esac
+  sleep 2
+done
+
+curl -sf "$BASE/v1/jobs/$job/result" | python3 -c 'import json,sys; print(json.load(sys.stdin)["text"])'
+```
+
+Поведение очереди, которое нужно учитывать:
+
+- `--jobs-retry` (по умолчанию 3) — повторяет только *временные* сбои:
+  таймауты инференса и паники воркеров. Файл, который не декодируется,
+  падает сразу, без ретраев.
+- `--jobs-max` (по умолчанию 100) — когда хранилище полно, submit возвращает
+  `429 queue_full` с `Retry-After`. Отступите и отправьте повторно.
+- `--jobs-ttl-secs` (по умолчанию 3600) — завершённые/упавшие/отменённые
+  задачи вытесняются после TTL. **Забирайте и сохраняйте результаты сразу** —
+  хранилище в памяти, поэтому перезапуск сервера теряет и очередь, и
+  незабранные результаты.
+
+### Проверка результата
+
+```sh
+curl -s http://127.0.0.1:9876/ready     # {"status":"ready",...} перед отправкой
+./submit-and-wait.sh episode.wav        # печатает текст транскрипта
+# проверка выключенного API: без --enable-jobs любой вызов /v1/jobs возвращает 404
+```
+
+## Рецепт: выбор формата выхода
+
+Пять форматов, по файлу на формат на входной файл. Выбирайте по потребителю:
+
+| Формат | Для чего | Примечания |
+|---|---|---|
+| `txt` | люди, grep, текстовые пайплайны | только текст транскрипта |
+| `json` | машины | `{"text", "words": [{"word","start","end","confidence"}], "duration"}` — пословные тайминги и confidence |
+| `srt` | видеоредакторы, загрузка на YouTube | кью SubRip, сгруппированные из пословных таймингов |
+| `vtt` | веб-плееры | WebVTT-вариант тех же кью |
+| `md` | заметки, архивы | YAML-шапка (`duration`, `language`, `speakers`) + транскрипт |
+
+```sh
+gigastt transcribe-batch episodes/ out/ --format txt,json        # default pair
+gigastt transcribe recording.wav -f srt -o recording.srt         # single file
+```
+
+Настройка субтитров (SRT/VTT): `--max-chars-per-line` (по умолчанию 80) и
+`--max-words-per-line` (по умолчанию 14) управляют группировкой кью; `0`
+отключает ограничение. Для эфирных титров обычно нужны строки короче:
+
+```sh
+gigastt transcribe recording.wav -f vtt --max-chars-per-line 42 -o recording.vtt
+```
+
+Дополнения Markdown: `--word-timestamps` добавляет пословную таблицу с
+таймингами и confidence — удобно для ручной вычитки, шумно для архивов.
+
+Тонкость для скриптов с одиночным `transcribe`: на уровне `info` логи идут в
+**stdout** вперемешку с транскриптом. Используйте `-o` для записи
+транскрипта в файл или глушите логи глобальным флагом, который ставится
+перед подкомандой:
+
+```sh
+gigastt --log-level error transcribe recording.wav          # stdout = transcript only
+```
+
+Извлечение текста из папки JSON-результатов:
+
+```sh
+jq -r '.text' transcripts/*.json
+```
+
+### Проверка результата
+
+```sh
+gigastt transcribe recording.wav -f srt -o /tmp/check.srt
+head -4 /tmp/check.srt
+# 1
+# 00:00:00,480 --> 00:00:02,160
+# Привет, как дела?
+jq -r '.duration' transcripts/episode.json    # JSON parses and has fields
+```
+
+## Рецепт: необычные входы — телефонные WAV, Opus, raw-потоки
+
+**G.711 / G.722 внутри WAV — работает само.** A-law/μ-law (телефонные
+экспорты 8 кГц) и G.722 ADPCM (Asterisk/Cisco/Teams, теги формата
+`0x0064`/`0x028F`) декодируются автоматически; batch-обходчик подхватывает
+их как любой другой `.wav`.
+
+**OGG/Opus и `.opus` (голосовые Telegram, браузерный MediaRecorder).**
+Контейнер определяется по содержимому, поэтому одиночная транскрибация
+работает как есть:
+
+```sh
+gigastt transcribe voice.opus
+```
+
+Но обходчики batch/watch сканируют по расширению (`wav,mp3,m4a,ogg,flac`) и
+**не подхватывают `.opus`-файлы**. Переименуйте их в `.ogg` перед прогоном —
+содержимое уже является OGG-контейнером, поэтому достаточно простого
+переименования:
+
+```sh
+for f in inbox/*.opus; do mv "$f" "${f%.opus}.ogg"; done
+gigastt transcribe-batch inbox/ transcripts/
+```
+
+**Raw-потоки без заголовка** (дампы RTP, Asterisk Monitor raw) не несут
+контейнера для определения — объявите кодек и частоту явно:
+
+```sh
+gigastt transcribe call.ulaw --codec pcmu --sample-rate 8000
+gigastt transcribe call.alaw --codec pcma --sample-rate 8000
+gigastt transcribe call.g722 --codec g722 --sample-rate 8000   # 16000 also accepted
+```
+
+`--codec` принимает `pcmu` (алиас `ulaw`), `pcma` (алиас `alaw`), `g722` и
+требует `--sample-rate`. Всё остальное — WebM, AMR, видео MP4, битый файл —
+падает с `invalid audio: Unsupported audio format: ...` (REST:
+`422 invalid_audio`).
+
+### Проверка результата
+
+```sh
+file recording.wav                 # confirms the container type
+gigastt --log-level error transcribe call.ulaw --codec pcmu --sample-rate 8000
+echo "exit: $?"                    # 0 = decoded and transcribed
+gigastt transcribe call.ulaw --codec pcmu 2>&1 | head -2
+# error: the following required arguments were not provided: --sample-rate
+```
+
+## Рецепт: производительность и память
+
+Голова `rnnt` на INT8 работает с **RTF ≈ 0,10** на M1 CPU — один воркер
+переваривает час аудио примерно за 6 минут. Архив на 100 часов при
+`--pool-size 4` закончится примерно за `100 ч × 0,10 / 4 ≈ 2,5 ч`
+астрономического времени. Полные измерения, другое железо и цифры WER:
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md).
+
+Прежде чем поднимать `--pool-size`, прикиньте память:
+
+- Каждый воркер загружает свою копию энкодера: **~0,4 ГБ resident** с
+  INT8-энкодером по умолчанию, **~1,7 ГБ** с FP32. Пул по умолчанию из 2 ≈
+  790 МБ RSS.
+- Движок не даёт пулу съесть больше половины всей RAM: завышенный
+  `--pool-size` **урезается с предупреждением** при загрузке, так что
+  проверяйте лог, а не предполагайте, что получили заказанный параллелизм.
+- Оставайтесь на INT8 (по умолчанию после авто-квантизации при первом
+  запуске): энкодер ужимается с 844 МБ до 215 МБ на диске с деградацией WER
+  ~0%, а FP32 учетверяет память на воркера без выигрыша в скорости пакетной
+  обработки.
+- На CPU-сборках `--encoder-intra-threads` по умолчанию равен числу
+  логических CPU, поделённому на размер пула, — правильное значение для
+  выделенной batch-машины; крутите только для совместно используемых.
+
+### Проверка результата
+
+```sh
+# предупреждение об урезании, если есть, появляется при загрузке:
+gigastt transcribe-batch calls/ transcripts/ --pool-size 8 2>&1 | grep -i "pool" | head -3
+# per-file throughput in the log: "transcribe complete audio_s=... wall_s=... rtf=0.129"
+time gigastt transcribe-batch calls/ transcripts/ --pool-size 4 --move-to calls/done/
+```
+
+## Частые ошибки
+
+- **Недокопированные файлы.** `transcribe-batch` транскрибирует то, что
+  лежит в папке *сейчас*, включая файл, который ещё копируется, — получите
+  ошибку декодирования или обрезанный транскрипт. Производители должны писать
+  во временное имя и делать `mv` в inbox (переименование атомарно в пределах
+  одной файловой системы). `watch` защищается settle-опросами; batch
+  рассчитывает на тихую папку.
+- **Случайная повторная обработка.** Без `--move-to`/`--delete-source`
+  каждый повторный прогон переделывает всю папку. Для регулярных прогонов
+  всегда задавайте политику исходников. Кроме того: `--move-to` схлопывает
+  вложенные папки — `a/week1/call.wav` и `a/week2/call.wav` столкнутся в
+  одном `done/call.wav` (а про транскрипты прогон предупредит
+  `duplicate output ... inputs with equal file stems overwrite each other`).
+  Держите имена исходников уникальными.
+- **Ожидание параллелизма, которого не получили.** `--pool-size 16` на
+  машине с 8 ГБ RAM молча урезается при загрузке (предупреждение в логе).
+  Проверяйте стартовый лог и помните, что FP32 учетверяет память на воркера.
+- **`invalid audio` / 422 на неподдерживаемом контейнере.** WebM, AMR, видео
+  MP4 или битая выгрузка не декодируются. Сначала сконвертируйте
+  (`ffmpeg -i in.webm -ar 16000 -ac 1 out.wav`) или, для raw-телефонии,
+  объявите `--codec` + `--sample-rate`. Файл `.opus` декодируем, но невидим
+  для batch/watch — переименуйте в `.ogg`.
+- **Watch «забывает» ошибки.** Файл, исчерпавший попытки, не повторяется,
+  пока не изменится его содержимое, а перезапуск наблюдателя регистрирует
+  его как бэклог (никогда не обрабатывается). Исправьте или замените файл
+  либо направьте на него `transcribe-batch` — для этого и нужен догоняющий
+  прогон из рецепта с обёрткой.
+- **Результаты задач испаряются.** Хранилище задач в памяти с TTL 1 ч на
+  терминальные задачи: перезапуск теряет очередь, а незабранные результаты
+  вытесняются. Сохраняйте результаты на клиенте; воспринимайте
+  `429 queue_full` как backpressure, а не как ошибку, достойную алерта.
+
+## Ссылки
+
+- [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md) —
+  полный справочник флагов `transcribe`, `transcribe-batch`, `watch`
+- [docs/api.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/api.md) —
+  эндпоинты jobs API, query-параметры, коды ошибок
+- [docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md) —
+  измерения RTF, памяти и WER
+- [docs/troubleshooting.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/troubleshooting.md) —
+  каталог ошибок декодирования и форматов
+- [Начало работы](01-getting-started.md) — установка и скачивание модели
+- [Развёртывание и эксплуатация](06-deployment-ops.md) — systemd-юниты и
+  таймеры для постоянно работающих конвейеров


### PR DESCRIPTION
## What

Workbook chapter 02 — **CLI and batch processing** (`transcribe` / `transcribe-batch` / `watch` / jobs API), in both books:

- `docs/workbook/en/src/02-cli-batch.md` (canonical EN)
- `docs/workbook/ru/src/02-cli-batch.md` (RU, identical heading skeleton, code/commands untranslated)

Seven recipes, each ending with a "Verify the result" check:

1. **One-off folder run** — `transcribe-batch`: formats, `--pool-size`, `--move-to`/`--delete-source` policies, exit codes (0/1/130), reading the `batch finished` summary
2. **Live folder** — `watch`: settle-poll protection against half-copied files, `--poll-interval-ms`, startup backlog skipped (vs batch), sticky failures, graceful Ctrl-C
3. **Inbox pipeline wrapper** — copy-paste `transcribe-inbox.sh` (inbox → done/ + failed/ with requeue), cron line, watch + batch catch-up combo, systemd timer pointer to chapter 06
4. **Queued pipeline** — jobs API: `--enable-jobs`, submit/poll/result/cancel/SSE events, `--jobs-retry` (transient only), `--jobs-max`/429, `--jobs-ttl-secs`, when jobs instead of watch
5. **Choosing output formats** — txt/json/md/srt/vtt by consumer, `--max-chars-per-line`/`--max-words-per-line`/`--word-timestamps`, logs-on-stdout scripting caveat (`-o` / `--log-level error`)
6. **Unusual inputs** — G.711/G.722 WAV auto-detect, `.opus` decodes but is not walked by batch/watch (rename to `.ogg`), raw `--codec`/`--sample-rate`
7. **Throughput and memory** — RTF ≈ 0.10 INT8, ~0.4 GB per worker, RAM clamp warning, INT8 vs FP32

Plus a "Common pitfalls" section (half-copied files, accidental reprocessing, pool-size clamping, 422/`invalid audio`, watch forgetting failures, job-result TTL).

## Sources verified against

- `crates/gigastt/src/main.rs` (CLI args, exit-code paths, offline engine loader)
- `crates/gigastt/src/batch.rs` (walker, retry backoff, watch state machine)
- `crates/gigastt/src/server/jobs.rs` + `server/http.rs` (job lifecycle, retryable errors, 202/404/409/429 semantics)
- `crates/gigastt-core/src/export.rs` (format renderers, extensions, SRT/VTT timestamps)
- `crates/gigastt-core/src/inference/mod.rs` (`cap_pool_size_for_ram`, ~0.4 GB/triplet)
- `docs/cli.md`, `docs/api.md`, `docs/benchmarks.md`

## Verification performed

- `mdbook build docs/workbook/en` and `.../ru` — zero errors
- Heading-skeleton parity EN ↔ RU — checked by script (identical level sequence)
- Relative intra-book links (`01-getting-started.md`, `06-deployment-ops.md`) resolve; repo-doc links are absolute GitHub URLs
- All 25 shell blocks per language pass `bash -n`
- **Ran live against the local model**: real `transcribe-batch` (exit 0 clean / exit 1 with a broken file, `--move-to` semantics), real `watch` (backlog skipped, new file settled + processed, SIGINT → `watch stopped`, exit 0), real jobs API on `serve --enable-jobs` (202 submit → processing → done, result fetch, 409 `job_not_finished` / `job_not_cancellable`, 404 `job_not_found`, 404 with jobs disabled, SSE progress events), raw `--codec pcmu --sample-rate 8000` on a generated μ-law file, G.711 WAV auto-detect
- Both included scripts executed for real: `transcribe-inbox.sh` (exit 1, successes → done/, failures → failed/, requeued next sweep) and `submit-and-wait.sh` (rc 0 against a live server)
- JSON examples validated; `typos` clean on both files

## Notes / deviations

- The chapter file is intentionally **not** added to `SUMMARY.md` (out of scope for this change; the book's chapter list is reconciled separately). The skeleton's `02-file-transcription.md` stub is untouched.
- Minor doc/code nuance spotted (not fixed here, `docs/api.md` is outside this change's file scope): the api.md error table lists `404 jobs_disabled` for calls without `--enable-jobs`, but since the routes are not registered when disabled, the actual response is a plain 404 with empty body (status correct, code never emitted). The chapter phrases it as "every `/v1/jobs` call returns 404" only.

No reference tables from `docs/cli.md` / `docs/api.md` are duplicated — the chapter links to them.
