### PR TITLE
feat(ane): backend-aware long-audio chunks + streaming pad floor

### DIFF
--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -187,13 +187,31 @@ const STREAM_DECODE_STRIDE_SAMPLES: usize = 16000 * 4 / 5;
 /// carries ~20–30s of useful context, so chunking above this costs no accuracy
 /// in the common case.
 const CHUNK_THRESHOLD_SAMPLES: usize = 16000 * 30;
-/// Length of each long-form decode window (samples @16kHz, 24s). Bounds the
-/// per-chunk encoder activation footprint.
-const CHUNK_WINDOW_SAMPLES: usize = 16000 * 24;
+/// Long-form decode window on ort / CoreML-EP / CUDA (samples @16kHz, 24s).
+/// Bounds per-chunk encoder activation memory; the ANE path uses a longer
+/// window via [`chunk_window_samples`].
+const CHUNK_WINDOW_SAMPLES_ORT: usize = 16000 * 24;
+/// Long-form decode window on the ANE encoder (samples @16kHz, 30s). Full chunks
+/// fill ANE bucket 3000 at ~99.97% (vs ~80% fill at 24s), recovering pad-up
+/// waste. Peak activation is free on-device; ort keeps the shorter window.
+const CHUNK_WINDOW_SAMPLES_ANE: usize = 16000 * 30;
 /// Overlap retained between consecutive long-form windows (samples @16kHz, 2s),
 /// so a word straddling a seam is decoded fully in at least one chunk. The
 /// stitch step de-dups words in the overlap region (see [`stitch_chunk_words`]).
 const CHUNK_OVERLAP_SAMPLES: usize = 16000 * 2;
+
+/// Select the long-form chunk window length for the active encoder backend.
+///
+/// ANE uses 30s so each full chunk nearly fills bucket 3000; every other
+/// backend keeps 24s to bound peak encoder activation memory on CPU/EP paths.
+/// Pure so the selection is unit-tested without a loaded model.
+pub(crate) fn chunk_window_samples(ane_encoder: bool) -> usize {
+    if ane_encoder {
+        CHUNK_WINDOW_SAMPLES_ANE
+    } else {
+        CHUNK_WINDOW_SAMPLES_ORT
+    }
+}
 
 /// Default number of session triplets in the pool.
 ///
@@ -916,6 +934,11 @@ pub struct Engine {
     vad_config: crate::vad::VadConfig,
     /// Whether the INT8 quantized encoder is in use.
     int8: bool,
+    /// True when pooled encoder sessions run on the ANE fixed-shape pad-up path.
+    /// Selects the 30s long-form chunk window (vs 24s for ort). Derived from
+    /// the loaded encoder session at boot, not from compile-time features alone,
+    /// so non-rnnt heads on an `ane`-feature binary still use the ort window.
+    ane_encoder: bool,
     /// Speaker encoder for diarization (None if model file is absent).
     ///
     /// Wrapped in `Arc` so per-session streaming pipelines can share the
@@ -1308,6 +1331,9 @@ impl Engine {
             }
         };
 
