### PR TITLE
chore: release 2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.1] - 2026-07-24
+
+### Fixed
+
+- **Streaming endpointing is now fully controlled by `--vad-min-silence-ms`
+  when the VAD is enabled.** Previously the decoder's hardcoded blank-run
+  heuristic (~600 ms of trailing silence) finalized the current segment even
+  with `--vad` active, so raising `--vad-min-silence-ms` could only cut
+  phrases *earlier*, never later — a natural pause between words split
+  utterances mid-phrase on WebSocket streams. With a VAD attached the
+  blank-run heuristic is now ignored and VAD-detected trailing silence owns
+  endpointing (the ~2.5 s window cap remains as a backstop); without a VAD
+  behavior is unchanged. File transcription, SSE, and the jobs API are
+  unaffected. Reported via the Irene Voice Assistant integration.
+
+### Added
+
+- **Top-level CLI help now points to the subcommand engine flags.**
+  `gigastt --help` shows a note that `--model-variant`, `--punctuation`,
+  `--itn`, `--vad`, and the other engine / post-processing options are
+  defined on the subcommands — see `gigastt serve --help` or
+  `gigastt transcribe --help` — instead of leaving users to conclude the
+  flags don't exist (#202).
+
 ## [2.14.0] - 2026-07-22
 
 ### Added
@@ -1875,7 +1899,11 @@ _Release candidate for v0.9.0 — bundles five P0 fixes plus two supporting item
 - Multi-format audio support: WAV, MP3, M4A/AAC, OGG/Vorbis, FLAC (via symphonia).
 - 39 unit tests (tokenizer, features, decode, inference, protocol).
 
-[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.3...HEAD
+[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.1...HEAD
+[2.14.1]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.0...v2.14.1
+[2.14.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.13.0...v2.14.0
+[2.13.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.12.0...v2.13.0
+[2.12.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.3...v2.12.0
 [2.11.3]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.2...v2.11.3
 [2.11.2]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.1...v2.11.2
 [2.11.1]: https://github.com/ekhodzitsky/gigastt/compare/v2.11.0...v2.11.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "anyhow",
  "audio-codec",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.14.0"
+version = "2.14.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
Version bump 2.14.0 -> 2.14.1 and the changelog section:

- **Fixed:** streaming endpointing is now fully controlled by `--vad-min-silence-ms` when the VAD is enabled — the hardcoded ~600 ms decoder blank-run heuristic no longer finalizes segments first (#203, reported via the Irene Voice Assistant integration).
- **Added:** top-level `gigastt --help` points to the subcommand engine flags (#202).
- Changelog footer: backfilled the missing 2.12.0–2.14.0 compare links.

After merge: tag `v2.14.1` to trigger the release pipeline (multi-arch builds, crates.io, SBOM/provenance, Homebrew tap).