### PR TITLE
chore: release 2.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1962,7 +1962,8 @@ _Release candidate for v0.9.0 — bundles five P0 fixes plus two supporting item
 - Multi-format audio support: WAV, MP3, M4A/AAC, OGG/Vorbis, FLAC (via symphonia).
 - 39 unit tests (tokenizer, features, decode, inference, protocol).
 
-[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.3...HEAD
+[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.4...HEAD
+[2.14.4]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.3...v2.14.4
 [2.14.3]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.2...v2.14.3
 [2.14.2]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.1...v2.14.2
 [2.14.1]: https://github.com/ekhodzitsky/gigastt/compare/v2.14.0...v2.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **OGG/Opus without an EOS page no longer fails demux** (Telegram Android
-  voice notes, some MediaRecorder captures). Symphonia surfaces a missing
-  end-of-stream flag as `IoError(UnexpectedEof)` instead of `Ok(None)`; after
-  any PCM has already been decoded we treat that as a clean stream end.
-  Headers-only / empty uploads still error. Fixes OpenAI
-  `/v1/audio/transcriptions` and `gigastt transcribe` for those files (#217).
-
 ### Changed
-
 
 - **Documentation hygiene pass.** Supported versions in `SECURITY.md` track
   2.14.x / 2.13.x; README / architecture crate pins use `gigastt-core = "2.14"`;
@@ -35,6 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   install recipe; appendices for error-code jump tables and offline checklists;
   closed the notarization open loop with an explicit out-of-band note; drift gate
   forbids previous-minor pins and required recipe tokens in the English book.
+
+## [2.14.4] - 2026-07-25
+
+### Fixed
+
+- **OGG/Opus without an EOS page no longer fails demux** (Telegram Android
+  voice notes, some MediaRecorder captures). Symphonia surfaces a missing
+  end-of-stream flag as `IoError(UnexpectedEof)` instead of `Ok(None)`; after
+  any PCM has already been decoded we treat that as a clean stream end.
+  Headers-only / empty uploads still error. Fixes OpenAI
+  `/v1/audio/transcriptions` and `gigastt transcribe` for those files (#217).
 
 ## [2.14.3] - 2026-07-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.14.3"
+version = "2.14.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.14.3"
+version = "2.14.4"
 dependencies = [
  "anyhow",
  "audio-codec",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.14.3"
+version = "2.14.4"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.14.3"
+version = "2.14.4"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.14.3"
+version = "2.14.4"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.14.3"
+version = "2.14.4"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Release 2.14.4

Moves the soft-EOF Ogg/Opus fix from Unreleased into **2.14.4**.

### Fixed
- OGG/Opus without EOS demux (#217) — Telegram Android voice notes

Version bump `2.14.3` → `2.14.4` (workspace + lockfile).