+        // Detect ANE from the loaded encoder session (not compile-time alone) so
+        // non-rnnt heads / injected factories keep the ort chunk window.
+        let ane_encoder = triplets.first().is_some_and(|t| t.encoder.is_ane_encoder());
         let (pool, batch_pool) = Self::split_triplets(triplets, batch_pool_size);
         let engine = Self {
             pool,
@@ -1321,6 +1347,7 @@ impl Engine {
             vad: None,
             vad_config: crate::vad::VadConfig::default(),
             int8: is_int8,
+            ane_encoder,
             #[cfg(feature = "diarization")]
             speaker_encoder,
         };
@@ -1860,6 +1887,7 @@ impl Engine {
             num_frames,
             &mut decoder_state,
             frame_offset,
+            true, // streaming: ANE low-latency pad floor when available
         )?;
 
         // Suppress words inside the already-emitted left context so a slid
@@ -2204,7 +2232,14 @@ impl Engine {
             tracing::info!("Extracted {} mel frames", num_frames);
             let mut decoder_state = DecoderState::new(self.tokenizer.blank_id());
             Ok(self
-                .run_inference(triplet, &features, num_frames, &mut decoder_state, 0)
+                .run_inference(
+                    triplet,
+                    &features,
+                    num_frames,
+                    &mut decoder_state,
+                    0,
+                    false, // file-mode fill floor
+                )
                 .map_err(|e| GigasttError::Inference { source: e.into() })?
                 .0)
         } else {
@@ -2251,32 +2286,35 @@ impl Engine {
     /// chunk's word timestamps by the chunk's absolute start, then stitch the
     /// per-chunk word lists with overlap de-dup via [`stitch_chunk_words`].
     ///
-    /// Peak encoder activation memory is bounded by [`CHUNK_WINDOW_SAMPLES`]
-    /// rather than the full file length. Chunk starts are aligned to encoder
-    /// frame boundaries (multiples of `HOP_LENGTH * ENCODER_SUBSAMPLING`) so the
-    /// per-chunk frame offset is exact, matching the streaming path's math.
+    /// Peak encoder activation memory is bounded by [`chunk_window_samples`]
+    /// (24s ort / 30s ANE) rather than the full file length. Chunk starts are
+    /// aligned to encoder frame boundaries (multiples of
+    /// `HOP_LENGTH * ENCODER_SUBSAMPLING`) so the per-chunk frame offset is
+    /// exact, matching the streaming path's math.
     fn transcribe_samples_chunked(
         &self,
         float_samples: &[f32],
         triplet: &mut SessionTriplet,
     ) -> Result<Vec<WordInfo>, GigasttError> {
         let total = float_samples.len();
-        let stride = CHUNK_WINDOW_SAMPLES - CHUNK_OVERLAP_SAMPLES;
+        let window = chunk_window_samples(self.ane_encoder);
+        let stride = window - CHUNK_OVERLAP_SAMPLES;
         // Align stride to an encoder-frame boundary so each chunk's frame offset
         // is integral; otherwise the offset would drift by a sub-frame each hop.
         let frame_samples = HOP_LENGTH * ENCODER_SUBSAMPLING;
         let stride = (stride / frame_samples) * frame_samples;
         tracing::info!(
-            "Long-form chunked decode: {:.1}s in ~{}s windows ({}s overlap)",
+            "Long-form chunked decode: {:.1}s in ~{}s windows ({}s overlap, ane={})",
             total as f64 / 16000.0,
-            CHUNK_WINDOW_SAMPLES / 16000,
+            window / 16000,
             CHUNK_OVERLAP_SAMPLES / 16000,
+            self.ane_encoder,
         );
 
         let mut merged: Vec<WordInfo> = Vec::new();
         let mut start = 0usize;
         while start < total {
-            let end = (start + CHUNK_WINDOW_SAMPLES).min(total);
+            let end = (start + window).min(total);
             let chunk = &float_samples[start..end];
             let (features, num_frames) = self.features.compute(chunk);
             let frame_offset = start / frame_samples;
@@ -2288,6 +2326,7 @@ impl Engine {
                     num_frames,
                     &mut decoder_state,
                     frame_offset,
+                    false, // file-mode fill floor
                 )
                 .map_err(|e| GigasttError::Inference { source: e.into() })?;
 
@@ -2378,6 +2417,9 @@ impl Engine {
         }
     }
 
+    /// Run encoder + decode. `low_latency` selects the streaming encoder path
+    /// ([`RuntimeSession::run_low_latency`]) so ANE can pad underfilled short
+    /// windows; file mode keeps the calibrated 0.5 fill floor.
     fn run_inference(
         &self,
         triplet: &mut SessionTriplet,
@@ -2385,6 +2427,7 @@ impl Engine {
         num_frames: usize,
         decoder_state: &mut DecoderState,
         frame_offset: usize,
+        low_latency: bool,
     ) -> anyhow::Result<(Vec<WordInfo>, bool)> {
         // Reuse the encoder input tensors: resize the signal tensor to the
         // current frame count and overwrite both buffers in place.
@@ -2398,10 +2441,17 @@ impl Engine {
             .context("encoder length tensor is not i64")?[0] = num_frames as i64;
 
         let enc_start = std::time::Instant::now();
-        let encoder_outputs = triplet
-            .encoder
-            .run(&triplet.encoder_inputs)
-            .context("Encoder inference failed")?;
+        let encoder_outputs = if low_latency {
+            triplet
+                .encoder
+                .run_low_latency(&triplet.encoder_inputs)
+                .context("Encoder inference failed")?
+        } else {
+            triplet
+                .encoder
+                .run(&triplet.encoder_inputs)
+                .context("Encoder inference failed")?
+        };
         tracing::info!(
             elapsed_ms = enc_start.elapsed().as_millis() as u64,
             "encoder_inference"
@@ -3120,8 +3170,19 @@ mod tests {
     fn test_chunk_constants_sane() {
         // Window > overlap (positive stride) and threshold ≥ window so the
         // single-pass path covers everything up to one full window.
-        assert!(CHUNK_WINDOW_SAMPLES > CHUNK_OVERLAP_SAMPLES);
-        assert!(CHUNK_THRESHOLD_SAMPLES >= CHUNK_WINDOW_SAMPLES);
+        assert!(CHUNK_WINDOW_SAMPLES_ORT > CHUNK_OVERLAP_SAMPLES);
+        assert!(CHUNK_WINDOW_SAMPLES_ANE > CHUNK_OVERLAP_SAMPLES);
+        assert!(CHUNK_THRESHOLD_SAMPLES >= CHUNK_WINDOW_SAMPLES_ORT);
+        assert!(CHUNK_THRESHOLD_SAMPLES >= CHUNK_WINDOW_SAMPLES_ANE);
+    }
+
+    #[test]
+    fn test_chunk_window_samples_backend_aware() {
+        // ort / non-ANE: 24s keeps peak encoder activation bounded.
+        assert_eq!(chunk_window_samples(false), 16000 * 24);
+        // ANE: 30s fills bucket 3000 at ~99.97%.
+        assert_eq!(chunk_window_samples(true), 16000 * 30);
+        assert!(chunk_window_samples(true) > chunk_window_samples(false));
     }
 
     #[test]

--- a/crates/gigastt-core/src/runtime/coreml/encoder_session.rs
+++ b/crates/gigastt-core/src/runtime/coreml/encoder_session.rs
@@ -25,10 +25,11 @@ const ENC_DIM: usize = 768;
 /// Mel feature bins (`[1, N_MELS, T]`, channels-first).
 const N_MELS: usize = 64;
 
-/// Minimum fraction of a bucket the real mel must fill for the pad-up path to be
-/// trusted. Below this, the mask-free zero-padded encoder output diverges enough
-/// from the unpadded baseline that a borderline token can flip; clips that don't
-/// reach the floor fall back to the variable-length ort encoder.
+/// Minimum fraction of a bucket the real mel must fill for the **file-mode**
+/// pad-up path to be trusted. Below this, the mask-free zero-padded encoder
+/// output diverges enough from the unpadded baseline that a borderline token can
+/// flip; clips that don't reach the floor fall back to the variable-length ort
+/// encoder.
 ///
 /// Calibrated by the pad-parity experiment (mask-free pad-up): at >= 50% fill the
 /// padded ANE output stays at cosine >= 0.94 vs the ort baseline and WER tracks
@@ -41,6 +42,19 @@ const N_MELS: usize = 64;
 /// zero-pad effect. A future reader must NOT "fix" this floor assuming the
 /// encoder sees f32 input; the f16 round-trip is baked into the threshold.
 const FILL_FLOOR: f64 = 0.5;
+
+/// Fill floor for **streaming / low-latency** encoder calls.
+///
+/// Streaming windows are capped at ~2.5 s (≈249 mel frames), which underfills
+/// the smallest shipped bucket (512 → file-mode floor 256) at ~48.6%. The file
+/// floor would force every streaming window onto ort. A zero floor lets any
+/// window that fits under the max bucket pad into the smallest eligible bucket
+/// (typically 512) and run on ANE.
+///
+/// Streaming pad may underfill the bucket and is preferred for latency on Mac
+/// ANE builds over the correct-but-slower ort fallback. File-mode keeps
+/// [`FILL_FLOOR`] = 0.5 so the quality/cost tradeoff on long clips is unchanged.
+const STREAMING_FILL_FLOOR: f64 = 0.0;
 
 /// `Retained<MLModel>` is not auto-`Send`/`Sync` (it wraps an Objective-C
 /// pointer), but Apple documents `-[MLModel predictionFromFeatures:error:]` as
@@ -125,8 +139,9 @@ pub fn trim_time(out: &[f32], channels: usize, t_padded: usize, t_keep: usize) -
 }
 
 /// ANE-backed encoder session. Runs the encoder on the Neural Engine via a
-/// per-bucket fixed-shape package when a clip pads-up into a bucket at >=
-/// [`FILL_FLOOR`]; otherwise delegates to the ort encoder fallback.
+/// per-bucket fixed-shape package when a clip pads-up into a bucket at the
+/// active fill floor ([`FILL_FLOOR`] for file mode, [`STREAMING_FILL_FLOOR`] for
+/// streaming); otherwise delegates to the ort encoder fallback.
 pub struct AneEncoderSession {
     /// Available compiled bucket models, sorted ascending by `size`.
     buckets: Vec<BucketModel>,
@@ -153,15 +168,16 @@ impl AneEncoderSession {
             .find(|b| b.size == size)
             .map(|b| &b.model)
     }
-}
 
-impl RuntimeSession for AneEncoderSession {
     /// Encoder contract (mirrors the ort ONNX encoder, which emits two outputs):
     /// `inputs[0] = mel [1, 64, T] F32`, `inputs[1] = length [1]` (ignored; T is
     /// read from the mel shape, which is authoritative on this path). Returns
     /// `[encoded [1, 768, T'] F32, encoded_len [1] I64]` so the engine's decode
     /// loop reads `encoder_outputs[1]` for the frame count exactly as for ort.
-    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+    ///
+    /// `floor` is the pad fill floor: file mode uses [`FILL_FLOOR`], streaming
+    /// uses [`STREAMING_FILL_FLOOR`].
+    fn run_with_floor(&self, inputs: &[Tensor], floor: f64) -> Result<Vec<Tensor>, RuntimeError> {
         if inputs.is_empty() {
             return Err(RuntimeError::InvalidInputCount {
                 expected: 2,
@@ -182,7 +198,7 @@ impl RuntimeSession for AneEncoderSession {
         let t = dims[2];
 
         let sizes = self.bucket_sizes();
-        match select_bucket(t, &sizes, FILL_FLOOR) {
+        match select_bucket(t, &sizes, floor) {
             Some(n) => {
                 let model = self.model_for(n).ok_or_else(|| {
                     RuntimeError::InferenceFailed(format!("no compiled model for bucket {n}"))
@@ -206,6 +222,7 @@ impl RuntimeSession for AneEncoderSession {
                 tracing::debug!(
                     t,
                     bucket = n,
+                    floor,
                     t_real_prime,
                     t_padded_prime,
                     "ANE encoder path (bucketed pad-up)"
@@ -225,11 +242,26 @@ impl RuntimeSession for AneEncoderSession {
             None => {
                 tracing::debug!(
                     t,
+                    floor,
                     "ANE encoder path (ort fallback: no bucket within fill-floor)"
                 );
                 self.ort_fallback.run(inputs)
             }
         }
+    }
+}
+
+impl RuntimeSession for AneEncoderSession {
+    fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        self.run_with_floor(inputs, FILL_FLOOR)
+    }
+
+    fn run_low_latency(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        self.run_with_floor(inputs, STREAMING_FILL_FLOOR)
+    }
+
+    fn is_ane_encoder(&self) -> bool {
+        true
     }
 }
 
@@ -252,33 +284,66 @@ mod tests {
 
     #[test]
     fn test_select_bucket_fill_floor_cases() {
-        let buckets = [768usize, 1536, 3000];
-        // 400/768 = 52% -> smallest N>=400 meeting floor.
-        assert_eq!(select_bucket(400, &buckets, 0.5), Some(768));
-        // 200/768 = 26% < floor -> no bucket, fallback.
+        let buckets = [512usize, 768, 1536, 3000];
+        // 400/512 = 78% → smallest N≥400 meeting floor is 512.
+        assert_eq!(select_bucket(400, &buckets, 0.5), Some(512));
+        // 300/512 = 58.6% → 512.
+        assert_eq!(select_bucket(300, &buckets, 0.5), Some(512));
+        // 200/512 = 39% < floor → no bucket, fallback.
         assert_eq!(select_bucket(200, &buckets, 0.5), None);
-        // 800 > 768 so 768 fails N>=T; smallest N>=800 is 1536 (800/1536=52%).
+        // 600 > 512 so 512 fails N≥T; 600/768 = 78% → 768.
+        assert_eq!(select_bucket(600, &buckets, 0.5), Some(768));
+        // 800 > 768 so 768 fails N≥T; smallest N≥800 is 1536 (800/1536=52%).
         assert_eq!(select_bucket(800, &buckets, 0.5), Some(1536));
-        // 769 -> 1536 (769/1536 = 50.06% >= floor).
+        // 769 → 1536 (769/1536 = 50.06% ≥ floor).
         assert_eq!(select_bucket(769, &buckets, 0.5), Some(1536));
-        // 4000 > max bucket -> fallback.
+        // 4000 > max bucket → fallback.
         assert_eq!(select_bucket(4000, &buckets, 0.5), None);
         // Exact fit.
         assert_eq!(select_bucket(768, &buckets, 0.5), Some(768));
+        assert_eq!(select_bucket(512, &buckets, 0.5), Some(512));
     }
 
     #[test]
     fn test_select_bucket_fill_equal_to_floor_is_selected() {
-        // 384/768 = exactly 0.5 == floor -> the `>=` comparison must include the
+        // 384/768 = exactly 0.5 == floor → the `>=` comparison must include the
         // boundary, so the bucket is selected (not rejected to the ort fallback).
         assert_eq!(select_bucket(384, &[768], 0.5), Some(768));
+        // 256/512 = exactly 0.5.
+        assert_eq!(select_bucket(256, &[512], 0.5), Some(512));
     }
 
     #[test]
     fn test_select_bucket_unsorted_input() {
-        let buckets = [3000usize, 768, 1536];
-        assert_eq!(select_bucket(400, &buckets, 0.5), Some(768));
+        let buckets = [3000usize, 512, 768, 1536];
+        assert_eq!(select_bucket(300, &buckets, 0.5), Some(512));
+        assert_eq!(select_bucket(400, &buckets, 0.5), Some(512));
+        assert_eq!(select_bucket(600, &buckets, 0.5), Some(768));
         assert_eq!(select_bucket(800, &buckets, 0.5), Some(1536));
+    }
+
+    /// Streaming-sized windows (~249 mel frames @ 2.5 s) sit under the file-mode
+    /// 50% floor of bucket 512 but must select that bucket under the streaming
+    /// floor so live sessions can run on ANE.
+    #[test]
+    fn test_select_bucket_streaming_floor_accepts_underfilled_window() {
+        let buckets = [512usize, 768, 1536, 3000];
+        // ~2.5 s streaming window.
+        const T: usize = 249;
+        // File-mode floor still rejects (249/512 ≈ 48.6% < 0.5).
+        assert_eq!(
+            select_bucket(T, &buckets, FILL_FLOOR),
+            None,
+            "file-mode floor must still reject underfilled streaming-sized T"
+        );
+        // Streaming floor pads into the smallest eligible bucket.
+        assert_eq!(
+            select_bucket(T, &buckets, STREAMING_FILL_FLOOR),
+            Some(512),
+            "streaming floor must select bucket 512 for a 249-frame window"
+        );
+        // Over-max still rejected even with zero floor.
+        assert_eq!(select_bucket(4000, &buckets, STREAMING_FILL_FLOOR), None);
     }
 
     #[test]
@@ -315,34 +380,31 @@ mod tests {
         assert_eq!(back, mel);
     }
 
-    /// Streaming smoke (no model / no ANE hardware): an `AneEncoderSession` with
-    /// the production bucket ladder but NO compiled bucket models routes a
-    /// streaming-sized window through the ort fallback rather than the ANE path.
+    /// File-mode smoke (no model / no ANE hardware): an `AneEncoderSession` with
+    /// no compiled bucket models routes a streaming-sized window through the ort
+    /// fallback on the file-mode path (`run` / [`FILL_FLOOR`]), because 250 mel
+    /// frames underfill bucket 512 at the 0.5 floor.
     ///
-    /// The streaming path (`Engine::decode_window`) caps its window at
-    /// `STREAM_MAX_WINDOW_SAMPLES` = 2.5 s ⇒ ≤ 250 mel frames, which is below the
-    /// 50%-fill floor of the smallest shipped bucket (768 ⇒ floor 384). So
-    /// `select_bucket` returns `None` for every streaming window and `run`
-    /// delegates to the ort fallback session: streaming works on CPU with no
-    /// crash and no ANE benefit (the intended "ANE = file-mode" behavior). This
-    /// pins that routing without needing a real `.mlpackage` or the Neural Engine
-    /// by using a mock fallback session and asserting it was invoked.
+    /// Pins that routing without a real `.mlpackage` by using a mock fallback
+    /// session and asserting it was invoked.
     #[test]
-    fn test_streaming_window_routes_to_ort_fallback() {
+    fn test_file_mode_underfilled_window_routes_to_ort_fallback() {
         use crate::runtime::mock::MockSession;
 
         // Production buckets; none has a compiled model loaded here.
-        const SHIPPED_BUCKETS: &[usize] = &[768, 1536, 3000];
-        // A streaming-sized window: 250 mel frames (the 2.5 s window cap), well
-        // below the 384-frame fill floor of the 768 bucket.
+        const SHIPPED_BUCKETS: &[usize] = &[512, 768, 1536, 3000];
+        // A streaming-sized window: 250 mel frames (the 2.5 s window cap).
         const T: usize = 250;
 
-        // Sanity: confirm no shipped bucket accepts this window at the floor, so
-        // `run` MUST take the fallback branch.
+        // Sanity: file-mode floor rejects; streaming floor would accept 512.
         assert_eq!(
             select_bucket(T, SHIPPED_BUCKETS, FILL_FLOOR),
             None,
-            "a 250-frame streaming window must not select any shipped bucket"
+            "a 250-frame window must not select any shipped bucket at FILL_FLOOR"
+        );
+        assert_eq!(
+            select_bucket(T, SHIPPED_BUCKETS, STREAMING_FILL_FLOOR),
+            Some(512)
         );
 
         // Mock ort encoder fallback: accepts the [1,64,T] mel + [1] length pair
@@ -360,8 +422,9 @@ mod tests {
             ],
         );
 
-        // No bucket models -> every window falls back.
+        // No bucket models -> every window falls back (file-mode or streaming).
         let session = AneEncoderSession::new(Vec::new(), Box::new(fallback));
+        assert!(session.is_ane_encoder());
 
         let mel = Tensor::new(
             Shape::new(vec![1, N_MELS, T]),

--- a/crates/gigastt-core/src/runtime/session.rs
+++ b/crates/gigastt-core/src/runtime/session.rs
@@ -3,4 +3,21 @@ use super::{error::RuntimeError, tensor::Tensor};
 /// One loaded model session: encoder, decoder, or joiner.
 pub trait RuntimeSession: Send + Sync + 'static {
     fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError>;
+
+    /// Low-latency encoder path used by streaming windows.
+    ///
+    /// Default delegates to [`Self::run`]. The ANE encoder overrides this to
+    /// accept a lower pad fill floor so short streaming windows can pad into the
+    /// smallest eligible bucket instead of falling back to ort.
+    fn run_low_latency(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
+        self.run(inputs)
+    }
+
+    /// True when this encoder runs on the ANE fixed-shape pad-up path.
+    ///
+    /// Used to pick a longer long-form chunk window (30s fills ANE bucket 3000
+    /// nearly full; ort keeps 24s for peak activation memory). Default false.
+    fn is_ane_encoder(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
## Summary
- **Long audio:** ANE encoder path uses a 30s chunk window (fills bucket 3000); ort/other keep 24s for memory.
- **Streaming:** low-latency encode path uses fill floor 0 so ~2.5s windows can pad into bucket 512 on ANE instead of always falling back to ort. File-mode fill floor 0.5 unchanged.

## Limitations
- Needs `gigastt download --ane` packages + macOS `--features ane` build for the ANE path to engage.
- No live hardware WER/RTF remeasure in this PR (unit/routing coverage).

## Test plan
- [x] `cargo test -p gigastt-core --lib`
- [x] `cargo test -p gigastt-core --lib --features ane`
- [ ] CI green on PR