### PR TITLE
chore: release 2.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Streaming window-cap no longer emits `final`.** Hitting the ~2.5 s encoder
-  window now commits a stable prefix and emits a non-final `partial` so the
-  utterance keeps growing. True `final` / `speech_final` is reserved for VAD
-  silence, decoder blank-run (when no VAD), or client `stop` — fixing premature
-  command execution in voice assistants (Irene) that treat every `final` as
-  "command complete". Additive wire fields on segments: `speech_final` (omitted
-  when false) and `endpoint_reason` (`vad` | `blank` | `stop`).
-
-### Added
-
-- **`--endpoint-mode auto|assistant|manual`** (`GIGASTT_ENDPOINT_MODE`) and
-  per-session WS `configure.endpoint_mode` / `configure.min_silence_ms`.
-  `assistant` ends utterances only on VAD silence (pair with `--vad`); `manual`
-  only on `stop`. Cap never finalizes under any mode.
-
 ### Changed
 
 - **Documentation hygiene pass.** Supported versions in `SECURITY.md` track
@@ -42,6 +25,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   install recipe; appendices for error-code jump tables and offline checklists;
   closed the notarization open loop with an explicit out-of-band note; drift gate
   forbids previous-minor pins and required recipe tokens in the English book.
+
+## [2.14.2] - 2026-07-24
+
+### Fixed
+
+- **Streaming window-cap no longer emits `final`.** Hitting the ~2.5 s encoder
+  window now commits a stable prefix and emits a non-final `partial` so the
+  utterance keeps growing. True `final` / `speech_final` is reserved for VAD
+  silence, decoder blank-run (when no VAD), or client `stop` — fixing premature
+  command execution in voice assistants (Irene) that treat every `final` as
+  "command complete". Additive wire fields on segments: `speech_final` (omitted
+  when false) and `endpoint_reason` (`vad` | `blank` | `stop`) (#212).
+
+### Added
+
+- **`--endpoint-mode auto|assistant|manual`** (`GIGASTT_ENDPOINT_MODE`) and
+  per-session WS `configure.endpoint_mode` / `configure.min_silence_ms`.
+  `assistant` ends utterances only on VAD silence (pair with `--vad`); `manual`
+  only on `stop`. Cap never finalizes under any mode (#212).
 
 ## [2.14.1] - 2026-07-24
 
@@ -1935,7 +1937,8 @@ _Release candidate for v0.9.0 — bundles five P0 fixes plus two supporting item
 - Multi-format audio support: WAV, MP3, M4A/AAC, OGG/Vorbis, FLAC (via symphonia).
 - 39 unit tests (tokenizer, features, decode, inference, protocol).
 
-[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.1...HEAD
+[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.2...HEAD
+[2.14.2]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.1...v2.14.2
 [2.14.1]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.0...v2.14.1
 [2.14.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.13.0...v2.14.0
 [2.13.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.12.0...v2.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.14.1"
+version = "2.14.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.14.1"
+version = "2.14.2"
 dependencies = [
  "anyhow",
  "audio-codec",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.14.1"
+version = "2.14.2"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.14.1"
+version = "2.14.2"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.14.1"
+version = "2.14.2"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.14.1"
+version = "2.14.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump workspace version **2.14.1 → 2.14.2**
- Cut CHANGELOG for the streaming endpoint fix (#212):
  - window cap no longer emits `final` / `speech_final`
  - `--endpoint-mode auto|assistant|manual`
  - `speech_final` + `endpoint_reason` on segments

## After merge

Tag `v2.14.2` to trigger `.github/workflows/release.yml`.