### PR TITLE
fix(docs): drop private bias::Biaser link from HotwordOverride docs

### DIFF
--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -2894,7 +2894,7 @@ pub const DEFAULT_HOTWORDS_BOOST: f32 = 5.0;
 /// Semantics when passed to the hotwords parameter of file-transcription APIs:
 /// - `None` (argument absent) → keep the engine boot biaser unchanged.
 /// - `Some(empty phrases)` → force biasing **off** for this request.
-/// - `Some(non-empty phrases)` → build a temporary [`bias::Biaser`] for this
+/// - `Some(non-empty phrases)` → build a temporary hotword biaser for this
 ///   request only (engine boot biaser is not consulted).
 ///
 /// Kept separate from [`TranscribeOverrides`] so that type remains `Copy`/`Eq`


### PR DESCRIPTION
## Summary
- Fixes **Doc Build** failure on main: public `HotwordOverride` docs linked to private `bias::Biaser` (`rustdoc::private-intra-doc-links`).
- Rephrase without the intra-doc link.

## Context
Main CI after #207/#208/#209:
- **Doc Build** — real regression from #208 (this fix)
- **Docker Build (CPU)** — `ghcr.io` login timeout (infra flake)

## Test plan
- [x] pre-commit green
- [x] `cargo doc -p gigastt-core --no-deps` clean