### PR TITLE
docs(workbook): write chapter 07 — models and backends (EN+RU)

### DIFF
--- a/docs/workbook/en/src/07-models-and-backends.md
+++ b/docs/workbook/en/src/07-models-and-backends.md
@@ -1,33 +1,331 @@
 # Models and backends
 
-> **Stub** — this chapter is a skeleton; the full recipe lands in a follow-up
-> change. Structure follows [`_template.md`](_template.md).
-
 ## Scenario
 
-You need a different model variant (RNN-T, e2e, multilingual CTC), a smaller
-quantized model, or a faster execution backend (CoreML, CUDA, ANE, Candle).
+You have gigastt running with the default `rnnt` head on the CPU backend, and
+now you need to make an informed change: a different recognition head
+(punctuation baked in, or languages beyond Russian), a leaner model download, a
+faster execution provider for your hardware, or a bigger session pool. This
+chapter answers four questions with checkable recipes: **which head**, **INT8
+or FP32**, **which backend**, and **how much RAM** the pool needs.
+
+WER and RTF numbers are **not duplicated here** — the canonical, CI-annotated
+tables live in
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md);
+this chapter links into them. Flags are checked against `gigastt <command>
+--help`; the full flag reference lives in
+[docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md).
 
 ## Prerequisites
 
-_To be written._
+- gigastt installed (binary, package, or image) — see
+  [Getting started](01-getting-started.md).
+- Disk: ~1.1 GB free for the default FP32-download path (FP32 set + the
+  generated INT8 encoder), or ~250 MB for the lean pre-quantized path.
+- For building a non-default backend from source: Rust 1.88+ and `protoc` on
+  `PATH` (build requirements:
+  [docs/architecture.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/architecture.md)).
 
 ## Recipe
 
