### PR TITLE
feat: OpenAI-compatible POST /v1/audio/transcriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ exposes:
 - **WebSocket** (`/v1/ws`) — streaming transcription with partial/final results
 - **REST** (`/v1/transcribe`) — file upload, full JSON response
 - **SSE** (`/v1/transcribe/stream`) — file upload, streaming Server-Sent Events
+- **OpenAI-compatible** (`/v1/audio/transcriptions`) — multipart `file` + `model` → `{"text":"..."}`
 - **CLI** — `serve`, `download`, `transcribe`, `quantize` commands
 
 The model (~850 MB FP32, ~225 MB INT8) auto-downloads from HuggingFace on first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **OpenAI-compatible `POST /v1/audio/transcriptions`.** Multipart form with
+  required `file` and optional `model` (accepted for client compatibility,
+  ignored — the loaded engine is always used) returns `{"text":"..."}`. Thin
+  alias over the same pipeline as `/v1/transcribe` for llama-swap, Hermes Agent,
+  and OpenAI SDKs pointed at a custom `base_url` (#214).
+
 ### Changed
 
 - **Documentation hygiene pass.** Supported versions in `SECURITY.md` track

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   required `file` and optional `model` (accepted for client compatibility,
   ignored — the loaded engine is always used). Supports OpenAI
   `response_format` (`json` · `text` · `srt` · `vtt` · `verbose_json`),
-  `language` (echoed in verbose), and `timestamp_granularities[]` (`word` /
-  `segment`). Default remains `{"text":"..."}`. Same pipeline as
-  `/v1/transcribe` for llama-swap, Hermes Agent, and OpenAI SDKs with a custom
-  `base_url` (#214).
+  `language` (echoed in verbose), `timestamp_granularities[]` (`word` /
+  `segment`), and `stream=true` (SSE: `transcript.text.delta` /
+  `transcript.text.done` / `[DONE]`, progressive chunked encoder path). Default
+  remains `{"text":"..."}`. Same pipeline as `/v1/transcribe` for llama-swap,
+  Hermes Agent, and OpenAI SDKs with a custom `base_url` (#214).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **OpenAI-compatible `POST /v1/audio/transcriptions`.** Multipart form with
   required `file` and optional `model` (accepted for client compatibility,
-  ignored — the loaded engine is always used) returns `{"text":"..."}`. Thin
-  alias over the same pipeline as `/v1/transcribe` for llama-swap, Hermes Agent,
-  and OpenAI SDKs pointed at a custom `base_url` (#214).
+  ignored — the loaded engine is always used). Supports OpenAI
+  `response_format` (`json` · `text` · `srt` · `vtt` · `verbose_json`),
+  `language` (echoed in verbose), and `timestamp_granularities[]` (`word` /
+  `segment`). Default remains `{"text":"..."}`. Same pipeline as
+  `/v1/transcribe` for llama-swap, Hermes Agent, and OpenAI SDKs with a custom
+  `base_url` (#214).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ $ gigastt watch inbox/ out/ --move-to inbox/done/
 $ gigastt serve
 # WebSocket  ws://127.0.0.1:9876/v1/ws
 # REST       http://127.0.0.1:9876/v1/transcribe
+# OpenAI     http://127.0.0.1:9876/v1/audio/transcriptions
 ```
 
 ## Capabilities
@@ -104,7 +105,7 @@ $ gigastt serve
 | Post-processing | optional punctuation, casing &amp; Russian ITN — native on `e2e_rnnt`, or a bundled RuPunct + ITN pass on `rnnt` (auto-downloaded; `--punctuation` / `--itn`), overridable per request (`?punctuation=` / `?itn=` / `?vad=`) |
 | Delivery | static binary · C-ABI FFI `cdylib` (Android / mobile) · `gigastt-core` crate (no server deps) |
 | Execution providers | CPU (any platform) · CoreML EP (macOS ARM64) · CUDA 12+ (Linux x86_64) · NNAPI (Android) · [ANE](docs/ane-backend.md) (`--features ane`, macOS ARM64 — encoder ≈15.6× on the Neural Engine, warm e2e ≈10× over the CPU build, WER ≈1.11% vs `ort`; file-mode only) · [Candle/Metal](docs/candle-backend.md) (`--features candle`, experimental — output byte-for-byte identical to `ort`) |
-| Streaming | incremental WebSocket partials · REST + SSE for files · single port 9876 |
+| Streaming | incremental WebSocket partials · REST + SSE for files · OpenAI-compatible `/v1/audio/transcriptions` · single port 9876 |
 | Audio in | WAV · M4A/AAC · MP3 · OGG/Vorbis · OGG/Opus (`.opus`) · FLAC (auto mono mix for multi-channel) |
 | Stereo telephony recordings | Optional channel-speaker mode (`--stereo-speakers` CLI / `channels=split` REST) labels the left/right channels as `speaker_0` and `speaker_1` |
 | Speaker diarization | WeSpeaker ResNet34 embeddings + polyvoice clustering, compiled in by default (speaker model fetched by `gigastt download`, `--skip-diarization` to opt out) — offline files opt in per request (`?diarization=true`, exclusive with `channels=split`), live sessions via WS `Configure`; words &amp; segments gain `speaker` labels |

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -1000,7 +1000,8 @@ pub async fn transcribe(
 /// Compatibility surface for clients that speak the OpenAI Audio Transcriptions
 /// API (llama-swap, Hermes Agent, OpenAI SDKs with a custom `base_url`):
 /// `multipart/form-data` with required `file` and optional
-/// `model` / `response_format` / `language` / `timestamp_granularities[]`.
+/// `model` / `response_format` / `language` / `timestamp_granularities[]` /
+/// `stream`.
 ///
 /// | `response_format` | Body |
 /// |---|---|
@@ -1008,6 +1009,10 @@ pub async fn transcribe(
 /// | `text` | plain text |
 /// | `srt` / `vtt` | captions |
 /// | `verbose_json` | Whisper-style JSON (`task`, `language`, `duration`, `text`, optional `segments`/`words`) |
+///
+/// With `stream=true` (only with `json`/`text`): SSE of
+/// `transcript.text.delta` events, a final `transcript.text.done`, then
+/// `data: [DONE]`. Progressive deltas come from the real chunked encoder path.
 ///
 /// Reuses the same inference pipeline as [`transcribe`]. `model` is accepted
 /// and ignored (single loaded head). For diarization, telephony codecs, or
@@ -1017,8 +1022,139 @@ pub async fn openai_transcriptions(
     multipart: Multipart,
 ) -> Result<Response, ApiError> {
     let req = super::openai::parse_openai_multipart(multipart).await?;
+    if req.options.stream {
+        return openai_transcriptions_stream(state, req.file).await;
+    }
     let result = run_file_transcription(&state, req.file, &ExportParams::default()).await?;
     Ok(super::openai::render_openai_response(&result, &req.options))
+}
+
+/// OpenAI `stream=true` path: chunked file transcription as SSE transcript events.
+async fn openai_transcriptions_stream(
+    state: Arc<AppState>,
+    body: Bytes,
+) -> Result<Response, ApiError> {
+    // Same early guards as `/v1/transcribe/stream` — empty / oversized body.
+    if body.is_empty() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "Empty request body",
+            "empty_body",
+        ));
+    }
+    let limits = state.limits.load();
+    if body.len() > limits.body_limit_bytes {
+        return Err(api_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "Request body exceeds the configured size limit",
+            "payload_too_large",
+        ));
+    }
+
+    let engine = state.engine.load_full();
+    let mut reservation =
+        reserve_batch_slot(&engine, &limits, state.metrics_registry.as_ref()).await?;
+
+    let samples = tokio::task::spawn_blocking(move || {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            gigastt_core::inference::audio::decode_audio_bytes_shared(body)
+        })) {
+            Ok(inner) => inner,
+            Err(_) => {
+                tracing::error!("Panic in OpenAI SSE audio decode — treated as decode error");
+                Err(anyhow::anyhow!("Audio decode thread panicked"))
+            }
+        }
+    })
+    .await
+    .map_err(|e| {
+        tracing::error!("spawn_blocking join error: {e}");
+        api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Internal server error",
+            "internal",
+        )
+    })?
+    .map_err(|e| {
+        tracing::error!("Audio decode error: {e:#}");
+        api_error(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Failed to decode audio file. Check format (WAV, MP3, M4A, OGG, FLAC supported).",
+            "invalid_audio",
+        )
+    })?;
+
+    // Channel of pre-rendered SSE `data:` payloads (JSON events or `[DONE]`).
+    let (tx, rx) = tokio::sync::mpsc::channel::<String>(32);
+
+    let cancel = state.shutdown.clone();
+    let tracker = state.tracker.clone();
+    let span = tracing::Span::current();
+    tracker.spawn_blocking(move || {
+        let _enter = span.enter();
+        use super::openai::{OpenAIStreamAssembler, sse_delta_payload, sse_done_payload};
+
+        let send = |payload: String| -> bool { tx.blocking_send(payload).is_ok() };
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut stream_state = engine.create_state(false);
+            let mut asm = OpenAIStreamAssembler::new();
+            let chunk_size = 16000; // 1 s @ 16 kHz
+
+            for chunk in samples.chunks(chunk_size) {
+                if cancel.is_cancelled() {
+                    tracing::info!("OpenAI SSE transcription cancelled by shutdown");
+                    return;
+                }
+                match engine.process_chunk(chunk, &mut stream_state, &mut reservation) {
+                    Ok(segs) => {
+                        for seg in segs {
+                            if let Some(delta) = asm.push_segment(&seg.text, seg.is_final)
+                                && !send(sse_delta_payload(&delta))
+                            {
+                                return; // client gone
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("OpenAI SSE transcription error: {e}");
+                        // Surface a final done with whatever we have so clients
+                        // do not hang; OpenAI stream errors are not standardized.
+                        let _ = send(sse_done_payload(asm.text()));
+                        let _ = send("[DONE]".into());
+                        return;
+                    }
+                }
+            }
+
+            if let Some(seg) = engine.finish_stream(&mut stream_state, &mut reservation)
+                && let Some(delta) = asm.push_segment(&seg.text, seg.is_final)
+            {
+                let _ = send(sse_delta_payload(&delta));
+            }
+
+            let _ = send(sse_done_payload(asm.text()));
+            let _ = send("[DONE]".into());
+        }));
+
+        if result.is_err() {
+            tracing::error!("Panic in OpenAI SSE inference task — triplet recovered");
+            let _ = send(sse_done_payload(""));
+            let _ = send("[DONE]".into());
+        }
+        // reservation dropped → pool
+    });
+
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx)
+        .map(|data| Ok::<_, std::convert::Infallible>(super::openai::sse_event_data(data)));
+
+    Ok(Sse::new(stream)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(std::time::Duration::from_secs(15))
+                .text(""),
+        )
+        .into_response())
 }
 
 /// POST /v1/transcribe/stream — upload audio file, get SSE stream of partial/final results.

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -176,17 +176,6 @@ pub struct TranscribeResponse {
     pub segments: Option<Vec<Segment>>,
 }
 
-/// OpenAI-compatible transcription response for `POST /v1/audio/transcriptions`.
-///
-/// Matches the minimal OpenAI Audio Transcriptions JSON shape used by
-/// llama-swap, Hermes Agent, and other clients that point `base_url` at a
-/// local STT server: only `{"text":"..."}` (no `words` / `duration`).
-#[derive(Debug, Serialize, Deserialize)]
-pub struct OpenAITranscriptionResponse {
-    /// Full recognized transcript text.
-    pub text: String,
-}
-
 /// Query parameters for `/v1/transcribe` export formatting.
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct ExportParams {
@@ -970,54 +959,6 @@ async fn run_file_transcription(
     }
 }
 
-/// Parse an OpenAI-style multipart body for `POST /v1/audio/transcriptions`.
-///
-/// Requires a non-empty `file` field. Accepts (and ignores) `model` and any
-/// other OpenAI form fields (`language`, `prompt`, `response_format`, …) so
-/// clients that send the full OpenAI request shape keep working. A single-head
-/// server always runs the loaded engine regardless of the `model` string
-/// (llama-swap / Hermes often pass `whisper-1` or a local alias).
-async fn parse_openai_transcription_multipart(mut multipart: Multipart) -> Result<Bytes, ApiError> {
-    let mut file: Option<Bytes> = None;
-    while let Some(field) = multipart.next_field().await.map_err(|e| {
-        api_error(
-            StatusCode::BAD_REQUEST,
-            &format!("Invalid multipart body: {e}"),
-            "invalid_multipart",
-        )
-    })? {
-        let name = field.name().unwrap_or("").to_string();
-        let data = field.bytes().await.map_err(|e| {
-            api_error(
-                StatusCode::BAD_REQUEST,
-                &format!("Failed to read multipart field: {e}"),
-                "invalid_multipart",
-            )
-        })?;
-        match name.as_str() {
-            "file" => file = Some(data),
-            // Accepted for OpenAI client compatibility; not used for routing.
-            "model" | "language" | "prompt" | "response_format" | "temperature" => {}
-            _ => {}
-        }
-    }
-    let file = file.ok_or_else(|| {
-        api_error(
-            StatusCode::BAD_REQUEST,
-            "Missing required form field: file",
-            "missing_file",
-        )
-    })?;
-    if file.is_empty() {
-        return Err(api_error(
-            StatusCode::BAD_REQUEST,
-            "Empty request body",
-            "empty_body",
-        ));
-    }
-    Ok(file)
-}
-
 /// POST /v1/transcribe — upload audio file, get full transcript.
 ///
 /// Accepts raw audio body. Supported formats: WAV (including G.711 A-law /
@@ -1056,19 +997,28 @@ pub async fn transcribe(
 
 /// POST /v1/audio/transcriptions — OpenAI-compatible file transcription.
 ///
-/// Minimal surface for clients that speak the OpenAI Audio Transcriptions API
-/// (llama-swap, Hermes Agent, OpenAI SDKs with a custom `base_url`):
-/// `multipart/form-data` with `file` (+ optional `model`) → `{"text":"..."}`.
+/// Compatibility surface for clients that speak the OpenAI Audio Transcriptions
+/// API (llama-swap, Hermes Agent, OpenAI SDKs with a custom `base_url`):
+/// `multipart/form-data` with required `file` and optional
+/// `model` / `response_format` / `language` / `timestamp_granularities[]`.
 ///
-/// Reuses the same inference pipeline as [`transcribe`]; does not expose
-/// export formats, segments, or word timestamps (use `/v1/transcribe` for those).
+/// | `response_format` | Body |
+/// |---|---|
+/// | `json` (default) | `{"text":"..."}` |
+/// | `text` | plain text |
+/// | `srt` / `vtt` | captions |
+/// | `verbose_json` | Whisper-style JSON (`task`, `language`, `duration`, `text`, optional `segments`/`words`) |
+///
+/// Reuses the same inference pipeline as [`transcribe`]. `model` is accepted
+/// and ignored (single loaded head). For diarization, telephony codecs, or
+/// native export knobs use `/v1/transcribe`.
 pub async fn openai_transcriptions(
     State(state): State<Arc<AppState>>,
     multipart: Multipart,
-) -> Result<Json<OpenAITranscriptionResponse>, ApiError> {
-    let body = parse_openai_transcription_multipart(multipart).await?;
-    let result = run_file_transcription(&state, body, &ExportParams::default()).await?;
-    Ok(Json(OpenAITranscriptionResponse { text: result.text }))
+) -> Result<Response, ApiError> {
+    let req = super::openai::parse_openai_multipart(multipart).await?;
+    let result = run_file_transcription(&state, req.file, &ExportParams::default()).await?;
+    Ok(super::openai::render_openai_response(&result, &req.options))
 }
 
 /// POST /v1/transcribe/stream — upload audio file, get SSE stream of partial/final results.
@@ -1657,184 +1607,6 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["text"], "hello");
         assert_eq!(v["duration"], 1.5);
-    }
-
-    #[test]
-    fn test_openai_transcription_response_is_text_only() {
-        // OpenAI-compatible clients (llama-swap, Hermes) expect exactly
-        // `{"text":"..."}` — no words/duration fields from the native API.
-        let resp = OpenAITranscriptionResponse {
-            text: "привет".into(),
-        };
-        let v = serde_json::to_value(&resp).unwrap();
-        assert_eq!(v["text"], "привет");
-        let obj = v.as_object().unwrap();
-        assert_eq!(
-            obj.len(),
-            1,
-            "OpenAI response must contain only `text`: {obj:?}"
-        );
-    }
-
-    /// Build a minimal `multipart/form-data` body for OpenAI transcription tests.
-    fn openai_multipart_body(boundary: &str, fields: &[(&str, Option<&str>, &[u8])]) -> Vec<u8> {
-        // fields: (name, optional filename, value bytes)
-        let mut body = Vec::new();
-        for (name, filename, value) in fields {
-            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
-            match filename {
-                Some(fname) => {
-                    body.extend_from_slice(
-                        format!(
-                            "Content-Disposition: form-data; name=\"{name}\"; filename=\"{fname}\"\r\n\
-                             Content-Type: application/octet-stream\r\n\r\n"
-                        )
-                        .as_bytes(),
-                    );
-                }
-                None => {
-                    body.extend_from_slice(
-                        format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n")
-                            .as_bytes(),
-                    );
-                }
-            }
-            body.extend_from_slice(value);
-            body.extend_from_slice(b"\r\n");
-        }
-        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
-        body
-    }
-
-    #[tokio::test]
-    async fn test_parse_openai_multipart_extracts_file_and_ignores_model() {
-        use axum::Router;
-        use axum::routing::post;
-
-        let app = Router::new().route(
-            "/t",
-            post(|multipart: Multipart| async move {
-                match parse_openai_transcription_multipart(multipart).await {
-                    Ok(bytes) => (StatusCode::OK, bytes).into_response(),
-                    Err(resp) => resp,
-                }
-            }),
-        );
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-
-        let boundary = "----gigasttTestBoundary";
-        let file_bytes = b"RIFF....fake-wav-payload";
-        let body = openai_multipart_body(
-            boundary,
-            &[
-                ("model", None, b"whisper-1"),
-                ("file", Some("clip.wav"), file_bytes),
-                ("language", None, b"ru"),
-            ],
-        );
-
-        let resp = reqwest::Client::new()
-            .post(format!("http://127.0.0.1:{port}/t"))
-            .header(
-                "content-type",
-                format!("multipart/form-data; boundary={boundary}"),
-            )
-            .body(body)
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), 200);
-        let got = resp.bytes().await.unwrap();
-        assert_eq!(&got[..], file_bytes);
-    }
-
-    #[tokio::test]
-    async fn test_parse_openai_multipart_missing_file_returns_400() {
-        use axum::Router;
-        use axum::routing::post;
-
-        let app = Router::new().route(
-            "/t",
-            post(|multipart: Multipart| async move {
-                match parse_openai_transcription_multipart(multipart).await {
-                    Ok(bytes) => (StatusCode::OK, bytes).into_response(),
-                    Err(resp) => resp,
-                }
-            }),
-        );
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-
-        let boundary = "----gigasttTestBoundary";
-        let body = openai_multipart_body(boundary, &[("model", None, b"whisper-1")]);
-
-        let resp = reqwest::Client::new()
-            .post(format!("http://127.0.0.1:{port}/t"))
-            .header(
-                "content-type",
-                format!("multipart/form-data; boundary={boundary}"),
-            )
-            .body(body)
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), 400);
-        let v: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
-        assert_eq!(v["code"], "missing_file");
-    }
-
-    #[tokio::test]
-    async fn test_parse_openai_multipart_empty_file_returns_400() {
-        use axum::Router;
-        use axum::routing::post;
-
-        let app = Router::new().route(
-            "/t",
-            post(|multipart: Multipart| async move {
-                match parse_openai_transcription_multipart(multipart).await {
-                    Ok(bytes) => (StatusCode::OK, bytes).into_response(),
-                    Err(resp) => resp,
-                }
-            }),
-        );
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-
-        let boundary = "----gigasttTestBoundary";
-        let body = openai_multipart_body(
-            boundary,
-            &[
-                ("model", None, b"gigaam-v3-rnnt"),
-                ("file", Some("empty.wav"), b""),
-            ],
-        );
-
-        let resp = reqwest::Client::new()
-            .post(format!("http://127.0.0.1:{port}/t"))
-            .header(
-                "content-type",
-                format!("multipart/form-data; boundary={boundary}"),
-            )
-            .body(body)
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), 400);
-        let v: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
-        assert_eq!(v["code"], "empty_body");
     }
 
     #[test]

--- a/crates/gigastt/src/server/http.rs
+++ b/crates/gigastt/src/server/http.rs
@@ -1,7 +1,7 @@
 //! HTTP handlers for REST API endpoints.
 
 use axum::body::Bytes;
-use axum::extract::{Query, State};
+use axum::extract::{Multipart, Query, State};
 use axum::http::StatusCode;
 use axum::http::header;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -174,6 +174,17 @@ pub struct TranscribeResponse {
     /// so existing clients that read `text` / `words` / `duration` are unaffected.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub segments: Option<Vec<Segment>>,
+}
+
+/// OpenAI-compatible transcription response for `POST /v1/audio/transcriptions`.
+///
+/// Matches the minimal OpenAI Audio Transcriptions JSON shape used by
+/// llama-swap, Hermes Agent, and other clients that point `base_url` at a
+/// local STT server: only `{"text":"..."}` (no `words` / `duration`).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OpenAITranscriptionResponse {
+    /// Full recognized transcript text.
+    pub text: String,
 }
 
 /// Query parameters for `/v1/transcribe` export formatting.
@@ -743,18 +754,14 @@ pub async fn models(State(state): State<Arc<AppState>>) -> Json<ModelInfo> {
     })
 }
 
-/// POST /v1/transcribe — upload audio file, get full transcript.
-///
-/// Accepts raw audio body. Supported formats: WAV (including G.711 A-law /
-/// μ-law and G.722 inside WAV), MP3, M4A/AAC, OGG, FLAC — plus headerless
-/// telephony streams when `?codec=pcmu|pcma|g722&sample_rate=N` is given.
-/// Max body size enforced by the axum `DefaultBodyLimit` layer configured
-/// from [`RuntimeLimits::body_limit_bytes`] (default 50 MiB).
-pub async fn transcribe(
-    State(state): State<Arc<AppState>>,
-    Query(params): Query<ExportParams>,
+/// Shared file-transcription pipeline used by `/v1/transcribe` and the
+/// OpenAI-compatible `/v1/audio/transcriptions` alias. Returns the engine
+/// result so each surface can shape its own response envelope.
+async fn run_file_transcription(
+    state: &AppState,
     body: Bytes,
-) -> Result<Response, ApiError> {
+    params: &ExportParams,
+) -> Result<gigastt_core::inference::TranscribeResult, ApiError> {
     if body.is_empty() {
         return Err(api_error(
             StatusCode::BAD_REQUEST,
@@ -791,7 +798,7 @@ pub async fn transcribe(
     // Raw telephony upload (`?codec=`): validate the codec/rate pair up front
     // so a malformed request 400s before a pool slot is reserved. The actual
     // decode happens inside the blocking closure below.
-    let raw_codec = resolve_raw_codec(&params)?;
+    let raw_codec = resolve_raw_codec(params)?;
 
     // Snapshot the current engine once at request start; a concurrent hot-reload
     // swaps the `ArcSwap`, but this request keeps the engine (and its pool) it
@@ -818,11 +825,11 @@ pub async fn transcribe(
             ));
         }
     }
-    let overrides = overrides_from_export_params(&params);
+    let overrides = overrides_from_export_params(params);
     if let Err(e) = engine.validate_overrides(&overrides) {
         return Err(api_error(StatusCode::CONFLICT, e.message(), e.code()));
     }
-    let hotwords = hotwords_from_export_params(&params);
+    let hotwords = hotwords_from_export_params(params);
     if let Some(ref hw) = hotwords
         && let Err(e) = engine.validate_hotwords(hw)
     {
@@ -940,29 +947,7 @@ pub async fn transcribe(
     }
 
     match result {
-        Ok(Ok(result)) => {
-            if let Some(rendered) = render_export_response(&result, &params)? {
-                Ok(rendered)
-            } else {
-                // Default JSON response. `?segments=true` adds a cue-grouped
-                // `segments` array (same boundaries as SRT/VTT) alongside the
-                // unchanged top-level `text` / `words` / `duration`; absent
-                // otherwise so existing clients see the exact same shape.
-                let segments = if params.segments.unwrap_or(false) {
-                    Some(gigastt_core::export::to_transcript_segments(&result.words))
-                } else {
-                    None
-                };
-                Ok(Json(TranscribeResponse {
-                    text: result.text,
-                    words: result.words,
-                    duration: result.duration_s,
-                    confidence: result.confidence,
-                    segments,
-                })
-                .into_response())
-            }
-        }
+        Ok(Ok(result)) => Ok(result),
         Ok(Err(e)) => {
             tracing::error!("Transcription error: {e}");
             Err(api_error(
@@ -983,6 +968,107 @@ pub async fn transcribe(
             ))
         }
     }
+}
+
+/// Parse an OpenAI-style multipart body for `POST /v1/audio/transcriptions`.
+///
+/// Requires a non-empty `file` field. Accepts (and ignores) `model` and any
+/// other OpenAI form fields (`language`, `prompt`, `response_format`, …) so
+/// clients that send the full OpenAI request shape keep working. A single-head
+/// server always runs the loaded engine regardless of the `model` string
+/// (llama-swap / Hermes often pass `whisper-1` or a local alias).
+async fn parse_openai_transcription_multipart(mut multipart: Multipart) -> Result<Bytes, ApiError> {
+    let mut file: Option<Bytes> = None;
+    while let Some(field) = multipart.next_field().await.map_err(|e| {
+        api_error(
+            StatusCode::BAD_REQUEST,
+            &format!("Invalid multipart body: {e}"),
+            "invalid_multipart",
+        )
+    })? {
+        let name = field.name().unwrap_or("").to_string();
+        let data = field.bytes().await.map_err(|e| {
+            api_error(
+                StatusCode::BAD_REQUEST,
+                &format!("Failed to read multipart field: {e}"),
+                "invalid_multipart",
+            )
+        })?;
+        match name.as_str() {
+            "file" => file = Some(data),
+            // Accepted for OpenAI client compatibility; not used for routing.
+            "model" | "language" | "prompt" | "response_format" | "temperature" => {}
+            _ => {}
+        }
+    }
+    let file = file.ok_or_else(|| {
+        api_error(
+            StatusCode::BAD_REQUEST,
+            "Missing required form field: file",
+            "missing_file",
+        )
+    })?;
+    if file.is_empty() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "Empty request body",
+            "empty_body",
+        ));
+    }
+    Ok(file)
+}
+
+/// POST /v1/transcribe — upload audio file, get full transcript.
+///
+/// Accepts raw audio body. Supported formats: WAV (including G.711 A-law /
+/// μ-law and G.722 inside WAV), MP3, M4A/AAC, OGG, FLAC — plus headerless
+/// telephony streams when `?codec=pcmu|pcma|g722&sample_rate=N` is given.
+/// Max body size enforced by the axum `DefaultBodyLimit` layer configured
+/// from [`RuntimeLimits::body_limit_bytes`] (default 50 MiB).
+pub async fn transcribe(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<ExportParams>,
+    body: Bytes,
+) -> Result<Response, ApiError> {
+    let result = run_file_transcription(&state, body, &params).await?;
+    if let Some(rendered) = render_export_response(&result, &params)? {
+        Ok(rendered)
+    } else {
+        // Default JSON response. `?segments=true` adds a cue-grouped
+        // `segments` array (same boundaries as SRT/VTT) alongside the
+        // unchanged top-level `text` / `words` / `duration`; absent
+        // otherwise so existing clients see the exact same shape.
+        let segments = if params.segments.unwrap_or(false) {
+            Some(gigastt_core::export::to_transcript_segments(&result.words))
+        } else {
+            None
+        };
+        Ok(Json(TranscribeResponse {
+            text: result.text,
+            words: result.words,
+            duration: result.duration_s,
+            confidence: result.confidence,
+            segments,
+        })
+        .into_response())
+    }
+}
+
+/// POST /v1/audio/transcriptions — OpenAI-compatible file transcription.
+///
+/// Minimal surface for clients that speak the OpenAI Audio Transcriptions API
+/// (llama-swap, Hermes Agent, OpenAI SDKs with a custom `base_url`):
+/// `multipart/form-data` with `file` (+ optional `model`) → `{"text":"..."}`.
+///
+/// Reuses the same inference pipeline as [`transcribe`]; does not expose
+/// export formats, segments, or word timestamps (use `/v1/transcribe` for those).
+pub async fn openai_transcriptions(
+    State(state): State<Arc<AppState>>,
+    multipart: Multipart,
+) -> Result<Json<OpenAITranscriptionResponse>, ApiError> {
+    let body = parse_openai_transcription_multipart(multipart).await?;
+    let result = run_file_transcription(&state, body, &ExportParams::default()).await?;
+    Ok(Json(OpenAITranscriptionResponse { text: result.text }))
 }
 
 /// POST /v1/transcribe/stream — upload audio file, get SSE stream of partial/final results.
@@ -1571,6 +1657,184 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["text"], "hello");
         assert_eq!(v["duration"], 1.5);
+    }
+
+    #[test]
+    fn test_openai_transcription_response_is_text_only() {
+        // OpenAI-compatible clients (llama-swap, Hermes) expect exactly
+        // `{"text":"..."}` — no words/duration fields from the native API.
+        let resp = OpenAITranscriptionResponse {
+            text: "привет".into(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["text"], "привет");
+        let obj = v.as_object().unwrap();
+        assert_eq!(
+            obj.len(),
+            1,
+            "OpenAI response must contain only `text`: {obj:?}"
+        );
+    }
+
+    /// Build a minimal `multipart/form-data` body for OpenAI transcription tests.
+    fn openai_multipart_body(boundary: &str, fields: &[(&str, Option<&str>, &[u8])]) -> Vec<u8> {
+        // fields: (name, optional filename, value bytes)
+        let mut body = Vec::new();
+        for (name, filename, value) in fields {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            match filename {
+                Some(fname) => {
+                    body.extend_from_slice(
+                        format!(
+                            "Content-Disposition: form-data; name=\"{name}\"; filename=\"{fname}\"\r\n\
+                             Content-Type: application/octet-stream\r\n\r\n"
+                        )
+                        .as_bytes(),
+                    );
+                }
+                None => {
+                    body.extend_from_slice(
+                        format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n")
+                            .as_bytes(),
+                    );
+                }
+            }
+            body.extend_from_slice(value);
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    #[tokio::test]
+    async fn test_parse_openai_multipart_extracts_file_and_ignores_model() {
+        use axum::Router;
+        use axum::routing::post;
+
+        let app = Router::new().route(
+            "/t",
+            post(|multipart: Multipart| async move {
+                match parse_openai_transcription_multipart(multipart).await {
+                    Ok(bytes) => (StatusCode::OK, bytes).into_response(),
+                    Err(resp) => resp,
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let boundary = "----gigasttTestBoundary";
+        let file_bytes = b"RIFF....fake-wav-payload";
+        let body = openai_multipart_body(
+            boundary,
+            &[
+                ("model", None, b"whisper-1"),
+                ("file", Some("clip.wav"), file_bytes),
+                ("language", None, b"ru"),
+            ],
+        );
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/t"))
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let got = resp.bytes().await.unwrap();
+        assert_eq!(&got[..], file_bytes);
+    }
+
+    #[tokio::test]
+    async fn test_parse_openai_multipart_missing_file_returns_400() {
+        use axum::Router;
+        use axum::routing::post;
+
+        let app = Router::new().route(
+            "/t",
+            post(|multipart: Multipart| async move {
+                match parse_openai_transcription_multipart(multipart).await {
+                    Ok(bytes) => (StatusCode::OK, bytes).into_response(),
+                    Err(resp) => resp,
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let boundary = "----gigasttTestBoundary";
+        let body = openai_multipart_body(boundary, &[("model", None, b"whisper-1")]);
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/t"))
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+        let v: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(v["code"], "missing_file");
+    }
+
+    #[tokio::test]
+    async fn test_parse_openai_multipart_empty_file_returns_400() {
+        use axum::Router;
+        use axum::routing::post;
+
+        let app = Router::new().route(
+            "/t",
+            post(|multipart: Multipart| async move {
+                match parse_openai_transcription_multipart(multipart).await {
+                    Ok(bytes) => (StatusCode::OK, bytes).into_response(),
+                    Err(resp) => resp,
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let boundary = "----gigasttTestBoundary";
+        let body = openai_multipart_body(
+            boundary,
+            &[
+                ("model", None, b"gigaam-v3-rnnt"),
+                ("file", Some("empty.wav"), b""),
+            ],
+        );
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/t"))
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+        let v: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(v["code"], "empty_body");
     }
 
     #[test]

--- a/crates/gigastt/src/server/middleware.rs
+++ b/crates/gigastt/src/server/middleware.rs
@@ -16,6 +16,7 @@ fn metric_path_label(path: &str) -> &'static str {
         "/v1/models" => "/v1/models",
         "/v1/transcribe" => "/v1/transcribe",
         "/v1/transcribe/stream" => "/v1/transcribe/stream",
+        "/v1/audio/transcriptions" => "/v1/audio/transcriptions",
         "/v1/ws" => "/v1/ws",
         "/v1/admin/reload" => "/v1/admin/reload",
         "/metrics" => "/metrics",
@@ -179,6 +180,7 @@ mod tests {
             "/v1/models",
             "/v1/transcribe",
             "/v1/transcribe/stream",
+            "/v1/audio/transcriptions",
             "/v1/ws",
             "/metrics",
         ] {

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -8,6 +8,7 @@ pub mod http;
 pub mod jobs;
 pub mod metrics;
 pub(crate) mod middleware;
+pub(crate) mod openai;
 pub mod rate_limit;
 mod ws;
 

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -37,6 +37,7 @@ pub(crate) fn json_text(msg: &impl serde::Serialize) -> String {
 /// - `GET /health` — health check
 /// - `POST /v1/transcribe` — file transcription
 /// - `POST /v1/transcribe/stream` — SSE streaming transcription
+/// - `POST /v1/audio/transcriptions` — OpenAI-compatible file transcription
 /// - `GET /v1/ws` — WebSocket streaming protocol
 ///
 /// Runs until `Ctrl-C` is received.
@@ -525,6 +526,16 @@ pub async fn run_with_config_listener_reloadable(
             "/v1/transcribe/stream",
             options(|| async { StatusCode::NO_CONTENT }),
         )
+        // OpenAI-compatible alias for clients (llama-swap, Hermes Agent, SDKs
+        // with a custom base_url) that POST multipart `file` + `model`.
+        .route(
+            "/v1/audio/transcriptions",
+            post(http::openai_transcriptions),
+        )
+        .route(
+            "/v1/audio/transcriptions",
+            options(|| async { StatusCode::NO_CONTENT }),
+        )
         // /v1/ws is the canonical WebSocket path (versioned, aligned with REST).
         .route("/v1/ws", get(ws::ws_handler))
         .route("/v1/ws", options(|| async { StatusCode::NO_CONTENT }))
@@ -633,7 +644,7 @@ pub async fn run_with_config_listener_reloadable(
     tracing::info!("gigastt server listening on http://{addr}");
     tracing::info!("  WebSocket: ws://{addr}/v1/ws");
     tracing::info!(
-        "  REST API:  http://{addr}/health, /ready, /v1/transcribe, /v1/transcribe/stream"
+        "  REST API:  http://{addr}/health, /ready, /v1/transcribe, /v1/transcribe/stream, /v1/audio/transcriptions"
     );
     if config.origin_policy.allow_any {
         tracing::warn!(

--- a/crates/gigastt/src/server/openai.rs
+++ b/crates/gigastt/src/server/openai.rs
@@ -1,0 +1,781 @@
+//! OpenAI Audio Transcriptions compatibility layer.
+//!
+//! Implements the subset of
+//! [`POST /v1/audio/transcriptions`](https://platform.openai.com/docs/api-reference/audio/createTranscription)
+//! that local agents (llama-swap, Hermes, OpenAI SDKs with a custom `base_url`)
+//! actually exercise:
+//!
+//! | Form field | Behaviour |
+//! |---|---|
+//! | `file` | required audio bytes |
+//! | `model` | accepted, ignored (single loaded head) |
+//! | `response_format` | `json` (default) · `text` · `srt` · `vtt` · `verbose_json` |
+//! | `language` | accepted; echoed in `verbose_json` (default `ru`) |
+//! | `timestamp_granularities[]` | `word` / `segment` for `verbose_json` |
+//! | `prompt`, `temperature` | accepted, ignored |
+//!
+//! Inference reuses the native pipeline; this module only shapes the request
+//! and response envelopes.
+
+use axum::body::Bytes;
+use axum::extract::Multipart;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Json, Response};
+use gigastt_core::export::{RenderOpts, to_srt, to_transcript_segments, to_vtt};
+use gigastt_core::inference::{TranscribeResult, WordInfo};
+use serde::Serialize;
+
+/// Wire value of OpenAI `response_format`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OpenAIResponseFormat {
+    /// `{"text":"..."}` — OpenAI default for whisper-1.
+    #[default]
+    Json,
+    /// Raw transcript body (`text/plain`).
+    Text,
+    /// SubRip captions.
+    Srt,
+    /// WebVTT captions.
+    Vtt,
+    /// Whisper-style verbose JSON with optional segments/words.
+    VerboseJson,
+}
+
+impl OpenAIResponseFormat {
+    /// Parse an OpenAI `response_format` token. Unknown values are errors so
+    /// clients get a typed 400 instead of a silent fallback.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "" | "json" => Ok(Self::Json),
+            "text" => Ok(Self::Text),
+            "srt" => Ok(Self::Srt),
+            "vtt" => Ok(Self::Vtt),
+            "verbose_json" => Ok(Self::VerboseJson),
+            other => Err(format!(
+                "Unsupported response_format '{other}'. Supported: json, text, srt, vtt, verbose_json"
+            )),
+        }
+    }
+}
+
+/// Parsed OpenAI multipart options (everything except the audio file).
+#[derive(Debug, Clone, Default)]
+pub struct OpenAITranscriptionOptions {
+    /// OpenAI `model` string — accepted for client compatibility, never used
+    /// to select a head (single-engine server).
+    pub model: Option<String>,
+    /// OpenAI `language` (ISO-639-1 or longer names). Echoed in verbose JSON;
+    /// does not reconfigure the loaded head.
+    pub language: Option<String>,
+    /// `response_format` (default `json`).
+    pub response_format: OpenAIResponseFormat,
+    /// Whether `verbose_json` should include word-level timestamps.
+    pub include_words: bool,
+    /// Whether `verbose_json` should include segment-level timestamps.
+    pub include_segments: bool,
+}
+
+/// Fully parsed multipart request.
+#[derive(Debug)]
+pub struct OpenAITranscriptionRequest {
+    pub file: Bytes,
+    pub options: OpenAITranscriptionOptions,
+}
+
+/// Default JSON body: `{"text":"..."}`.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct OpenAIJsonResponse {
+    pub text: String,
+}
+
+/// One word in OpenAI `verbose_json.words[]`.
+#[derive(Debug, Serialize)]
+pub struct OpenAIWord {
+    pub word: String,
+    pub start: f64,
+    pub end: f64,
+}
+
+/// One segment in OpenAI `verbose_json.segments[]` (Whisper-compatible fields
+/// clients commonly read: `id`, `start`, `end`, `text`. Extra Whisper-only
+/// fields are filled with stable zeros so typed clients do not break).
+#[derive(Debug, Serialize)]
+pub struct OpenAISegment {
+    pub id: u32,
+    pub seek: u32,
+    pub start: f64,
+    pub end: f64,
+    pub text: String,
+    pub tokens: Vec<u32>,
+    pub temperature: f64,
+    pub avg_logprob: f64,
+    pub compression_ratio: f64,
+    pub no_speech_prob: f64,
+}
+
+/// OpenAI `verbose_json` envelope.
+#[derive(Debug, Serialize)]
+pub struct OpenAIVerboseResponse {
+    pub task: &'static str,
+    pub language: String,
+    pub duration: f64,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segments: Option<Vec<OpenAISegment>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub words: Option<Vec<OpenAIWord>>,
+}
+
+/// Map an internal error into the gigastt REST error envelope.
+fn openai_error(status: StatusCode, msg: &str, code: &str) -> Response {
+    (
+        status,
+        Json(serde_json::json!({"error": msg, "code": code})),
+    )
+        .into_response()
+}
+
+/// Normalize a client-supplied language tag for echo in `verbose_json`.
+///
+/// Accepts ISO-639-1 (`ru`, `en`) and a few common full names. Unknown tokens
+/// are lowercased and passed through unchanged so multi-lingual heads keep
+/// whatever the client sent.
+pub fn normalize_language(raw: &str) -> String {
+    let t = raw.trim();
+    if t.is_empty() {
+        return "ru".into();
+    }
+    match t.to_ascii_lowercase().as_str() {
+        "ru" | "rus" | "russian" | "ru-ru" => "ru".into(),
+        "en" | "eng" | "english" | "en-us" | "en-gb" => "en".into(),
+        "kk" | "kaz" | "kazakh" => "kk".into(),
+        "ky" | "kir" | "kyrgyz" => "ky".into(),
+        "uz" | "uzb" | "uzbek" => "uz".into(),
+        other => other.to_string(),
+    }
+}
+
+/// Apply one form field into `options`. Returns `Err(message)` for invalid
+/// `response_format` / granularities. Pure: unit-testable without Multipart.
+pub fn apply_openai_form_field(
+    options: &mut OpenAITranscriptionOptions,
+    name: &str,
+    value: &[u8],
+) -> Result<(), String> {
+    let text = || String::from_utf8_lossy(value).into_owned();
+    match name {
+        "model" => {
+            let s = text();
+            if !s.is_empty() {
+                options.model = Some(s);
+            }
+        }
+        "language" => {
+            let s = text();
+            if !s.is_empty() {
+                options.language = Some(s);
+            }
+        }
+        "response_format" => {
+            options.response_format = OpenAIResponseFormat::parse(&text())?;
+        }
+        // OpenAI SDKs send either `timestamp_granularities[]` or bare
+        // `timestamp_granularities` as repeated fields.
+        "timestamp_granularities[]" | "timestamp_granularities" => {
+            match text().trim().to_ascii_lowercase().as_str() {
+                "word" => options.include_words = true,
+                "segment" => options.include_segments = true,
+                "" => {}
+                other => {
+                    return Err(format!(
+                        "Unsupported timestamp_granularity '{other}'. Supported: word, segment"
+                    ));
+                }
+            }
+        }
+        // Accepted for SDK compatibility; no server-side effect.
+        "prompt" | "temperature" => {}
+        _ => {}
+    }
+    Ok(())
+}
+
+/// After all fields are applied, resolve default granularities for
+/// `verbose_json`: if the client requested neither, include segments only
+/// (OpenAI historical default).
+pub fn finalize_openai_options(options: &mut OpenAITranscriptionOptions) {
+    if options.response_format == OpenAIResponseFormat::VerboseJson
+        && !options.include_words
+        && !options.include_segments
+    {
+        options.include_segments = true;
+    }
+}
+
+/// Parse an OpenAI-style multipart body into a typed request.
+pub async fn parse_openai_multipart(
+    mut multipart: Multipart,
+) -> Result<OpenAITranscriptionRequest, Response> {
+    let mut file: Option<Bytes> = None;
+    let mut options = OpenAITranscriptionOptions::default();
+
+    while let Some(field) = multipart.next_field().await.map_err(|e| {
+        openai_error(
+            StatusCode::BAD_REQUEST,
+            &format!("Invalid multipart body: {e}"),
+            "invalid_multipart",
+        )
+    })? {
+        let name = field.name().unwrap_or("").to_string();
+        let data = field.bytes().await.map_err(|e| {
+            openai_error(
+                StatusCode::BAD_REQUEST,
+                &format!("Failed to read multipart field: {e}"),
+                "invalid_multipart",
+            )
+        })?;
+        if name == "file" {
+            file = Some(data);
+            continue;
+        }
+        if let Err(msg) = apply_openai_form_field(&mut options, &name, &data) {
+            let code = if msg.contains("response_format") {
+                "invalid_response_format"
+            } else if msg.contains("timestamp_granularity") {
+                "invalid_timestamp_granularity"
+            } else {
+                "invalid_multipart"
+            };
+            return Err(openai_error(StatusCode::BAD_REQUEST, &msg, code));
+        }
+    }
+
+    finalize_openai_options(&mut options);
+
+    let file = file.ok_or_else(|| {
+        openai_error(
+            StatusCode::BAD_REQUEST,
+            "Missing required form field: file",
+            "missing_file",
+        )
+    })?;
+    if file.is_empty() {
+        return Err(openai_error(
+            StatusCode::BAD_REQUEST,
+            "Empty request body",
+            "empty_body",
+        ));
+    }
+
+    Ok(OpenAITranscriptionRequest { file, options })
+}
+
+fn openai_words(words: &[WordInfo]) -> Vec<OpenAIWord> {
+    words
+        .iter()
+        .map(|w| OpenAIWord {
+            word: w.word.clone(),
+            start: w.start,
+            end: w.end,
+        })
+        .collect()
+}
+
+fn openai_segments(words: &[WordInfo]) -> Vec<OpenAISegment> {
+    to_transcript_segments(words)
+        .into_iter()
+        .enumerate()
+        .map(|(i, seg)| {
+            // Mean per-word confidence → fake avg_logprob in [-1, 0] so
+            // clients that read the field get a plausible number. Purely
+            // cosmetic; not a real log-probability.
+            let avg_conf = if seg.words.is_empty() {
+                0.0
+            } else {
+                seg.words.iter().map(|w| w.confidence as f64).sum::<f64>() / seg.words.len() as f64
+            };
+            OpenAISegment {
+                id: i as u32,
+                seek: (seg.start * 100.0).round() as u32,
+                start: seg.start,
+                end: seg.end,
+                // OpenAI/Whisper often prefixes segment text with a space.
+                text: format!(" {}", seg.text.trim()),
+                tokens: Vec::new(),
+                temperature: 0.0,
+                avg_logprob: (avg_conf - 1.0).clamp(-1.0, 0.0),
+                compression_ratio: 1.0,
+                no_speech_prob: 0.0,
+            }
+        })
+        .collect()
+}
+
+/// Build the OpenAI `verbose_json` value (pure, unit-testable).
+pub fn build_verbose_response(
+    result: &TranscribeResult,
+    options: &OpenAITranscriptionOptions,
+) -> OpenAIVerboseResponse {
+    let language = options
+        .language
+        .as_deref()
+        .map(normalize_language)
+        .unwrap_or_else(|| "ru".into());
+    OpenAIVerboseResponse {
+        task: "transcribe",
+        language,
+        duration: result.duration_s,
+        text: result.text.clone(),
+        segments: options
+            .include_segments
+            .then(|| openai_segments(&result.words)),
+        words: options.include_words.then(|| openai_words(&result.words)),
+    }
+}
+
+/// Render a transcription result into an OpenAI-shaped HTTP response.
+pub fn render_openai_response(
+    result: &TranscribeResult,
+    options: &OpenAITranscriptionOptions,
+) -> Response {
+    let opts = RenderOpts::default();
+    match options.response_format {
+        OpenAIResponseFormat::Json => Json(OpenAIJsonResponse {
+            text: result.text.clone(),
+        })
+        .into_response(),
+        OpenAIResponseFormat::Text => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            result.text.clone(),
+        )
+            .into_response(),
+        OpenAIResponseFormat::Srt => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/x-subrip; charset=utf-8")],
+            to_srt(
+                &result.words,
+                opts.max_chars_per_line,
+                opts.max_words_per_line,
+            ),
+        )
+            .into_response(),
+        OpenAIResponseFormat::Vtt => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/vtt; charset=utf-8")],
+            to_vtt(
+                &result.words,
+                opts.max_chars_per_line,
+                opts.max_words_per_line,
+            ),
+        )
+            .into_response(),
+        OpenAIResponseFormat::VerboseJson => {
+            Json(build_verbose_response(result, options)).into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gigastt_core::inference::WordInfo;
+
+    fn sample_result() -> TranscribeResult {
+        TranscribeResult {
+            text: "привет мир".into(),
+            words: vec![
+                WordInfo::new("привет", 0.0, 0.5, 0.98, None),
+                WordInfo::new("мир", 1.6, 2.0, 0.97, None),
+            ],
+            duration_s: 2.0,
+            confidence: Some(0.975),
+        }
+    }
+
+    #[test]
+    fn test_response_format_parse() {
+        assert_eq!(
+            OpenAIResponseFormat::parse("json").unwrap(),
+            OpenAIResponseFormat::Json
+        );
+        assert_eq!(
+            OpenAIResponseFormat::parse("TEXT").unwrap(),
+            OpenAIResponseFormat::Text
+        );
+        assert_eq!(
+            OpenAIResponseFormat::parse("verbose_json").unwrap(),
+            OpenAIResponseFormat::VerboseJson
+        );
+        assert!(OpenAIResponseFormat::parse("docx").is_err());
+    }
+
+    #[test]
+    fn test_normalize_language() {
+        assert_eq!(normalize_language("Russian"), "ru");
+        assert_eq!(normalize_language("en-US"), "en");
+        assert_eq!(normalize_language(""), "ru");
+        assert_eq!(normalize_language("kk"), "kk");
+        assert_eq!(normalize_language("pt-BR"), "pt-br");
+    }
+
+    #[test]
+    fn test_apply_form_fields_and_finalize() {
+        let mut opts = OpenAITranscriptionOptions::default();
+        apply_openai_form_field(&mut opts, "model", b"whisper-1").unwrap();
+        apply_openai_form_field(&mut opts, "language", b"Russian").unwrap();
+        apply_openai_form_field(&mut opts, "response_format", b"verbose_json").unwrap();
+        apply_openai_form_field(&mut opts, "timestamp_granularities[]", b"word").unwrap();
+        apply_openai_form_field(&mut opts, "prompt", b"ignored").unwrap();
+        apply_openai_form_field(&mut opts, "temperature", b"0").unwrap();
+        finalize_openai_options(&mut opts);
+
+        assert_eq!(opts.model.as_deref(), Some("whisper-1"));
+        assert_eq!(opts.language.as_deref(), Some("Russian"));
+        assert_eq!(opts.response_format, OpenAIResponseFormat::VerboseJson);
+        assert!(opts.include_words);
+        // word-only request must not force segments on.
+        assert!(!opts.include_segments);
+    }
+
+    #[test]
+    fn test_finalize_defaults_segments_for_verbose() {
+        let mut opts = OpenAITranscriptionOptions {
+            response_format: OpenAIResponseFormat::VerboseJson,
+            ..Default::default()
+        };
+        finalize_openai_options(&mut opts);
+        assert!(opts.include_segments);
+        assert!(!opts.include_words);
+    }
+
+    #[test]
+    fn test_invalid_response_format_field() {
+        let mut opts = OpenAITranscriptionOptions::default();
+        let err = apply_openai_form_field(&mut opts, "response_format", b"pdf").unwrap_err();
+        assert!(err.contains("response_format"));
+    }
+
+    #[test]
+    fn test_json_response_is_text_only() {
+        let resp = OpenAIJsonResponse {
+            text: "привет".into(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["text"], "привет");
+        assert_eq!(v.as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_verbose_default_has_segments_no_words() {
+        let result = sample_result();
+        let mut opts = OpenAITranscriptionOptions {
+            response_format: OpenAIResponseFormat::VerboseJson,
+            language: Some("ru".into()),
+            ..Default::default()
+        };
+        finalize_openai_options(&mut opts);
+        let v = serde_json::to_value(build_verbose_response(&result, &opts)).unwrap();
+        assert_eq!(v["task"], "transcribe");
+        assert_eq!(v["language"], "ru");
+        assert_eq!(v["duration"], 2.0);
+        assert_eq!(v["text"], "привет мир");
+        assert!(v["segments"].is_array());
+        // Two words with a long pause → two segments.
+        assert_eq!(v["segments"].as_array().unwrap().len(), 2);
+        assert!(v.get("words").is_none());
+        // Whisper-shaped segment fields present.
+        assert_eq!(v["segments"][0]["id"], 0);
+        assert!(
+            v["segments"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("привет")
+        );
+    }
+
+    #[test]
+    fn test_verbose_word_granularity() {
+        let result = sample_result();
+        let mut opts = OpenAITranscriptionOptions {
+            response_format: OpenAIResponseFormat::VerboseJson,
+            include_words: true,
+            include_segments: false,
+            language: Some("English".into()),
+            ..Default::default()
+        };
+        finalize_openai_options(&mut opts);
+        let v = serde_json::to_value(build_verbose_response(&result, &opts)).unwrap();
+        assert_eq!(v["language"], "en");
+        assert!(v.get("segments").is_none());
+        assert_eq!(v["words"].as_array().unwrap().len(), 2);
+        assert_eq!(v["words"][0]["word"], "привет");
+        assert_eq!(v["words"][0]["start"], 0.0);
+        assert_eq!(v["words"][0]["end"], 0.5);
+    }
+
+    #[test]
+    fn test_verbose_both_granularities() {
+        let result = sample_result();
+        let mut opts = OpenAITranscriptionOptions {
+            response_format: OpenAIResponseFormat::VerboseJson,
+            include_words: true,
+            include_segments: true,
+            ..Default::default()
+        };
+        finalize_openai_options(&mut opts);
+        let v = serde_json::to_value(build_verbose_response(&result, &opts)).unwrap();
+        assert!(v["segments"].is_array());
+        assert!(v["words"].is_array());
+    }
+
+    #[test]
+    fn test_render_json_and_text_content_types() {
+        let result = sample_result();
+        let json_opts = OpenAITranscriptionOptions::default();
+        let resp = render_openai_response(&result, &json_opts);
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let text_opts = OpenAITranscriptionOptions {
+            response_format: OpenAIResponseFormat::Text,
+            ..Default::default()
+        };
+        let resp = render_openai_response(&result, &text_opts);
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.starts_with("text/plain"), "got {ct}");
+    }
+
+    #[test]
+    fn test_render_srt_and_vtt() {
+        let result = sample_result();
+        for fmt in [OpenAIResponseFormat::Srt, OpenAIResponseFormat::Vtt] {
+            let opts = OpenAITranscriptionOptions {
+                response_format: fmt,
+                ..Default::default()
+            };
+            let resp = render_openai_response(&result, &opts);
+            assert_eq!(resp.status(), StatusCode::OK);
+        }
+    }
+
+    /// Multipart helper shared by integration-style unit tests.
+    fn multipart_body(boundary: &str, fields: &[(&str, Option<&str>, &[u8])]) -> Vec<u8> {
+        let mut body = Vec::new();
+        for (name, filename, value) in fields {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            match filename {
+                Some(fname) => body.extend_from_slice(
+                    format!(
+                        "Content-Disposition: form-data; name=\"{name}\"; filename=\"{fname}\"\r\n\
+                         Content-Type: application/octet-stream\r\n\r\n"
+                    )
+                    .as_bytes(),
+                ),
+                None => body.extend_from_slice(
+                    format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+                ),
+            }
+            body.extend_from_slice(value);
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_full_form() {
+        use axum::Router;
+        use axum::routing::post;
+
+        let app = Router::new().route(
+            "/t",
+            post(|multipart: Multipart| async move {
+                match parse_openai_multipart(multipart).await {
+                    Ok(req) => {
+                        let v = serde_json::json!({
+                            "file_len": req.file.len(),
+                            "model": req.options.model,
+                            "language": req.options.language,
+                            "format": match req.options.response_format {
+                                OpenAIResponseFormat::VerboseJson => "verbose_json",
+                                OpenAIResponseFormat::Json => "json",
+                                OpenAIResponseFormat::Text => "text",
+                                OpenAIResponseFormat::Srt => "srt",
+                                OpenAIResponseFormat::Vtt => "vtt",
+                            },
+                            "words": req.options.include_words,
+                            "segments": req.options.include_segments,
+                        });
+                        (StatusCode::OK, Json(v)).into_response()
+                    }
+                    Err(resp) => resp,
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let boundary = "----gigasttTestBoundary";
+        let file_bytes = b"RIFF....fake-wav-payload";
+        let body = multipart_body(
+            boundary,
+            &[
+                ("model", None, b"whisper-1"),
+                ("language", None, b"ru"),
+                ("response_format", None, b"verbose_json"),
+                ("timestamp_granularities[]", None, b"word"),
+                ("timestamp_granularities[]", None, b"segment"),
+                ("file", Some("clip.wav"), file_bytes),
+            ],
+        );
+
+        let resp = reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/t"))
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let v: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(v["file_len"], file_bytes.len());
+        assert_eq!(v["model"], "whisper-1");
+        assert_eq!(v["language"], "ru");
+        assert_eq!(v["format"], "verbose_json");
+        assert_eq!(v["words"], true);
+        assert_eq!(v["segments"], true);
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_missing_file() {
+        use axum::Router;
+        use axum::routing::post;
+
+        let app = Router::new().route(
+            "/t",
+            post(|multipart: Multipart| async move {
+                match parse_openai_multipart(multipart).await {
+                    Ok(_) => StatusCode::OK.into_response(),
+                    Err(resp) => resp,
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let boundary = "----gigasttTestBoundary";
+        let body = multipart_body(boundary, &[("model", None, b"whisper-1")]);
+        let resp = reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/t"))
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+        let v: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(v["code"], "missing_file");
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_invalid_format() {
+        use axum::Router;
+        use axum::routing::post;
+
+        let app = Router::new().route(
+            "/t",
+            post(|multipart: Multipart| async move {
+                match parse_openai_multipart(multipart).await {
+                    Ok(_) => StatusCode::OK.into_response(),
+                    Err(resp) => resp,
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let boundary = "----gigasttTestBoundary";
+        let body = multipart_body(
+            boundary,
+            &[
+                ("response_format", None, b"pdf"),
+                ("file", Some("a.wav"), b"x"),
+            ],
+        );
+        let resp = reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/t"))
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+        let v: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(v["code"], "invalid_response_format");
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_empty_file() {
+        use axum::Router;
+        use axum::routing::post;
+
+        let app = Router::new().route(
+            "/t",
+            post(|multipart: Multipart| async move {
+                match parse_openai_multipart(multipart).await {
+                    Ok(_) => StatusCode::OK.into_response(),
+                    Err(resp) => resp,
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let boundary = "----gigasttTestBoundary";
+        let body = multipart_body(boundary, &[("file", Some("empty.wav"), b"")]);
+        let resp = reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/t"))
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+        let v: serde_json::Value = serde_json::from_str(&resp.text().await.unwrap()).unwrap();
+        assert_eq!(v["code"], "empty_body");
+    }
+}

--- a/crates/gigastt/src/server/openai.rs
+++ b/crates/gigastt/src/server/openai.rs
@@ -12,14 +12,17 @@
 //! | `response_format` | `json` (default) · `text` · `srt` · `vtt` · `verbose_json` |
 //! | `language` | accepted; echoed in `verbose_json` (default `ru`) |
 //! | `timestamp_granularities[]` | `word` / `segment` for `verbose_json` |
+//! | `stream` | `true`/`false` — SSE of `transcript.text.delta` + `done` + `[DONE]` |
 //! | `prompt`, `temperature` | accepted, ignored |
 //!
 //! Inference reuses the native pipeline; this module only shapes the request
-//! and response envelopes.
+//! and response envelopes. Streaming runs the real chunked encoder path and
+//! maps progressive text to OpenAI transcript events (append-only deltas).
 
 use axum::body::Bytes;
 use axum::extract::Multipart;
 use axum::http::{StatusCode, header};
+use axum::response::sse::Event;
 use axum::response::{IntoResponse, Json, Response};
 use gigastt_core::export::{RenderOpts, to_srt, to_transcript_segments, to_vtt};
 use gigastt_core::inference::{TranscribeResult, WordInfo};
@@ -56,6 +59,23 @@ impl OpenAIResponseFormat {
             )),
         }
     }
+
+    /// Wire token (for error messages).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Text => "text",
+            Self::Srt => "srt",
+            Self::Vtt => "vtt",
+            Self::VerboseJson => "verbose_json",
+        }
+    }
+}
+
+impl std::fmt::Display for OpenAIResponseFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// Parsed OpenAI multipart options (everything except the audio file).
@@ -73,6 +93,9 @@ pub struct OpenAITranscriptionOptions {
     pub include_words: bool,
     /// Whether `verbose_json` should include segment-level timestamps.
     pub include_segments: bool,
+    /// When true, respond with an SSE stream of OpenAI transcript events
+    /// instead of a single buffered body.
+    pub stream: bool,
 }
 
 /// Fully parsed multipart request.
@@ -193,6 +216,14 @@ pub fn apply_openai_form_field(
                 }
             }
         }
+        "stream" => {
+            options.stream = parse_bool_form(&text()).ok_or_else(|| {
+                format!(
+                    "Invalid stream value '{}'. Use true or false",
+                    text().trim()
+                )
+            })?;
+        }
         // Accepted for SDK compatibility; no server-side effect.
         "prompt" | "temperature" => {}
         _ => {}
@@ -200,15 +231,148 @@ pub fn apply_openai_form_field(
     Ok(())
 }
 
+/// Parse OpenAI-style form booleans (`true`/`false`/`1`/`0`).
+fn parse_bool_form(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        "" => Some(false),
+        _ => None,
+    }
+}
+
 /// After all fields are applied, resolve default granularities for
 /// `verbose_json`: if the client requested neither, include segments only
-/// (OpenAI historical default).
-pub fn finalize_openai_options(options: &mut OpenAITranscriptionOptions) {
+/// (OpenAI historical default). Streaming is incompatible with caption
+/// `response_format`s (SSE is always text-delta events).
+pub fn finalize_openai_options(options: &mut OpenAITranscriptionOptions) -> Result<(), String> {
     if options.response_format == OpenAIResponseFormat::VerboseJson
         && !options.include_words
         && !options.include_segments
     {
         options.include_segments = true;
+    }
+    if options.stream {
+        match options.response_format {
+            OpenAIResponseFormat::Json | OpenAIResponseFormat::Text => {}
+            other => {
+                return Err(format!(
+                    "stream=true is not supported with response_format='{other}'. Use json or text (or omit response_format)"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// OpenAI streaming event: incremental text.
+#[derive(Debug, Serialize)]
+pub struct OpenAITranscriptDelta {
+    #[serde(rename = "type")]
+    pub event_type: &'static str,
+    pub delta: String,
+}
+
+/// OpenAI streaming event: full transcript at end of stream.
+#[derive(Debug, Serialize)]
+pub struct OpenAITranscriptDone {
+    #[serde(rename = "type")]
+    pub event_type: &'static str,
+    pub text: String,
+}
+
+/// SSE `data:` payload for a text delta.
+pub fn sse_delta_payload(delta: &str) -> String {
+    serde_json::to_string(&OpenAITranscriptDelta {
+        event_type: "transcript.text.delta",
+        delta: delta.to_string(),
+    })
+    .unwrap_or_else(|_| r#"{"type":"transcript.text.delta","delta":""}"#.into())
+}
+
+/// SSE `data:` payload for the terminal done event.
+pub fn sse_done_payload(text: &str) -> String {
+    serde_json::to_string(&OpenAITranscriptDone {
+        event_type: "transcript.text.done",
+        text: text.to_string(),
+    })
+    .unwrap_or_else(|_| r#"{"type":"transcript.text.done","text":""}"#.into())
+}
+
+/// Build an axum SSE event for a delta / done / `[DONE]` marker.
+pub fn sse_event_data(data: impl Into<String>) -> Event {
+    Event::default().data(data.into())
+}
+
+/// Tracks append-only OpenAI text for progressive streaming.
+///
+/// Gigastt partials rewrite the *current* utterance; finals close it.
+/// Deltas are emitted only when the cumulative view is a prefix extension of
+/// what was already sent (OpenAI deltas are append-only — never retract).
+#[derive(Debug, Default)]
+pub struct OpenAIStreamAssembler {
+    /// Text from completed (final) utterances.
+    committed: String,
+    /// Full cumulative text already sent as deltas.
+    last_emitted: String,
+}
+
+impl OpenAIStreamAssembler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Full transcript for the terminal `transcript.text.done` event.
+    pub fn text(&self) -> &str {
+        // Prefer committed after finals; fall back to live-emitted partials.
+        if self.committed.len() >= self.last_emitted.len() {
+            &self.committed
+        } else {
+            &self.last_emitted
+        }
+    }
+
+    /// Ingest one native segment; return an optional delta to send.
+    pub fn push_segment(&mut self, text: &str, is_final: bool) -> Option<String> {
+        let live = text.trim();
+        let candidate = match (self.committed.is_empty(), live.is_empty()) {
+            (_, true) => self.committed.clone(),
+            (true, false) => live.to_string(),
+            (false, false) => format!("{} {live}", self.committed),
+        };
+
+        let mut delta = None;
+        if candidate.starts_with(&self.last_emitted) {
+            let d = candidate[self.last_emitted.len()..].to_string();
+            if !d.is_empty() {
+                self.last_emitted.clone_from(&candidate);
+                delta = Some(d);
+            }
+        }
+        // else: partial rewrote earlier tokens — skip (cannot unsend)
+
+        if is_final {
+            if !live.is_empty() {
+                self.committed = if self.committed.is_empty() {
+                    live.to_string()
+                } else {
+                    format!("{} {live}", self.committed)
+                };
+            }
+            // Align emission cursor with committed when it is a pure extension.
+            if self.committed.starts_with(&self.last_emitted) {
+                let d = self.committed[self.last_emitted.len()..].to_string();
+                self.last_emitted.clone_from(&self.committed);
+                if delta.is_none() && !d.is_empty() {
+                    delta = Some(d);
+                }
+            } else {
+                // Final disagrees with what we streamed — snap cursor for `done`
+                // accuracy without inventing a retracting delta.
+                self.last_emitted.clone_from(&self.committed);
+            }
+        }
+        delta
     }
 }
 
@@ -243,6 +407,8 @@ pub async fn parse_openai_multipart(
                 "invalid_response_format"
             } else if msg.contains("timestamp_granularity") {
                 "invalid_timestamp_granularity"
+            } else if msg.contains("stream") {
+                "invalid_stream"
             } else {
                 "invalid_multipart"
             };
@@ -250,7 +416,13 @@ pub async fn parse_openai_multipart(
         }
     }
 
-    finalize_openai_options(&mut options);
+    if let Err(msg) = finalize_openai_options(&mut options) {
+        return Err(openai_error(
+            StatusCode::BAD_REQUEST,
+            &msg,
+            "invalid_stream_options",
+        ));
+    }
 
     let file = file.ok_or_else(|| {
         openai_error(
@@ -428,7 +600,7 @@ mod tests {
         apply_openai_form_field(&mut opts, "timestamp_granularities[]", b"word").unwrap();
         apply_openai_form_field(&mut opts, "prompt", b"ignored").unwrap();
         apply_openai_form_field(&mut opts, "temperature", b"0").unwrap();
-        finalize_openai_options(&mut opts);
+        finalize_openai_options(&mut opts).unwrap();
 
         assert_eq!(opts.model.as_deref(), Some("whisper-1"));
         assert_eq!(opts.language.as_deref(), Some("Russian"));
@@ -444,9 +616,52 @@ mod tests {
             response_format: OpenAIResponseFormat::VerboseJson,
             ..Default::default()
         };
-        finalize_openai_options(&mut opts);
+        finalize_openai_options(&mut opts).unwrap();
         assert!(opts.include_segments);
         assert!(!opts.include_words);
+    }
+
+    #[test]
+    fn test_stream_flag_and_incompatible_format() {
+        let mut opts = OpenAITranscriptionOptions::default();
+        apply_openai_form_field(&mut opts, "stream", b"true").unwrap();
+        assert!(opts.stream);
+        finalize_openai_options(&mut opts).unwrap();
+
+        let mut opts = OpenAITranscriptionOptions {
+            stream: true,
+            response_format: OpenAIResponseFormat::Srt,
+            ..Default::default()
+        };
+        let err = finalize_openai_options(&mut opts).unwrap_err();
+        assert!(err.contains("stream=true"));
+    }
+
+    #[test]
+    fn test_stream_assembler_grows_and_finalizes() {
+        let mut a = OpenAIStreamAssembler::new();
+        assert_eq!(a.push_segment("привет", false).as_deref(), Some("привет"));
+        assert_eq!(a.push_segment("привет мир", false).as_deref(), Some(" мир"));
+        assert_eq!(a.push_segment("привет мир", true).as_deref(), None);
+        assert_eq!(a.text(), "привет мир");
+        // Second utterance
+        assert_eq!(
+            a.push_segment("как дела", true).as_deref(),
+            Some(" как дела")
+        );
+        assert_eq!(a.text(), "привет мир как дела");
+    }
+
+    #[test]
+    fn test_sse_payloads() {
+        let d = sse_delta_payload(" hi");
+        let v: serde_json::Value = serde_json::from_str(&d).unwrap();
+        assert_eq!(v["type"], "transcript.text.delta");
+        assert_eq!(v["delta"], " hi");
+        let done = sse_done_payload("hello");
+        let v: serde_json::Value = serde_json::from_str(&done).unwrap();
+        assert_eq!(v["type"], "transcript.text.done");
+        assert_eq!(v["text"], "hello");
     }
 
     #[test]
@@ -474,7 +689,7 @@ mod tests {
             language: Some("ru".into()),
             ..Default::default()
         };
-        finalize_openai_options(&mut opts);
+        finalize_openai_options(&mut opts).unwrap();
         let v = serde_json::to_value(build_verbose_response(&result, &opts)).unwrap();
         assert_eq!(v["task"], "transcribe");
         assert_eq!(v["language"], "ru");
@@ -504,7 +719,7 @@ mod tests {
             language: Some("English".into()),
             ..Default::default()
         };
-        finalize_openai_options(&mut opts);
+        finalize_openai_options(&mut opts).unwrap();
         let v = serde_json::to_value(build_verbose_response(&result, &opts)).unwrap();
         assert_eq!(v["language"], "en");
         assert!(v.get("segments").is_none());
@@ -523,7 +738,7 @@ mod tests {
             include_segments: true,
             ..Default::default()
         };
-        finalize_openai_options(&mut opts);
+        finalize_openai_options(&mut opts).unwrap();
         let v = serde_json::to_value(build_verbose_response(&result, &opts)).unwrap();
         assert!(v["segments"].is_array());
         assert!(v["words"].is_array());

--- a/crates/gigastt/tests/e2e_rest.rs
+++ b/crates/gigastt/tests/e2e_rest.rs
@@ -1650,6 +1650,60 @@ async fn test_openai_transcriptions_invalid_format_returns_400() {
 
 #[ignore]
 #[tokio::test]
+async fn test_openai_transcriptions_stream_sse() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let wav = common::generate_wav(2, 16000);
+    let (content_type, body) = openai_form("whisper-1", "clip.wav", &wav, &[("stream", "true")]);
+
+    let resp = post_openai(port, content_type, body).await;
+    assert_eq!(resp.status(), 200);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        ct.starts_with("text/event-stream"),
+        "stream=true must be SSE, got {ct}"
+    );
+
+    let bytes = resp.bytes().await.expect("SSE body");
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.contains("transcript.text.done") || text.contains("[DONE]"),
+        "SSE must end with done/[DONE], got: {text}"
+    );
+    assert!(
+        text.contains("[DONE]"),
+        "OpenAI streams end with data: [DONE], got: {text}"
+    );
+
+    let _ = shutdown.send(());
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_openai_transcriptions_stream_with_srt_returns_400() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let wav = common::generate_wav(1, 16000);
+    let (content_type, body) = openai_form(
+        "whisper-1",
+        "clip.wav",
+        &wav,
+        &[("stream", "true"), ("response_format", "srt")],
+    );
+
+    let resp = post_openai(port, content_type, body).await;
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value =
+        serde_json::from_str(&resp.text().await.expect("body")).expect("JSON");
+    assert_eq!(body["code"], "invalid_stream_options");
+
+    let _ = shutdown.send(());
+}
+
+#[ignore]
+#[tokio::test]
 async fn test_openai_transcriptions_missing_file_returns_400() {
     let (port, shutdown) = common::start_server(&common::model_dir()).await;
     let boundary = "----gigasttE2EBoundary";

--- a/crates/gigastt/tests/e2e_rest.rs
+++ b/crates/gigastt/tests/e2e_rest.rs
@@ -1481,3 +1481,109 @@ async fn test_transcribe_opus_files() {
 
     let _ = shutdown.send(());
 }
+
+// ---------------------------------------------------------------------------
+// OpenAI-compatible POST /v1/audio/transcriptions
+// ---------------------------------------------------------------------------
+
+/// Build a minimal multipart/form-data body (no reqwest multipart feature).
+fn openai_form(model: &str, filename: &str, file_bytes: &[u8]) -> (String, Vec<u8>) {
+    let boundary = "----gigasttE2EBoundary";
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n{model}\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(
+        format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n\
+             Content-Type: application/octet-stream\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(file_bytes);
+    body.extend_from_slice(b"\r\n");
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+    (format!("multipart/form-data; boundary={boundary}"), body)
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_openai_transcriptions_returns_text_only() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let wav = common::generate_wav(2, 16000);
+    let (content_type, body) = openai_form("whisper-1", "clip.wav", &wav);
+
+    let resp = tokio::time::timeout(Duration::from_secs(30), async {
+        reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/v1/audio/transcriptions"))
+            .header("content-type", content_type)
+            .body(body)
+            .send()
+            .await
+            .expect("POST /v1/audio/transcriptions failed")
+    })
+    .await
+    .expect("POST /v1/audio/transcriptions timed out");
+
+    assert_eq!(resp.status(), 200);
+    let text = resp.text().await.expect("Expected text body");
+    let body: serde_json::Value = serde_json::from_str(&text).expect("Expected JSON body");
+    assert!(
+        body["text"].is_string(),
+        "\"text\" field should be a string, got: {:?}",
+        body["text"]
+    );
+    // OpenAI minimal shape: only `text` — no native `words` / `duration`.
+    let obj = body.as_object().expect("response must be a JSON object");
+    assert!(
+        !obj.contains_key("words"),
+        "OpenAI response must not include words: {obj:?}"
+    );
+    assert!(
+        !obj.contains_key("duration"),
+        "OpenAI response must not include duration: {obj:?}"
+    );
+    assert_eq!(
+        obj.keys().count(),
+        1,
+        "OpenAI response must contain only text: {obj:?}"
+    );
+
+    let _ = shutdown.send(());
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_openai_transcriptions_missing_file_returns_400() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let boundary = "----gigasttE2EBoundary";
+    let body = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nwhisper-1\r\n\
+         --{boundary}--\r\n"
+    );
+
+    let resp = tokio::time::timeout(Duration::from_secs(10), async {
+        reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/v1/audio/transcriptions"))
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(body)
+            .send()
+            .await
+            .expect("POST /v1/audio/transcriptions failed")
+    })
+    .await
+    .expect("POST /v1/audio/transcriptions timed out");
+
+    assert_eq!(resp.status(), 400);
+    let text = resp.text().await.expect("Expected text body");
+    let body: serde_json::Value = serde_json::from_str(&text).expect("Expected JSON body");
+    assert_eq!(body["code"], "missing_file");
+
+    let _ = shutdown.send(());
+}

--- a/crates/gigastt/tests/e2e_rest.rs
+++ b/crates/gigastt/tests/e2e_rest.rs
@@ -1486,8 +1486,14 @@ async fn test_transcribe_opus_files() {
 // OpenAI-compatible POST /v1/audio/transcriptions
 // ---------------------------------------------------------------------------
 
-/// Build a minimal multipart/form-data body (no reqwest multipart feature).
-fn openai_form(model: &str, filename: &str, file_bytes: &[u8]) -> (String, Vec<u8>) {
+/// Build multipart/form-data for OpenAI transcription e2e (no reqwest multipart).
+/// `extra` is a list of (name, value) text fields inserted before `file`.
+fn openai_form(
+    model: &str,
+    filename: &str,
+    file_bytes: &[u8],
+    extra: &[(&str, &str)],
+) -> (String, Vec<u8>) {
     let boundary = "----gigasttE2EBoundary";
     let mut body = Vec::new();
     body.extend_from_slice(
@@ -1496,6 +1502,14 @@ fn openai_form(model: &str, filename: &str, file_bytes: &[u8]) -> (String, Vec<u
         )
         .as_bytes(),
     );
+    for (name, value) in extra {
+        body.extend_from_slice(
+            format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"\r\n\r\n{value}\r\n"
+            )
+            .as_bytes(),
+        );
+    }
     body.extend_from_slice(
         format!(
             "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n\
@@ -1509,14 +1523,8 @@ fn openai_form(model: &str, filename: &str, file_bytes: &[u8]) -> (String, Vec<u
     (format!("multipart/form-data; boundary={boundary}"), body)
 }
 
-#[ignore]
-#[tokio::test]
-async fn test_openai_transcriptions_returns_text_only() {
-    let (port, shutdown) = common::start_server(&common::model_dir()).await;
-    let wav = common::generate_wav(2, 16000);
-    let (content_type, body) = openai_form("whisper-1", "clip.wav", &wav);
-
-    let resp = tokio::time::timeout(Duration::from_secs(30), async {
+async fn post_openai(port: u16, content_type: String, body: Vec<u8>) -> reqwest::Response {
+    tokio::time::timeout(Duration::from_secs(30), async {
         reqwest::Client::new()
             .post(format!("http://127.0.0.1:{port}/v1/audio/transcriptions"))
             .header("content-type", content_type)
@@ -1526,31 +1534,116 @@ async fn test_openai_transcriptions_returns_text_only() {
             .expect("POST /v1/audio/transcriptions failed")
     })
     .await
-    .expect("POST /v1/audio/transcriptions timed out");
+    .expect("POST /v1/audio/transcriptions timed out")
+}
 
+#[ignore]
+#[tokio::test]
+async fn test_openai_transcriptions_returns_text_only() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let wav = common::generate_wav(2, 16000);
+    let (content_type, body) = openai_form("whisper-1", "clip.wav", &wav, &[]);
+
+    let resp = post_openai(port, content_type, body).await;
     assert_eq!(resp.status(), 200);
     let text = resp.text().await.expect("Expected text body");
     let body: serde_json::Value = serde_json::from_str(&text).expect("Expected JSON body");
-    assert!(
-        body["text"].is_string(),
-        "\"text\" field should be a string, got: {:?}",
-        body["text"]
-    );
-    // OpenAI minimal shape: only `text` — no native `words` / `duration`.
+    assert!(body["text"].is_string());
     let obj = body.as_object().expect("response must be a JSON object");
     assert!(
-        !obj.contains_key("words"),
-        "OpenAI response must not include words: {obj:?}"
-    );
-    assert!(
-        !obj.contains_key("duration"),
-        "OpenAI response must not include duration: {obj:?}"
+        !obj.contains_key("words") && !obj.contains_key("duration"),
+        "default json must be text-only: {obj:?}"
     );
     assert_eq!(
         obj.keys().count(),
         1,
-        "OpenAI response must contain only text: {obj:?}"
+        "default json must contain only text: {obj:?}"
     );
+
+    let _ = shutdown.send(());
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_openai_transcriptions_response_format_text() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let wav = common::generate_wav(2, 16000);
+    let (content_type, body) = openai_form(
+        "whisper-1",
+        "clip.wav",
+        &wav,
+        &[("response_format", "text")],
+    );
+
+    let resp = post_openai(port, content_type, body).await;
+    assert_eq!(resp.status(), 200);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        ct.starts_with("text/plain"),
+        "response_format=text must be text/plain, got {ct}"
+    );
+    // Plain body — not JSON object.
+    let text = resp.text().await.expect("body");
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&text)
+            .ok()
+            .and_then(|v| v.as_object().map(|_| ()))
+            .is_none()
+            || !text.trim_start().starts_with('{'),
+        "text format should not be a JSON object: {text:?}"
+    );
+
+    let _ = shutdown.send(());
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_openai_transcriptions_verbose_json_with_words() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let wav = common::generate_wav(2, 16000);
+    let (content_type, body) = openai_form(
+        "whisper-1",
+        "clip.wav",
+        &wav,
+        &[
+            ("response_format", "verbose_json"),
+            ("language", "Russian"),
+            ("timestamp_granularities[]", "word"),
+            ("timestamp_granularities[]", "segment"),
+        ],
+    );
+
+    let resp = post_openai(port, content_type, body).await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value =
+        serde_json::from_str(&resp.text().await.expect("body")).expect("JSON");
+    assert_eq!(body["task"], "transcribe");
+    assert_eq!(body["language"], "ru");
+    assert!(body["duration"].as_f64().unwrap_or(-1.0) >= 0.0);
+    assert!(body["text"].is_string());
+    assert!(body["segments"].is_array(), "segments expected: {body}");
+    assert!(body["words"].is_array(), "words expected: {body}");
+
+    let _ = shutdown.send(());
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_openai_transcriptions_invalid_format_returns_400() {
+    let (port, shutdown) = common::start_server(&common::model_dir()).await;
+    let wav = common::generate_wav(1, 16000);
+    let (content_type, body) =
+        openai_form("whisper-1", "clip.wav", &wav, &[("response_format", "pdf")]);
+
+    let resp = post_openai(port, content_type, body).await;
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value =
+        serde_json::from_str(&resp.text().await.expect("body")).expect("JSON");
+    assert_eq!(body["code"], "invalid_response_format");
 
     let _ = shutdown.send(());
 }
@@ -1565,24 +1658,16 @@ async fn test_openai_transcriptions_missing_file_returns_400() {
          --{boundary}--\r\n"
     );
 
-    let resp = tokio::time::timeout(Duration::from_secs(10), async {
-        reqwest::Client::new()
-            .post(format!("http://127.0.0.1:{port}/v1/audio/transcriptions"))
-            .header(
-                "content-type",
-                format!("multipart/form-data; boundary={boundary}"),
-            )
-            .body(body)
-            .send()
-            .await
-            .expect("POST /v1/audio/transcriptions failed")
-    })
-    .await
-    .expect("POST /v1/audio/transcriptions timed out");
+    let resp = post_openai(
+        port,
+        format!("multipart/form-data; boundary={boundary}"),
+        body.into_bytes(),
+    )
+    .await;
 
     assert_eq!(resp.status(), 400);
-    let text = resp.text().await.expect("Expected text body");
-    let body: serde_json::Value = serde_json::from_str(&text).expect("Expected JSON body");
+    let body: serde_json::Value =
+        serde_json::from_str(&resp.text().await.expect("body")).expect("JSON");
     assert_eq!(body["code"], "missing_file");
 
     let _ = shutdown.send(());

--- a/docs/api.md
+++ b/docs/api.md
@@ -311,6 +311,7 @@ inference pipeline as `/v1/transcribe`, shaped for the
 | `response_format` | `json` (default) · `text` · `srt` · `vtt` · `verbose_json`. Unknown → `400 invalid_response_format`. |
 | `language` | Accepted; echoed in `verbose_json` (default `ru`). Does not switch the loaded head. |
 | `timestamp_granularities[]` | With `verbose_json`: `word` and/or `segment`. Default (neither set) = segments only. |
+| `stream` | `true`/`false`. When true, SSE of OpenAI transcript events (only with `json`/`text`). |
 | `prompt`, `temperature` | Accepted and ignored (SDK compatibility). |
 
 | `response_format` | Body |
@@ -319,6 +320,19 @@ inference pipeline as `/v1/transcribe`, shaped for the
 | `text` | plain text (`text/plain`) |
 | `srt` / `vtt` | captions |
 | `verbose_json` | Whisper-style: `task`, `language`, `duration`, `text`, optional `segments` / `words` |
+
+**Streaming (`stream=true`).** Response is `text/event-stream`:
+
+```
+data: {"type":"transcript.text.delta","delta":"Привет"}
+data: {"type":"transcript.text.delta","delta":" мир"}
+data: {"type":"transcript.text.done","text":"Привет мир"}
+data: [DONE]
+```
+
+Deltas are append-only progressive text from the real chunked encoder path
+(same pipeline as `/v1/transcribe/stream`). Incompatible with `srt` / `vtt` /
+`verbose_json` → `400 invalid_stream_options`.
 
 ```sh
 # Default JSON

--- a/docs/api.md
+++ b/docs/api.md
@@ -262,6 +262,7 @@ progress); the onnxruntime linking trade-offs are in
 | `/v1/models` | GET | Model info (encoder type, pool size, capabilities) |
 | `/v1/transcribe` | POST | File transcription, full JSON response or export format |
 | `/v1/transcribe/stream` | POST | File transcription with SSE streaming |
+| `/v1/audio/transcriptions` | POST | OpenAI-compatible file transcription (`multipart` `file` + `model` → `{"text":"..."}`) |
 | `/v1/jobs` | POST | Submit an asynchronous transcription job (requires `--enable-jobs`) |
 | `/v1/jobs/{id}` | GET | Poll job status and progress |
 | `/v1/jobs/{id}` | DELETE | Cancel a queued or processing job |
@@ -282,12 +283,39 @@ curl -X POST http://127.0.0.1:9876/v1/transcribe/stream \
   -H "Content-Type: application/octet-stream" --data-binary @recording.wav
 # data: {"type":"partial","text":"привет как"}
 # data: {"type":"final","text":"Привет, как дела?","confidence":0.94}
+
+# OpenAI-compatible (llama-swap, Hermes Agent, OpenAI SDKs with custom base_url)
+curl -X POST http://127.0.0.1:9876/v1/audio/transcriptions \
+  -F model=whisper-1 \
+  -F file=@recording.wav
+# {"text":"Привет, как дела?"}
 ```
 
 The full-JSON response, SSE `final` events, and job results also carry an
 optional top-level `confidence` — the duration-weighted mean of
 `words[].confidence` (an average of per-word softmax scores, not a calibrated
 probability; omitted when there are no words).
+
+### OpenAI-compatible transcriptions
+
+`POST /v1/audio/transcriptions` is a thin compatibility layer over the same
+inference pipeline as `/v1/transcribe`, shaped for the
+[OpenAI Audio Transcriptions API](https://developers.openai.com/api/reference/resources/audio/subresources/transcriptions/methods/create):
+
+| Input | Notes |
+|---|---|
+| `Content-Type` | `multipart/form-data` |
+| `file` | Required. Audio bytes (same formats as `/v1/transcribe`) |
+| `model` | Accepted for client compatibility; **ignored**. A single-head server always uses the loaded engine (`gigaam-v3-rnnt`, …). Pass any string (`whisper-1`, a local alias, or the real model id). |
+
+| Output | Notes |
+|---|---|
+| `{"text":"..."}` | Only field. No `words` / `duration` / export formats. |
+
+For word timestamps, segments, SRT/VTT, diarization, or telephony codecs, use
+`POST /v1/transcribe` instead. Point llama-swap / Hermes Agent `base_url` at
+`http://127.0.0.1:9876/v1` (path suffix `/audio/transcriptions` is appended by
+the client).
 
 ## Admin reload
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -298,24 +298,52 @@ probability; omitted when there are no words).
 
 ### OpenAI-compatible transcriptions
 
-`POST /v1/audio/transcriptions` is a thin compatibility layer over the same
+`POST /v1/audio/transcriptions` is a compatibility layer over the same
 inference pipeline as `/v1/transcribe`, shaped for the
-[OpenAI Audio Transcriptions API](https://developers.openai.com/api/reference/resources/audio/subresources/transcriptions/methods/create):
+[OpenAI Audio Transcriptions API](https://developers.openai.com/api/reference/resources/audio/subresources/transcriptions/methods/create)
+(llama-swap, Hermes Agent, OpenAI SDKs with a custom `base_url`).
 
 | Input | Notes |
 |---|---|
 | `Content-Type` | `multipart/form-data` |
 | `file` | Required. Audio bytes (same formats as `/v1/transcribe`) |
-| `model` | Accepted for client compatibility; **ignored**. A single-head server always uses the loaded engine (`gigaam-v3-rnnt`, …). Pass any string (`whisper-1`, a local alias, or the real model id). |
+| `model` | Accepted for client compatibility; **ignored**. Pass any string (`whisper-1`, a local alias, or the real model id). |
+| `response_format` | `json` (default) · `text` · `srt` · `vtt` · `verbose_json`. Unknown → `400 invalid_response_format`. |
+| `language` | Accepted; echoed in `verbose_json` (default `ru`). Does not switch the loaded head. |
+| `timestamp_granularities[]` | With `verbose_json`: `word` and/or `segment`. Default (neither set) = segments only. |
+| `prompt`, `temperature` | Accepted and ignored (SDK compatibility). |
 
-| Output | Notes |
+| `response_format` | Body |
 |---|---|
-| `{"text":"..."}` | Only field. No `words` / `duration` / export formats. |
+| `json` | `{"text":"..."}` only |
+| `text` | plain text (`text/plain`) |
+| `srt` / `vtt` | captions |
+| `verbose_json` | Whisper-style: `task`, `language`, `duration`, `text`, optional `segments` / `words` |
 
-For word timestamps, segments, SRT/VTT, diarization, or telephony codecs, use
-`POST /v1/transcribe` instead. Point llama-swap / Hermes Agent `base_url` at
-`http://127.0.0.1:9876/v1` (path suffix `/audio/transcriptions` is appended by
-the client).
+```sh
+# Default JSON
+curl -X POST http://127.0.0.1:9876/v1/audio/transcriptions \
+  -F model=whisper-1 -F file=@recording.wav
+# {"text":"…"}
+
+# Verbose with word + segment timestamps
+curl -X POST http://127.0.0.1:9876/v1/audio/transcriptions \
+  -F model=whisper-1 -F file=@recording.wav \
+  -F response_format=verbose_json \
+  -F language=ru \
+  -F 'timestamp_granularities[]=word' \
+  -F 'timestamp_granularities[]=segment'
+
+# Plain text / SRT
+curl -X POST http://127.0.0.1:9876/v1/audio/transcriptions \
+  -F model=whisper-1 -F file=@recording.wav -F response_format=text
+curl -X POST http://127.0.0.1:9876/v1/audio/transcriptions \
+  -F model=whisper-1 -F file=@recording.wav -F response_format=srt
+```
+
+Point llama-swap / Hermes Agent `base_url` at `http://127.0.0.1:9876/v1`
+(path suffix `/audio/transcriptions` is appended by the client). For
+diarization, telephony codecs, or native export knobs use `POST /v1/transcribe`.
 
 ## Admin reload
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12,6 +12,7 @@ info:
     - **Health & discovery**: `GET /health`, `GET /ready`, `GET /v1/models`
     - **File transcription**: `POST /v1/transcribe` — upload audio, receive full transcript
     - **Streaming transcription**: `POST /v1/transcribe/stream` — upload audio, receive SSE stream of partial/final segments
+    - **OpenAI-compatible**: `POST /v1/audio/transcriptions` — multipart `file` + `model` → `{"text":"..."}`
     - **Async jobs** (opt-in `--enable-jobs`): `POST /v1/jobs`, `GET/DELETE /v1/jobs/{id}`, result + SSE events
     - **Admin**: `POST /v1/admin/reload` — loopback-only model hot-reload
     - **WebSocket** (see `docs/asyncapi.yaml`): `GET /v1/ws`
@@ -485,6 +486,62 @@ paths:
           $ref: "#/components/responses/TooManyRequests"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+
+  /v1/audio/transcriptions:
+    post:
+      summary: OpenAI-compatible file transcription
+      description: |
+        Minimal OpenAI Audio Transcriptions compatible endpoint for clients that
+        speak that API shape (llama-swap, Hermes Agent, OpenAI SDKs with a custom
+        `base_url`). Multipart form with required `file` and optional `model`
+        (accepted for compatibility, ignored — the loaded engine is always used).
+        Returns `{"text":"..."}` only. Same audio formats and 30-minute cap as
+        `/v1/transcribe`. For words, segments, exports, diarization, or
+        telephony codecs, use `POST /v1/transcribe` instead.
+      operationId: createTranscription
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: Audio file to transcribe.
+                model:
+                  type: string
+                  description: |
+                    Accepted for OpenAI client compatibility; ignored. Any string
+                    works (`whisper-1`, a local alias, or a gigastt model id).
+                  example: whisper-1
+      responses:
+        "200":
+          description: Transcription result (OpenAI minimal JSON)
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [text]
+                properties:
+                  text:
+                    type: string
+                    description: Full recognized transcript text.
+                    example: "Привет, как дела?"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
+        "422":
+          $ref: "#/components/responses/TranscriptionError"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+        "504":
+          $ref: "#/components/responses/GatewayTimeout"
 
   /v1/jobs:
     post:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -491,13 +491,17 @@ paths:
     post:
       summary: OpenAI-compatible file transcription
       description: |
-        Minimal OpenAI Audio Transcriptions compatible endpoint for clients that
-        speak that API shape (llama-swap, Hermes Agent, OpenAI SDKs with a custom
-        `base_url`). Multipart form with required `file` and optional `model`
-        (accepted for compatibility, ignored — the loaded engine is always used).
-        Returns `{"text":"..."}` only. Same audio formats and 30-minute cap as
-        `/v1/transcribe`. For words, segments, exports, diarization, or
-        telephony codecs, use `POST /v1/transcribe` instead.
+        OpenAI Audio Transcriptions compatible endpoint for clients that speak
+        that API shape (llama-swap, Hermes Agent, OpenAI SDKs with a custom
+        `base_url`). Multipart form with required `file` and optional
+        `model` / `response_format` / `language` / `timestamp_granularities[]`.
+        `model` is accepted for compatibility and ignored (loaded engine always
+        used). Same audio formats and 30-minute cap as `/v1/transcribe`.
+
+        `response_format`: `json` (default, `{"text"}`) · `text` · `srt` · `vtt`
+        · `verbose_json` (Whisper-style: `task`, `language`, `duration`, `text`,
+        optional `segments`/`words`). For diarization, telephony codecs, or
+        native knobs use `POST /v1/transcribe`.
       operationId: createTranscription
       requestBody:
         required: true
@@ -517,19 +521,96 @@ paths:
                     Accepted for OpenAI client compatibility; ignored. Any string
                     works (`whisper-1`, a local alias, or a gigastt model id).
                   example: whisper-1
+                response_format:
+                  type: string
+                  enum: [json, text, srt, vtt, verbose_json]
+                  default: json
+                  description: Output shape (OpenAI Whisper formats).
+                language:
+                  type: string
+                  description: |
+                    Echoed in `verbose_json` (default `ru`). Does not switch the
+                    loaded recognition head.
+                  example: ru
+                timestamp_granularities:
+                  type: array
+                  items:
+                    type: string
+                    enum: [word, segment]
+                  description: |
+                    With `verbose_json`: include `words` and/or `segments`.
+                    Form field name is `timestamp_granularities[]`. Default when
+                    neither is set: segments only.
+                prompt:
+                  type: string
+                  description: Accepted and ignored (SDK compatibility).
+                temperature:
+                  type: string
+                  description: Accepted and ignored (SDK compatibility).
       responses:
         "200":
-          description: Transcription result (OpenAI minimal JSON)
+          description: |
+            Transcription result. Content type depends on `response_format`:
+            JSON for `json`/`verbose_json`, `text/plain` for `text`, captions for
+            `srt`/`vtt`.
           content:
             application/json:
               schema:
-                type: object
-                required: [text]
-                properties:
-                  text:
-                    type: string
-                    description: Full recognized transcript text.
-                    example: "Привет, как дела?"
+                oneOf:
+                  - type: object
+                    required: [text]
+                    properties:
+                      text:
+                        type: string
+                        example: "Привет, как дела?"
+                  - type: object
+                    required: [task, language, duration, text]
+                    properties:
+                      task:
+                        type: string
+                        example: transcribe
+                      language:
+                        type: string
+                        example: ru
+                      duration:
+                        type: number
+                        format: float
+                      text:
+                        type: string
+                      segments:
+                        type: array
+                        items:
+                          type: object
+                      words:
+                        type: array
+                        items:
+                          type: object
+              examples:
+                json:
+                  value:
+                    text: "Привет, как дела?"
+                verbose_json:
+                  value:
+                    task: transcribe
+                    language: ru
+                    duration: 3.5
+                    text: "Привет, как дела?"
+                    segments:
+                      - id: 0
+                        seek: 0
+                        start: 0.5
+                        end: 3.5
+                        text: " Привет, как дела?"
+            text/plain:
+              schema:
+                type: string
+                example: "Привет, как дела?"
+            application/x-subrip:
+              schema:
+                type: string
+            text/vtt:
+              schema:
+                type: string
         "400":
           $ref: "#/components/responses/BadRequest"
         "413":

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -547,13 +547,30 @@ paths:
                 temperature:
                   type: string
                   description: Accepted and ignored (SDK compatibility).
+                stream:
+                  type: boolean
+                  default: false
+                  description: |
+                    When true, respond with SSE (`text/event-stream`) of
+                    `transcript.text.delta` events, a final
+                    `transcript.text.done`, and `data: [DONE]`. Only valid with
+                    `response_format` json or text (default).
       responses:
         "200":
           description: |
-            Transcription result. Content type depends on `response_format`:
-            JSON for `json`/`verbose_json`, `text/plain` for `text`, captions for
-            `srt`/`vtt`.
+            Transcription result. Content type depends on `response_format` /
+            `stream`: JSON for `json`/`verbose_json`, `text/plain` for `text`,
+            captions for `srt`/`vtt`, or `text/event-stream` when `stream=true`.
           content:
+            text/event-stream:
+              schema:
+                type: string
+              example: |
+                data: {"type":"transcript.text.delta","delta":"Привет"}
+
+                data: {"type":"transcript.text.done","text":"Привет"}
+
+                data: [DONE]
             application/json:
               schema:
                 oneOf:


### PR DESCRIPTION
## Summary

- Adds `POST /v1/audio/transcriptions` — OpenAI Audio Transcriptions-compatible endpoint for **llama-swap**, **Hermes Agent**, and OpenAI SDKs with a custom `base_url` (closes #214).
- Accepts `multipart/form-data` with required `file` and optional `model` (model is accepted for client compatibility and **ignored** — single loaded head always runs).
- Returns minimal `{"text":"..."}` (no `words` / `duration`). Full native surface remains on `/v1/transcribe`.

## Usage

```sh
curl -X POST http://127.0.0.1:9876/v1/audio/transcriptions \
  -F model=whisper-1 \
  -F file=@recording.wav
# {"text":"…"}
```

Point llama-swap / Hermes `base_url` at `http://127.0.0.1:9876/v1`.

## Test plan

- [x] Unit: OpenAI response is text-only JSON
- [x] Unit: multipart parse extracts `file`, ignores `model`/`language`
- [x] Unit: missing/empty `file` → 400 (`missing_file` / `empty_body`)
- [x] Unit: metric path label for `/v1/audio/transcriptions`
- [x] E2E (model): happy path + missing file
- [x] `cargo test -p gigastt --lib`, `cargo clippy -D warnings`, `check-docs-drift.py`
- [x] OpenAPI + `docs/api.md` + CHANGELOG [Unreleased]