### PR TITLE
ci: stop ghcr login and noisy benches from reddening the gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,7 +687,11 @@ jobs:
   bench:
     # PR-only: criterion needs a main baseline to diff against, and the
     # regression gate is meaningless on the very push that moves main.
+    # Shared GH runners are noisy: sub-10% swings are common and have
+    # reddened otherwise-clean PRs. Keep the report, but don't block merge —
+    # real regressions show up in the soak/WER gates and local benches.
     if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'dependabot/')
+    continue-on-error: true
     runs-on: ubuntu-latest
     name: Benchmarks (regression gate)
     steps:
@@ -882,9 +886,14 @@ jobs:
       # The layer cache lives in ghcr.io (free for public repos), keeping the
       # 10 GB Actions cache budget untouched. GITHUB_TOKEN grants packages:read
       # on PRs (forks included), so warm reads work everywhere; writes happen
-      # on main pushes only. An unreadable cache ref is a soft warning — the
-      # build goes cold, it never fails.
+      # on main pushes only.
+      #
+      # Login is best-effort: ghcr.io token timeouts (shared runner / network
+      # blips) must not fail CI. An unreadable cache ref degrades to a cold
+      # build; cache-to is only attempted when login succeeded on a main push.
       - uses: docker/login-action@v4
+        id: ghcr-login
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -897,7 +906,7 @@ jobs:
           load: true
           tags: gigastt:ci
           cache-from: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:cpu
-          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:cpu,mode=max' || '' }}
+          cache-to: ${{ steps.ghcr-login.outcome == 'success' && github.event_name == 'push' && 'type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:cpu,mode=max' || '' }}
       - name: Smoke test (--version)
         run: |
           docker run --rm gigastt:ci --version | tee version.out
@@ -931,9 +940,11 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h /
       - uses: docker/setup-buildx-action@v4
-      # Layer cache in ghcr.io — rationale in docker-build above. This job is
-      # main-push-only, so the cache is always written back.
+      # Layer cache in ghcr.io — rationale in docker-build above. Login is
+      # best-effort (same ghcr timeout story as Docker Build (CPU)).
       - uses: docker/login-action@v4
+        id: ghcr-login
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -945,7 +956,7 @@ jobs:
           push: false
           tags: gigastt-${{ matrix.name }}:ci
           cache-from: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:${{ matrix.name }}
-          cache-to: type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:${{ matrix.name }},mode=max
+          cache-to: ${{ steps.ghcr-login.outcome == 'success' && format('type=registry,ref=ghcr.io/ekhodzitsky/gigastt-buildcache:{0},mode=max', matrix.name) || '' }}
 
   sdk-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Hardens main/PR CI so known infra noise cannot leave the branch red.

1. **Docker ghcr.io login** — `continue-on-error: true`. Timeouts no longer fail `Docker Build (CPU)` / cuda / benchmark. `cache-to` only when login succeeded.
2. **Benchmarks (regression gate)** — `continue-on-error: true`. Shared-runner ±5–6% swings stay reported but do not block merges.

## Context
After #207–#209, main CI failed on:
- **Doc Build** — fixed in #210 (private rustdoc link)
- **Docker Build (CPU)** — `ghcr.io` login timeout (this PR)

## Test plan
- [x] pre-commit
- [ ] Main CI green after merge (Doc Build + Docker Build (CPU))