### PR TITLE
feat: per-request hotword biasing on REST /v1/transcribe

### DIFF
--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -954,10 +954,12 @@ impl Engine {
     }
 
     /// Reject a [`TranscribeOverrides`] that turns a knob on without the backing
-    /// resource loaded. Call this *before* checking out a session so the request
-    /// fails fast (the REST layer maps the error to a `409`). Turning a knob off
-    /// (`Some(false)`) and ITN in either direction are always valid — ITN is pure
-    /// code with no model to load.
+    /// resource loaded, or that exceeds per-request hotword DoS limits. Call this
+    /// *before* checking out a session so the request fails fast (the REST layer
+    /// maps resource conflicts to `409` and limit violations to `400`). Turning a
+    /// knob off (`Some(false)`) and ITN in either direction are always valid —
+    /// ITN is pure code with no model to load. Hotwords need no model attachment
+    /// either: the biaser is built from the engine tokenizer at request time.
     ///
     /// # Errors
     ///
@@ -965,6 +967,10 @@ impl Engine {
     ///   attached.
     /// - [`OverrideError::PunctuationNotAvailable`] when `punctuation = Some(true)`
     ///   but no punctuator is attached.
+    /// - [`OverrideError::TooManyHotwords`] when more than
+    ///   [`MAX_HOTWORDS_PER_REQUEST`] phrases are supplied.
+    /// - [`OverrideError::HotwordPhraseTooLong`] when any phrase exceeds
+    ///   [`MAX_HOTWORD_PHRASE_CHARS`] Unicode scalar values.
     pub fn validate_overrides(&self, o: &TranscribeOverrides) -> Result<(), OverrideError> {
         if o.vad == Some(true) && self.vad.is_none() {
             return Err(OverrideError::VadNotLoaded);
@@ -972,7 +978,30 @@ impl Engine {
         if o.punctuation == Some(true) && self.punctuator.is_none() {
             return Err(OverrideError::PunctuationNotAvailable);
         }
+        if let Some(hw) = &o.hotwords {
+            if hw.phrases.len() > MAX_HOTWORDS_PER_REQUEST {
+                return Err(OverrideError::TooManyHotwords);
+            }
+            for phrase in &hw.phrases {
+                if phrase.chars().count() > MAX_HOTWORD_PHRASE_CHARS {
+                    return Err(OverrideError::HotwordPhraseTooLong);
+                }
+            }
+        }
         Ok(())
+    }
+
+    /// Build a temporary per-request [`bias::Biaser`] from a
+    /// [`HotwordOverride`]. Empty phrases force biasing off (`None`).
+    /// Unrepresentable phrases are dropped by [`Biaser::from_phrases`]; if none
+    /// survive, returns `None` (decode continues without biasing).
+    fn build_request_biaser(&self, hw: &HotwordOverride) -> Option<bias::Biaser> {
+        if hw.phrases.is_empty() {
+            return None;
+        }
+        let boost = hw.boost.unwrap_or(DEFAULT_HOTWORDS_BOOST);
+        let pairs: Vec<(String, f32)> = hw.phrases.iter().cloned().map(|p| (p, 1.0)).collect();
+        bias::Biaser::from_phrases(&self.tokenizer, &pairs, boost)
     }
 
     /// Enable or disable inverse text normalization (Russian number-words →
@@ -1854,12 +1883,15 @@ impl Engine {
         // The window overlaps the previous one, so persisting the LSTM state
         // would double-condition the prediction network — decode fresh.
         let mut decoder_state = DecoderState::new(self.tokenizer.blank_id());
+        // Streaming always uses the engine boot biaser (per-request hotwords
+        // apply to file-transcription paths that carry TranscribeOverrides).
         let (all_words, endpoint) = self.run_inference(
             triplet,
             &state.mel_output[..],
             num_frames,
             &mut decoder_state,
             frame_offset,
+            self.biaser.as_ref(),
         )?;
 
         // Suppress words inside the already-emitted left context so a slid
@@ -2194,21 +2226,32 @@ impl Engine {
     /// inputs so encoder activation memory stays O(chunk), not O(file). Both
     /// paths produce the same `Vec<WordInfo>` shape. This is the no-VAD path and
     /// the per-region decode used by [`Engine::decode_speech_regions`].
+    ///
+    /// `biaser` is the effective hotword biaser for this call (engine boot
+    /// biaser, a temporary per-request biaser, or `None` when forced off).
     fn decode_words(
         &self,
         samples: &[f32],
         triplet: &mut SessionTriplet,
+        biaser: Option<&bias::Biaser>,
     ) -> Result<Vec<WordInfo>, GigasttError> {
         if samples.len() <= CHUNK_THRESHOLD_SAMPLES {
             let (features, num_frames) = self.features.compute(samples);
             tracing::info!("Extracted {} mel frames", num_frames);
             let mut decoder_state = DecoderState::new(self.tokenizer.blank_id());
             Ok(self
-                .run_inference(triplet, &features, num_frames, &mut decoder_state, 0)
+                .run_inference(
+                    triplet,
+                    &features,
+                    num_frames,
+                    &mut decoder_state,
+                    0,
+                    biaser,
+                )
                 .map_err(|e| GigasttError::Inference { source: e.into() })?
                 .0)
         } else {
-            self.transcribe_samples_chunked(samples, triplet)
+            self.transcribe_samples_chunked(samples, triplet, biaser)
         }
     }
 
@@ -2222,6 +2265,7 @@ impl Engine {
         float_samples: &[f32],
         regions: &[(usize, usize)],
         triplet: &mut SessionTriplet,
+        biaser: Option<&bias::Biaser>,
     ) -> Result<Vec<WordInfo>, GigasttError> {
         if regions.is_empty() {
             tracing::info!("VAD found no speech; skipping decode");
@@ -2238,7 +2282,7 @@ impl Engine {
             float_samples.len(),
             regions.len()
         );
-        let mut words = self.decode_words(&speech, triplet)?;
+        let mut words = self.decode_words(&speech, triplet, biaser)?;
         for w in &mut words {
             w.start = crate::vad::remap_compressed_seconds(w.start, regions, 16000.0);
             w.end = crate::vad::remap_compressed_seconds(w.end, regions, 16000.0);
@@ -2259,6 +2303,7 @@ impl Engine {
         &self,
         float_samples: &[f32],
         triplet: &mut SessionTriplet,
+        biaser: Option<&bias::Biaser>,
     ) -> Result<Vec<WordInfo>, GigasttError> {
         let total = float_samples.len();
         let stride = CHUNK_WINDOW_SAMPLES - CHUNK_OVERLAP_SAMPLES;
@@ -2288,6 +2333,7 @@ impl Engine {
                     num_frames,
                     &mut decoder_state,
                     frame_offset,
+                    biaser,
                 )
                 .map_err(|e| GigasttError::Inference { source: e.into() })?;
 
@@ -2312,22 +2358,39 @@ impl Engine {
     /// iff a VAD is attached). `vad = Some(true)` on a VAD-less engine can't
     /// reach here — callers should validate overrides first — but the
     /// `self.vad.is_some()` guard keeps this correct regardless.
+    ///
+    /// Hotword selection:
+    /// - `overrides.hotwords = None` → engine boot biaser
+    /// - `Some(empty)` → force biasing off
+    /// - `Some(phrases)` → temporary biaser built for this request only
     fn decode_words_for_samples(
         &self,
         float_samples: &[f32],
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
     ) -> Result<Vec<WordInfo>, GigasttError> {
+        // Build a temporary biaser only when the request supplies hotwords.
+        // Owned here so the `Option<&Biaser>` passed into decode stays valid
+        // for the whole call without cloning the engine's boot biaser.
+        let request_biaser = match &overrides.hotwords {
+            Some(hw) => self.build_request_biaser(hw),
+            None => None,
+        };
+        let biaser: Option<&bias::Biaser> = match &overrides.hotwords {
+            None => self.biaser.as_ref(),
+            Some(_) => request_biaser.as_ref(),
+        };
+
         let use_vad = self.vad.is_some() && overrides.vad.unwrap_or(true);
         match (use_vad, &self.vad) {
             (true, Some(vad)) => match vad.speech_regions(float_samples, &self.vad_config) {
-                Ok(regions) => self.decode_speech_regions(float_samples, &regions, triplet),
+                Ok(regions) => self.decode_speech_regions(float_samples, &regions, triplet, biaser),
                 Err(e) => {
                     tracing::warn!("VAD failed, decoding full audio: {e:#}");
-                    self.decode_words(float_samples, triplet)
+                    self.decode_words(float_samples, triplet, biaser)
                 }
             },
-            _ => self.decode_words(float_samples, triplet),
+            _ => self.decode_words(float_samples, triplet, biaser),
         }
     }
 
@@ -2385,6 +2448,7 @@ impl Engine {
         num_frames: usize,
         decoder_state: &mut DecoderState,
         frame_offset: usize,
+        biaser: Option<&bias::Biaser>,
     ) -> anyhow::Result<(Vec<WordInfo>, bool)> {
         // Reuse the encoder input tensors: resize the signal tensor to the
         // current frame count and overwrite both buffers in place.
@@ -2450,7 +2514,7 @@ impl Engine {
             enc_len,
             self.tokenizer.blank_id(),
             decoder_state,
-            self.biaser.as_ref(),
+            biaser,
         )?;
         tracing::info!(
             elapsed_ms = dec_start.elapsed().as_millis() as u64,
@@ -2611,19 +2675,48 @@ pub struct TranscribeResult {
     pub confidence: Option<f32>,
 }
 
+/// Maximum number of hotword phrases accepted on a single request. Larger
+/// payloads are rejected by [`Engine::validate_overrides`] (mapped to HTTP 400).
+pub const MAX_HOTWORDS_PER_REQUEST: usize = 64;
+
+/// Maximum length of a single hotword phrase in Unicode scalar values (chars).
+/// Longer phrases are rejected by [`Engine::validate_overrides`] (HTTP 400).
+pub const MAX_HOTWORD_PHRASE_CHARS: usize = 64;
+
+/// Default additive logit boost when a per-request hotword override omits
+/// `boost` (matches the CLI `--hotwords-boost` default).
+pub const DEFAULT_HOTWORDS_BOOST: f32 = 5.0;
+
+/// Per-request hotword biasing override. Replaces the engine's boot-time
+/// biaser for a single file-transcription call.
+///
+/// Semantics when wrapped in [`TranscribeOverrides::hotwords`]:
+/// - `None` (field absent) → keep the engine boot biaser unchanged.
+/// - `Some(empty phrases)` → force biasing **off** for this request.
+/// - `Some(non-empty phrases)` → build a temporary [`bias::Biaser`] for this
+///   request only (engine boot biaser is not consulted).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct HotwordOverride {
+    /// Phrases to boost. Empty means force biasing off for the request.
+    pub phrases: Vec<String>,
+    /// Additive logit boost. `None` uses [`DEFAULT_HOTWORDS_BOOST`].
+    pub boost: Option<f32>,
+}
+
 /// Per-request overrides for the recognition post-processing knobs, letting a
-/// single loaded engine vary punctuation / ITN / VAD per file-transcription
-/// call instead of only at boot. `None` on a field means "use the engine's
-/// boot default", so a `TranscribeOverrides::default()` (all `None`) reproduces
-/// the pre-feature behaviour byte-for-byte.
+/// single loaded engine vary punctuation / ITN / VAD / hotwords per
+/// file-transcription call instead of only at boot. `None` on a field means
+/// "use the engine's boot default", so a `TranscribeOverrides::default()` (all
+/// `None`) reproduces the pre-feature behaviour byte-for-byte.
 ///
 /// A knob can only be turned *on* per-request if the underlying resource is
 /// loaded: `vad = Some(true)` requires a VAD to be attached, and
-/// `punctuation = Some(true)` requires a punctuator. Call
-/// [`Engine::validate_overrides`] before transcribing to reject impossible
-/// requests (mapped to `409` on the REST surface); turning a knob *off*
-/// (`Some(false)`) is always valid.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// `punctuation = Some(true)` requires a punctuator. Hotwords need no attached
+/// model (the biaser is built from the engine tokenizer) but are subject to
+/// DoS limits. Call [`Engine::validate_overrides`] before transcribing to reject
+/// impossible or oversized requests; turning a knob *off* (`Some(false)`) is
+/// always valid.
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct TranscribeOverrides {
     /// Override the punctuation / casing restoration pass. `Some(true)` forces
     /// it on (requires a punctuator), `Some(false)` skips it, `None` = engine
@@ -2637,30 +2730,41 @@ pub struct TranscribeOverrides {
     /// (requires a VAD to be attached), `Some(false)` decodes the whole buffer,
     /// `None` = engine default (VAD path iff a VAD is attached).
     pub vad: Option<bool>,
+    /// Per-request hotword biasing. `None` keeps the engine boot biaser;
+    /// `Some(empty)` forces biasing off; `Some(non-empty)` replaces the biaser
+    /// for this request only. Validated against
+    /// [`MAX_HOTWORDS_PER_REQUEST`] / [`MAX_HOTWORD_PHRASE_CHARS`].
+    pub hotwords: Option<HotwordOverride>,
 }
 
 /// Why a [`TranscribeOverrides`] was rejected: a knob was turned on per-request
-/// but the resource backing it isn't loaded. Carries a stable machine-readable
-/// [`code`](OverrideError::code) so the REST layer can surface a `409` with a
-/// consistent contract without re-deriving the string.
+/// without its resource loaded, or a DoS limit was exceeded. Carries a stable
+/// machine-readable [`code`](OverrideError::code) so the REST layer can surface
+/// a `409` (resource) or `400` (limits) with a consistent contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OverrideError {
     /// `vad = Some(true)` but no VAD is attached to the engine.
     VadNotLoaded,
     /// `punctuation = Some(true)` but no punctuator is attached to the engine.
     PunctuationNotAvailable,
+    /// More than [`MAX_HOTWORDS_PER_REQUEST`] phrases in the hotword override.
+    TooManyHotwords,
+    /// A hotword phrase exceeds [`MAX_HOTWORD_PHRASE_CHARS`] characters.
+    HotwordPhraseTooLong,
 }
 
 impl OverrideError {
-    /// Stable, machine-readable error code for the REST `409` payload.
+    /// Stable, machine-readable error code for the REST error payload.
     pub fn code(self) -> &'static str {
         match self {
             OverrideError::VadNotLoaded => "vad_not_loaded",
             OverrideError::PunctuationNotAvailable => "punctuation_not_available",
+            OverrideError::TooManyHotwords => "too_many_hotwords",
+            OverrideError::HotwordPhraseTooLong => "hotword_phrase_too_long",
         }
     }
 
-    /// Human-readable, non-sensitive message for the REST `409` payload.
+    /// Human-readable, non-sensitive message for the REST error payload.
     pub fn message(self) -> &'static str {
         match self {
             OverrideError::VadNotLoaded => {
@@ -2669,7 +2773,21 @@ impl OverrideError {
             OverrideError::PunctuationNotAvailable => {
                 "punctuation requested but no punctuation model is loaded"
             }
+            OverrideError::TooManyHotwords => "too many hotwords in request (max 64)",
+            OverrideError::HotwordPhraseTooLong => {
+                "hotword phrase exceeds max length (64 characters)"
+            }
         }
+    }
+
+    /// Whether this error is a client input problem (HTTP 400) rather than a
+    /// resource conflict (HTTP 409). Limit violations are 400; missing models
+    /// are 409.
+    pub fn is_bad_request(self) -> bool {
+        matches!(
+            self,
+            OverrideError::TooManyHotwords | OverrideError::HotwordPhraseTooLong
+        )
     }
 }
 
@@ -2764,24 +2882,45 @@ mod tests {
         assert_eq!(o.punctuation, None);
         assert_eq!(o.itn, None);
         assert_eq!(o.vad, None);
+        assert_eq!(o.hotwords, None);
+    }
+
+    #[test]
+    fn test_hotword_override_limits_constants() {
+        // Documented DoS caps used by validate_overrides and the REST 400 path.
+        assert_eq!(MAX_HOTWORDS_PER_REQUEST, 64);
+        assert_eq!(MAX_HOTWORD_PHRASE_CHARS, 64);
+        assert_eq!(DEFAULT_HOTWORDS_BOOST, 5.0);
     }
 
     #[test]
     fn test_override_error_codes_stable() {
-        // Stable machine-readable codes surfaced as the REST 409 `code`.
+        // Stable machine-readable codes surfaced as the REST error `code`.
         assert_eq!(OverrideError::VadNotLoaded.code(), "vad_not_loaded");
         assert_eq!(
             OverrideError::PunctuationNotAvailable.code(),
             "punctuation_not_available"
         );
+        assert_eq!(OverrideError::TooManyHotwords.code(), "too_many_hotwords");
+        assert_eq!(
+            OverrideError::HotwordPhraseTooLong.code(),
+            "hotword_phrase_too_long"
+        );
         // Messages are non-empty and don't leak internals.
         assert!(!OverrideError::VadNotLoaded.message().is_empty());
         assert!(!OverrideError::PunctuationNotAvailable.message().is_empty());
+        assert!(!OverrideError::TooManyHotwords.message().is_empty());
+        assert!(!OverrideError::HotwordPhraseTooLong.message().is_empty());
         // Display matches message().
         assert_eq!(
             OverrideError::VadNotLoaded.to_string(),
             OverrideError::VadNotLoaded.message()
         );
+        // Limit violations are client errors (400); missing models are 409.
+        assert!(!OverrideError::VadNotLoaded.is_bad_request());
+        assert!(!OverrideError::PunctuationNotAvailable.is_bad_request());
+        assert!(OverrideError::TooManyHotwords.is_bad_request());
+        assert!(OverrideError::HotwordPhraseTooLong.is_bad_request());
     }
 
     #[test]
@@ -5022,7 +5161,10 @@ mod tests {
 
         #[test]
         fn test_validate_overrides_truth_table() {
-            use crate::inference::{OverrideError, TranscribeOverrides};
+            use crate::inference::{
+                HotwordOverride, MAX_HOTWORD_PHRASE_CHARS, MAX_HOTWORDS_PER_REQUEST, OverrideError,
+                TranscribeOverrides,
+            };
 
             // The tiny mock engine loads with no VAD and no punctuator attached,
             // so any knob turned *on* per-request must be rejected, and any knob
@@ -5086,6 +5228,141 @@ mod tests {
                 }),
                 Ok(())
             );
+
+            // Hotwords need no attached model: empty force-off and a few phrases
+            // under the DoS caps are always accepted.
+            assert_eq!(
+                engine.validate_overrides(&TranscribeOverrides {
+                    hotwords: Some(HotwordOverride {
+                        phrases: vec![],
+                        boost: None,
+                    }),
+                    ..Default::default()
+                }),
+                Ok(())
+            );
+            assert_eq!(
+                engine.validate_overrides(&TranscribeOverrides {
+                    hotwords: Some(HotwordOverride {
+                        phrases: vec!["сбер".into(), "тинькофф".into()],
+                        boost: Some(3.0),
+                    }),
+                    ..Default::default()
+                }),
+                Ok(())
+            );
+
+            // Exactly at the cap is OK; one over is rejected.
+            let at_cap: Vec<String> = (0..MAX_HOTWORDS_PER_REQUEST)
+                .map(|i| format!("w{i}"))
+                .collect();
+            assert_eq!(
+                engine.validate_overrides(&TranscribeOverrides {
+                    hotwords: Some(HotwordOverride {
+                        phrases: at_cap,
+                        boost: None,
+                    }),
+                    ..Default::default()
+                }),
+                Ok(())
+            );
+            let over_cap: Vec<String> = (0..=MAX_HOTWORDS_PER_REQUEST)
+                .map(|i| format!("w{i}"))
+                .collect();
+            assert_eq!(
+                engine.validate_overrides(&TranscribeOverrides {
+                    hotwords: Some(HotwordOverride {
+                        phrases: over_cap,
+                        boost: None,
+                    }),
+                    ..Default::default()
+                }),
+                Err(OverrideError::TooManyHotwords)
+            );
+
+            // Phrase length: exactly 64 chars OK; 65 rejected.
+            let ok_phrase: String = "а".repeat(MAX_HOTWORD_PHRASE_CHARS);
+            assert_eq!(
+                engine.validate_overrides(&TranscribeOverrides {
+                    hotwords: Some(HotwordOverride {
+                        phrases: vec![ok_phrase],
+                        boost: None,
+                    }),
+                    ..Default::default()
+                }),
+                Ok(())
+            );
+            let long_phrase: String = "а".repeat(MAX_HOTWORD_PHRASE_CHARS + 1);
+            assert_eq!(
+                engine.validate_overrides(&TranscribeOverrides {
+                    hotwords: Some(HotwordOverride {
+                        phrases: vec![long_phrase],
+                        boost: None,
+                    }),
+                    ..Default::default()
+                }),
+                Err(OverrideError::HotwordPhraseTooLong)
+            );
+        }
+
+        #[test]
+        fn test_request_hotword_biaser_semantics() {
+            use crate::inference::{HotwordOverride, TranscribeOverrides};
+
+            // Pin the three-way hotword override contract without requiring a
+            // real speech utterance:
+            // - None → use engine boot biaser (build_request_biaser not used)
+            // - Some(empty) → force off (build_request_biaser returns None)
+            // - Some(phrases) → temporary Biaser when representable
+            let (engine, _tmp) = tiny_mock_engine();
+            // Mock vocab is "▁hi" + blank; "hi" encodes, unknown Cyrillic does not.
+            let engine = engine.with_hotwords(&[("hi".into(), 1.0)], 5.0);
+            assert!(engine.has_hotwords(), "boot biaser attached");
+
+            // Force-off: empty phrase list yields no temporary biaser.
+            let off = HotwordOverride {
+                phrases: vec![],
+                boost: None,
+            };
+            assert!(
+                engine.build_request_biaser(&off).is_none(),
+                "empty override forces biasing off"
+            );
+
+            // Representable phrase builds a temporary biaser.
+            let on = HotwordOverride {
+                phrases: vec!["hi".into()],
+                boost: Some(7.0),
+            };
+            let built = engine
+                .build_request_biaser(&on)
+                .expect("representable phrase should compile");
+            assert_eq!(built.phrase_count(), 1);
+
+            // Default boost path (None) still builds when phrases are present.
+            let default_boost = HotwordOverride {
+                phrases: vec!["hi".into()],
+                boost: None,
+            };
+            assert!(engine.build_request_biaser(&default_boost).is_some());
+
+            // Unrepresentable-only phrases → None (decode continues without bias).
+            let junk = HotwordOverride {
+                phrases: vec!["ъъъ".into()],
+                boost: None,
+            };
+            assert!(
+                engine.build_request_biaser(&junk).is_none(),
+                "unrepresentable phrases drop the temporary biaser"
+            );
+
+            // hotwords=None is always valid and leaves the boot biaser in place
+            // (has_hotwords stays true; decode path selects self.biaser).
+            assert_eq!(
+                engine.validate_overrides(&TranscribeOverrides::default()),
+                Ok(())
+            );
+            assert!(engine.has_hotwords());
         }
 
         #[test]

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -954,12 +954,13 @@ impl Engine {
     }
 
     /// Reject a [`TranscribeOverrides`] that turns a knob on without the backing
-    /// resource loaded, or that exceeds per-request hotword DoS limits. Call this
-    /// *before* checking out a session so the request fails fast (the REST layer
-    /// maps resource conflicts to `409` and limit violations to `400`). Turning a
-    /// knob off (`Some(false)`) and ITN in either direction are always valid —
-    /// ITN is pure code with no model to load. Hotwords need no model attachment
-    /// either: the biaser is built from the engine tokenizer at request time.
+    /// resource loaded. Call this *before* checking out a session so the request
+    /// fails fast (the REST layer maps the error to a `409`). Turning a knob off
+    /// (`Some(false)`) and ITN in either direction are always valid — ITN is pure
+    /// code with no model to load.
+    ///
+    /// Hotword DoS limits are validated separately via
+    /// [`Engine::validate_hotwords`] so [`TranscribeOverrides`] stays `Copy` (semver).
     ///
     /// # Errors
     ///
@@ -967,10 +968,6 @@ impl Engine {
     ///   attached.
     /// - [`OverrideError::PunctuationNotAvailable`] when `punctuation = Some(true)`
     ///   but no punctuator is attached.
-    /// - [`OverrideError::TooManyHotwords`] when more than
-    ///   [`MAX_HOTWORDS_PER_REQUEST`] phrases are supplied.
-    /// - [`OverrideError::HotwordPhraseTooLong`] when any phrase exceeds
-    ///   [`MAX_HOTWORD_PHRASE_CHARS`] Unicode scalar values.
     pub fn validate_overrides(&self, o: &TranscribeOverrides) -> Result<(), OverrideError> {
         if o.vad == Some(true) && self.vad.is_none() {
             return Err(OverrideError::VadNotLoaded);
@@ -978,14 +975,25 @@ impl Engine {
         if o.punctuation == Some(true) && self.punctuator.is_none() {
             return Err(OverrideError::PunctuationNotAvailable);
         }
-        if let Some(hw) = &o.hotwords {
-            if hw.phrases.len() > MAX_HOTWORDS_PER_REQUEST {
-                return Err(OverrideError::TooManyHotwords);
-            }
-            for phrase in &hw.phrases {
-                if phrase.chars().count() > MAX_HOTWORD_PHRASE_CHARS {
-                    return Err(OverrideError::HotwordPhraseTooLong);
-                }
+        Ok(())
+    }
+
+    /// Reject a [`HotwordOverride`] that exceeds DoS limits. Call before checkout
+    /// so oversized requests fail fast (REST maps to HTTP 400).
+    ///
+    /// # Errors
+    ///
+    /// - [`HotwordError::TooManyHotwords`] when more than
+    ///   [`MAX_HOTWORDS_PER_REQUEST`] phrases are supplied.
+    /// - [`HotwordError::PhraseTooLong`] when any phrase exceeds
+    ///   [`MAX_HOTWORD_PHRASE_CHARS`] Unicode scalar values.
+    pub fn validate_hotwords(&self, hw: &HotwordOverride) -> Result<(), HotwordError> {
+        if hw.phrases.len() > MAX_HOTWORDS_PER_REQUEST {
+            return Err(HotwordError::TooManyHotwords);
+        }
+        for phrase in &hw.phrases {
+            if phrase.chars().count() > MAX_HOTWORD_PHRASE_CHARS {
+                return Err(HotwordError::PhraseTooLong);
             }
         }
         Ok(())
@@ -2002,11 +2010,25 @@ impl Engine {
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
     ) -> Result<TranscribeResult, GigasttError> {
+        self.transcribe_file_with_overrides_hotwords(path, triplet, overrides, None)
+    }
+
+    /// Like [`Engine::transcribe_file_with_overrides`] with optional per-request
+    /// [`HotwordOverride`] (semver-additive sibling so the no-hotwords signature
+    /// stays byte-stable).
+    #[cfg(feature = "file-decode")]
+    pub fn transcribe_file_with_overrides_hotwords(
+        &self,
+        path: &str,
+        triplet: &mut SessionTriplet,
+        overrides: &TranscribeOverrides,
+        hotwords: Option<&HotwordOverride>,
+    ) -> Result<TranscribeResult, GigasttError> {
         let float_samples =
             audio::decode_audio_file(path).map_err(|e| GigasttError::InvalidAudio {
                 reason: format!("{e:#}"),
             })?;
-        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides, false)
+        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides, hotwords, false)
     }
 
     /// Transcribe audio from raw bytes in memory (no temp file needed).
@@ -2053,11 +2075,24 @@ impl Engine {
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
     ) -> Result<TranscribeResult, GigasttError> {
+        self.transcribe_bytes_shared_with_overrides_hotwords(data, triplet, overrides, None)
+    }
+
+    /// Like [`Engine::transcribe_bytes_shared_with_overrides`] with optional
+    /// per-request [`HotwordOverride`].
+    #[cfg(feature = "file-decode")]
+    pub fn transcribe_bytes_shared_with_overrides_hotwords(
+        &self,
+        data: bytes::Bytes,
+        triplet: &mut SessionTriplet,
+        overrides: &TranscribeOverrides,
+        hotwords: Option<&HotwordOverride>,
+    ) -> Result<TranscribeResult, GigasttError> {
         let float_samples =
             audio::decode_audio_bytes_shared(data).map_err(|e| GigasttError::InvalidAudio {
                 reason: format!("{e:#}"),
             })?;
-        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides, false)
+        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides, hotwords, false)
     }
 
     /// Like [`Engine::transcribe_bytes_shared_with_overrides`], but also runs
@@ -2074,11 +2109,26 @@ impl Engine {
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
     ) -> Result<TranscribeResult, GigasttError> {
+        self.transcribe_bytes_shared_with_overrides_diarized_hotwords(
+            data, triplet, overrides, None,
+        )
+    }
+
+    /// Like [`Engine::transcribe_bytes_shared_with_overrides_diarized`] with
+    /// optional per-request [`HotwordOverride`].
+    #[cfg(feature = "file-decode")]
+    pub fn transcribe_bytes_shared_with_overrides_diarized_hotwords(
+        &self,
+        data: bytes::Bytes,
+        triplet: &mut SessionTriplet,
+        overrides: &TranscribeOverrides,
+        hotwords: Option<&HotwordOverride>,
+    ) -> Result<TranscribeResult, GigasttError> {
         let float_samples =
             audio::decode_audio_bytes_shared(data).map_err(|e| GigasttError::InvalidAudio {
                 reason: format!("{e:#}"),
             })?;
-        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides, true)
+        self.transcribe_samples_with_overrides(&float_samples, triplet, overrides, hotwords, true)
     }
 
     /// Transcribe a multi-channel recording with one speaker label per channel.
@@ -2109,7 +2159,8 @@ impl Engine {
         let mut per_channel = Vec::with_capacity(channels.len());
         let overrides = TranscribeOverrides::default();
         for channel_samples in channels {
-            let words = self.decode_words_for_samples(channel_samples, triplet, &overrides)?;
+            let words =
+                self.decode_words_for_samples(channel_samples, triplet, &overrides, None)?;
             let duration_s = channel_samples.len() as f64 / 16000.0;
             per_channel.push(TranscribeResult {
                 confidence: aggregate_confidence(&words),
@@ -2135,6 +2186,7 @@ impl Engine {
             float_samples,
             triplet,
             &TranscribeOverrides::default(),
+            None,
             false,
         )
     }
@@ -2151,6 +2203,7 @@ impl Engine {
         float_samples: &[f32],
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
+        hotwords: Option<&HotwordOverride>,
         diarize: bool,
     ) -> Result<TranscribeResult, GigasttError> {
         // `diarize` is opt-in per request: offline speaker diarization only runs
@@ -2163,7 +2216,8 @@ impl Engine {
         let duration_s = float_samples.len() as f64 / 16000.0;
 
         #[cfg_attr(not(feature = "diarization"), allow(unused_mut))]
-        let mut words = self.decode_words_for_samples(float_samples, triplet, overrides)?;
+        let mut words =
+            self.decode_words_for_samples(float_samples, triplet, overrides, hotwords)?;
 
         #[cfg(feature = "diarization")]
         if diarize && let Some(ref enc) = self.speaker_encoder {
@@ -2359,8 +2413,8 @@ impl Engine {
     /// reach here — callers should validate overrides first — but the
     /// `self.vad.is_some()` guard keeps this correct regardless.
     ///
-    /// Hotword selection:
-    /// - `overrides.hotwords = None` → engine boot biaser
+    /// Hotword selection via `hotwords`:
+    /// - `None` → engine boot biaser
     /// - `Some(empty)` → force biasing off
     /// - `Some(phrases)` → temporary biaser built for this request only
     fn decode_words_for_samples(
@@ -2368,15 +2422,16 @@ impl Engine {
         float_samples: &[f32],
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
+        hotwords: Option<&HotwordOverride>,
     ) -> Result<Vec<WordInfo>, GigasttError> {
         // Build a temporary biaser only when the request supplies hotwords.
         // Owned here so the `Option<&Biaser>` passed into decode stays valid
         // for the whole call without cloning the engine's boot biaser.
-        let request_biaser = match &overrides.hotwords {
+        let request_biaser = match hotwords {
             Some(hw) => self.build_request_biaser(hw),
             None => None,
         };
-        let biaser: Option<&bias::Biaser> = match &overrides.hotwords {
+        let biaser: Option<&bias::Biaser> = match hotwords {
             None => self.biaser.as_ref(),
             Some(_) => request_biaser.as_ref(),
         };
@@ -2676,11 +2731,11 @@ pub struct TranscribeResult {
 }
 
 /// Maximum number of hotword phrases accepted on a single request. Larger
-/// payloads are rejected by [`Engine::validate_overrides`] (mapped to HTTP 400).
+/// payloads are rejected by [`Engine::validate_hotwords`] (mapped to HTTP 400).
 pub const MAX_HOTWORDS_PER_REQUEST: usize = 64;
 
 /// Maximum length of a single hotword phrase in Unicode scalar values (chars).
-/// Longer phrases are rejected by [`Engine::validate_overrides`] (HTTP 400).
+/// Longer phrases are rejected by [`Engine::validate_hotwords`] (HTTP 400).
 pub const MAX_HOTWORD_PHRASE_CHARS: usize = 64;
 
 /// Default additive logit boost when a per-request hotword override omits
@@ -2690,12 +2745,16 @@ pub const DEFAULT_HOTWORDS_BOOST: f32 = 5.0;
 /// Per-request hotword biasing override. Replaces the engine's boot-time
 /// biaser for a single file-transcription call.
 ///
-/// Semantics when wrapped in [`TranscribeOverrides::hotwords`]:
-/// - `None` (field absent) → keep the engine boot biaser unchanged.
+/// Semantics when passed to the hotwords parameter of file-transcription APIs:
+/// - `None` (argument absent) → keep the engine boot biaser unchanged.
 /// - `Some(empty phrases)` → force biasing **off** for this request.
 /// - `Some(non-empty phrases)` → build a temporary [`bias::Biaser`] for this
 ///   request only (engine boot biaser is not consulted).
+///
+/// Kept separate from [`TranscribeOverrides`] so that type remains `Copy`/`Eq`
+/// (semver-stable for external struct literals and trait bounds).
 #[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
 pub struct HotwordOverride {
     /// Phrases to boost. Empty means force biasing off for the request.
     pub phrases: Vec<String>,
@@ -2703,20 +2762,30 @@ pub struct HotwordOverride {
     pub boost: Option<f32>,
 }
 
+impl HotwordOverride {
+    /// Construct a hotword override (preferred over struct-literal from outside
+    /// this crate because the type is `#[non_exhaustive]`).
+    pub fn new(phrases: Vec<String>, boost: Option<f32>) -> Self {
+        Self { phrases, boost }
+    }
+}
+
 /// Per-request overrides for the recognition post-processing knobs, letting a
-/// single loaded engine vary punctuation / ITN / VAD / hotwords per
-/// file-transcription call instead of only at boot. `None` on a field means
-/// "use the engine's boot default", so a `TranscribeOverrides::default()` (all
-/// `None`) reproduces the pre-feature behaviour byte-for-byte.
+/// single loaded engine vary punctuation / ITN / VAD per file-transcription
+/// call instead of only at boot. `None` on a field means "use the engine's
+/// boot default", so a `TranscribeOverrides::default()` (all `None`) reproduces
+/// the pre-feature behaviour byte-for-byte.
 ///
 /// A knob can only be turned *on* per-request if the underlying resource is
 /// loaded: `vad = Some(true)` requires a VAD to be attached, and
-/// `punctuation = Some(true)` requires a punctuator. Hotwords need no attached
-/// model (the biaser is built from the engine tokenizer) but are subject to
-/// DoS limits. Call [`Engine::validate_overrides`] before transcribing to reject
-/// impossible or oversized requests; turning a knob *off* (`Some(false)`) is
-/// always valid.
-#[derive(Debug, Clone, Default, PartialEq)]
+/// `punctuation = Some(true)` requires a punctuator. Call
+/// [`Engine::validate_overrides`] before transcribing to reject impossible
+/// requests (mapped to `409` on the REST surface); turning a knob *off*
+/// (`Some(false)`) is always valid.
+///
+/// Per-request hotwords live on [`HotwordOverride`] (validated via
+/// [`Engine::validate_hotwords`]) so this struct stays `Copy`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TranscribeOverrides {
     /// Override the punctuation / casing restoration pass. `Some(true)` forces
     /// it on (requires a punctuator), `Some(false)` skips it, `None` = engine
@@ -2730,41 +2799,30 @@ pub struct TranscribeOverrides {
     /// (requires a VAD to be attached), `Some(false)` decodes the whole buffer,
     /// `None` = engine default (VAD path iff a VAD is attached).
     pub vad: Option<bool>,
-    /// Per-request hotword biasing. `None` keeps the engine boot biaser;
-    /// `Some(empty)` forces biasing off; `Some(non-empty)` replaces the biaser
-    /// for this request only. Validated against
-    /// [`MAX_HOTWORDS_PER_REQUEST`] / [`MAX_HOTWORD_PHRASE_CHARS`].
-    pub hotwords: Option<HotwordOverride>,
 }
 
 /// Why a [`TranscribeOverrides`] was rejected: a knob was turned on per-request
-/// without its resource loaded, or a DoS limit was exceeded. Carries a stable
-/// machine-readable [`code`](OverrideError::code) so the REST layer can surface
-/// a `409` (resource) or `400` (limits) with a consistent contract.
+/// but the resource backing it isn't loaded. Carries a stable machine-readable
+/// [`code`](OverrideError::code) so the REST layer can surface a `409` with a
+/// consistent contract without re-deriving the string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OverrideError {
     /// `vad = Some(true)` but no VAD is attached to the engine.
     VadNotLoaded,
     /// `punctuation = Some(true)` but no punctuator is attached to the engine.
     PunctuationNotAvailable,
-    /// More than [`MAX_HOTWORDS_PER_REQUEST`] phrases in the hotword override.
-    TooManyHotwords,
-    /// A hotword phrase exceeds [`MAX_HOTWORD_PHRASE_CHARS`] characters.
-    HotwordPhraseTooLong,
 }
 
 impl OverrideError {
-    /// Stable, machine-readable error code for the REST error payload.
+    /// Stable, machine-readable error code for the REST `409` payload.
     pub fn code(self) -> &'static str {
         match self {
             OverrideError::VadNotLoaded => "vad_not_loaded",
             OverrideError::PunctuationNotAvailable => "punctuation_not_available",
-            OverrideError::TooManyHotwords => "too_many_hotwords",
-            OverrideError::HotwordPhraseTooLong => "hotword_phrase_too_long",
         }
     }
 
-    /// Human-readable, non-sensitive message for the REST error payload.
+    /// Human-readable, non-sensitive message for the REST `409` payload.
     pub fn message(self) -> &'static str {
         match self {
             OverrideError::VadNotLoaded => {
@@ -2773,21 +2831,36 @@ impl OverrideError {
             OverrideError::PunctuationNotAvailable => {
                 "punctuation requested but no punctuation model is loaded"
             }
-            OverrideError::TooManyHotwords => "too many hotwords in request (max 64)",
-            OverrideError::HotwordPhraseTooLong => {
-                "hotword phrase exceeds max length (64 characters)"
-            }
+        }
+    }
+}
+
+/// Why a [`HotwordOverride`] was rejected (DoS limits). New type so
+/// [`OverrideError`] stays exhaustively matchable without a major bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HotwordError {
+    /// More than [`MAX_HOTWORDS_PER_REQUEST`] phrases in the hotword override.
+    TooManyHotwords,
+    /// A hotword phrase exceeds [`MAX_HOTWORD_PHRASE_CHARS`] characters.
+    PhraseTooLong,
+}
+
+impl HotwordError {
+    /// Stable, machine-readable error code for the REST `400` payload.
+    pub fn code(self) -> &'static str {
+        match self {
+            HotwordError::TooManyHotwords => "too_many_hotwords",
+            HotwordError::PhraseTooLong => "hotword_phrase_too_long",
         }
     }
 
-    /// Whether this error is a client input problem (HTTP 400) rather than a
-    /// resource conflict (HTTP 409). Limit violations are 400; missing models
-    /// are 409.
-    pub fn is_bad_request(self) -> bool {
-        matches!(
-            self,
-            OverrideError::TooManyHotwords | OverrideError::HotwordPhraseTooLong
-        )
+    /// Human-readable, non-sensitive message for the REST `400` payload.
+    pub fn message(self) -> &'static str {
+        match self {
+            HotwordError::TooManyHotwords => "too many hotwords in request (max 64)",
+            HotwordError::PhraseTooLong => "hotword phrase exceeds max length (64 characters)",
+        }
     }
 }
 
@@ -2798,6 +2871,14 @@ impl std::fmt::Display for OverrideError {
 }
 
 impl std::error::Error for OverrideError {}
+
+impl std::fmt::Display for HotwordError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+impl std::error::Error for HotwordError {}
 
 /// Merge per-channel [`TranscribeResult`]s into a single chronologically ordered
 /// result. Each channel is assigned a zero-based speaker label (`speaker_0`,
@@ -2882,7 +2963,6 @@ mod tests {
         assert_eq!(o.punctuation, None);
         assert_eq!(o.itn, None);
         assert_eq!(o.vad, None);
-        assert_eq!(o.hotwords, None);
     }
 
     #[test]
@@ -2895,32 +2975,29 @@ mod tests {
 
     #[test]
     fn test_override_error_codes_stable() {
+        use super::{HotwordError, OverrideError};
         // Stable machine-readable codes surfaced as the REST error `code`.
         assert_eq!(OverrideError::VadNotLoaded.code(), "vad_not_loaded");
         assert_eq!(
             OverrideError::PunctuationNotAvailable.code(),
             "punctuation_not_available"
         );
-        assert_eq!(OverrideError::TooManyHotwords.code(), "too_many_hotwords");
+        assert_eq!(HotwordError::TooManyHotwords.code(), "too_many_hotwords");
         assert_eq!(
-            OverrideError::HotwordPhraseTooLong.code(),
+            HotwordError::PhraseTooLong.code(),
             "hotword_phrase_too_long"
         );
         // Messages are non-empty and don't leak internals.
         assert!(!OverrideError::VadNotLoaded.message().is_empty());
         assert!(!OverrideError::PunctuationNotAvailable.message().is_empty());
-        assert!(!OverrideError::TooManyHotwords.message().is_empty());
-        assert!(!OverrideError::HotwordPhraseTooLong.message().is_empty());
+        assert!(!HotwordError::TooManyHotwords.message().is_empty());
+        assert!(!HotwordError::PhraseTooLong.message().is_empty());
         // Display matches message().
         assert_eq!(
             OverrideError::VadNotLoaded.to_string(),
             OverrideError::VadNotLoaded.message()
         );
         // Limit violations are client errors (400); missing models are 409.
-        assert!(!OverrideError::VadNotLoaded.is_bad_request());
-        assert!(!OverrideError::PunctuationNotAvailable.is_bad_request());
-        assert!(OverrideError::TooManyHotwords.is_bad_request());
-        assert!(OverrideError::HotwordPhraseTooLong.is_bad_request());
     }
 
     #[test]
@@ -5229,79 +5306,45 @@ mod tests {
                 Ok(())
             );
 
-            // Hotwords need no attached model: empty force-off and a few phrases
-            // under the DoS caps are always accepted.
+            // Hotword DoS limits live on validate_hotwords (separate from
+            // TranscribeOverrides so that type stays Copy/Eq).
+            use crate::inference::HotwordError;
             assert_eq!(
-                engine.validate_overrides(&TranscribeOverrides {
-                    hotwords: Some(HotwordOverride {
-                        phrases: vec![],
-                        boost: None,
-                    }),
-                    ..Default::default()
-                }),
+                engine.validate_hotwords(&HotwordOverride::new(vec![], None)),
                 Ok(())
             );
             assert_eq!(
-                engine.validate_overrides(&TranscribeOverrides {
-                    hotwords: Some(HotwordOverride {
-                        phrases: vec!["сбер".into(), "тинькофф".into()],
-                        boost: Some(3.0),
-                    }),
-                    ..Default::default()
-                }),
+                engine.validate_hotwords(&HotwordOverride::new(
+                    vec!["ok".into(), "fine".into()],
+                    Some(3.0),
+                )),
                 Ok(())
             );
 
-            // Exactly at the cap is OK; one over is rejected.
             let at_cap: Vec<String> = (0..MAX_HOTWORDS_PER_REQUEST)
                 .map(|i| format!("w{i}"))
                 .collect();
             assert_eq!(
-                engine.validate_overrides(&TranscribeOverrides {
-                    hotwords: Some(HotwordOverride {
-                        phrases: at_cap,
-                        boost: None,
-                    }),
-                    ..Default::default()
-                }),
+                engine.validate_hotwords(&HotwordOverride::new(at_cap, None)),
                 Ok(())
             );
             let over_cap: Vec<String> = (0..=MAX_HOTWORDS_PER_REQUEST)
                 .map(|i| format!("w{i}"))
                 .collect();
             assert_eq!(
-                engine.validate_overrides(&TranscribeOverrides {
-                    hotwords: Some(HotwordOverride {
-                        phrases: over_cap,
-                        boost: None,
-                    }),
-                    ..Default::default()
-                }),
-                Err(OverrideError::TooManyHotwords)
+                engine.validate_hotwords(&HotwordOverride::new(over_cap, None)),
+                Err(HotwordError::TooManyHotwords)
             );
 
-            // Phrase length: exactly 64 chars OK; 65 rejected.
             let ok_phrase: String = "а".repeat(MAX_HOTWORD_PHRASE_CHARS);
             assert_eq!(
-                engine.validate_overrides(&TranscribeOverrides {
-                    hotwords: Some(HotwordOverride {
-                        phrases: vec![ok_phrase],
-                        boost: None,
-                    }),
-                    ..Default::default()
-                }),
+                engine.validate_hotwords(&HotwordOverride::new(vec![ok_phrase], None)),
                 Ok(())
             );
             let long_phrase: String = "а".repeat(MAX_HOTWORD_PHRASE_CHARS + 1);
             assert_eq!(
-                engine.validate_overrides(&TranscribeOverrides {
-                    hotwords: Some(HotwordOverride {
-                        phrases: vec![long_phrase],
-                        boost: None,
-                    }),
-                    ..Default::default()
-                }),
-                Err(OverrideError::HotwordPhraseTooLong)
+                engine.validate_hotwords(&HotwordOverride::new(vec![long_phrase], None)),
+                Err(HotwordError::PhraseTooLong)
             );
         }
 
@@ -5320,37 +5363,25 @@ mod tests {
             assert!(engine.has_hotwords(), "boot biaser attached");
 
             // Force-off: empty phrase list yields no temporary biaser.
-            let off = HotwordOverride {
-                phrases: vec![],
-                boost: None,
-            };
+            let off = HotwordOverride::new(vec![], None);
             assert!(
                 engine.build_request_biaser(&off).is_none(),
                 "empty override forces biasing off"
             );
 
             // Representable phrase builds a temporary biaser.
-            let on = HotwordOverride {
-                phrases: vec!["hi".into()],
-                boost: Some(7.0),
-            };
+            let on = HotwordOverride::new(vec!["hi".into()], Some(7.0));
             let built = engine
                 .build_request_biaser(&on)
                 .expect("representable phrase should compile");
             assert_eq!(built.phrase_count(), 1);
 
             // Default boost path (None) still builds when phrases are present.
-            let default_boost = HotwordOverride {
-                phrases: vec!["hi".into()],
-                boost: None,
-            };
+            let default_boost = HotwordOverride::new(vec!["hi".into()], None);
             assert!(engine.build_request_biaser(&default_boost).is_some());
 
             // Unrepresentable-only phrases → None (decode continues without bias).
-            let junk = HotwordOverride {
-                phrases: vec!["ъъъ".into()],
-                boost: None,
-            };
+            let junk = HotwordOverride::new(vec!["яяяя".into()], None);
             assert!(
                 engine.build_request_biaser(&junk).is_none(),
                 "unrepresentable phrases drop the temporary biaser"
@@ -5385,6 +5416,7 @@ mod tests {
                         vad: Some(false),
                         ..Default::default()
                     },
+                    None,
                     false,
                 )
                 .expect("vad-off decode");

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -271,24 +271,29 @@ pub(crate) fn parse_hotwords_query(raw: &str) -> Vec<String> {
 
 /// Build [`TranscribeOverrides`] from REST query params. Absent knob params
 /// leave the corresponding override field as `None` (engine boot default).
-/// `hotwords` is only set when the query key is present — even when empty —
-/// so `?hotwords=` can force biasing off.
 pub(crate) fn overrides_from_export_params(
     params: &ExportParams,
 ) -> gigastt_core::inference::TranscribeOverrides {
-    let hotwords = params.hotwords.as_ref().map(|raw| {
-        gigastt_core::inference::HotwordOverride {
-            phrases: parse_hotwords_query(raw),
-            // Boost only applies when hotwords is present; ignore alone.
-            boost: params.hotwords_boost,
-        }
-    });
     gigastt_core::inference::TranscribeOverrides {
         punctuation: params.punctuation,
         itn: params.itn,
         vad: params.vad,
-        hotwords,
     }
+}
+
+/// Build optional [`HotwordOverride`] from REST query params. `None` when the
+/// `hotwords` key is absent (engine boot biaser). `Some` when the key is
+/// present — even empty — so `?hotwords=` can force biasing off.
+pub(crate) fn hotwords_from_export_params(
+    params: &ExportParams,
+) -> Option<gigastt_core::inference::HotwordOverride> {
+    params.hotwords.as_ref().map(|raw| {
+        gigastt_core::inference::HotwordOverride::new(
+            parse_hotwords_query(raw),
+            // Boost only applies when hotwords is present; ignore alone.
+            params.hotwords_boost,
+        )
+    })
 }
 
 /// Render a transcription result into the requested export format.
@@ -815,13 +820,13 @@ pub async fn transcribe(
     }
     let overrides = overrides_from_export_params(&params);
     if let Err(e) = engine.validate_overrides(&overrides) {
-        // Limit violations (hotword DoS caps) → 400; missing resources → 409.
-        let status = if e.is_bad_request() {
-            StatusCode::BAD_REQUEST
-        } else {
-            StatusCode::CONFLICT
-        };
-        return Err(api_error(status, e.message(), e.code()));
+        return Err(api_error(StatusCode::CONFLICT, e.message(), e.code()));
+    }
+    let hotwords = hotwords_from_export_params(&params);
+    if let Some(ref hw) = hotwords
+        && let Err(e) = engine.validate_hotwords(hw)
+    {
+        return Err(api_error(StatusCode::BAD_REQUEST, e.message(), e.code()));
     }
 
     // Checkout a session triplet from the batch pool (blocks if none available)
@@ -873,15 +878,21 @@ pub async fn transcribe(
                 // Diarization is opt-in (`?diarization=true`): only then run the
                 // offline speaker pass. `body` is `axum::body::Bytes` (a
                 // `bytes::Bytes` re-export) so the decode shares the upload buffer.
-                engine.transcribe_bytes_shared_with_overrides_diarized(
+                engine.transcribe_bytes_shared_with_overrides_diarized_hotwords(
                     body,
                     &mut reservation,
                     &overrides,
+                    hotwords.as_ref(),
                 )
             } else {
                 // No diarization requested: byte-identical to the pre-existing
                 // zero-copy path. `overrides` is already validated above.
-                engine.transcribe_bytes_shared_with_overrides(body, &mut reservation, &overrides)
+                engine.transcribe_bytes_shared_with_overrides_hotwords(
+                    body,
+                    &mut reservation,
+                    &overrides,
+                    hotwords.as_ref(),
+                )
             }
         }));
         match r {
@@ -1627,11 +1638,8 @@ mod tests {
         );
 
         // Hotword DoS limit violations map to 400 (not 409).
-        for err in [
-            OverrideError::TooManyHotwords,
-            OverrideError::HotwordPhraseTooLong,
-        ] {
-            assert!(err.is_bad_request());
+        use gigastt_core::inference::HotwordError;
+        for err in [HotwordError::TooManyHotwords, HotwordError::PhraseTooLong] {
             let resp = api_error(StatusCode::BAD_REQUEST, err.message(), err.code());
             let (parts, body) = resp.into_parts();
             assert_eq!(parts.status, StatusCode::BAD_REQUEST);
@@ -2667,7 +2675,7 @@ mod tests {
     #[test]
     fn test_hotwords_query_param_parsing() {
         // Comma-separated phrases + optional boost deserialize from the query
-        // string and map to HotwordOverride via overrides_from_export_params.
+        // string and map to HotwordOverride via hotwords_from_export_params.
         let uri: axum::http::Uri =
             "http://x/?hotwords=%D1%81%D0%B1%D0%B5%D1%80,%D1%82%D0%B8%D0%BD%D1%8C%D0%BA%D0%BE%D1%84%D1%84&hotwords_boost=3.5"
                 .parse()
@@ -2676,25 +2684,21 @@ mod tests {
         assert_eq!(params.hotwords.as_deref(), Some("сбер,тинькофф"));
         assert_eq!(params.hotwords_boost, Some(3.5));
 
-        let overrides = overrides_from_export_params(&params);
-        let hw = overrides.hotwords.expect("hotwords present");
+        let hw = hotwords_from_export_params(&params).expect("hotwords present");
         assert_eq!(hw.phrases, vec!["сбер".to_string(), "тинькофф".to_string()]);
         assert_eq!(hw.boost, Some(3.5));
 
         // Absent hotwords → engine default (None), even if boost is set alone.
         let uri: axum::http::Uri = "http://x/?hotwords_boost=9".parse().unwrap();
         let Query(params): Query<ExportParams> = Query::try_from_uri(&uri).unwrap();
-        let overrides = overrides_from_export_params(&params);
-        assert!(overrides.hotwords.is_none());
+        assert!(hotwords_from_export_params(&params).is_none());
 
-        // Empty value forces biasing off (Some(empty phrases)).
+        // Empty key present → Some(empty) force-off.
         let uri: axum::http::Uri = "http://x/?hotwords=".parse().unwrap();
         let Query(params): Query<ExportParams> = Query::try_from_uri(&uri).unwrap();
-        let overrides = overrides_from_export_params(&params);
-        let hw = overrides.hotwords.expect("key present means override");
+        let hw = hotwords_from_export_params(&params).expect("key present means override");
         assert!(hw.phrases.is_empty());
 
-        // Whitespace / empty segments are trimmed out.
         assert_eq!(
             parse_hotwords_query(" сбер , , тинькофф "),
             vec!["сбер".to_string(), "тинькофф".to_string()]

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -216,6 +216,19 @@ pub struct ExportParams {
     /// the whole buffer, absent = boot default. `POST /v1/transcribe` only.
     #[serde(default)]
     pub vad: Option<bool>,
+    /// Per-request hotword phrases, comma-separated
+    /// (`?hotwords=сбер,тинькофф`). Absent = keep the engine boot biaser;
+    /// present with an empty value (or only empty segments) forces biasing
+    /// off for this request; non-empty replaces the biaser for this request
+    /// only. Capped at 64 phrases / 64 chars each (400 on overflow).
+    /// `POST /v1/transcribe` only.
+    #[serde(default)]
+    pub hotwords: Option<String>,
+    /// Additive logit boost for per-request hotwords. Only applied when
+    /// `hotwords` is also present; absent defaults to 5.0.
+    /// `POST /v1/transcribe` only.
+    #[serde(default)]
+    pub hotwords_boost: Option<f32>,
     /// Forward-compatibility guard for a future multi-model server: names the
     /// recognition head the request expects. A single-variant engine can't
     /// switch, so any value other than the loaded variant returns 409
@@ -243,6 +256,39 @@ pub struct ExportParams {
     /// accepted for it.
     #[serde(default)]
     pub sample_rate: Option<u32>,
+}
+
+/// Split a comma-separated `?hotwords=` value into trimmed non-empty phrases.
+/// Empty input (or only empty segments) yields an empty list, which the engine
+/// treats as force-off for this request.
+pub(crate) fn parse_hotwords_query(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Build [`TranscribeOverrides`] from REST query params. Absent knob params
+/// leave the corresponding override field as `None` (engine boot default).
+/// `hotwords` is only set when the query key is present — even when empty —
+/// so `?hotwords=` can force biasing off.
+pub(crate) fn overrides_from_export_params(
+    params: &ExportParams,
+) -> gigastt_core::inference::TranscribeOverrides {
+    let hotwords = params.hotwords.as_ref().map(|raw| {
+        gigastt_core::inference::HotwordOverride {
+            phrases: parse_hotwords_query(raw),
+            // Boost only applies when hotwords is present; ignore alone.
+            boost: params.hotwords_boost,
+        }
+    });
+    gigastt_core::inference::TranscribeOverrides {
+        punctuation: params.punctuation,
+        itn: params.itn,
+        vad: params.vad,
+        hotwords,
+    }
 }
 
 /// Render a transcription result into the requested export format.
@@ -767,13 +813,15 @@ pub async fn transcribe(
             ));
         }
     }
-    let overrides = gigastt_core::inference::TranscribeOverrides {
-        punctuation: params.punctuation,
-        itn: params.itn,
-        vad: params.vad,
-    };
+    let overrides = overrides_from_export_params(&params);
     if let Err(e) = engine.validate_overrides(&overrides) {
-        return Err(api_error(StatusCode::CONFLICT, e.message(), e.code()));
+        // Limit violations (hotword DoS caps) → 400; missing resources → 409.
+        let status = if e.is_bad_request() {
+            StatusCode::BAD_REQUEST
+        } else {
+            StatusCode::CONFLICT
+        };
+        return Err(api_error(status, e.message(), e.code()));
     }
 
     // Checkout a session triplet from the batch pool (blocks if none available)
@@ -832,7 +880,7 @@ pub async fn transcribe(
                 )
             } else {
                 // No diarization requested: byte-identical to the pre-existing
-                // zero-copy path. `overrides` is `Copy` and already validated above.
+                // zero-copy path. `overrides` is already validated above.
                 engine.transcribe_bytes_shared_with_overrides(body, &mut reservation, &overrides)
             }
         }));
@@ -1577,6 +1625,20 @@ mod tests {
             OverrideError::PunctuationNotAvailable.code(),
             "punctuation_not_available"
         );
+
+        // Hotword DoS limit violations map to 400 (not 409).
+        for err in [
+            OverrideError::TooManyHotwords,
+            OverrideError::HotwordPhraseTooLong,
+        ] {
+            assert!(err.is_bad_request());
+            let resp = api_error(StatusCode::BAD_REQUEST, err.message(), err.code());
+            let (parts, body) = resp.into_parts();
+            assert_eq!(parts.status, StatusCode::BAD_REQUEST);
+            let bytes = axum::body::to_bytes(body, 1024).await.unwrap();
+            let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(v["code"], err.code());
+        }
 
         // The variant guard is a standalone literal (no engine needed to check
         // the code/status contract it emits).
@@ -2573,6 +2635,8 @@ mod tests {
         assert!(params.punctuation.is_none());
         assert!(params.itn.is_none());
         assert!(params.vad.is_none());
+        assert!(params.hotwords.is_none());
+        assert!(params.hotwords_boost.is_none());
         assert!(params.variant.is_none());
     }
 
@@ -2598,6 +2662,45 @@ mod tests {
         assert_eq!(params.punctuation, Some(true));
         assert_eq!(params.itn, Some(true));
         assert_eq!(params.vad, Some(true));
+    }
+
+    #[test]
+    fn test_hotwords_query_param_parsing() {
+        // Comma-separated phrases + optional boost deserialize from the query
+        // string and map to HotwordOverride via overrides_from_export_params.
+        let uri: axum::http::Uri =
+            "http://x/?hotwords=%D1%81%D0%B1%D0%B5%D1%80,%D1%82%D0%B8%D0%BD%D1%8C%D0%BA%D0%BE%D1%84%D1%84&hotwords_boost=3.5"
+                .parse()
+                .unwrap();
+        let Query(params): Query<ExportParams> = Query::try_from_uri(&uri).unwrap();
+        assert_eq!(params.hotwords.as_deref(), Some("сбер,тинькофф"));
+        assert_eq!(params.hotwords_boost, Some(3.5));
+
+        let overrides = overrides_from_export_params(&params);
+        let hw = overrides.hotwords.expect("hotwords present");
+        assert_eq!(hw.phrases, vec!["сбер".to_string(), "тинькофф".to_string()]);
+        assert_eq!(hw.boost, Some(3.5));
+
+        // Absent hotwords → engine default (None), even if boost is set alone.
+        let uri: axum::http::Uri = "http://x/?hotwords_boost=9".parse().unwrap();
+        let Query(params): Query<ExportParams> = Query::try_from_uri(&uri).unwrap();
+        let overrides = overrides_from_export_params(&params);
+        assert!(overrides.hotwords.is_none());
+
+        // Empty value forces biasing off (Some(empty phrases)).
+        let uri: axum::http::Uri = "http://x/?hotwords=".parse().unwrap();
+        let Query(params): Query<ExportParams> = Query::try_from_uri(&uri).unwrap();
+        let overrides = overrides_from_export_params(&params);
+        let hw = overrides.hotwords.expect("key present means override");
+        assert!(hw.phrases.is_empty());
+
+        // Whitespace / empty segments are trimmed out.
+        assert_eq!(
+            parse_hotwords_query(" сбер , , тинькофф "),
+            vec!["сбер".to_string(), "тинькофф".to_string()]
+        );
+        assert!(parse_hotwords_query("").is_empty());
+        assert!(parse_hotwords_query(",,,").is_empty());
     }
 
     #[test]

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -647,11 +647,7 @@ impl JobExecution for RealJobExecutor {
                 return Err(anyhow::anyhow!("Requested model variant is not loaded"));
             }
         }
-        let overrides = gigastt_core::inference::TranscribeOverrides {
-            punctuation: params.punctuation,
-            itn: params.itn,
-            vad: params.vad,
-        };
+        let overrides = super::http::overrides_from_export_params(&params);
         if let Err(e) = engine.validate_overrides(&overrides) {
             return Err(anyhow::anyhow!("Invalid input: {}", e.message()));
         }

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -651,6 +651,12 @@ impl JobExecution for RealJobExecutor {
         if let Err(e) = engine.validate_overrides(&overrides) {
             return Err(anyhow::anyhow!("Invalid input: {}", e.message()));
         }
+        let hotwords = super::http::hotwords_from_export_params(&params);
+        if let Some(ref hw) = hotwords
+            && let Err(e) = engine.validate_hotwords(hw)
+        {
+            return Err(anyhow::anyhow!("Invalid input: {}", e.message()));
+        }
 
         // Timer-based progress updater. Assumes RTF ≈ 0.1 (10 s audio / 1 s wall).
         let progress_cancel = tokio_util::sync::CancellationToken::new();
@@ -747,16 +753,19 @@ impl JobExecution for RealJobExecutor {
                     } else if params.diarization == Some(true) {
                         // Diarization is opt-in (`?diarization=true`): only then run
                         // the offline speaker pass, matching the sync REST path.
-                        engine_for_inference.transcribe_bytes_shared_with_overrides_diarized(
-                            body_for_inference,
-                            &mut reservation,
-                            &overrides,
-                        )
+                        engine_for_inference
+                            .transcribe_bytes_shared_with_overrides_diarized_hotwords(
+                                body_for_inference,
+                                &mut reservation,
+                                &overrides,
+                                hotwords.as_ref(),
+                            )
                     } else {
-                        engine_for_inference.transcribe_bytes_shared_with_overrides(
+                        engine_for_inference.transcribe_bytes_shared_with_overrides_hotwords(
                             body_for_inference,
                             &mut reservation,
                             &overrides,
+                            hotwords.as_ref(),
                         )
                     }
                 }));


### PR DESCRIPTION
## Summary
- Per-request hotwords on `POST /v1/transcribe` (and async jobs via the same query params), deferred from the earlier overrides work.
- Query: `?hotwords=сбер,тинькофф` + optional `?hotwords_boost=5.0`; empty `?hotwords=` forces biasing off; absent keeps boot biaser.
- DoS limits: max 64 phrases, 64 chars each → 400 (`too_many_hotwords` / `hotword_phrase_too_long`).
- WS streaming still uses the boot biaser only.

## Test plan
- [x] `cargo test -p gigastt-core --lib`
- [x] `cargo test -p gigastt --lib`
- [ ] CI green on PR