-_To be written._
+### Choosing a recognition head
+
+The recognition head is selected with `--model-variant` (env
+`GIGASTT_MODEL_VARIANT`) on `serve` / `download` / `transcribe`. All heads
+share the mel frontend and the 16 kHz mono input contract; they differ in
+ONNX files, vocabulary, and decoding.
+
+| Head | Size on disk | Languages | Output text | Accuracy | Pick when |
+|---|---|---|---|---|---|
+| `rnnt` (default) | 844 MB FP32 encoder → ~215 MB INT8 (auto-quantized) + decoder/joiner/vocab (a few MB) | Russian | Bare lowercase; pair with `--punctuation` / `--itn` (on by default in `auto`) | Lowest Russian WER of the four — [table](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#accuracy-by-domain--wer--95-ci) | Russian-only workloads; the default for a reason |
+| `e2e_rnnt` | Same size class as `rnnt` (~850 MB FP32 → INT8 generated locally) | Russian | Punctuation / casing / ITN **baked in**, one pass | Higher WER than `rnnt`, but the best punctuation/casing F1 — [comparison](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#punctuation-quality--e2e_rnnt-vs-rnnt--rupunct-restore) | You want readable Russian in a single pass with no restore step |
+| `ml_ctc` | ~225 MB pre-quantized INT8, encoder-only (no decoder/joiner) | ru/en/kk/ky/uz | Bare lowercase | [Multilingual tables](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#english--wer--librispeech-test-clean) | Multilingual audio on a small footprint |
+| `ml_ctc_large` | ~592 MB pre-quantized INT8, encoder-only | ru/en/kk/ky/uz | Bare lowercase | Best multilingual accuracy; approaches `rnnt` on Russian clean read — [table](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#accuracy-by-domain--wer--95-ci) | Mixed-language audio, or English/Kazakh/Kyrgyz/Uzbek at all |
+
+Two hard constraints the table implies:
+
+- `rnnt` / `e2e_rnnt` have a **Cyrillic-only** vocabulary — they cannot
+  transcribe English at all. For English (or kk/ky/uz) the Multilingual heads
+  are the only option.
+- The Multilingual heads are encoder-only CTC: they always ship and run as
+  pre-quantized INT8 — there is no FP32 download and no on-device quantization
+  step for them.
+
+Download and run a different head:
+
+```sh
+gigastt download --model-variant e2e_rnnt
+gigastt serve --model-variant e2e_rnnt
+```
+
+Auto-detection rules (from `crates/gigastt-core/src/model/mod.rs`):
+
+- No `--model-variant` → the engine detects the installed head from the files
+  in the model directory and uses a complete install **as-is** (no network
+  request at all).
+- An explicit `--model-variant` that differs from the installed head → the
+  requested set is downloaded **alongside**; variants are never mixed within
+  one inference, and a warning is logged. When several heads' files coexist
+  and no variant is requested, auto-detect prefers `rnnt`.
+- An empty model directory + no flag → the default `rnnt` is downloaded.
+
+**Verify:**
+
+```sh
+curl -s http://127.0.0.1:9876/health
+# {"status":"ok","model":"gigaam-v3-e2e-rnnt","variant":"e2e_rnnt",...}
+curl -s http://127.0.0.1:9876/v1/models
+# .id / .name reflect the loaded head; .encoder reports int8 vs fp32
+```
+
+### INT8 or FP32
+
+Short answer: **INT8, always, unless you are debugging the model itself.** The
+INT8 encoder runs as true integer compute (`DynamicQuantizeLinear` +
+`MatMulInteger`/`ConvInteger` kernels), shrinks the encoder 844 MB → 215 MB
+(~3.9×), and measures ~0% WER degradation — numbers and methodology:
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#headline-single-engine-metrics).
+
+What happens on each path (RNN-T heads):
+
+- **Default** — `gigastt download` (or the first `serve` / `transcribe`)
+  fetches the FP32 set from HuggingFace (`istupakov/gigaam-v3-onnx`), then
+  runs the native-Rust quantization pass once (~2 min) and writes
+  `v3_rnnt_encoder_int8.onnx` next to it. The engine **prefers the INT8
+  encoder** whenever the file is present.
+- **Lean** — `gigastt download --prequantized` fetches the pre-quantized INT8
+  bundle (INT8 encoder + decoder + joiner + vocab) from the pinned GitHub
+  Release instead: no ~844 MB FP32 download, no ~2-minute quantization. Also
+  the fallback when HuggingFace is unreachable but GitHub is not.
+- **Multilingual** — `ml_ctc` / `ml_ctc_large` download istupakov's
+  pre-quantized INT8 encoder directly from HuggingFace; `--prequantized` is a
+  no-op refinement for them (there is no separate bundle).
+- **Manual** — `gigastt quantize [--force]` re-runs the quantization on the
+  head detected in `--model-dir` (e.g. after replacing the FP32 encoder with
+  your own fine-tune).
+- **Opt out** — `--skip-quantize` (env `GIGASTT_SKIP_QUANTIZE=1`) skips the
+  quantization step; the engine then loads the FP32 encoder at ~4× the RAM per
+  pool slot and slower CPU kernels. Keep this for debugging only.
+
+**Verify:**
+
+```sh
+ls ~/.gigastt/models/
+# v3_rnnt_encoder_int8.onnx present alongside decoder/joint/vocab
+gigastt transcribe sample.wav 2>&1 | grep 'transcribe complete'
+# ... encoder=int8/cpu ... rtf=0.1xx
+```
+
+The `encoder=int8/<backend>` field in the completion log line is the ground
+truth for which encoder file was loaded.
+
+### Execution provider for your hardware
+
+The backend is a **compile-time Cargo feature**, not a runtime flag — the
+provider is baked into the binary you install or build:
+
+| Your hardware | Feature | Provider | Notes |
+|---|---|---|---|
+| Any (default) | — | CPU (ONNX Runtime) | The reference build; RTF well under 1.0 with the INT8 encoder |
+| macOS ARM64 (M1–M4) | `--features coreml` | CoreML + Neural Engine | Prebuilt macOS release binaries **already ship this feature**; ~3× encoder on short clips, ~5.6× on long files vs CPU |
+| Linux x86_64 + NVIDIA | `--features cuda` | CUDA 12+ | No prebuilt tarball — use the `-cuda` Docker image or `Dockerfile.cuda`; falls back to CPU when no GPU is present at runtime |
+| Android / ARM64 | `--features nnapi` | NNAPI (NPU/DSP) | Not mutually exclusive with the others |
+| macOS ARM64, experimental | `--features ane` | Native Apple Neural Engine (Core ML `.mlpackage`) | `rnnt` head only, file-mode acceleration; see below |
+| Apple Silicon, experimental | `--features candle` | Pure-Rust Candle on Metal | `rnnt` head only, FP32; see below |
+
+Build the one that matches:
+
+```sh
+cargo build --release                      # CPU, any platform
+cargo build --release --features coreml    # macOS ARM64
+cargo build --release --features cuda      # Linux x86_64 + NVIDIA (CUDA 12+)
+cargo build --release --features nnapi     # Android / ARM64
+```
+
+Exclusivity is enforced at compile time: `coreml` and `cuda` are mutually
+exclusive; `ane` conflicts with `coreml`/`cuda`/`nnapi`/`candle`; `candle`
+conflicts with `coreml`/`cuda`. A `compile_error!` fires on a bad combination.
+
+Runtime behavior worth knowing:
+
+- **CPU fallback is deliberate, never a crash.** The CoreML build runs a ~1 s
+  warmup probe at startup; on failure it logs `falling back to CPU execution
+  provider` and rebuilds the sessions on CPU. The CUDA binary likewise runs on
+  CPU when no GPU is visible (e.g. a container started without `--gpus all`).
+- **CUDA packaging.** There is no prebuilt CUDA tarball — the release matrix
+  ships CPU binaries for Linux (x86_64, aarch64), Windows, and a
+  CoreML-enabled macOS ARM64 binary. For GPU use the published
+  `ghcr.io/ekhodzitsky/gigastt:<ver>-cuda` image (recipes:
+  [Deployment & ops](06-deployment-ops.md)) or build with
+  [Dockerfile.cuda](https://github.com/ekhodzitsky/gigastt/blob/main/Dockerfile.cuda).
+- **Native ANE backend** (`--features ane`, macOS ARM64): runs the `rnnt`
+  encoder on the Neural Engine via per-bucket fixed-shape Core ML packages,
+  ~10× warm end-to-end over the CPU build (decode-bound). Fetch the packages
+  with `gigastt download --ane` (into `~/.gigastt/models/ane/`); an `e2e_rnnt`
+  model transparently falls back to the `ort` encoder, and streaming windows
+  always take the CPU path — ANE is a file-mode accelerator. Full design and
+  honest numbers:
+  [docs/ane-backend.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/ane-backend.md).
+- **Candle backend** (`--features candle`, experimental): pure-Rust inference
+  on the Metal GPU, byte-for-byte parity with `ort`, `rnnt` head only, FP32
+  weights converted once with `scripts/convert_gigaam_candle.py`. Details:
+  [docs/candle-backend.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/candle-backend.md).
+
+**Verify:**
+
+```sh
+gigastt transcribe sample.wav 2>&1 | grep 'transcribe complete'
+# encoder=int8/coreml  → the CoreML build is active (int8/cuda, int8/cpu, ...)
+# encoder=int8/ane     → the native ANE backend handled the encoder
+```
+
+On a CoreML build, also watch startup: the absence of `falling back to CPU
+execution provider` means the warmup probe passed.
+
+### Model files in an offline perimeter
+
+Everything the engine needs lives in one directory — `~/.gigastt/models/` by
+default, overridable with `--model-dir` on `serve` / `download` / `transcribe`
+/ `quantize`. That makes the model set a plain file artifact you can stage and
+move around:
+
+```sh
+# On a connected machine:
+gigastt download --prequantized --model-dir /srv/gigastt-models
+
+# Copy to the target host any way you like (rsync, USB, artifact store):
+rsync -a /srv/gigastt-models/ offline-host:/srv/gigastt-models/
+
+# On the offline host — refuse every network fetch, fail fast instead of hanging:
+gigastt --offline serve --model-dir /srv/gigastt-models
+```
+
+Properties that make this safe:
+
+- **Integrity is verified by the binary, not by you.** Every download is
+  SHA-256-checked against checksums pinned in the code, staged as `.partial`,
+  and atomically renamed into place; a corrupt file is removed, never
+  promoted. A checksum failure exits with code `65` (network `69`, disk `74`,
+  Ctrl-C `130`) — scriptable.
+- **A complete model set means zero network.** With a full head's files
+  present (encoder — INT8 or FP32 — plus decoder/joiner/vocab for the RNN-T
+  heads, or INT8 encoder + vocab for the Multilingual ones), startup performs
+  no network request, even without `--offline`. `--offline` /
+  `GIGASTT_OFFLINE=1` turns any *missing* optional model (punctuation, VAD,
+  diarization) into an immediate error naming the file to provide.
+- **The head is auto-detected from the files** — a copied directory needs no
+  `--model-variant` flag on the target host.
+- When copying, include the `*_int8.onnx` encoder (or copy the FP32 encoder
+  too and run `gigastt quantize --model-dir …` on the target), the vocab, and
+  — for `rnnt`/`e2e_rnnt` — the decoder and joiner.
+
+For a fully packaged offline install (tarball with binary + INT8 model +
+punctuation model + systemd unit, or the two-deb variant), use the release
+offline bundle — recipe and verification steps in
+[Deployment & ops](06-deployment-ops.md); inventory in
+[README-OFFLINE.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/offline/README-OFFLINE.md).
+
+**Verify:**
+
+```sh
+gigastt --offline transcribe sample.wav --model-dir /srv/gigastt-models
+# transcribes with no network; a missing file errors immediately, naming the file
+```
+
+### Sizing the session pool (RAM)
+
+Every pool slot deserializes **its own encoder copy**, so RSS scales linearly
+with `--pool-size` (default 2). The engine budgets each slot at roughly
+`2 × encoder-file-size` resident (measured ~1.9× on the INT8 `rnnt` encoder,
+CPU provider, release build):
+
+| Head (as loaded) | Encoder file | ≈ RAM per pool slot | Default pool 2 |
+|---|---|---|---|
+| `rnnt` / `e2e_rnnt` INT8 | ~215 MB | ~0.4 GB | ~790 MB total RSS |
+| `rnnt` / `e2e_rnnt` FP32 (`--skip-quantize`) | 844 MB | ~1.6 GB | ~3.3 GB — never in production |
+| `ml_ctc` INT8 | ~225 MB | ~0.45 GB | ~0.9 GB |
+| `ml_ctc_large` INT8 | ~592 MB | ~1.2 GB | ~2.4 GB |
+
+Two safety nets are built in:
+
+- **RAM auto-cap.** At load, the requested pool is clamped so the pooled
+  encoders stay under half of total RAM — a `Capping pool size N -> M` warning
+  is logged when it fires. The cap never raises your request, and never goes
+  below 1.
+- **Degraded boot.** `--pool-min-size 1` (the default) lets the server start
+  on a partially loaded pool instead of crashing when memory runs out mid-load.
+
+Rule of thumb: `RAM ≥ pool_size × per-slot + ~1 GB for the OS and request
+peaks`. On a 4 GB box that means `--pool-size 1–2` with the INT8 encoder —
+the same conclusion as the OOM pitfall in
+[Deployment & ops](06-deployment-ops.md).
+
+**Verify:**
+
+```sh
+# no "Capping pool size" warning at startup, and:
+curl -s http://127.0.0.1:9876/ready
+# {"status":"ready","pool_available":2,"pool_total":2}
+```
 
 ## Verifying the result
 
-_To be written._
+End-to-end smoke after any change in this chapter:
+
+```sh
+ls ~/.gigastt/models/                  # the head's full file set, incl. *_int8.onnx + vocab
+gigastt transcribe sample.wav 2>&1 | grep 'transcribe complete'
+# encoder=<int8|fp32>/<cpu|coreml|cuda|ane|candle>, rtf well under 1.0
+curl -s http://127.0.0.1:9876/health   # "model"/"variant" match the head you picked
+curl -s http://127.0.0.1:9876/ready    # ready, pool_available >= 1
+```
+
+Then confirm the accuracy expectation against
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md)
+rather than re-measuring casually — the harness, manifests, and normalization
+matter more than the stopwatch.
 
 ## Common pitfalls
 
-_To be written._
+- **English audio comes out as garbage with the default head.** Not a bug:
+  `rnnt` / `e2e_rnnt` have a Cyrillic-only vocabulary and cannot emit Latin
+  text at all. Switch to `--model-variant ml_ctc` (or `ml_ctc_large`).
+- **`--model-variant` seems to be ignored after the first download.** The
+  engine auto-detects the head from the model directory; an explicit variant
+  that differs from the installed one triggers a *second* download alongside
+  (with a `variants are never mixed` warning), and a later flag-less start
+  prefers `rnnt` again. Delete the unused head's files to keep the directory
+  unambiguous and reclaim disk.
+- **First `serve` looks hung.** That is the one-time ~850 MB FP32 download +
+  ~2 min quantization; `/health` answers `200` with `model:"loading"` while
+  `/ready` stays `503 initializing`. Skip the window with `gigastt download
+  --prequantized`, and gate clients on `/ready`, never on `/health`.
+- **OOM after switching to `ml_ctc_large`.** Each slot now costs ~1.2 GB.
+  Lower `--pool-size`, keep `--pool-min-size 1` so a tight host boots
+  degraded, and watch for the `Capping pool size` warning at startup.
+- **The CoreML build is no faster than CPU.** Look for `falling back to CPU
+  execution provider` in the startup log — the warmup probe failed and the
+  engine is (deliberately) running on CPU. The completion log's
+  `encoder=int8/cpu` field confirms it.
+- **The CUDA container runs at CPU speed.** The GPU is not visible: the
+  container needs the NVIDIA Container Toolkit and `--gpus all`. The binary
+  falls back to CPU silently — check `encoder=int8/cuda` in the completion log.
+- **`error: ane and coreml are mutually exclusive` (or similar) at build
+  time.** Backend features conflict by design; build exactly one of `coreml` /
+  `cuda` / `ane` / `candle` (`nnapi` is the exception).
+- **`SHA-256 mismatch` during `gigastt download`.** The staged download was
+  corrupt or tampered with; it is removed, not promoted, and the CLI exits `65`.
+  Re-run the command — do not hand-rename a `.partial` file into place.
 
 ## Links
 
-- [docs/architecture.md](../../../architecture.md) — engine and pipeline overview
-- [docs/ane-backend.md](../../../ane-backend.md) — Apple Neural Engine backend
-- [docs/candle-backend.md](../../../candle-backend.md) — Candle/Metal backend
-- [docs/embedding-packaging.md](../../../embedding-packaging.md) — onnxruntime linking
-- [docs/benchmarks.md](../../../benchmarks.md) — accuracy and speed measurements
+- [Getting started](01-getting-started.md) — install and first transcription
+- [CLI and batch processing](02-cli-batch.md) — throughput/memory recipe for the offline CLI
+- [Deployment & ops](06-deployment-ops.md) — offline bundle, systemd, OOM runbook entries
+- [docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md) — canonical WER / RTF / footprint tables
+- [docs/architecture.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/architecture.md) — pipeline, providers, quantization internals
+- [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md) — full flag reference
+- [docs/ane-backend.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/ane-backend.md) — native Apple Neural Engine backend
+- [docs/candle-backend.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/candle-backend.md) — Candle/Metal backend
+- [docs/verifying-releases.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/verifying-releases.md) — release artifact verification
+- [packaging/offline/README-OFFLINE.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/offline/README-OFFLINE.md) — offline bundle inventory

--- a/docs/workbook/ru/src/07-models-and-backends.md
+++ b/docs/workbook/ru/src/07-models-and-backends.md
@@ -1,34 +1,339 @@
 # Модели и бэкенды
 
-> **Заглушка** — глава представляет собой скелет; полный рецепт появится в
-> следующем изменении. Структура следует [`_template.md`](_template.md).
-
 ## Сценарий
 
-Вам нужен другой вариант модели (RNN-T, e2e, мультиязычный CTC), более
-компактная квантованная модель или более быстрый бэкенд исполнения (CoreML,
-CUDA, ANE, Candle).
+gigastt уже работает с головой `rnnt` по умолчанию на CPU-бэкенде, и теперь
+нужно осознанно что-то поменять: другую голову распознавания (пунктуация «из
+коробки» или языки помимо русского), более лёгкую загрузку модели, более
+быстрый execution provider под ваше железо или больший пул сессий. Эта глава
+отвечает на четыре вопроса проверяемыми рецептами: **какую голову**, **INT8
+или FP32**, **какой бэкенд** и **сколько RAM** нужно пулу.
+
+Цифры WER и RTF здесь **не дублируются** — канонические таблицы с доверительными
+интервалами живут в
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md);
+глава лишь ссылается на них. Флаги сверены с `gigastt <command> --help`; полный
+справочник флагов —
+[docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md).
 
 ## Предпосылки
 
-_Будет написано._
+- Установленный gigastt (бинарь, пакет или образ) — см.
+  [Начало работы](01-getting-started.md).
+- Диск: ~1,1 ГБ свободно для стандартного пути с FP32-загрузкой (FP32-набор
+  плюс сгенерированный INT8-энкодер) или ~250 МБ для лёгкого pre-quantized пути.
+- Для сборки нестандартного бэкенда из исходников: Rust 1.88+ и `protoc` в
+  `PATH` (требования сборки:
+  [docs/architecture.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/architecture.md)).
 
 ## Рецепт
 
-_Будет написано._
+### Выбор головы распознавания
+
+Голова выбирается флагом `--model-variant` (env `GIGASTT_MODEL_VARIANT`) у
+команд `serve` / `download` / `transcribe`. Все головы используют общий
+mel-фронтенд и контракт входа 16 кГц моно; различаются ONNX-файлами,
+словарём и декодированием.
+
+| Голова | Размер на диске | Языки | Текст на выходе | Точность | Когда брать |
+|---|---|---|---|---|---|
+| `rnnt` (по умолчанию) | энкодер 844 МБ FP32 → ~215 МБ INT8 (авто-квантизация) + decoder/joiner/vocab (несколько МБ) | русский | «Голый» lowercase; дополняйте `--punctuation` / `--itn` (включены по умолчанию в режиме `auto`) | Лучший русский WER из четырёх — [таблица](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#accuracy-by-domain--wer--95-ci) | Русскоязычные нагрузки; дефолт не случаен |
+| `e2e_rnnt` | Тот же класс размера, что у `rnnt` (~850 МБ FP32 → INT8 генерируется локально) | русский | Пунктуация / регистр / ITN **встроены**, один проход | WER выше, чем у `rnnt`, но лучший F1 пунктуации/регистра — [сравнение](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#punctuation-quality--e2e_rnnt-vs-rnnt--rupunct-restore) | Нужен читаемый русский текст за один проход, без шага восстановления |
+| `ml_ctc` | ~225 МБ pre-quantized INT8, только энкодер (без decoder/joiner) | ru/en/kk/ky/uz | «Голый» lowercase | [Мультиязычные таблицы](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#english--wer--librispeech-test-clean) | Мультиязычное аудио при малом футпринте |
+| `ml_ctc_large` | ~592 МБ pre-quantized INT8, только энкодер | ru/en/kk/ky/uz | «Голый» lowercase | Лучшая мультиязычная точность; на чистом русском чтении приближается к `rnnt` — [таблица](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#accuracy-by-domain--wer--95-ci) | Смешанные языки или английский/казахский/кыргызский/узбекский как таковые |
+
+Два жёстких ограничения, следующих из таблицы:
+
+- У `rnnt` / `e2e_rnnt` **кириллический** словарь — английский они не могут
+  транскрибировать в принципе. Для английского (или kk/ky/uz) подходят только
+  Multilingual-головы.
+- Multilingual-головы — это encoder-only CTC: они всегда поставляются и
+  работают как pre-quantized INT8 — ни FP32-загрузки, ни шага квантизации на
+  устройстве для них не существует.
+
+Загрузка и запуск другой головы:
+
+```sh
+gigastt download --model-variant e2e_rnnt
+gigastt serve --model-variant e2e_rnnt
+```
+
+Правила автоопределения (из `crates/gigastt-core/src/model/mod.rs`):
+
+- Без `--model-variant` движок определяет установленную голову по файлам в
+  каталоге модели и использует полный комплект **как есть** (вообще без
+  сетевых запросов).
+- Явный `--model-variant`, отличный от установленной головы, → запрошенный
+  набор скачивается **рядом**; головы никогда не смешиваются в одном инференсе,
+  в лог пишется предупреждение. Если файлы нескольких голов сосуществуют, а
+  вариант не задан, автоопределение предпочитает `rnnt`.
+- Пустой каталог модели + отсутствие флага → скачивается дефолтный `rnnt`.
+
+**Проверка:**
+
+```sh
+curl -s http://127.0.0.1:9876/health
+# {"status":"ok","model":"gigaam-v3-e2e-rnnt","variant":"e2e_rnnt",...}
+curl -s http://127.0.0.1:9876/v1/models
+# .id / .name отражают загруженную голову; .encoder показывает int8 или fp32
+```
+
+### INT8 или FP32
+
+Короткий ответ: **всегда INT8, если только вы не отлаживаете саму модель.**
+INT8-энкодер работает как настоящие целочисленные вычисления (ядра
+`DynamicQuantizeLinear` + `MatMulInteger`/`ConvInteger`), сжимает энкодер
+844 МБ → 215 МБ (~3,9×) и даёт ~0% деградации WER — цифры и методология:
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md#headline-single-engine-metrics).
+
+Что происходит на каждом пути (RNN-T-головы):
+
+- **По умолчанию** — `gigastt download` (или первый `serve` / `transcribe`)
+  скачивает FP32-набор с HuggingFace (`istupakov/gigaam-v3-onnx`), затем
+  однократно (~2 мин) выполняет квантизацию нативным Rust-кодом и пишет
+  `v3_rnnt_encoder_int8.onnx` рядом. Движок **предпочитает INT8-энкодер**,
+  когда файл присутствует.
+- **Лёгкий путь** — `gigastt download --prequantized` скачивает готовый
+  INT8-бандл (INT8-энкодер + decoder + joiner + vocab) из закреплённого
+  GitHub Release: ни ~844 МБ FP32-загрузки, ни ~2-минутной квантизации. Это
+  также запасной вариант, когда HuggingFace недоступен, а GitHub — нет.
+- **Multilingual** — `ml_ctc` / `ml_ctc_large` скачивают pre-quantized
+  INT8-энкодер istupakov'а напрямую с HuggingFace; `--prequantized` для них —
+  холостое уточнение (отдельного бандла нет).
+- **Вручную** — `gigastt quantize [--force]` повторно запускает квантизацию
+  для головы, определённой в `--model-dir` (например, после подмены FP32-
+  энкодера своим файнтюном).
+- **Отказ** — `--skip-quantize` (env `GIGASTT_SKIP_QUANTIZE=1`) пропускает шаг
+  квантизации; движок тогда загружает FP32-энкодер с ~4× расходом RAM на слот
+  пула и более медленными CPU-ядрами. Оставьте это только для отладки.
+
+**Проверка:**
+
+```sh
+ls ~/.gigastt/models/
+# v3_rnnt_encoder_int8.onnx присутствует рядом с decoder/joint/vocab
+gigastt transcribe sample.wav 2>&1 | grep 'transcribe complete'
+# ... encoder=int8/cpu ... rtf=0.1xx
+```
+
+Поле `encoder=int8/<backend>` в строке лога о завершении — истина о том, какой
+файл энкодера был загружен.
+
+### Бэкенд под ваше железо
+
+Бэкенд — это **compile-time Cargo-фича**, а не runtime-флаг: провайдер зашит в
+бинарь, который вы устанавливаете или собираете:
+
+| Ваше железо | Фича | Провайдер | Примечания |
+|---|---|---|---|
+| Любое (по умолчанию) | — | CPU (ONNX Runtime) | Эталонная сборка; RTF заметно ниже 1.0 с INT8-энкодером |
+| macOS ARM64 (M1–M4) | `--features coreml` | CoreML + Neural Engine | Готовые релизные бинари macOS **уже собраны с этой фичей**; ~3× энкодер на коротких клипах, ~5,6× на длинных файлах против CPU |
+| Linux x86_64 + NVIDIA | `--features cuda` | CUDA 12+ | Готового tarball нет — берите Docker-образ `-cuda` или `Dockerfile.cuda`; при отсутствии GPU в рантайме откатывается на CPU |
+| Android / ARM64 | `--features nnapi` | NNAPI (NPU/DSP) | Не является взаимоисключающей с остальными |
+| macOS ARM64, экспериментально | `--features ane` | Нативный Apple Neural Engine (Core ML `.mlpackage`) | Только голова `rnnt`, ускорение файлового режима; см. ниже |
+| Apple Silicon, экспериментально | `--features candle` | Чистый Rust Candle на Metal | Только голова `rnnt`, FP32; см. ниже |
+
+Соберите подходящий вариант:
+
+```sh
+cargo build --release                      # CPU, любая платформа
+cargo build --release --features coreml    # macOS ARM64
+cargo build --release --features cuda      # Linux x86_64 + NVIDIA (CUDA 12+)
+cargo build --release --features nnapi     # Android / ARM64
+```
+
+Исключительность проверяется на этапе компиляции: `coreml` и `cuda` взаимно
+исключают друг друга; `ane` конфликтует с `coreml`/`cuda`/`nnapi`/`candle`;
+`candle` конфликтует с `coreml`/`cuda`. На плохой комбинации срабатывает
+`compile_error!`.
+
+Поведение в рантайме, о котором стоит знать:
+
+- **Откат на CPU — намеренный, никогда не падение.** CoreML-сборка при старте
+  выполняет ~1-секундную warmup-проверку; при неудаче пишет в лог `falling
+  back to CPU execution provider` и пересобирает сессии на CPU. CUDA-бинарь
+  аналогично работает на CPU, когда GPU не виден (например, контейнер запущен
+  без `--gpus all`).
+- **Упаковка CUDA.** Готового CUDA-tarball нет — релизная матрица собирает
+  CPU-бинари для Linux (x86_64, aarch64), Windows и CoreML-сборку для macOS
+  ARM64. Для GPU берите опубликованный образ
+  `ghcr.io/ekhodzitsky/gigastt:<ver>-cuda` (рецепты:
+  [Развёртывание и эксплуатация](06-deployment-ops.md)) или собирайте через
+  [Dockerfile.cuda](https://github.com/ekhodzitsky/gigastt/blob/main/Dockerfile.cuda).
+- **Нативный ANE-бэкенд** (`--features ane`, macOS ARM64): выполняет энкодер
+  `rnnt` на Neural Engine через пакеты Core ML с фиксированными формами по
+  бакетам, ~10× тёплого end-to-end ускорения против CPU-сборки (упор в
+  декодирование). Пакеты скачиваются командой `gigastt download --ane` (в
+  `~/.gigastt/models/ane/`); модель `e2e_rnnt` прозрачно откатывается на
+  `ort`-энкодер, а стриминговые окна всегда идут по CPU-пути — ANE является
+  ускорителем файлового режима. Полный дизайн и честные цифры:
+  [docs/ane-backend.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/ane-backend.md).
+- **Candle-бэкенд** (`--features candle`, экспериментально): чисто-Rust
+  инференс на Metal GPU, побайтовая идентичность с `ort`, только голова
+  `rnnt`, FP32-веса, однократно конвертируемые скриптом
+  `scripts/convert_gigaam_candle.py`. Подробности:
+  [docs/candle-backend.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/candle-backend.md).
+
+**Проверка:**
+
+```sh
+gigastt transcribe sample.wav 2>&1 | grep 'transcribe complete'
+# encoder=int8/coreml  → активна CoreML-сборка (int8/cuda, int8/cpu, ...)
+# encoder=int8/ane     → энкодер обработал нативный ANE-бэкенд
+```
+
+На CoreML-сборке также смотрите стартовый лог: отсутствие строки `falling back
+to CPU execution provider` означает, что warmup-проверка прошла.
+
+### Файлы модели в замкнутом контуре
+
+Всё, что нужно движку, живёт в одном каталоге — `~/.gigastt/models/` по
+умолчанию, переопределяется флагом `--model-dir` у `serve` / `download` /
+`transcribe` / `quantize`. Поэтому набор моделей — это обычный файловый
+артефакт, который можно подготовить и переносить:
+
+```sh
+# На машине с сетью:
+gigastt download --prequantized --model-dir /srv/gigastt-models
+
+# Любым способом скопируйте на целевой хост (rsync, USB, хранилище артефактов):
+rsync -a /srv/gigastt-models/ offline-host:/srv/gigastt-models/
+
+# На офлайн-хосте — запретить любые сетевые обращения, падать сразу, а не висеть:
+gigastt --offline serve --model-dir /srv/gigastt-models
+```
+
+Свойства, которые делают это безопасным:
+
+- **Целостность проверяет бинарь, а не вы.** Каждая загрузка проверяется по
+  SHA-256 против контрольных сумм, закреплённых в коде, складывается в
+  `.partial` и атомарно переименовывается на место; повреждённый файл
+  удаляется, а не принимается. Несовпадение контрольной суммы завершает
+  процесс с кодом `65` (сеть `69`, диск `74`, Ctrl-C `130`) — пригодно для
+  скриптов.
+- **Полный набор модели = ноль сети.** При наличии полного комплекта головы
+  (энкодер — INT8 или FP32 — плюс decoder/joiner/vocab для RNN-T-голов или
+  INT8-энкодер + vocab для Multilingual) запуск не выполняет ни одного
+  сетевого запроса, даже без `--offline`. `--offline` / `GIGASTT_OFFLINE=1`
+  превращает любую *недостающую* опциональную модель (пунктуация, VAD,
+  диаризация) в немедленную ошибку с именем файла, который нужно предоставить.
+- **Голова автоопределяется по файлам** — скопированному каталогу не нужен
+  флаг `--model-variant` на целевом хосте.
+- При копировании включайте `*_int8.onnx`-энкодер (или скопируйте также FP32-
+  энкодер и выполните `gigastt quantize --model-dir …` на целевом хосте),
+  vocab и — для `rnnt`/`e2e_rnnt` — decoder и joiner.
+
+Для полностью упакованной офлайн-установки (tarball с бинарём + INT8-моделью +
+моделью пунктуации + systemd-юнит или вариант из двух deb-пакетов) берите
+релизный offline-бандл — рецепт и шаги проверки в
+[Развёртывание и эксплуатация](06-deployment-ops.md); состав —
+[README-OFFLINE.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/offline/README-OFFLINE.md).
+
+**Проверка:**
+
+```sh
+gigastt --offline transcribe sample.wav --model-dir /srv/gigastt-models
+# транскрибирует без сети; недостающий файл — немедленная ошибка с именем файла
+```
+
+### Память под пул сессий
+
+Каждый слот пула десериализует **свою копию энкодера**, поэтому RSS растёт
+линейно с `--pool-size` (по умолчанию 2). Движок закладывает на слот примерно
+`2 × размер-файла-энкодера` резидентной памяти (измерено ~1,9× на INT8-
+энкодере `rnnt`, CPU-провайдер, release-сборка):
+
+| Голова (как загружена) | Файл энкодера | ≈ RAM на слот пула | Дефолтный пул 2 |
+|---|---|---|---|
+| `rnnt` / `e2e_rnnt` INT8 | ~215 МБ | ~0,4 ГБ | ~790 МБ суммарного RSS |
+| `rnnt` / `e2e_rnnt` FP32 (`--skip-quantize`) | 844 МБ | ~1,6 ГБ | ~3,3 ГБ — никогда в проде |
+| `ml_ctc` INT8 | ~225 МБ | ~0,45 ГБ | ~0,9 ГБ |
+| `ml_ctc_large` INT8 | ~592 МБ | ~1,2 ГБ | ~2,4 ГБ |
+
+Встроены две защиты:
+
+- **Авто-ограничение по RAM.** При загрузке запрошенный пул урезается так,
+  чтобы энкодеры пула оставались в пределах половины общей RAM — при срабатывании
+  пишется предупреждение `Capping pool size N -> M`. Ограничение никогда не
+  повышает ваш запрос и никогда не опускается ниже 1.
+- **Деградированный запуск.** `--pool-min-size 1` (по умолчанию) позволяет
+  серверу стартовать на частично загруженном пуле вместо падения, когда память
+  заканчивается посреди загрузки.
+
+Эмпирическое правило: `RAM ≥ pool_size × расход-на-слот + ~1 ГБ на ОС и пики
+запросов`. На машине с 4 ГБ это означает `--pool-size 1–2` с INT8-энкодером —
+тот же вывод, что и в пункте про OOM в
+[Развёртывание и эксплуатация](06-deployment-ops.md).
+
+**Проверка:**
+
+```sh
+# нет предупреждения "Capping pool size" при старте, и:
+curl -s http://127.0.0.1:9876/ready
+# {"status":"ready","pool_available":2,"pool_total":2}
+```
 
 ## Проверка результата
 
-_Будет написано._
+Сквозной смоук после любого изменения из этой главы:
+
+```sh
+ls ~/.gigastt/models/                  # полный набор файлов головы, включая *_int8.onnx + vocab
+gigastt transcribe sample.wav 2>&1 | grep 'transcribe complete'
+# encoder=<int8|fp32>/<cpu|coreml|cuda|ane|candle>, rtf заметно ниже 1.0
+curl -s http://127.0.0.1:9876/health   # "model"/"variant" соответствуют выбранной голове
+curl -s http://127.0.0.1:9876/ready    # ready, pool_available >= 1
+```
+
+Затем сверьте ожидания по точности с
+[docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md),
+а не с кустарными замерами — харнесс, манифесты и нормализация значат больше,
+чем секундомер.
 
 ## Частые ошибки
 
-_Будет написано._
+- **Английское аудио превращается в мусор с головой по умолчанию.** Это не
+  баг: у `rnnt` / `e2e_rnnt` кириллический словарь, и латиницу они выдавать не
+  могут в принципе. Переключитесь на `--model-variant ml_ctc` (или
+  `ml_ctc_large`).
+- **`--model-variant` словно игнорируется после первой загрузки.** Движок
+  автоопределяет голову по каталогу модели; явный вариант, отличный от
+  установленного, инициирует *вторую* загрузку рядом (с предупреждением
+  `variants are never mixed`), а следующий запуск без флага снова предпочтёт
+  `rnnt`. Удалите файлы неиспользуемой головы, чтобы каталог был однозначным,
+  и верните место на диске.
+- **Первый `serve` выглядит зависшим.** Это одноразовая загрузка ~850 МБ FP32
+  + ~2 мин квантизации; `/health` отвечает `200` с `model:"loading"`, пока
+  `/ready` остаётся `503 initializing`. Уберите это окно командой `gigastt
+  download --prequantized` и стробируйте клиентов по `/ready`, никогда по
+  `/health`.
+- **OOM после переключения на `ml_ctc_large`.** Каждый слот теперь стоит ~1,2
+  ГБ. Снизьте `--pool-size`, держите `--pool-min-size 1`, чтобы тесный хост
+  загружался деградированно, и следите за предупреждением `Capping pool size`
+  при старте.
+- **CoreML-сборка не быстрее CPU.** Ищите в стартовом логе `falling back to
+  CPU execution provider` — warmup-проверка не прошла, и движок (намеренно)
+  работает на CPU. Поле `encoder=int8/cpu` в логе завершения это подтверждает.
+- **CUDA-контейнер работает на скорости CPU.** GPU не виден: контейнеру нужны
+  NVIDIA Container Toolkit и `--gpus all`. Бинарь молча откатывается на CPU —
+  проверяйте `encoder=int8/cuda` в логе завершения.
+- **`error: ane and coreml are mutually exclusive` (или похожая) при сборке.**
+  Бэкенд-фичи конфликтуют по дизайну; собирайте ровно одну из `coreml` /
+  `cuda` / `ane` / `candle` (`nnapi` — исключение).
+- **`SHA-256 mismatch` во время `gigastt download`.** Стейджинговая загрузка
+  повреждена или подменена; она удаляется, а не принимается, CLI завершается с
+  кодом `65`. Просто перезапустите команду — не переименовывайте `.partial`
+  вручную на место.
 
 ## Ссылки
 
-- [docs/architecture.md](../../../architecture.md) — обзор движка и пайплайна
-- [docs/ane-backend.md](../../../ane-backend.md) — бэкенд Apple Neural Engine
-- [docs/candle-backend.md](../../../candle-backend.md) — бэкенд Candle/Metal
-- [docs/embedding-packaging.md](../../../embedding-packaging.md) — линковка onnxruntime
-- [docs/benchmarks.md](../../../benchmarks.md) — измерения точности и скорости
+- [Начало работы](01-getting-started.md) — установка и первая транскрипция
+- [CLI и пакетная обработка](02-cli-batch.md) — рецепт по пропускной способности и памяти для офлайн-CLI
+- [Развёртывание и эксплуатация](06-deployment-ops.md) — offline-бандл, systemd, пункты ранбука про OOM
+- [docs/benchmarks.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/benchmarks.md) — канонические таблицы WER / RTF / футпринта
+- [docs/architecture.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/architecture.md) — пайплайн, провайдеры, внутренности квантизации
+- [docs/cli.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/cli.md) — полный справочник флагов
+- [docs/ane-backend.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/ane-backend.md) — нативный бэкенд Apple Neural Engine
+- [docs/candle-backend.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/candle-backend.md) — бэкенд Candle/Metal
+- [docs/verifying-releases.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/verifying-releases.md) — проверка релизных артефактов
+- [packaging/offline/README-OFFLINE.md](https://github.com/ekhodzitsky/gigastt/blob/main/packaging/offline/README-OFFLINE.md) — состав offline-бандла


### PR DESCRIPTION
## What

Writes the workbook chapter **07 — Models and backends** (EN canonical + RU
mirror), replacing the stub in both books. The chapter follows
`_template.md` and covers, with verifiable recipes:

- **Choosing a recognition head** — `rnnt` vs `e2e_rnnt` vs `ml_ctc` /
  `ml_ctc_large`: a head → size → languages → output → accuracy (link, not
  duplicated numbers) → when-to-pick table, plus the auto-detection rules from
  `crates/gigastt-core/src/model/mod.rs`.
- **INT8 or FP32** — what downloads by default, `download --prequantized`,
  the pre-quantized-only Multilingual heads, manual `gigastt quantize
  [--force]`, `--skip-quantize`, and the memory/speed trade-off.
- **Execution provider per hardware** — CPU / `coreml` / `cuda` / `nnapi` /
  `ane` / `candle`: build commands, compile-time exclusivity, CPU fallback
  behavior, CUDA packaging reality (no tarball — Docker `-cuda` image or
  `Dockerfile.cuda`).
- **Model files in an offline perimeter** — `--model-dir`, moving
  `~/.gigastt/models` between machines, pinned SHA-256 + `.partial` + atomic
  rename, download exit codes, `--offline` / `GIGASTT_OFFLINE=1`, pointer to
  the release offline bundle.
- **Sizing the session pool (RAM)** — per-slot cost per head (~2× encoder
  file), the RAM auto-cap (`Capping pool size N -> M`), `--pool-min-size 1`,
  and a rule-of-thumb budget.

## Verification

- All flags, file names, log strings, exit codes, and sizes checked against
  `crates/gigastt/src/main.rs`, `crates/gigastt-core/src/model/mod.rs`,
  `crates/gigastt-core/src/inference/mod.rs`,
  `crates/gigastt/src/server/http.rs`, `docs/architecture.md`,
  `docs/ane-backend.md`, `docs/candle-backend.md`, `Dockerfile.cuda`, and
  `.github/workflows/release.yml`. WER/RTF figures are linked to
  `docs/benchmarks.md` (canonical), not duplicated.
- EN/RU heading skeletons identical (verified by diff of heading markers).
- `mdbook build docs/workbook/en` and `mdbook build docs/workbook/ru` — both
  green.
- `typos` on both chapter files — clean.
- Book→repo links are absolute GitHub URLs (incl. section anchors into
  `docs/benchmarks.md`); intra-book links are relative. Commands, code, JSON,
  and log lines are untranslated in the RU mirror.

## Scope

Only `docs/workbook/en/src/07-models-and-backends.md` and
`docs/workbook/ru/src/07-models-and-backends.md` are touched; `SUMMARY.md`
files already listed the chapter and are unchanged.
