### PR TITLE
perf(core): resample file decode incrementally instead of whole-buffer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,12 @@ jobs:
           shared-key: ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test --workspace --lib --bins
+      # Long-duration resampler equivalence gate (~50 s in debug): the staged
+      # decode path must not drift more than a whole-buffer resample over 300 s
+      # of 44.1 kHz audio. Too slow for every PR, so it runs on main push only.
+      - name: Long-duration resampler numeric gate
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: cargo test -p gigastt-core --lib -- --ignored streaming_decode_long_44k1
       - name: Lean embedded build (no tokio/reqwest/symphonia)
         run: |
           cargo build -p gigastt-core --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **File decode resamples incrementally instead of in one whole-buffer pass.**
+  Decoded packets now drain through a stateful resampler in ~1 s staged chunks, so
+  peak RSS no longer carries three full-length copies of the source-rate audio.
+  Measured decode-only peak RSS for a 20-minute 48 kHz stereo WAV: **706 MiB → 82 MiB
+  (8.6×)**, with decode wall time slightly improved. Output is bit-identical for
+  48 kHz sources and numerically tighter at 44.1 kHz, where the staged resampler keeps
+  rubato's fractional phase bounded instead of letting it accumulate over millions of
+  samples. All public decode signatures are unchanged.
+
 ### Fixed
 
 - **`ort` is pinned to exactly `2.0.0-rc.12`.** The previous requirement was a caret, so

--- a/crates/gigastt-core/src/inference/audio/decode.rs
+++ b/crates/gigastt-core/src/inference/audio/decode.rs
@@ -27,7 +27,7 @@ use super::max_decode_samples;
 #[cfg(feature = "file-decode")]
 use super::opus::{decode_opus_channels, next_demux_packet};
 #[cfg(feature = "file-decode")]
-use super::resample::{SampleRate, resample};
+use super::resample::{RESAMPLE_STAGING_FRAMES, ResampleTo16k, SampleRate};
 #[cfg(feature = "file-decode")]
 use super::telephony::{sniffs_as_g722_wav, try_decode_g722_wav};
 
@@ -301,24 +301,44 @@ fn decode_audio_inner_channels<'s>(
 
     tracing::info!("Audio ({source_label}): {sample_rate}Hz, {channels}ch (split)");
 
+    // Each channel is an independent stream, so each gets its own staging
+    // buffer and cached resampler; none of them ever holds more than one
+    // chunk of source-rate audio.
+    let hint = match n_frames_hint {
+        Some(n) if n > 0 && n <= max_samples as u64 => Some(n as usize),
+        _ => None,
+    };
+    // Source-rate frame count of the first channel, tracked separately because
+    // the accumulators now hold 16 kHz samples while the duration cap is
+    // expressed in source-rate frames.
+    let mut source_frames: usize = 0;
+
     // Symphonia demuxes OGG/Opus but ships no Opus decoder, so Opus packets
     // go through the `opus-rs` fallback and rejoin the shared resample tail.
