### PR TITLE
refactor(inference): isolate polyvoice diarization surface

### DIFF
--- a/crates/gigastt-core/src/inference/diarization.rs
+++ b/crates/gigastt-core/src/inference/diarization.rs
@@ -1,0 +1,223 @@
+//! Speaker diarization via [polyvoice] (feature-gated).
+//!
+//! ## Why the deprecated polyvoice surface lives here
+//!
+//! polyvoice 0.9 deprecates `FbankOnnxExtractor` / `EmbeddingExtractor` /
+//! `EmbeddingError` in favour of the v1.0 `polyvoice::embedder::Embedder`
+//! trait (+ `ResNet34Adapter` / `CamPlusPlusExtractor`). We **cannot** migrate
+//! yet:
+//!
+//! 1. **Streaming path** — gigastt's per-session WS diarization uses
+//!    [`polyvoice::streaming::StreamingPipeline`], which is still generic over
+//!    the legacy trait (`E: EmbeddingExtractor`). polyvoice has not wired
+//!    `Embedder` into streaming (the crate suppresses the same deprecation
+//!    warnings module-wide for that reason).
+//! 2. **Offline path** — the validated default offline API is still
+//!    [`polyvoice::Pipeline`] (also `E: EmbeddingExtractor`). The v1.0
+//!    `pipeline_v2` uses `Embedder` but is offline-only, experimental (reverted
+//!    from default after a long-form DER regression), and pulls in
+//!    segmentation / clusterer / resegmentation models we do not ship today.
+//! 3. **Adapter still wraps the legacy type** — even polyvoice's own
+//!    `ResNet34Adapter` (the `Embedder` for WeSpeaker) is a thin wrapper around
+//!    `FbankOnnxExtractor`. Switching to it without switching pipelines buys
+//!    nothing.
+//!
+//! Until polyvoice accepts `Embedder` on `StreamingPipeline` (and the
+//! production offline path), this module is the **sole** home of the deprecated
+//! surface. Do not re-import those types into `inference/mod.rs`.
+//!
+//! The WeSpeaker model (`wespeaker_resnet34.onnx`) expects rank-3 fbank input;
+//! keep [`load_speaker_encoder`] on the 3-arg `FbankOnnxExtractor` constructor,
+//! not the old rank-2 waveform `OnnxEmbeddingExtractor`.
+
+// Entire module is the polyvoice-legacy containment boundary.
+#![allow(deprecated)]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use polyvoice::streaming::StreamingPipeline;
+use polyvoice::{
+    ClusterConfig, DiarizationConfig as DiaConfig, EmbeddingError, EmbeddingExtractor, EnergyVad,
+    FbankOnnxExtractor, Pipeline, VadConfig,
+};
+
+/// WeSpeaker ResNet34 embedding dimension.
+pub(crate) const SPEAKER_EMBEDDING_DIM: usize = 256;
+/// ONNX session pool size shared across concurrent diarization sessions.
+const SPEAKER_POOL_SIZE: usize = 4;
+
+/// Shared WeSpeaker encoder handle (`Arc` over the legacy fbank ONNX extractor).
+pub type SpeakerEncoder = Arc<FbankOnnxExtractor>;
+
+/// Per-session streaming diarization state.
+pub type StreamingDiarizationState = StreamingPipeline<EnergyVad, SharedExtractor>;
+
+/// Adapter that lets a single shared [`FbankOnnxExtractor`] back the
+/// per-session [`StreamingPipeline`]s, which take ownership of their extractor.
+/// The ONNX session pool inside the extractor is shared across sessions via `Arc`.
+pub struct SharedExtractor(Arc<FbankOnnxExtractor>);
+
+impl EmbeddingExtractor for SharedExtractor {
+    fn extract(&self, samples: &[f32], config: &DiaConfig) -> Result<Vec<f32>, EmbeddingError> {
+        self.0.extract(samples, config)
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.0.embedding_dim()
+    }
+}
+
+/// Load a WeSpeaker ResNet34 encoder from `model_path`.
+///
+/// Uses the 3-arg fbank constructor (rank-3 input). A missing/corrupt path
+/// returns `Err` — never panics.
+pub(crate) fn load_speaker_encoder(
+    model_path: &Path,
+    pool_size: usize,
+) -> anyhow::Result<FbankOnnxExtractor> {
+    FbankOnnxExtractor::new(model_path, SPEAKER_EMBEDDING_DIM, pool_size)
+}
+
+/// Load the speaker encoder from `model_dir/wespeaker_resnet34.onnx` if present.
+///
+/// Logs and returns `None` when the file is missing or fails to load — diarization
+/// stays unavailable rather than failing engine boot.
+pub fn try_load_speaker_encoder(model_dir: &Path) -> Option<SpeakerEncoder> {
+    let model_path = model_dir.join("wespeaker_resnet34.onnx");
+    if !model_path.exists() {
+        tracing::warn!("wespeaker_resnet34.onnx not found, diarization unavailable");
+        return None;
+    }
+    match load_speaker_encoder(&model_path, SPEAKER_POOL_SIZE) {
+        Ok(enc) => {
+            tracing::info!("Speaker encoder loaded (diarization available)");
+            Some(Arc::new(enc))
+        }
+        Err(e) => {
+            tracing::warn!("Speaker encoder not loaded, diarization unavailable: {e:#}");
+            None
+        }
+    }
+}
+
+/// Open a per-session streaming diarization pipeline sharing `encoder`.
+pub fn open_streaming(encoder: &SpeakerEncoder) -> Option<StreamingDiarizationState> {
+    let config = DiaConfig {
+        cluster: ClusterConfig {
+            threshold: 0.5,
+            ..ClusterConfig::default()
+        },
+        ..DiaConfig::default()
+    };
+    let vad_config = VadConfig::default();
+    let vad = EnergyVad::new(-40.0, 16000, vad_config.frame_size);
+    let extractor = SharedExtractor(Arc::clone(encoder));
+    match StreamingPipeline::new(vad, extractor, config, vad_config) {
+        Ok(pipeline) => Some(pipeline),
+        Err(e) => {
+            tracing::warn!("Failed to initialize streaming diarization: {e:#}");
+            None
+        }
+    }
+}
+
+/// Feed PCM samples into the streaming pipeline; log and ignore feed errors.
+pub fn feed_chunk(state: &mut StreamingDiarizationState, samples: &[f32]) {
+    if let Err(e) = state.feed(samples) {
+        tracing::warn!("Diarization feed failed: {e:#}");
+    }
+}
+
+/// Speaker index of the most recent turn, if any.
+pub fn last_turn_speaker(state: &StreamingDiarizationState) -> Option<u32> {
+    state.turns().last().map(|t| t.speaker.0)
+}
+
+/// One offline diarization turn (seconds + speaker index).
+#[derive(Debug, Clone)]
+pub struct LabeledTurn {
+    pub start: f64,
+    pub end: f64,
+    pub speaker: u32,
+}
+
+/// Run offline diarization over `samples` (16 kHz mono f32).
+///
+/// Returns `None` on pipeline failure (already logged). Empty input yields
+/// `Some(vec![])`.
+pub fn run_offline(encoder: &SpeakerEncoder, samples: &[f32]) -> Option<Vec<LabeledTurn>> {
+    let config = DiaConfig::default();
+    let vad_config = VadConfig::default();
+    let pipeline = Pipeline::new(config, vad_config);
+    let mut vad = EnergyVad::new(-40.0, 16000, vad_config.frame_size);
+    match pipeline.run(samples, encoder.as_ref(), &mut vad) {
+        Ok(dia_result) => Some(
+            dia_result
+                .turns
+                .into_iter()
+                .map(|t| LabeledTurn {
+                    start: t.time.start,
+                    end: t.time.end,
+                    speaker: t.speaker.0,
+                })
+                .collect(),
+        ),
+        Err(e) => {
+            tracing::warn!("Offline diarization failed: {e:#}");
+            None
+        }
+    }
+}
+
+/// Assign `speaker` on each word by midpoint-in-turn lookup.
+pub fn assign_speakers_by_midpoint(turns: &[LabeledTurn], words: &mut [super::WordInfo]) {
+    for word in words {
+        let mid = (word.start + word.end) / 2.0;
+        if let Some(turn) = turns.iter().find(|t| t.start <= mid && t.end >= mid) {
+            word.speaker = Some(turn.speaker);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Model-free guard for the WeSpeaker rank-3 fbank fix: `load_speaker_encoder`
+    // must stay wired to polyvoice's `FbankOnnxExtractor` (rank-3 fbank input) via
+    // its 3-arg constructor, NOT the old rank-2 raw-waveform
+    // `OnnxEmbeddingExtractor` (4-arg) that caused the `Got: 2 Expected: 3`
+    // failure. The extractor reads the ONNX model at construction, so a
+    // nonexistent path returns Err (never panics/Ok).
+    #[test]
+    fn test_load_speaker_encoder_missing_model_errors() {
+        let missing = Path::new("/nonexistent/gigastt-test/wespeaker_resnet34.onnx");
+        let result = load_speaker_encoder(missing, 1);
+        assert!(
+            result.is_err(),
+            "a missing WeSpeaker model must surface as Err, not panic or Ok"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires the WeSpeaker diarization model"]
+    fn test_speaker_encoder_accepts_waveform_audio() {
+        let model_path =
+            Path::new(&crate::model::default_model_dir()).join("wespeaker_resnet34.onnx");
+        let encoder = load_speaker_encoder(&model_path, 1).expect("speaker encoder should load");
+        let samples: Vec<f32> = (0..24_000)
+            .map(|i| {
+                let phase = std::f32::consts::TAU * 220.0 * i as f32 / 16_000.0;
+                0.1 * phase.sin()
+            })
+            .collect();
+
+        let embedding = encoder
+            .extract(&samples, &DiaConfig::default())
+            .expect("waveform must be converted to rank-3 fbank features");
+
+        assert_eq!(embedding.len(), SPEAKER_EMBEDDING_DIM);
+        assert!(embedding.iter().all(|value| value.is_finite()));
+    }
+}

--- a/crates/gigastt-core/src/inference/engine.rs
+++ b/crates/gigastt-core/src/inference/engine.rs
@@ -29,20 +29,7 @@ use super::types::{
 use super::{ENCODER_SUBSAMPLING, HOP_LENGTH, N_FFT, N_MELS, SECONDS_PER_FRAME, now_timestamp};
 
 #[cfg(feature = "diarization")]
-use super::state::{SPEAKER_EMBEDDING_DIM, SPEAKER_POOL_SIZE, SharedExtractor};
-#[cfg(feature = "diarization")]
-#[allow(deprecated)]
-use polyvoice::FbankOnnxExtractor;
-#[cfg(feature = "diarization")]
-use polyvoice::streaming::StreamingPipeline;
-#[cfg(feature = "diarization")]
-use polyvoice::{ClusterConfig, DiarizationConfig as DiaConfig, EnergyVad, Pipeline, VadConfig};
-
-#[cfg(feature = "diarization")]
-#[allow(deprecated)] // legacy FbankOnnxExtractor — see import note above
-fn load_speaker_encoder(model_path: &Path, pool_size: usize) -> anyhow::Result<FbankOnnxExtractor> {
-    FbankOnnxExtractor::new(model_path, SPEAKER_EMBEDDING_DIM, pool_size)
-}
+use super::diarization::{self, SpeakerEncoder};
 
 /// Total physical RAM in bytes, or `0` if it can't be determined (in which case
 /// the pool RAM cap is a no-op). macOS: `sysctl HW_MEMSIZE`; Linux/other unix:
@@ -339,8 +326,7 @@ pub struct Engine {
     /// Wrapped in `Arc` so per-session streaming pipelines can share the
     /// underlying ONNX session pool without each owning their own copy.
     #[cfg(feature = "diarization")]
-    #[allow(deprecated)] // legacy FbankOnnxExtractor — see import note above
-    pub speaker_encoder: Option<std::sync::Arc<FbankOnnxExtractor>>,
+    pub speaker_encoder: Option<SpeakerEncoder>,
 }
 
 impl Engine {
@@ -777,26 +763,7 @@ impl Engine {
         );
 
         #[cfg(feature = "diarization")]
-        let speaker_encoder = {
-            let model_path = model_dir.join("wespeaker_resnet34.onnx");
-            if model_path.exists() {
-                match load_speaker_encoder(&model_path, SPEAKER_POOL_SIZE) {
-                    Ok(enc) => {
-                        tracing::info!("Speaker encoder loaded (diarization available)");
-                        Some(std::sync::Arc::new(enc))
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Speaker encoder not loaded, diarization unavailable: {e:#}"
-                        );
-                        None
-                    }
-                }
-            } else {
-                tracing::warn!("wespeaker_resnet34.onnx not found, diarization unavailable");
-                None
-            }
-        };
+        let speaker_encoder = diarization::try_load_speaker_encoder(model_dir);
 
         // Detect ANE from the loaded encoder session (not compile-time alone) so
         // non-rnnt heads / injected factories keep the ort chunk window.
@@ -1171,25 +1138,7 @@ impl Engine {
     pub fn create_state(&self, diarization_enabled: bool) -> StreamingState {
         #[cfg(feature = "diarization")]
         let diarization_state = match (diarization_enabled, &self.speaker_encoder) {
-            (true, Some(enc)) => {
-                let config = DiaConfig {
-                    cluster: ClusterConfig {
-                        threshold: 0.5,
-                        ..ClusterConfig::default()
-                    },
-                    ..DiaConfig::default()
-                };
-                let vad_config = VadConfig::default();
-                let vad = EnergyVad::new(-40.0, 16000, vad_config.frame_size);
-                let extractor = SharedExtractor(std::sync::Arc::clone(enc));
-                match StreamingPipeline::new(vad, extractor, config, vad_config) {
-                    Ok(pipeline) => Some(pipeline),
-                    Err(e) => {
-                        tracing::warn!("Failed to initialize streaming diarization: {e:#}");
-                        None
-                    }
-                }
-            }
+            (true, Some(enc)) => diarization::open_streaming(enc),
             _ => None,
         };
 
@@ -1254,10 +1203,8 @@ impl Engine {
         // Diarization tracks speakers continuously, so feed every chunk's audio
         // even when this chunk doesn't trigger a decode (see the stride gate).
         #[cfg(feature = "diarization")]
-        if let Some(dia) = state.diarization_state.as_mut()
-            && let Err(e) = dia.feed(samples)
-        {
-            tracing::warn!("Diarization feed failed: {e:#}");
+        if let Some(dia) = state.diarization_state.as_mut() {
+            diarization::feed_chunk(dia, samples);
         }
 
         // Sliding-window streaming: accumulate audio; the encoder re-runs on the
@@ -1436,9 +1383,8 @@ impl Engine {
 
         #[cfg(feature = "diarization")]
         if let Some(dia) = state.diarization_state.as_mut()
-            && let Some(turn) = dia.turns().last()
+            && let Some(speaker) = diarization::last_turn_speaker(dia)
         {
-            let speaker = turn.speaker.0;
             for w in &mut tail {
                 w.speaker = Some(speaker);
             }
@@ -1744,28 +1690,11 @@ impl Engine {
             self.decode_words_for_samples(float_samples, triplet, overrides, hotwords)?;
 
         #[cfg(feature = "diarization")]
-        if diarize && let Some(ref enc) = self.speaker_encoder {
-            let config = DiaConfig::default();
-            let vad_config = VadConfig::default();
-            let pipeline = Pipeline::new(config, vad_config);
-            let mut vad = EnergyVad::new(-40.0, 16000, vad_config.frame_size);
-            match pipeline.run(float_samples, enc.as_ref(), &mut vad) {
-                Ok(dia_result) => {
-                    for word in &mut words {
-                        let mid = (word.start + word.end) / 2.0;
-                        if let Some(turn) = dia_result
-                            .turns
-                            .iter()
-                            .find(|t| t.time.start <= mid && t.time.end >= mid)
-                        {
-                            word.speaker = Some(turn.speaker.0);
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!("Offline diarization failed: {e:#}");
-                }
-            }
+        if diarize
+            && let Some(ref enc) = self.speaker_encoder
+            && let Some(turns) = diarization::run_offline(enc, float_samples)
+        {
+            diarization::assign_speakers_by_midpoint(&turns, &mut words);
         }
 
         let result = self.finish_transcribe_result(words, duration_s, overrides);
@@ -2258,7 +2187,8 @@ impl TokenFormatter {
 mod tests {
     use super::*;
     #[cfg(feature = "diarization")]
-    use crate::inference::state::SPEAKER_EMBEDDING_DIM;
+    #[cfg(feature = "diarization")]
+    use crate::inference::diarization::SPEAKER_EMBEDDING_DIM;
     use crate::inference::state::aggregate_confidence;
     use crate::inference::{
         DEFAULT_HOTWORDS_BOOST, DecoderState, EndpointMode, EndpointReason, FeatureExtractor,
@@ -2268,7 +2198,7 @@ mod tests {
     };
     #[cfg(feature = "diarization")]
     #[allow(deprecated)]
-    use polyvoice::EmbeddingExtractor;
+    use polyvoice::{DiarizationConfig as DiaConfig, EmbeddingExtractor};
 
     #[test]
     fn test_transcribe_overrides_default_all_none() {
@@ -3803,7 +3733,7 @@ vocab = "pack_vocab.txt"
     #[test]
     fn test_load_speaker_encoder_missing_model_errors() {
         let missing = Path::new("/nonexistent/gigastt-test/wespeaker_resnet34.onnx");
-        let result = load_speaker_encoder(missing, 1);
+        let result = diarization::load_speaker_encoder(missing, 1);
         assert!(
             result.is_err(),
             "a missing WeSpeaker model must surface as Err, not panic or Ok"
@@ -3817,7 +3747,8 @@ vocab = "pack_vocab.txt"
     fn test_speaker_encoder_accepts_waveform_audio() {
         let model_path =
             Path::new(&crate::model::default_model_dir()).join("wespeaker_resnet34.onnx");
-        let encoder = load_speaker_encoder(&model_path, 1).expect("speaker encoder should load");
+        let encoder =
+            diarization::load_speaker_encoder(&model_path, 1).expect("speaker encoder should load");
         let samples: Vec<f32> = (0..24_000)
             .map(|i| {
                 let phase = std::f32::consts::TAU * 220.0 * i as f32 / 16_000.0;

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -6,6 +6,10 @@ pub mod audio;
 mod bias;
 mod ctc;
 mod decode;
+/// Speaker diarization (polyvoice). Feature-gated; see module docs for why the
+/// deprecated polyvoice embedder surface is contained here rather than migrated.
+#[cfg(feature = "diarization")]
+mod diarization;
 mod engine;
 mod features;
 mod pool;
@@ -28,8 +32,10 @@ compile_error!("Features `coreml` and `cuda` are mutually exclusive. Choose one.
 
 pub use engine::Engine;
 pub use pool::{OwnedReservation, Pool, PoolError, PoolGuard, SessionPool, SessionTriplet};
+// Diarization adapter/types: all `#[allow(deprecated)]` polyvoice usage lives in
+// `diarization` — see that module's docs for the migration blocker.
 #[cfg(feature = "diarization")]
-pub use state::SharedExtractor;
+pub use diarization::{SharedExtractor, SpeakerEncoder, StreamingDiarizationState};
 pub use state::{
     DecoderState, EndpointMode, EndpointReason, FeatureExtractor, StreamingState,
     TranscriptAssembler, TranscriptSegment, WordInfo,

--- a/crates/gigastt-core/src/inference/state.rs
+++ b/crates/gigastt-core/src/inference/state.rs
@@ -2,51 +2,12 @@
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "diarization")]
-use polyvoice::streaming::StreamingPipeline;
-// `EmbeddingError`, `EmbeddingExtractor`, and `FbankOnnxExtractor` were
-// deprecated in polyvoice 0.7.0 in favour of the v1.0 `polyvoice::embedder`
-// `Embedder` trait. We keep them because our per-session diarization path,
-// `StreamingPipeline`, is itself bound on the legacy `EmbeddingExtractor` trait
-// (`impl<V, E> StreamingPipeline<V, E> where E: EmbeddingExtractor`) — polyvoice
-// has not yet wired the new `Embedder` into streaming, and suppresses these same
-// warnings crate-wide for that reason. Mirror it here; migrate once the streaming
-// pipeline accepts `Embedder`.
-#[cfg(feature = "diarization")]
-#[allow(deprecated)]
-use polyvoice::{
-    DiarizationConfig as DiaConfig, EmbeddingError, EmbeddingExtractor, EnergyVad,
-    FbankOnnxExtractor,
-};
-
 use super::PRED_HIDDEN;
 use super::audio;
+#[cfg(feature = "diarization")]
+use super::diarization::StreamingDiarizationState;
 use super::features::MelSpectrogram;
 use super::now_timestamp;
-
-#[cfg(feature = "diarization")]
-pub(crate) const SPEAKER_EMBEDDING_DIM: usize = 256;
-#[cfg(feature = "diarization")]
-pub(crate) const SPEAKER_POOL_SIZE: usize = 4;
-
-/// Adapter that lets a single shared [`FbankOnnxExtractor`] back the
-/// per-session [`StreamingPipeline`]s, which take ownership of their extractor.
-/// The ONNX session pool inside the extractor is shared across sessions via `Arc`.
-#[cfg(feature = "diarization")]
-#[allow(deprecated)] // legacy FbankOnnxExtractor — see import note above
-pub struct SharedExtractor(pub(crate) std::sync::Arc<FbankOnnxExtractor>);
-
-#[cfg(feature = "diarization")]
-#[allow(deprecated)] // legacy EmbeddingExtractor trait — see import note above
-impl EmbeddingExtractor for SharedExtractor {
-    fn extract(&self, samples: &[f32], config: &DiaConfig) -> Result<Vec<f32>, EmbeddingError> {
-        self.0.extract(samples, config)
-    }
-
-    fn embedding_dim(&self) -> usize {
-        self.0.embedding_dim()
-    }
-}
 
 #[non_exhaustive]
 pub struct DecoderState {
@@ -189,7 +150,7 @@ pub struct StreamingState {
     pub endpoint_mode: EndpointMode,
     /// Diarization state (present only when diarization is enabled).
     #[cfg(feature = "diarization")]
-    pub diarization_state: Option<StreamingPipeline<EnergyVad, SharedExtractor>>,
+    pub diarization_state: Option<StreamingDiarizationState>,
 }
 
 /// Audio feature extraction pipeline.


### PR DESCRIPTION
## Summary
- Move all polyvoice / diarization code into `inference/diarization.rs`.
- Full drop/migration **not feasible** yet: polyvoice 0.9 `StreamingPipeline` still requires deprecated `EmbeddingExtractor`.
- Feature + dependency retained; public types re-exported; docs explain the blocker.

## Test plan
- [x] `cargo check -p gigastt-core --features diarization`
- [x] clippy with diarization
- [x] pre-commit workspace suite