### PR TITLE
refactor(server): share file transcription core across REST and jobs

### DIFF
--- a/crates/gigastt/src/server/file_transcribe.rs
+++ b/crates/gigastt/src/server/file_transcribe.rs
@@ -1,0 +1,125 @@
+//! Shared file-transcription core for REST, OpenAI, and jobs.
+//!
+//! Surfaces keep their own HTTP / progress envelopes; the blocking
+//! channels / diarization / hotwords routing lives here so those paths
+//! cannot drift.
+
+use axum::body::Bytes;
+use gigastt_core::error::GigasttError;
+use gigastt_core::inference::{
+    Engine, HotwordOverride, OwnedReservation, SessionTriplet, TranscribeOverrides,
+    TranscribeResult,
+};
+
+/// Options for a single file-transcription run after request validation.
+#[derive(Clone, Default)]
+pub(crate) struct FileTranscribeOpts {
+    pub overrides: TranscribeOverrides,
+    pub hotwords: Option<HotwordOverride>,
+    pub split_channels: bool,
+    pub diarization: bool,
+    /// When set, decode the body as a raw telephony stream and re-wrap as WAV
+    /// before the engine path. REST-only today; jobs do not expose `?codec=`.
+    pub raw_codec: Option<(gigastt_core::inference::audio::TelephonyCodec, u32)>,
+}
+
+/// Decode raw telephony bytes to an in-memory PCM16 WAV for engine paths.
+pub(crate) fn raw_codec_to_wav(
+    body: &[u8],
+    codec: gigastt_core::inference::audio::TelephonyCodec,
+    sample_rate: u32,
+) -> Result<Bytes, GigasttError> {
+    let samples = gigastt_core::inference::audio::decode_telephony_raw(body, codec, sample_rate)
+        .map_err(|e| GigasttError::InvalidAudio {
+            reason: format!("{e:#}"),
+        })?;
+    Ok(Bytes::from(
+        gigastt_core::inference::audio::encode_wav_pcm16(&samples, 16000),
+    ))
+}
+
+/// Blocking file transcription against a reserved triplet.
+///
+/// Handles raw-codec rewrap, `channels=split` with mono fallback, diarization,
+/// and the default mono path. Callers own pool checkout, panic wrapping, and
+/// timeout policy.
+pub(crate) fn run_file_transcribe_blocking(
+    engine: &Engine,
+    body: Bytes,
+    reservation: &mut OwnedReservation<SessionTriplet>,
+    opts: &FileTranscribeOpts,
+) -> Result<TranscribeResult, GigasttError> {
+    let body = match opts.raw_codec {
+        Some((codec, rate)) => raw_codec_to_wav(&body, codec, rate)?,
+        None => body,
+    };
+
+    if opts.split_channels {
+        let channels =
+            gigastt_core::inference::audio::decode_audio_bytes_shared_channels(body.clone())
+                .map_err(|e| GigasttError::InvalidAudio {
+                    reason: format!("{e:#}"),
+                })?;
+        let fallback_reason = match channels.len() {
+            0 => Some("no channels"),
+            1 => Some("mono audio"),
+            2 if gigastt_core::inference::audio::is_dual_mono(&channels) => Some("dual-mono audio"),
+            n if n > 2 => Some("more than two channels"),
+            _ => None,
+        };
+        if let Some(reason) = fallback_reason {
+            tracing::warn!(
+                "channels=split requested but {reason} detected; falling back to mono transcription"
+            );
+            engine.transcribe_bytes_shared(body, reservation)
+        } else {
+            engine.transcribe_channels(&channels, reservation)
+        }
+    } else if opts.diarization {
+        engine.transcribe_bytes_shared_with_overrides_diarized_hotwords(
+            body,
+            reservation,
+            &opts.overrides,
+            opts.hotwords.as_ref(),
+        )
+    } else {
+        engine.transcribe_bytes_shared_with_overrides_hotwords(
+            body,
+            reservation,
+            &opts.overrides,
+            opts.hotwords.as_ref(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_transcribe_opts_default() {
+        let opts = FileTranscribeOpts::default();
+        assert!(!opts.split_channels);
+        assert!(!opts.diarization);
+        assert!(opts.hotwords.is_none());
+        assert!(opts.raw_codec.is_none());
+        assert!(opts.overrides.punctuation.is_none());
+        assert!(opts.overrides.itn.is_none());
+        assert!(opts.overrides.vad.is_none());
+    }
+
+    #[test]
+    fn test_raw_codec_to_wav_rejects_empty_pcmu() {
+        // Empty PCMU body is invalid for telephony decode.
+        let err = raw_codec_to_wav(
+            &[],
+            gigastt_core::inference::audio::TelephonyCodec::Pcmu,
+            8000,
+        )
+        .unwrap_err();
+        match err {
+            GigasttError::InvalidAudio { .. } => {}
+            other => panic!("expected InvalidAudio, got {other:?}"),
+        }
+    }
+}

--- a/crates/gigastt/src/server/http/transcribe.rs
+++ b/crates/gigastt/src/server/http/transcribe.rs
@@ -76,23 +76,8 @@ pub(super) fn resolve_raw_codec(
     Ok(Some((codec, sample_rate)))
 }
 
-/// Decode a raw telephony byte stream and re-wrap it as an in-memory PCM16
-/// WAV, so every downstream engine path (mono, `channels=split`, diarized)
-/// works unchanged. Runs inside the blocking inference closure; errors map to
-/// the same 422 as container decode failures.
-pub(super) fn raw_codec_to_wav(
-    body: &[u8],
-    codec: gigastt_core::inference::audio::TelephonyCodec,
-    sample_rate: u32,
-) -> Result<Bytes, gigastt_core::error::GigasttError> {
-    let samples = gigastt_core::inference::audio::decode_telephony_raw(body, codec, sample_rate)
-        .map_err(|e| gigastt_core::error::GigasttError::InvalidAudio {
-            reason: format!("{e:#}"),
-        })?;
-    Ok(Bytes::from(
-        gigastt_core::inference::audio::encode_wav_pcm16(&samples, 16000),
-    ))
-}
+#[cfg(test)]
+pub(super) use super::super::file_transcribe::raw_codec_to_wav;
 
 /// Check out a session triplet from the engine's batch pool with the configured
 /// timeout and record the pool metrics, returning an owned reservation whose
@@ -233,63 +218,26 @@ pub(super) async fn run_file_transcription(
     let mut reservation =
         reserve_batch_slot(&engine, &limits, state.metrics_registry.as_ref()).await?;
 
+    let file_opts = super::super::file_transcribe::FileTranscribeOpts {
+        overrides,
+        hotwords,
+        split_channels,
+        diarization: request_diarization,
+        raw_codec,
+    };
+
     let inference_start = std::time::Instant::now();
     let span = tracing::Span::current();
     let handle = tokio::task::spawn_blocking(move || {
         let _enter = span.enter();
         // catch_unwind ensures triplet is returned to pool even on panic
         let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            // Raw telephony upload: decode the headerless byte stream and
-            // re-wrap it as an in-memory WAV so every downstream path (mono,
-            // channels=split, diarized) works unchanged.
-            let body = match raw_codec {
-                Some((codec, rate)) => raw_codec_to_wav(&body, codec, rate)?,
-                None => body,
-            };
-            if split_channels {
-                let channels = gigastt_core::inference::audio::decode_audio_bytes_shared_channels(
-                    body.clone(),
-                )
-                .map_err(|e| gigastt_core::error::GigasttError::InvalidAudio {
-                    reason: format!("{e:#}"),
-                })?;
-                let fallback_reason = match channels.len() {
-                    0 => Some("no channels"),
-                    1 => Some("mono audio"),
-                    2 if gigastt_core::inference::audio::is_dual_mono(&channels) => {
-                        Some("dual-mono audio")
-                    }
-                    n if n > 2 => Some("more than two channels"),
-                    _ => None,
-                };
-                if let Some(reason) = fallback_reason {
-                    tracing::warn!(
-                        "channels=split requested but {reason} detected; falling back to mono transcription"
-                    );
-                    engine.transcribe_bytes_shared(body, &mut reservation)
-                } else {
-                    engine.transcribe_channels(&channels, &mut reservation)
-                }
-            } else if request_diarization {
-                // Diarization is opt-in (`?diarization=true`): only then run the
-                // offline speaker pass. `body` is `axum::body::Bytes` (a
-                // `bytes::Bytes` re-export) so the decode shares the upload buffer.
-                engine.transcribe_bytes_shared_with_overrides_diarized_hotwords(
-                    body,
-                    &mut reservation,
-                    &overrides,
-                    hotwords.as_ref(),
-                )
-            } else {
-                // No diarization requested: byte-identical to the pre-existing
-                // zero-copy path. `overrides` is already validated above.
-                engine.transcribe_bytes_shared_with_overrides_hotwords(
-                    body,
-                    &mut reservation,
-                    &overrides,
-                    hotwords.as_ref(),
-                )
-            }
+            super::super::file_transcribe::run_file_transcribe_blocking(
+                &engine,
+                body,
+                &mut reservation,
+                &file_opts,
+            )
         }));
         match r {
             Ok(inference_result) => inference_result,

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -719,55 +719,22 @@ impl JobExecution for RealJobExecutor {
             let engine_for_inference = engine.clone();
             let body_for_inference = body.clone();
             let span = tracing::Span::current();
+            let file_opts = super::file_transcribe::FileTranscribeOpts {
+                overrides,
+                hotwords,
+                split_channels: params.channels.as_deref() == Some("split"),
+                diarization: params.diarization == Some(true),
+                raw_codec: None,
+            };
             let handle = tokio::task::spawn_blocking(move || {
                 let _enter = span.enter();
                 let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    if params.channels.as_deref() == Some("split") {
-                        let channels =
-                            gigastt_core::inference::audio::decode_audio_bytes_shared_channels(
-                                body_for_inference.clone(),
-                            )
-                            .map_err(|e| {
-                                gigastt_core::error::GigasttError::InvalidAudio {
-                                    reason: format!("{e:#}"),
-                                }
-                            })?;
-                        let fallback_reason = match channels.len() {
-                            0 => Some("no channels"),
-                            1 => Some("mono audio"),
-                            2 if gigastt_core::inference::audio::is_dual_mono(&channels) => {
-                                Some("dual-mono audio")
-                            }
-                            n if n > 2 => Some("more than two channels"),
-                            _ => None,
-                        };
-                        if let Some(reason) = fallback_reason {
-                            tracing::warn!(
-                                "channels=split requested but {reason} detected; falling back to mono transcription"
-                            );
-                            engine_for_inference
-                                .transcribe_bytes_shared(body_for_inference, &mut reservation)
-                        } else {
-                            engine_for_inference.transcribe_channels(&channels, &mut reservation)
-                        }
-                    } else if params.diarization == Some(true) {
-                        // Diarization is opt-in (`?diarization=true`): only then run
-                        // the offline speaker pass, matching the sync REST path.
-                        engine_for_inference
-                            .transcribe_bytes_shared_with_overrides_diarized_hotwords(
-                                body_for_inference,
-                                &mut reservation,
-                                &overrides,
-                                hotwords.as_ref(),
-                            )
-                    } else {
-                        engine_for_inference.transcribe_bytes_shared_with_overrides_hotwords(
-                            body_for_inference,
-                            &mut reservation,
-                            &overrides,
-                            hotwords.as_ref(),
-                        )
-                    }
+                    super::file_transcribe::run_file_transcribe_blocking(
+                        &engine_for_inference,
+                        body_for_inference,
+                        &mut reservation,
+                        &file_opts,
+                    )
                 }));
                 match r {
                     Ok(result) => result,
@@ -789,7 +756,8 @@ impl JobExecution for RealJobExecutor {
                 )
                 .await
                 {
-                    Ok(r) => r.map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
+                    Ok(r) => r
+                        .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
                         .map_err(anyhow::Error::from),
                     Err(_) => Err(anyhow::anyhow!("inference_timeout")),
                 }

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -4,6 +4,7 @@
 
 mod bootstrap;
 pub mod config;
+mod file_transcribe;
 pub mod http;
 pub mod jobs;
 pub mod metrics;


### PR DESCRIPTION
## Summary
- New `server/file_transcribe.rs` with `run_file_transcribe_blocking` + `FileTranscribeOpts`.
- REST (`run_file_transcription`) and jobs (`RealJobExecutor`) call the same blocking core for channels/diarization/hotwords/raw-codec.
- OpenAI non-stream path continues via REST helper, so it inherits the share.
- Stacked on #220 (`refactor/http-handlers`).

## Test plan
- [x] `cargo clippy -p gigastt --lib -- -D warnings`
- [x] `cargo test -p gigastt --lib` (172+ passed in prior run; pre-commit runs full suite)
- [x] raw_codec + file_transcribe unit tests