-    let mut per_channel: Vec<Vec<f32>> = if audio_params.codec == CODEC_ID_OPUS {
-        decode_opus_channels(&mut *format, track_id, channels, max_samples)?
+    let acc: Vec<ResampleTo16k> = if audio_params.codec == CODEC_ID_OPUS {
+        let decoded = decode_opus_channels(&mut *format, track_id, channels, max_samples)?;
+        source_frames = decoded.first().map(|v| v.len()).unwrap_or(0);
+        let mut acc = Vec::with_capacity(decoded.len());
+        for samples in decoded {
+            let mut chan = ResampleTo16k::new(SampleRate(sample_rate), Some(samples.len()));
+            for piece in samples.chunks(RESAMPLE_STAGING_FRAMES) {
+                chan.stage().extend_from_slice(piece);
+                chan.flush_full()?;
+            }
+            acc.push(chan);
+        }
+        acc
     } else {
         let mut decoder = symphonia::default::get_codecs()
             .make_audio_decoder(audio_params, &AudioDecoderOptions::default())
             .context("Unsupported audio codec")?;
 
-        let mut per_channel: Vec<Vec<f32>> = (0..channels)
-            .map(|_| match n_frames_hint {
-                Some(n) if n > 0 && n <= max_samples as u64 => Vec::with_capacity(n as usize),
-                _ => Vec::new(),
-            })
+        let mut acc: Vec<ResampleTo16k> = (0..channels)
+            .map(|_| ResampleTo16k::new(SampleRate(sample_rate), hint))
             .collect();
 
         loop {
-            let have_pcm = per_channel.first().is_some_and(|c| !c.is_empty());
+            let have_pcm = source_frames > 0;
             let Some(packet) = next_demux_packet(&mut *format, have_pcm)? else {
                 break;
             };
@@ -332,8 +352,10 @@ fn decode_audio_inner_channels<'s>(
             let num_frames = decoded.frames();
             let ch = spec.channels().count();
 
-            if ch > per_channel.len() {
-                per_channel.resize_with(ch, Vec::new);
+            if ch > acc.len() {
+                // A channel that appears mid-stream starts from this packet,
+                // so it gets no length hint.
+                acc.resize_with(ch, || ResampleTo16k::new(SampleRate(sample_rate), None));
             }
 
             if ch > 1 {
@@ -341,50 +363,53 @@ fn decode_audio_inner_channels<'s>(
                 decoded.copy_to_vec_interleaved(&mut interleaved);
                 for frame in 0..num_frames {
                     for c in 0..ch {
-                        per_channel[c].push(interleaved[frame * ch + c]);
+                        acc[c].stage().push(interleaved[frame * ch + c]);
                     }
                 }
-            } else if !per_channel.is_empty() {
-                let offset = per_channel[0].len();
-                per_channel[0].resize(offset + num_frames, 0.0);
-                decoded.copy_to_slice_interleaved(&mut per_channel[0][offset..]);
+            } else if !acc.is_empty() {
+                let stage = acc[0].stage();
+                let offset = stage.len();
+                stage.resize(offset + num_frames, 0.0);
+                decoded.copy_to_slice_interleaved(&mut stage[offset..]);
+            }
+            // Both branches above grow the first channel by `num_frames`; the
+            // `ch <= 1` branch is skipped entirely when there is no channel.
+            if !acc.is_empty() {
+                source_frames += num_frames;
             }
 
-            if per_channel.first().map(|v| v.len()).unwrap_or(0) > max_samples {
-                let observed_s =
-                    per_channel.first().map(|v| v.len()).unwrap_or(0) as f64 / sample_rate as f64;
+            if source_frames > max_samples {
+                let observed_s = source_frames as f64 / sample_rate as f64;
                 anyhow::bail!(
                     "Audio file too long ({:.0}s). Maximum supported: {MAX_DURATION_S:.0}s.",
                     observed_s
                 );
             }
+
+            for chan in &mut acc {
+                chan.flush_full()?;
+            }
         }
 
-        per_channel
+        acc
     };
 
-    let duration_s = per_channel
-        .first()
-        .map(|v| v.len() as f64 / sample_rate as f64)
-        .unwrap_or(0.0);
+    let duration_s = source_frames as f64 / sample_rate as f64;
     tracing::info!(
         "Decoded {} channel(s), first channel {} samples at {}Hz ({:.1}s)",
-        per_channel.len(),
-        per_channel.first().map(|v| v.len()).unwrap_or(0),
+        acc.len(),
+        source_frames,
         sample_rate,
         duration_s
     );
 
+    let channel_count = acc.len();
+    let per_channel = acc
+        .into_iter()
+        .map(ResampleTo16k::finish)
+        .collect::<Result<Vec<_>>>()?;
     if sample_rate != 16000 {
-        per_channel = per_channel
-            .into_iter()
-            .map(|ch| {
-                resample(&ch, SampleRate(sample_rate), SampleRate(16000))
-                    .context("Resampling failed")
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let channels = per_channel.len();
-        tracing::info!("Resampled {channels} channel(s) to 16kHz");
+        tracing::info!("Resampled {channel_count} channel(s) to 16kHz");
     }
 
     Ok(per_channel)
@@ -394,9 +419,6 @@ fn decode_audio_inner_channels<'s>(
 pub fn mix_channels_to_mono(channels: &[Vec<f32>]) -> Vec<f32> {
     if channels.is_empty() {
         return Vec::new();
-    }
-    if channels.len() == 1 {
-        return channels[0].clone();
     }
     let n = channels.iter().map(|c| c.len()).min().unwrap_or(0);
     (0..n)
@@ -490,24 +512,42 @@ fn decode_audio_inner<'s>(
     // is bounded by the same budget.
     let max_samples: usize = max_decode_samples(sample_rate);
 
+    // Decoded packets are staged at the source rate and drained to 16 kHz as
+    // they fill, so peak memory is O(one staging chunk) instead of O(file).
+    let mut acc = ResampleTo16k::new(
+        SampleRate(sample_rate),
+        match n_frames_hint {
+            Some(n) if n > 0 && n <= max_samples as u64 => Some(n as usize),
+            _ => None,
+        },
+    );
+    // Source-rate frame count, tracked separately because the accumulator now
+    // holds 16 kHz samples while the duration cap is expressed in source-rate
+    // frames.
+    let mut source_frames: usize = 0;
+
     // Symphonia demuxes OGG/Opus but ships no Opus decoder, so Opus packets
     // go through the `opus-rs` fallback (mono mix included) and rejoin the
     // shared duration-log / resample tail.
-    let mut all_samples: Vec<f32> = if audio_params.codec == CODEC_ID_OPUS {
-        let per_channel = decode_opus_channels(&mut *format, track_id, channels, max_samples)?;
-        mix_channels_to_mono(&per_channel)
+    if audio_params.codec == CODEC_ID_OPUS {
+        let mono = mix_channels_to_mono(&decode_opus_channels(
+            &mut *format,
+            track_id,
+            channels,
+            max_samples,
+        )?);
+        source_frames = mono.len();
+        for piece in mono.chunks(RESAMPLE_STAGING_FRAMES) {
+            acc.stage().extend_from_slice(piece);
+            acc.flush_full()?;
+        }
     } else {
         let mut decoder = symphonia::default::get_codecs()
             .make_audio_decoder(audio_params, &AudioDecoderOptions::default())
             .context("Unsupported audio codec")?;
 
-        let mut all_samples: Vec<f32> = match n_frames_hint {
-            Some(n) if n > 0 && n <= max_samples as u64 => Vec::with_capacity(n as usize),
-            _ => Vec::new(),
-        };
-
         loop {
-            let have_pcm = !all_samples.is_empty();
+            let have_pcm = source_frames > 0;
             let Some(packet) = next_demux_packet(&mut *format, have_pcm)? else {
                 break;
             };
@@ -525,47 +565,48 @@ fn decode_audio_inner<'s>(
             if ch > 1 {
                 let mut interleaved: Vec<f32> = Vec::with_capacity(num_frames * ch);
                 decoded.copy_to_vec_interleaved(&mut interleaved);
+                let stage = acc.stage();
                 for frame in 0..num_frames {
                     let mut sum = 0.0_f32;
                     for c in 0..ch {
                         sum += interleaved[frame * ch + c];
                     }
-                    all_samples.push(sum / ch as f32);
+                    stage.push(sum / ch as f32);
                 }
             } else {
-                let offset = all_samples.len();
-                all_samples.resize(offset + num_frames, 0.0);
-                decoded.copy_to_slice_interleaved(&mut all_samples[offset..]);
+                let stage = acc.stage();
+                let offset = stage.len();
+                stage.resize(offset + num_frames, 0.0);
+                decoded.copy_to_slice_interleaved(&mut stage[offset..]);
             }
+            source_frames += num_frames;
 
             // Incremental duration cap: abort before the next packet is decoded
             // if the accumulated buffer already exceeds the duration budget.
             // This prevents a crafted upload from allocating hundreds of MiB of
             // PCM before the post-loop guard gets a chance to run.
-            if all_samples.len() > max_samples {
-                let observed_s = all_samples.len() as f64 / sample_rate as f64;
+            if source_frames > max_samples {
+                let observed_s = source_frames as f64 / sample_rate as f64;
                 anyhow::bail!(
                     "Audio file too long ({:.0}s). Maximum supported: {MAX_DURATION_S:.0}s.",
                     observed_s
                 );
             }
+
+            acc.flush_full()?;
         }
+    }
 
-        all_samples
-    };
-
-    let duration_s = all_samples.len() as f64 / sample_rate as f64;
+    let duration_s = source_frames as f64 / sample_rate as f64;
     tracing::info!(
         "Decoded {} samples at {}Hz ({:.1}s)",
-        all_samples.len(),
+        source_frames,
         sample_rate,
         duration_s
     );
 
-    // Resample to 16kHz if needed
+    let all_samples = acc.finish()?;
     if sample_rate != 16000 {
-        all_samples = resample(&all_samples, SampleRate(sample_rate), SampleRate(16000))
-            .context("Resampling failed")?;
         tracing::info!("Resampled to 16kHz: {} samples", all_samples.len());
     }
 

--- a/crates/gigastt-core/src/inference/audio/resample.rs
+++ b/crates/gigastt-core/src/inference/audio/resample.rs
@@ -197,9 +197,18 @@ pub(super) const RESAMPLE_STAGING_FRAMES: usize = super::MAX_DECODE_SAMPLE_RATE 
 /// version produced. At any other rate the staging buffer is capped at
 /// [`RESAMPLE_STAGING_FRAMES`] source-rate samples and drained through
 /// [`resample_with_cache`], whose FIR history and fractional phase carry
-/// across flushes — the concatenated output therefore matches a single
-/// whole-buffer [`resample`] call while peak memory stays O(one chunk)
-/// instead of O(file).
+/// across flushes, so peak memory stays O(one chunk) instead of O(file) and no
+/// seam appears at a flush boundary.
+///
+/// Against a single whole-buffer [`resample`] call the concatenated output is
+/// bit-identical at integer ratios (48/32/8 kHz, where `1/ratio` is exact in
+/// f64). At a non-integer ratio the two separate slowly as the input grows,
+/// because [`resample`] runs rubato's fractional-position accumulator over the
+/// whole file in one pass and loses sub-sample resolution as it grows, while
+/// this path restarts it near zero every flush. The staged path is the more
+/// accurate of the two — it stays phase-locked to an analytic tone at every
+/// length while the whole-buffer reference walks; see the long-input test in
+/// `tests.rs` for the measured bounds.
 #[cfg(feature = "file-decode")]
 pub(super) struct ResampleTo16k {
     from_rate: SampleRate,

--- a/crates/gigastt-core/src/inference/audio/resample.rs
+++ b/crates/gigastt-core/src/inference/audio/resample.rs
@@ -1,5 +1,7 @@
 //! Sample-rate types and high-quality polyphase FIR resampling (rubato).
 
+#[cfg(feature = "file-decode")]
+use anyhow::Context;
 use anyhow::Result;
 use rubato::Resampler;
 
@@ -175,6 +177,112 @@ pub fn resample_with_cache(
         }
     }
     Ok(())
+}
+
+/// Source-rate samples staged before each streaming resample flush.
+///
+/// One second at the highest rate the decode budget admits: big enough that
+/// the cached resampler — whose capacity freezes on its first call — never has
+/// to split a later chunk, small enough that the staged copy stays a few
+/// hundred KiB no matter how long the file is.
+#[cfg(feature = "file-decode")]
+pub(super) const RESAMPLE_STAGING_FRAMES: usize = super::MAX_DECODE_SAMPLE_RATE as usize;
+
+/// Decoded-sample accumulator that resamples to 16 kHz while the file decodes.
+///
+/// Packet decoders append straight into [`stage`](Self::stage) and call
+/// [`flush_full`](Self::flush_full) once per packet. When the source is
+/// already 16 kHz the staged buffer *is* the output: no resampler is built and
+/// no sample is copied, so that path stays byte-for-byte what the whole-buffer
+/// version produced. At any other rate the staging buffer is capped at
+/// [`RESAMPLE_STAGING_FRAMES`] source-rate samples and drained through
+/// [`resample_with_cache`], whose FIR history and fractional phase carry
+/// across flushes — the concatenated output therefore matches a single
+/// whole-buffer [`resample`] call while peak memory stays O(one chunk)
+/// instead of O(file).
+#[cfg(feature = "file-decode")]
+pub(super) struct ResampleTo16k {
+    from_rate: SampleRate,
+    stage: Vec<f32>,
+    out: Vec<f32>,
+    cache: Option<rubato::Async<f32>>,
+    scratch: Vec<f32>,
+}
+
+#[cfg(feature = "file-decode")]
+impl ResampleTo16k {
+    /// `source_frames_hint` is the container's declared frame count (already
+    /// bounded by the decode budget); it reserves the 16 kHz output up front.
+    pub(super) fn new(from_rate: SampleRate, source_frames_hint: Option<usize>) -> Self {
+        if from_rate.0 == 16_000 {
+            // Passthrough: the staging buffer is handed back verbatim, so it
+            // takes the whole reservation and `out` is never touched.
+            return Self {
+                from_rate,
+                stage: match source_frames_hint {
+                    Some(n) => Vec::with_capacity(n),
+                    None => Vec::new(),
+                },
+                out: Vec::new(),
+                cache: None,
+                scratch: Vec::new(),
+            };
+        }
+        let out = match source_frames_hint {
+            Some(n) => {
+                Vec::with_capacity((n as u64 * 16_000 / u64::from(from_rate.0.max(1))) as usize)
+            }
+            None => Vec::new(),
+        };
+        Self {
+            from_rate,
+            stage: Vec::with_capacity(RESAMPLE_STAGING_FRAMES),
+            out,
+            cache: None,
+            scratch: Vec::new(),
+        }
+    }
+
+    /// The buffer decoded packets append to, in SOURCE-rate samples.
+    pub(super) fn stage(&mut self) -> &mut Vec<f32> {
+        &mut self.stage
+    }
+
+    /// Drain the staging buffer once it holds a full chunk.
+    pub(super) fn flush_full(&mut self) -> Result<()> {
+        if self.from_rate.0 == 16_000 || self.stage.len() < RESAMPLE_STAGING_FRAMES {
+            return Ok(());
+        }
+        self.drain()
+    }
+
+    /// Drain whatever is still staged and yield the 16 kHz samples.
+    pub(super) fn finish(mut self) -> Result<Vec<f32>> {
+        if self.from_rate.0 == 16_000 {
+            return Ok(self.stage);
+        }
+        self.drain()?;
+        Ok(self.out)
+    }
+
+    fn drain(&mut self) -> Result<()> {
+        if self.stage.is_empty() {
+            return Ok(());
+        }
+        // `resample_with_cache` consumes its input, so hand it the staging
+        // buffer and leave a same-sized empty one in its place.
+        let chunk = std::mem::replace(&mut self.stage, Vec::with_capacity(RESAMPLE_STAGING_FRAMES));
+        resample_with_cache(
+            chunk,
+            self.from_rate,
+            SampleRate(16_000),
+            &mut self.cache,
+            &mut self.scratch,
+        )
+        .context("Resampling failed")?;
+        self.out.extend_from_slice(&self.scratch);
+        Ok(())
+    }
 }
 
 /// Run one chunk through the cached resampler, replacing `dst` with the output.

--- a/crates/gigastt-core/src/inference/audio/telephony.rs
+++ b/crates/gigastt-core/src/inference/audio/telephony.rs
@@ -10,7 +10,7 @@ use super::MAX_DURATION_S;
 #[cfg(feature = "file-decode")]
 use super::max_decode_samples;
 #[cfg(feature = "file-decode")]
-use super::resample::{SampleRate, resample};
+use super::resample::{RESAMPLE_STAGING_FRAMES, ResampleTo16k, SampleRate};
 
 /// WAV format tags for ITU-T G.722 ADPCM. Symphonia's RIFF demuxer maps them
 /// to `CODEC_TYPE_NULL` and there is no decoder for it, so G.722-in-WAV (what
@@ -231,12 +231,15 @@ pub fn decode_telephony_raw(
             "Audio file too long ({observed_s:.0}s). Maximum supported: {MAX_DURATION_S:.0}s."
         );
     }
-    let mut samples: Vec<f32> = pcm.iter().map(|&s| f32::from(s) / 32768.0).collect();
-    if rate != 16000 {
-        samples =
-            resample(&samples, SampleRate(rate), SampleRate(16000)).context("Resampling failed")?;
+    // Convert and resample in staged chunks so the full-length source-rate
+    // f32 buffer is never materialized alongside the 16 kHz output.
+    let mut acc = ResampleTo16k::new(SampleRate(rate), Some(pcm.len()));
+    for piece in pcm.chunks(RESAMPLE_STAGING_FRAMES) {
+        acc.stage()
+            .extend(piece.iter().map(|&s| f32::from(s) / 32768.0));
+        acc.flush_full()?;
     }
-    Ok(samples)
+    acc.finish()
 }
 
 /// Wrap mono f32 samples in a PCM16 RIFF/WAVE container. Lets raw-codec

--- a/crates/gigastt-core/src/inference/audio/tests.rs
+++ b/crates/gigastt-core/src/inference/audio/tests.rs
@@ -1441,3 +1441,183 @@ fn test_encode_wav_pcm16_clamps_and_sanitizes() {
     assert!(decoded[2].abs() < 1e-3, "NaN must become silence");
     assert!((decoded[3] - 0.5).abs() < 1e-3);
 }
+
+// --- streaming resample equivalence (whole-buffer reference) ---
+
+/// PCM16 samples of a committed 16 kHz mono WAV fixture, used as a real-signal
+/// input for the streaming-resample equivalence tests.
+fn fixture_tone_pcm() -> Vec<i16> {
+    let wav = include_bytes!("../../../tests/fixtures/telephony/tone_src.wav");
+    let data = super::telephony::find_riff_chunk(wav, b"data").expect("fixture data chunk");
+    data.chunks_exact(2)
+        .map(|b| i16::from_le_bytes([b[0], b[1]]))
+        .collect()
+}
+
+/// Linear sine sweep, PCM16. Sweeping across the whole band is the adversarial
+/// case for a resampler seam: any FIR-history reset shows up as a spike.
+fn sweep_pcm(rate: u32, seconds: f32) -> Vec<i16> {
+    let n = (rate as f32 * seconds) as usize;
+    (0..n)
+        .map(|i| {
+            let t = i as f32 / rate as f32;
+            let f = 50.0 + (0.45 * rate as f32 - 50.0) * (t / seconds);
+            (0.8 * (std::f32::consts::PI * f * t).sin() * 32000.0) as i16
+        })
+        .collect()
+}
+
+/// Assert the streaming path agrees with a whole-buffer `resample()` of the
+/// same decoded signal: same length within one sample, max per-sample delta
+/// below 1e-4.
+fn assert_matches_whole_buffer(streamed: &[f32], reference: &[f32], what: &str) {
+    let len_diff = streamed.len().abs_diff(reference.len());
+    assert!(
+        len_diff <= 1,
+        "{what}: length diverged, streaming {} vs whole-buffer {}",
+        streamed.len(),
+        reference.len()
+    );
+    let cmp = streamed.len().min(reference.len());
+    assert!(cmp > 0, "{what}: nothing to compare");
+    let mut max_diff = 0.0f32;
+    let mut max_at = 0usize;
+    for i in 0..cmp {
+        let d = (streamed[i] - reference[i]).abs();
+        if d > max_diff {
+            max_diff = d;
+            max_at = i;
+        }
+    }
+    assert!(
+        max_diff <= 1e-4,
+        "{what}: max |streaming - whole-buffer| = {max_diff} at sample {max_at}"
+    );
+}
+
+/// Decoding the same PCM twice — once with a 16 kHz header (passthrough, so
+/// the result is exactly what the decoder produced) and once with a `rate`
+/// header (the streaming resample path) — must agree with running the
+/// passthrough result through the whole-buffer `resample()`.
+fn check_mono_equivalence(pcm: &[i16], rate: u32, what: &str) {
+    let at_source = decode_audio_bytes(&make_wav_bytes(pcm, 16000)).unwrap();
+    let reference = resample(&at_source, SampleRate(rate), SampleRate(16000)).unwrap();
+    let streamed = decode_audio_bytes(&make_wav_bytes(pcm, rate)).unwrap();
+    assert_matches_whole_buffer(&streamed, &reference, what);
+}
+
+fn check_stereo_equivalence(left: &[i16], right: &[i16], rate: u32, what: &str) {
+    // Mono-mix path.
+    let mixed_at_source = decode_audio_bytes(&make_stereo_wav_bytes(left, right, 16000)).unwrap();
+    let mixed_reference = resample(&mixed_at_source, SampleRate(rate), SampleRate(16000)).unwrap();
+    let mixed_streamed = decode_audio_bytes(&make_stereo_wav_bytes(left, right, rate)).unwrap();
+    assert_matches_whole_buffer(&mixed_streamed, &mixed_reference, &format!("{what} mixed"));
+
+    // Split-channel path.
+    let split_at_source =
+        decode_audio_bytes_shared_channels(Bytes::from(make_stereo_wav_bytes(left, right, 16000)))
+            .unwrap();
+    let split_streamed =
+        decode_audio_bytes_shared_channels(Bytes::from(make_stereo_wav_bytes(left, right, rate)))
+            .unwrap();
+    assert_eq!(split_streamed.len(), split_at_source.len());
+    for (c, (streamed, source)) in split_streamed.iter().zip(&split_at_source).enumerate() {
+        let reference = resample(source, SampleRate(rate), SampleRate(16000)).unwrap();
+        assert_matches_whole_buffer(streamed, &reference, &format!("{what} channel {c}"));
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
+fn test_streaming_decode_matches_whole_buffer_resample_48k() {
+    let pcm = sweep_pcm(48_000, 2.5);
+    check_mono_equivalence(&pcm, 48_000, "48k sweep mono");
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
+fn test_streaming_decode_matches_whole_buffer_resample_44k1() {
+    let pcm = sweep_pcm(44_100, 2.5);
+    check_mono_equivalence(&pcm, 44_100, "44.1k sweep mono");
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
+fn test_streaming_decode_matches_whole_buffer_resample_stereo_48k() {
+    let left = sweep_pcm(48_000, 2.5);
+    let right: Vec<i16> = left.iter().rev().copied().collect();
+    check_stereo_equivalence(&left, &right, 48_000, "48k sweep stereo");
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
+fn test_streaming_decode_matches_whole_buffer_resample_stereo_44k1() {
+    let left = sweep_pcm(44_100, 2.5);
+    let right: Vec<i16> = left.iter().rev().copied().collect();
+    check_stereo_equivalence(&left, &right, 44_100, "44.1k sweep stereo");
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
+fn test_streaming_decode_matches_whole_buffer_resample_fixture() {
+    let pcm = fixture_tone_pcm();
+    assert!(
+        pcm.len() >= super::resample::RESAMPLE_STAGING_FRAMES,
+        "fixture must span at least one staging flush, got {} samples",
+        pcm.len()
+    );
+    check_mono_equivalence(&pcm, 48_000, "fixture 48k");
+    check_mono_equivalence(&pcm, 44_100, "fixture 44.1k");
+}
+
+#[test]
+fn test_streaming_decode_16k_input_is_bit_identical() {
+    // A 16 kHz source must never reach the resampler: every sample stays the
+    // raw PCM16 conversion and the frame count is preserved exactly.
+    let pcm = fixture_tone_pcm();
+    let mono = decode_audio_bytes(&make_wav_bytes(&pcm, 16000)).unwrap();
+    assert_eq!(mono.len(), pcm.len());
+    for (i, (&raw, &got)) in pcm.iter().zip(&mono).enumerate() {
+        let expected = f32::from(raw) / 32768.0;
+        assert_eq!(
+            got.to_bits(),
+            expected.to_bits(),
+            "sample {i} was filtered: {got} vs {expected}"
+        );
+    }
+
+    let right: Vec<i16> = pcm.iter().rev().copied().collect();
+    let channels =
+        decode_audio_bytes_shared_channels(Bytes::from(make_stereo_wav_bytes(&pcm, &right, 16000)))
+            .unwrap();
+    assert_eq!(channels.len(), 2);
+    for (c, raw) in [&pcm, &right].iter().enumerate() {
+        assert_eq!(channels[c].len(), raw.len());
+        for (i, (&r, &got)) in raw.iter().zip(&channels[c]).enumerate() {
+            let expected = f32::from(r) / 32768.0;
+            assert_eq!(
+                got.to_bits(),
+                expected.to_bits(),
+                "channel {c} sample {i} was filtered: {got} vs {expected}"
+            );
+        }
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
+fn test_telephony_raw_streaming_matches_whole_buffer_resample() {
+    // 8 kHz G.711 upsamples to 16 kHz through the same staged path.
+    let pcm = sweep_pcm(8_000, 2.5);
+    let mut encoder = audio_codec::pcmu::PcmuEncoder::new();
+    let encoded = audio_codec::Encoder::encode(&mut encoder, &pcm);
+    let mut decoder = audio_codec::pcmu::PcmuDecoder::new();
+    let round_tripped = audio_codec::Decoder::decode(&mut decoder, &encoded);
+    let at_source: Vec<f32> = round_tripped
+        .iter()
+        .map(|&s| f32::from(s) / 32768.0)
+        .collect();
+    let reference = resample(&at_source, SampleRate(8_000), SampleRate(16_000)).unwrap();
+    let streamed = decode_telephony_raw(&encoded, TelephonyCodec::Pcmu, 8_000).unwrap();
+    assert_matches_whole_buffer(&streamed, &reference, "pcmu 8k");
+}

--- a/crates/gigastt-core/src/inference/audio/tests.rs
+++ b/crates/gigastt-core/src/inference/audio/tests.rs
@@ -1467,6 +1467,64 @@ fn sweep_pcm(rate: u32, seconds: f32) -> Vec<i16> {
         .collect()
 }
 
+/// Pure tone, PCM16, with the phase accumulated in f64 so the *input* carries
+/// no drift of its own. Where `sweep_pcm` probes chunk seams, a single tone
+/// probes long-run phase accumulation: it has an analytic ground truth, so each
+/// path can be scored against the truth instead of only against the other one.
+/// `freq` is chosen to complete a whole number of cycles per 16 kHz analysis
+/// window, which makes the phase estimate below leakage-free.
+fn tone_pcm(rate: u32, seconds: f64, freq: f64) -> Vec<i16> {
+    let n = (f64::from(rate) * seconds) as usize;
+    (0..n)
+        .map(|i| {
+            let t = i as f64 / f64::from(rate);
+            (0.8 * (std::f64::consts::TAU * freq * t).sin() * 32000.0) as i16
+        })
+        .collect()
+}
+
+/// Largest deviation, across one-second windows, of the measured phase of
+/// `freq` from the phase of the first window. A resampler whose fractional read
+/// position accumulates error stretches time slightly, which shows up here as a
+/// phase that walks away from where it started.
+fn max_phase_drift_16k(samples: &[f32], freq: f64) -> f64 {
+    const WINDOW: usize = 16_000;
+    let phase_of = |start: usize| {
+        let mut re = 0.0f64;
+        let mut im = 0.0f64;
+        for (i, &v) in samples[start..start + WINDOW].iter().enumerate() {
+            let w = std::f64::consts::TAU * freq * ((start + i) as f64 / 16_000.0);
+            re += f64::from(v) * w.cos();
+            im += f64::from(v) * w.sin();
+        }
+        im.atan2(re)
+    };
+    let first = phase_of(0);
+    let mut worst = 0.0f64;
+    for w in 0..samples.len() / WINDOW {
+        let mut d = phase_of(w * WINDOW) - first;
+        // Wrap into (-pi, pi] so a drift that crosses a cycle stays comparable.
+        d -= std::f64::consts::TAU * (d / std::f64::consts::TAU).round();
+        worst = worst.max(d.abs());
+    }
+    worst
+}
+
+/// Signal-to-error ratio, in dB, of `candidate` measured against `reference`.
+fn signal_to_error_db(reference: &[f32], candidate: &[f32]) -> f64 {
+    let mut err = 0.0f64;
+    let mut sig = 0.0f64;
+    for (&r, &c) in reference.iter().zip(candidate) {
+        let d = f64::from(r) - f64::from(c);
+        err += d * d;
+        sig += f64::from(r) * f64::from(r);
+    }
+    if err == 0.0 {
+        return f64::INFINITY;
+    }
+    10.0 * (sig / err).log10()
+}
+
 /// Assert the streaming path agrees with a whole-buffer `resample()` of the
 /// same decoded signal: same length within one sample, max per-sample delta
 /// below 1e-4.
@@ -1557,13 +1615,90 @@ fn test_streaming_decode_matches_whole_buffer_resample_stereo_44k1() {
     check_stereo_equivalence(&left, &right, 44_100, "44.1k sweep stereo");
 }
 
+/// Long-input gate for the staged resample at a NON-INTEGER ratio.
+///
+/// The fixtures above hold both paths to 1e-4 per sample, but they are 2.5 s
+/// long and that tolerance is only reachable at that scale. rubato carries its
+/// fractional read position in a single f64 that runs monotonically for the
+/// whole of one `process` call (`idx += 1/ratio` per output sample) and takes
+/// the sub-sample offset as `idx * 256 - floor(idx * 256)`, so the resolution
+/// of that offset halves every time `idx` doubles. One whole-buffer call over
+/// 300 s of 44.1 kHz audio drives `idx` to 13.2 million, where the offset is
+/// quantised to ~1e-6; the staged path restarts `idx` near zero on every flush
+/// and holds ~1e-9. The two therefore separate as the input grows, and past
+/// ~300 s the gap is over the 1e-4 per-sample bound the short fixtures use —
+/// this case measures 1.2e-4, which is why it is scored on the error-to-signal
+/// ratio instead. Sweeping the duration over the same comparison gives max
+/// per-sample deltas of 6.7e-7 at 30 s, 1.2e-5 at 120 s, 1.3e-4 at 300 s and
+/// 4.1e-4 at 600 s.
+///
+/// What separates is the *reference*, not the path under test. Against the
+/// analytic tone the staged path's phase is flat with duration (9.2e-5 rad at
+/// 30 s, 9.3e-5 rad at 600 s) while the whole-buffer path's walks (9.3e-5 rad
+/// at 30 s, 4.2e-4 rad at 600 s); this case measures 8.4e-5 rad staged against
+/// 2.4e-4 rad whole-buffer. Asserting the ordering pins that direction: a plain
+/// delta cannot say which side moved, but this fails if the staged path ever
+/// becomes the one that drifts. Integer ratios are exempt from all of it —
+/// `1/ratio` is exact in f64 at 48/32/8 kHz, so those stay bit-identical at any
+/// length and keep the strict per-sample gate.
+///
+/// Costs ~50 s in a debug build, which is why one duration is covered rather
+/// than a sweep; 300 s is the shortest that reaches the regime.
+#[test]
+#[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
+fn test_streaming_decode_long_44k1_input_holds_phase_better_than_whole_buffer() {
+    // A whole number of cycles per one-second analysis window, so the phase
+    // estimate sees no spectral leakage.
+    const FREQ: f64 = 1_000.0;
+    let pcm = tone_pcm(44_100, 300.0, FREQ);
+
+    let at_source = decode_audio_bytes(&make_wav_bytes(&pcm, 16000)).unwrap();
+    let reference = resample(&at_source, SampleRate(44_100), SampleRate(16000)).unwrap();
+    let streamed = decode_audio_bytes(&make_wav_bytes(&pcm, 44_100)).unwrap();
+
+    // Length stays exact: the divergence is sub-sample phase, never a dropped
+    // or duplicated frame at a flush boundary.
+    assert_eq!(
+        streamed.len(),
+        reference.len(),
+        "long 44.1k input: length diverged"
+    );
+
+    // Error-to-signal floor for non-integer ratios at this length, in place of
+    // the per-sample tolerance the short fixtures use.
+    let snr = signal_to_error_db(&reference, &streamed);
+    assert!(
+        snr >= 70.0,
+        "long 44.1k input: streaming vs whole-buffer SNR {snr:.1} dB below the 70 dB floor"
+    );
+
+    let streamed_drift = max_phase_drift_16k(&streamed, FREQ);
+    let reference_drift = max_phase_drift_16k(&reference, FREQ);
+    assert!(
+        streamed_drift <= reference_drift,
+        "long 44.1k input: staged path drifted {streamed_drift:.3e} rad, \
+         more than the whole-buffer reference's {reference_drift:.3e} rad"
+    );
+    // Absolute floor as well, so the ordering assertion cannot be satisfied by
+    // both paths degrading together.
+    assert!(
+        streamed_drift <= 2e-4,
+        "long 44.1k input: staged path phase drift {streamed_drift:.3e} rad exceeds 2e-4"
+    );
+}
+
 #[test]
 #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
 fn test_streaming_decode_matches_whole_buffer_resample_fixture() {
-    let pcm = fixture_tone_pcm();
+    // The fixture is exactly one staging chunk long, so on its own it drains
+    // once and never crosses a chunk boundary — the seam this test exists to
+    // guard would go unobserved. Doubling it puts a full flush on each side of
+    // a boundary plus a short tail, so a resampler that dropped its FIR history
+    // between flushes shows up here.
+    let pcm = [fixture_tone_pcm(), fixture_tone_pcm()].concat();
     assert!(
-        pcm.len() >= super::resample::RESAMPLE_STAGING_FRAMES,
-        "fixture must span at least one staging flush, got {} samples",
+        pcm.len() > super::resample::RESAMPLE_STAGING_FRAMES,
+        "fixture must span more than one staging flush, got {} samples",
         pcm.len()
     );
     check_mono_equivalence(&pcm, 48_000, "fixture 48k");
@@ -1607,8 +1742,15 @@ fn test_streaming_decode_16k_input_is_bit_identical() {
 #[test]
 #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
 fn test_telephony_raw_streaming_matches_whole_buffer_resample() {
-    // 8 kHz G.711 upsamples to 16 kHz through the same staged path.
-    let pcm = sweep_pcm(8_000, 2.5);
+    // 8 kHz G.711 upsamples to 16 kHz through the same staged path. Long
+    // enough to fill the staging buffer more than once — at 2.5 s the whole
+    // clip fits in a single flush and no chunk boundary is ever crossed.
+    let pcm = sweep_pcm(8_000, 12.5);
+    assert!(
+        pcm.len() > super::resample::RESAMPLE_STAGING_FRAMES,
+        "clip must span more than one staging flush, got {} samples",
+        pcm.len()
+    );
     let mut encoder = audio_codec::pcmu::PcmuEncoder::new();
     let encoded = audio_codec::Encoder::encode(&mut encoder, &pcm);
     let mut decoder = audio_codec::pcmu::PcmuDecoder::new();

--- a/crates/gigastt-core/src/inference/audio/tests.rs
+++ b/crates/gigastt-core/src/inference/audio/tests.rs
@@ -1643,8 +1643,11 @@ fn test_streaming_decode_matches_whole_buffer_resample_stereo_44k1() {
 /// length and keep the strict per-sample gate.
 ///
 /// Costs ~50 s in a debug build, which is why one duration is covered rather
-/// than a sweep; 300 s is the shortest that reaches the regime.
+/// than a sweep; 300 s is the shortest that reaches the regime. That cost is
+/// also why it is `#[ignore]`d: PR CI runs `cargo test --workspace --lib` and
+/// stays fast, while the main-push lane runs this by name.
 #[test]
+#[ignore = "~50 s in debug; long-duration numeric gate, run on main push"]
 #[cfg_attr(miri, ignore = "rubato sinc resampler is too slow under Miri")]
 fn test_streaming_decode_long_44k1_input_holds_phase_better_than_whole_buffer() {
     // A whole number of cycles per one-second analysis window, so the phase

--- a/crates/gigastt/src/server/file_transcribe.rs
+++ b/crates/gigastt/src/server/file_transcribe.rs
@@ -68,6 +68,9 @@ pub(crate) fn run_file_transcribe_blocking(
             _ => None,
         };
         if let Some(reason) = fallback_reason {
+            // The mono path re-decodes from `body`; release the split channels
+            // first so both copies are never resident at once.
+            drop(channels);
             tracing::warn!(
                 "channels=split requested but {reason} detected; falling back to mono transcription"
             );

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -634,6 +634,8 @@ impl JobExecution for RealJobExecutor {
 
         const TARGET_SAMPLE_RATE: f64 = 16_000.0;
         let total_seconds = samples.len() as f64 / TARGET_SAMPLE_RATE;
+        // Only the duration was needed here; the engine re-decodes from `body`.
+        drop(samples);
         let _ = store
             .update(id, Box::new(move |j| j.total_seconds = total_seconds))
             .await;


### PR DESCRIPTION
## Problem

File decode accumulated the entire file at the source rate and then resampled it in one
whole-buffer call. At the peak, four full-length f32 buffers were live at once: the
accumulator (kept alive by the caller across the call), the NaN-sanitising copy inside
`resample`, rubato's internal scratch sized to `chunk = samples.len()`, and the 16 kHz
output.

Measured with `/usr/bin/time -l` on a release example that calls only `decode_audio_file`:

| input | peak RSS |
|---|---|
| 600 s 48 kHz stereo | 391 757 824 B |
| 1200 s 48 kHz stereo | 730 365 952 B |
| 1200 s 16 kHz mono (no resample) | 83 296 256 B |

That is **564 347 B of peak RSS per second of audio** for the common 48 kHz stereo case,
8.8× the size of the 16 kHz mono PCM it produces — and the blow-up is the resample, not
the decode.

## Change

Decoded packets now land in a fixed ~1 s staging buffer that drains through the existing
stateful `resample_with_cache`, whose FIR history and fractional phase carry across
flushes. Same for the per-channel path (which additionally stopped holding un-yielded
channels resident through a lazy `into_iter().map()`) and for raw telephony decode.
When the source is already 16 kHz no resampler is built at all and the passthrough stays
byte-for-byte what it was. The duration cap keeps its exact semantics and error string via
a separate source-rate frame counter, since the accumulator now holds 16 kHz samples.

Three incidental drops of buffers that were held longer than needed: the split-channel
vectors before the dual-mono mono fallback, the job runner's duration-probe samples, and
the single-channel clone in `mix_channels_to_mono`.

## Result

| | before | after |
|---|---|---|
| peak RSS, 1200 s 48 kHz stereo | 739 770 368 B | **85 475 328 B** (8.65×) |
| decode wall time, same file | 2.10 s | 1.67 s |

## Equivalence

- **48 kHz → bit-identical** over 1 919 999 samples (integer ratio; `1/ratio` is exact in f64).
- **44.1 kHz → same length, max per-sample |Δ| 3.6e-5** on the short fixtures.
- At 300 s the delta crosses 1e-4, and the direction is the opposite of what one might
  assume: rubato accumulates its fractional read position in a single f64 across a whole
  `process` call, so a whole-buffer call drives the index to 13.2 M and quantises the
  sub-sample offset to ~1e-6, while the staged path restarts near zero on every flush and
  holds ~1e-9. Scored against an analytic tone, the staged path's phase error is flat with
  duration (9.24e-5 rad at 30 s, 9.35e-5 rad at 600 s) while the whole-buffer reference's
  walks (9.32e-5 → 4.19e-4 rad). The long-duration test therefore scores an
  error-to-signal floor (≥ 70 dB, measured 82.8 dB) plus exact length, and asserts the
  staged path stays the *less* drifting of the two.
- The new differential tests are mutation-verified: resetting the resampler cache on every
  flush turns 7 of 8 of them red, the only survivor being the 16 kHz passthrough that never
  reaches the resampler.
- That long gate costs ~50 s in debug, so it is `#[ignore]`d and runs by name in the
  main-push CI lane; PR CI stays at ~8 s for the crate.

All existing `audio/tests.rs`, `audio/proptests.rs` and the decode fuzz target are
unchanged. No public signature, wire shape, CLI flag or error code changed.

`cargo test -p gigastt-core --lib` → 514 passed, `-p gigastt --lib` → 201 passed,
`cargo clippy -p gigastt-core -p gigastt --all-targets` clean.

## Not in scope

The Opus fallback still accumulates per channel before the shared tail — its resample is
now staged, but its decode peak is unchanged. Same treatment follows with the windowed
decode work.