### PR TITLE
ci(codecov): stop badge dip to unit-only ~75% via flags + carryforward

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,6 +456,11 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           files: ./cobertura-unit.xml
+          # Flag must match codecov.yml `flags.unit` so e2e can carryforward
+          # across commits and the badge does not dip to unit-only (~75%) while
+          # Coverage (E2E) is still running on main.
+          flags: unit
+          name: unit
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -809,6 +814,11 @@ jobs:
           cargo llvm-cov --no-report -p gigastt --test e2e_errors    -- --ignored --test-threads=1
           cargo llvm-cov --no-report -p gigastt --test e2e_shutdown  -- --ignored --test-threads=1
           cargo llvm-cov --no-report -p gigastt --test e2e_rate_limit -- --ignored --test-threads=1
+          # jobs + admin reload were missing from coverage-e2e while present as
+          # dedicated targets — they close large miss blocks in server/jobs.rs
+          # and the loopback reload path in server/mod.rs + http.rs.
+          cargo llvm-cov --no-report -p gigastt --test e2e_jobs         -- --ignored --test-threads=1
+          cargo llvm-cov --no-report -p gigastt --test e2e_admin_reload -- --ignored --test-threads=1
           # CLI subprocess + REST/SSE handler coverage. e2e_cli has non-ignored
           # tests too, so use --include-ignored to run the whole target.
           cargo llvm-cov --no-report -p gigastt --test e2e_cli       -- --include-ignored --test-threads=1
@@ -821,6 +831,9 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           files: ./cobertura-e2e.xml
+          # Flag must match codecov.yml `flags.e2e` (carryforward: true).
+          flags: e2e
+          name: e2e
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,15 @@
 #   * e2e  — model-gated lib/bin + integration + CLI subprocess coverage
 #            (main-push only; needs the ~850 MB model)
 #
-# Measured line coverage of the merged report is ~94% and function coverage
-# ~95.5%. The remaining uncovered lines are dominated by fault-injection-only
-# paths (ONNX-runtime internal failures, network model-download errors, forced
-# panics / inference timeouts, OS-signal handlers) and defensive guards that are
+# Both uploads MUST pass `flags: unit` / `flags: e2e` in codecov-action so
+# carryforward works. Without flags, a fresh main commit shows unit-only
+# coverage (~75%) until Coverage (E2E) finishes (~20+ min later), and the
+# badge dips even though real merged coverage is unchanged.
+#
+# Merged line coverage of production paths is ~90–91%. The remaining
+# uncovered lines are dominated by fault-injection-only paths (ONNX-runtime
+# internal failures, network model-download errors, forced panics /
+# inference timeouts, OS-signal handlers) and defensive guards that are
 # unreachable in normal operation — deliberately left untested rather than
 # covered with brittle mocks.
 
@@ -47,3 +52,9 @@ comment:
 ignore:
   - "**/tests/**"
   - "crates/gigastt-core/src/onnx_proto.rs" # prost-generated ONNX protobuf types
+  # Native addons / bindgen stubs are exercised outside cargo llvm-cov
+  # (npm vitest for node; uniffi-bindgen is a thin CLI wrapper). Counting
+  # them in the Rust report permanently dilutes the badge without adding
+  # signal about server/core quality.
+  - "crates/gigastt-node/**"
+  - "crates/gigastt-uniffi/src/bin/**"


### PR DESCRIPTION
## Summary
- Pass `flags: unit` / `flags: e2e` on both codecov-action uploads so `codecov.yml` carryforward works — the badge no longer drops to unit-only (~75%) while Coverage (E2E) is still running on main.
- Run `e2e_jobs` and `e2e_admin_reload` under `coverage-e2e` (they were missing from the coverage job while existing as dedicated targets).
- Ignore `crates/gigastt-node/**` and the uniffi-bindgen stub from the Rust report (exercised outside cargo llvm-cov).

## Context
Latest main showed **75.04% / sessions=1** right after the unit Coverage job; previous commits were **~90.6% / sessions=2**. The dip was unit-only upload without e2e merge or carryforward (flags were defined in `codecov.yml` but never set on the action).

## Test plan
- [ ] PR CI: unit Coverage job green; codecov upload includes flag `unit`
- [ ] After merge to main: Coverage (E2E) uploads with flag `e2e`
- [ ] Badge stays ~90%+ on a subsequent main push (unit-only intermediate report no longer collapses the project total)
- [ ] Codecov flags API shows `unit` and `e2e` (no longer count: 0)