### PR TITLE
fix(deps): pin ort to exactly 2.0.0-rc.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`ort` is pinned to exactly `2.0.0-rc.12`.** The previous requirement was a caret, so
+  any dependency resolution without this repository's `Cargo.lock` picked up
+  `2.0.0-rc.13` (published 2026-07-28), where the `CoreML` / `CUDA` / `NNAPI` execution
+  providers moved behind `ort`'s own Cargo features. `gigastt-core` then failed to compile
+  with six `E0433` errors — affecting a fresh `cargo install gigastt`, any downstream
+  `cargo add`, and `cargo-semver-checks`' isolated rustdoc build. Workspace builds were
+  shielded by the lockfile; new consumers were not. Adopting rc.13 is a separate change
+  that has to gate the provider arms per feature.
+
 - **Punctuation restoration no longer silently gives up on long transcripts.**
   Restoration ran a single tokenizer pass over the whole transcript against a
   2048-position model and swallowed the resulting runtime error, so any recording

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -66,7 +66,7 @@ ane = ["dep:tar", "dep:objc2", "dep:objc2-core-ml", "dep:objc2-foundation", "dep
 __internals = []
 
 [dependencies]
-ort = "2.0.0-rc.12"
+ort = "=2.0.0-rc.12"
 candle-core = { version = "0.11", optional = true }
 candle-nn = { version = "0.11", optional = true }
 safetensors = { version = "0.8", optional = true }


### PR DESCRIPTION
## Problem

`crates/gigastt-core/Cargo.toml` declared `ort = "2.0.0-rc.12"`, which Cargo reads as a
caret requirement — so it also accepts `2.0.0-rc.13`, published today (2026-07-28 06:47 UTC).
In rc.13 the `CoreML`, `CUDA` and `NNAPI` execution providers moved behind `ort`'s own Cargo
features, while `OrtExecutionProvider::execution_providers`
(`crates/gigastt-core/src/runtime/ort/factory.rs:31-60`) references them from ungated match
arms.

Workspace builds were shielded by `Cargo.lock`. Anything that resolves dependencies fresh was
not:

- a new user's `cargo install gigastt` / `cargo add gigastt-core`
- `cargo-semver-checks`, which builds rustdoc in a throwaway crate outside the workspace —
  this is how it surfaced, as a red Semver Checks job on an unrelated PR

Reproduced locally with the exact recipe cargo-semver-checks prints:

```
cargo new --lib /tmp/ortrepro && cd /tmp/ortrepro
printf '\n[workspace]\n' >> Cargo.toml
cargo add --path <repo>/crates/gigastt-ffi
cargo doc
```

→ resolves `ort 2.0.0-rc.13` and fails with 6 × `E0433` (`cannot find CoreML in ep`,
`cannot find coreml in ep` ×3, `cannot find CUDA in ep`, `cannot find NNAPI in ep`),
`error: could not compile gigastt-core (lib)`.

## Change

One character of dependency metadata: `ort = "=2.0.0-rc.12"`. `Cargo.lock` already resolved
to rc.12, so no lockfile change and no behaviour change for this repository.

## Verification

The same isolated recipe against the patched tree resolves `ort 2.0.0-rc.12` and
`cargo doc` exits 0.

## Follow-up

Adopting rc.13 is a separate change: the provider arms in `factory.rs` need per-feature
gating so the default build stops referencing types that are now feature-gated.

Note that the currently published 2.15.0 carries the caret and is therefore affected for
fresh consumers — a patch release is worth considering once this lands.