### PR TITLE
chore: release 2.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **OpenAI-compatible `POST /v1/audio/transcriptions`.** Multipart form with
-  required `file` and optional `model` (accepted for client compatibility,
-  ignored — the loaded engine is always used). Supports OpenAI
-  `response_format` (`json` · `text` · `srt` · `vtt` · `verbose_json`),
-  `language` (echoed in verbose), `timestamp_granularities[]` (`word` /
-  `segment`), and `stream=true` (SSE: `transcript.text.delta` /
-  `transcript.text.done` / `[DONE]`, progressive chunked encoder path). Default
-  remains `{"text":"..."}`. Same pipeline as `/v1/transcribe` for llama-swap,
-  Hermes Agent, and OpenAI SDKs with a custom `base_url` (#214).
-
 ### Changed
 
 - **Documentation hygiene pass.** Supported versions in `SECURITY.md` track
@@ -37,6 +25,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   install recipe; appendices for error-code jump tables and offline checklists;
   closed the notarization open loop with an explicit out-of-band note; drift gate
   forbids previous-minor pins and required recipe tokens in the English book.
+
+## [2.14.3] - 2026-07-25
+
+### Added
+
+- **OpenAI-compatible `POST /v1/audio/transcriptions`.** Multipart form with
+  required `file` and optional `model` (accepted for client compatibility,
+  ignored — the loaded engine is always used). Supports OpenAI
+  `response_format` (`json` · `text` · `srt` · `vtt` · `verbose_json`),
+  `language` (echoed in verbose), `timestamp_granularities[]` (`word` /
+  `segment`), and `stream=true` (SSE: `transcript.text.delta` /
+  `transcript.text.done` / `[DONE]`, progressive chunked encoder path). Default
+  remains `{"text":"..."}`. Same pipeline as `/v1/transcribe` for llama-swap,
+  Hermes Agent, and OpenAI SDKs with a custom `base_url` (#214, #215).
 
 ## [2.14.2] - 2026-07-24
 
@@ -1949,7 +1951,8 @@ _Release candidate for v0.9.0 — bundles five P0 fixes plus two supporting item
 - Multi-format audio support: WAV, MP3, M4A/AAC, OGG/Vorbis, FLAC (via symphonia).
 - 39 unit tests (tokenizer, features, decode, inference, protocol).
 
-[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.2...HEAD
+[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.3...HEAD
+[2.14.3]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.2...v2.14.3
 [2.14.2]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.1...v2.14.2
 [2.14.1]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.0...v2.14.1
 [2.14.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.13.0...v2.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.14.2"
+version = "2.14.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.14.2"
+version = "2.14.3"
 dependencies = [
  "anyhow",
  "audio-codec",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.14.2"
+version = "2.14.3"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.14.2"
+version = "2.14.3"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.14.2"
+version = "2.14.3"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.14.2"
+version = "2.14.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump workspace version **2.14.2 → 2.14.3**
- CHANGELOG cut for OpenAI-compatible `POST /v1/audio/transcriptions` (#214, #215)

Tag `v2.14.3` after merge to trigger `release.yml`.