### PR TITLE
refactor(core): pull long-form decode windows from a PCM source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,7 @@ jobs:
               - 'docs/**'
               - 'crates/gigastt/src/main.rs'
               - 'crates/gigastt/src/server/ws.rs'
-              - 'crates/gigastt-core/src/inference/audio.rs'
+              - 'crates/gigastt-core/src/inference/audio/**'
               - 'scripts/check-docs-drift.py'
               - 'scripts/check-docs-drift.allowlist'
               - 'README*.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rubato's fractional phase bounded instead of letting it accumulate over millions of
   samples. All public decode signatures are unchanged.
 
+- Long-form file decode pulls its overlapping windows from an internal window
+  source instead of indexing one whole-file buffer, and trims the merged word
+  list by binary search instead of rescanning it once per window. Window
+  geometry, seam policy and decoded output are unchanged (verified
+  bit-identical, including word timestamps, across both decode branches).
+
 ### Fixed
 
 - **`ort` is pinned to exactly `2.0.0-rc.12`.** The previous requirement was a caret, so

--- a/crates/gigastt-core/src/inference/audio/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/mod.rs
@@ -4,6 +4,7 @@ mod decode;
 mod opus;
 mod pcm;
 mod resample;
+mod stream;
 mod telephony;
 
 #[cfg(test)]
@@ -27,7 +28,7 @@ pub(crate) use super::{HOP_LENGTH, N_FFT};
 pub(crate) const MAX_BUFFER_SAMPLES: usize = 16000 * 5; // 5 seconds at 16kHz
 /// Hard upper bound on file-transcription audio length (seconds). Long-form
 /// inputs are decoded in bounded overlapping chunks (see
-/// `Engine::transcribe_samples_chunked`), so peak encoder memory is O(chunk)
+/// `Engine::decode_words_streaming`), so peak encoder memory is O(chunk)
 /// regardless of file length; this cap bounds the fully decoded PCM buffer
 /// instead. 30 minutes ≈ the largest uncompressed PCM16@16kHz upload the
 /// default 50 MiB body limit admits (~27 min), and bounds the decoded f32
@@ -78,6 +79,10 @@ pub(crate) use pcm::{consume_audio_buffer, prepare_audio_buffer};
 pub use pcm::{parse_pcm16_with_carry, parse_pcm16_with_carry_into};
 
 pub use resample::{SampleRate, resample, resample_with_cache};
+
+// Long-form window source. Crate-internal: the file-decode loop is the only
+// consumer today, and the streaming source lands behind the same trait.
+pub(crate) use stream::{PcmWindows, SliceWindows, WindowSpec};
 
 pub use telephony::TelephonyCodec;
 #[cfg(feature = "file-decode")]

--- a/crates/gigastt-core/src/inference/audio/stream.rs
+++ b/crates/gigastt-core/src/inference/audio/stream.rs
@@ -1,0 +1,276 @@
+//! Windowed PCM source for long-form file decode.
+//!
+//! Long-form decode used to own its `while start < total { … }` loop directly
+//! over one `&[f32]` holding the whole file. This module puts that window
+//! geometry behind a small source trait so the decode loop no longer assumes
+//! the PCM is fully materialized: [`SliceWindows`] is the buffer-backed source
+//! used today, and a decoder-backed source can be added later without touching
+//! the loop.
+//!
+//! [`PcmWindows::next_window`] **lends** its window — the returned
+//! [`PcmWindow`] borrows the source — so a source can hand out a view into a
+//! decoder's own scratch buffer instead of copying. That borrow shape is why
+//! this is not an [`Iterator`].
+
+use crate::error::GigasttError;
+use crate::inference::{ENCODER_SUBSAMPLING, HOP_LENGTH};
+
+/// Samples per encoder output frame (`HOP_LENGTH * ENCODER_SUBSAMPLING`,
+/// 640 @16 kHz). Window starts are multiples of this so each window's frame
+/// offset is integral.
+const FRAME_SAMPLES: usize = HOP_LENGTH * ENCODER_SUBSAMPLING;
+
+/// Long-form window geometry, all in samples @16 kHz.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WindowSpec {
+    single_pass_max: usize,
+    window: usize,
+    stride: usize,
+}
+
+impl WindowSpec {
+    /// Build a spec from the single-pass ceiling, the window length, and the
+    /// overlap retained between consecutive windows.
+    ///
+    /// The stride (`window - overlap`) is aligned **down** to an encoder-frame
+    /// boundary so every window start maps to an integral frame offset;
+    /// otherwise the offset would drift by a sub-frame each hop. It is clamped
+    /// to one frame so a mis-specified `overlap >= window` cannot produce a
+    /// zero-stride (non-advancing) source.
+    pub(crate) fn new(single_pass_max: usize, window: usize, overlap: usize) -> Self {
+        let stride =
+            (window.saturating_sub(overlap) / FRAME_SAMPLES * FRAME_SAMPLES).max(FRAME_SAMPLES);
+        Self {
+            single_pass_max,
+            window,
+            stride,
+        }
+    }
+
+    /// Window length in samples.
+    pub(crate) fn window(&self) -> usize {
+        self.window
+    }
+
+    /// Frame-aligned distance between consecutive window starts.
+    pub(crate) fn stride(&self) -> usize {
+        self.stride
+    }
+
+    /// Samples shared by two consecutive windows (`window - stride`). Equals the
+    /// requested overlap whenever that overlap is already frame-aligned.
+    pub(crate) fn overlap(&self) -> usize {
+        self.window.saturating_sub(self.stride)
+    }
+
+    /// True when `total` samples are short enough for the single-pass (one
+    /// encoder Run over the whole buffer) branch.
+    pub(crate) fn is_single_pass(&self, total: usize) -> bool {
+        total <= self.single_pass_max
+    }
+}
+
+/// One decode window lent by a [`PcmWindows`] source.
+pub(crate) struct PcmWindow<'a> {
+    /// Absolute offset of `samples[0]` in the stream, in samples @16 kHz.
+    pub(crate) start_sample: usize,
+    /// The window's PCM.
+    pub(crate) samples: &'a [f32],
+}
+
+/// A source of overlapping decode windows.
+pub(crate) trait PcmWindows {
+    /// The window geometry this source yields.
+    fn spec(&self) -> WindowSpec;
+
+    /// Lend the next window, or `Ok(None)` once the stream is exhausted.
+    fn next_window(&mut self) -> Result<Option<PcmWindow<'_>>, GigasttError>;
+}
+
+/// [`PcmWindows`] over a fully materialized buffer.
+///
+/// Yields exactly the `(start, end)` sequence of the loop it replaced:
+/// `while start < total { end = min(start + window, total); …; if end == total
+/// { break } start += stride }`.
+pub(crate) struct SliceWindows<'a> {
+    samples: &'a [f32],
+    spec: WindowSpec,
+    next_start: usize,
+    done: bool,
+}
+
+impl<'a> SliceWindows<'a> {
+    pub(crate) fn new(samples: &'a [f32], spec: WindowSpec) -> Self {
+        Self {
+            samples,
+            spec,
+            next_start: 0,
+            done: false,
+        }
+    }
+}
+
+impl PcmWindows for SliceWindows<'_> {
+    fn spec(&self) -> WindowSpec {
+        self.spec
+    }
+
+    fn next_window(&mut self) -> Result<Option<PcmWindow<'_>>, GigasttError> {
+        let total = self.samples.len();
+        if self.done || self.next_start >= total {
+            return Ok(None);
+        }
+        let start = self.next_start;
+        let end = (start + self.spec.window()).min(total);
+        // The replaced loop stopped on `end == total` rather than on the next
+        // start passing `total`, so a window that reaches the end is the last
+        // one even when `start + stride` is still short of `total`.
+        if end == total {
+            self.done = true;
+        } else {
+            self.next_start = start + self.spec.stride();
+        }
+        Ok(Some(PcmWindow {
+            start_sample: start,
+            samples: &self.samples[start..end],
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The loop `SliceWindows` replaced, verbatim, as the reference oracle.
+    fn legacy_windows(total: usize, window: usize, stride: usize) -> Vec<(usize, usize)> {
+        let mut out = Vec::new();
+        let mut start = 0usize;
+        while start < total {
+            let end = (start + window).min(total);
+            out.push((start, end - start));
+            if end == total {
+                break;
+            }
+            start += stride;
+        }
+        out
+    }
+
+    fn observed(total: usize, spec: WindowSpec) -> Vec<(usize, usize)> {
+        let samples = vec![0.0f32; total];
+        let mut src = SliceWindows::new(&samples, spec);
+        let mut out = Vec::new();
+        while let Some(w) = src.next_window().expect("slice source never fails") {
+            out.push((w.start_sample, w.samples.len()));
+        }
+        out
+    }
+
+    /// The ort long-form geometry, spelled out so this test pins the numbers the
+    /// engine feeds rather than following it.
+    fn ort_spec() -> WindowSpec {
+        WindowSpec::new(16000 * 30, 16000 * 24, 16000 * 2)
+    }
+
+    #[test]
+    fn test_window_spec_stride_is_frame_aligned() {
+        let spec = ort_spec();
+        assert_eq!(spec.window(), 384_000);
+        assert_eq!(spec.stride(), 352_000);
+        assert_eq!(spec.stride() % FRAME_SAMPLES, 0);
+        // 2 s overlap is already frame-aligned, so it survives the alignment.
+        assert_eq!(spec.overlap(), 32_000);
+        // ANE geometry: 30 s window, same 2 s overlap.
+        let ane = WindowSpec::new(16000 * 30, 16000 * 30, 16000 * 2);
+        assert_eq!(ane.stride(), 448_000);
+        assert_eq!(ane.stride() % FRAME_SAMPLES, 0);
+        assert_eq!(ane.overlap(), 32_000);
+    }
+
+    #[test]
+    fn test_window_spec_single_pass_boundary() {
+        let spec = ort_spec();
+        assert!(spec.is_single_pass(0));
+        assert!(spec.is_single_pass(479_999));
+        assert!(spec.is_single_pass(480_000)); // exactly 30 s stays single-pass
+        assert!(!spec.is_single_pass(480_001));
+    }
+
+    #[test]
+    fn test_window_spec_degenerate_overlap_still_advances() {
+        // overlap >= window would give a zero stride and a non-advancing source.
+        let spec = WindowSpec::new(0, 1000, 4000);
+        assert_eq!(spec.stride(), FRAME_SAMPLES);
+        assert_eq!(observed(5000, spec).len(), 8);
+    }
+
+    #[test]
+    fn test_slice_windows_matches_legacy_loop_swept() {
+        let spec = ort_spec();
+        let (window, stride) = (spec.window(), spec.stride());
+        let mut lengths: Vec<usize> = Vec::new();
+        // Coarse sweep across 0..3x window.
+        let mut n = 0usize;
+        while n <= 3 * window {
+            lengths.push(n);
+            n += 4_001; // deliberately coprime with the stride/frame grid
+        }
+        // Exact boundaries: window/stride multiples ± 1, the single-pass
+        // threshold, and the degenerate sub-frame tail band.
+        for anchor in [
+            0,
+            1,
+            FRAME_SAMPLES,
+            window,
+            stride,
+            stride + window,
+            2 * stride,
+            2 * stride + window,
+            480_000, // single-pass branch boundary
+        ] {
+            for d in [-1isize, 0, 1] {
+                let v = anchor as isize + d;
+                if v >= 0 {
+                    lengths.push(v as usize);
+                }
+            }
+        }
+        lengths.extend(704_000..=704_320); // degenerate band, every length
+        lengths.sort_unstable();
+        lengths.dedup();
+
+        for total in lengths {
+            assert_eq!(
+                observed(total, spec),
+                legacy_windows(total, window, stride),
+                "window sequence diverged at total={total}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_slice_windows_empty_yields_nothing() {
+        assert!(observed(0, ort_spec()).is_empty());
+    }
+
+    #[test]
+    fn test_slice_windows_stop_exactly_at_the_end() {
+        let spec = ort_spec();
+        let total = 1_440_000; // 90 s
+        let seq = observed(total, spec);
+        assert!(!seq.is_empty());
+        // Exactly one window reaches the end, and it is the last one emitted.
+        assert_eq!(
+            seq.iter()
+                .filter(|(start, len)| start + len == total)
+                .count(),
+            1
+        );
+        let (start, len) = seq[seq.len() - 1];
+        assert_eq!(start + len, total);
+        // Every start is frame-aligned, so the frame offset is integral.
+        for (start, _) in &seq {
+            assert_eq!(start % FRAME_SAMPLES, 0);
+        }
+    }
+}

--- a/crates/gigastt-core/src/inference/engine.rs
+++ b/crates/gigastt-core/src/inference/engine.rs
@@ -12,6 +12,7 @@ use crate::runtime::production_factory_variant;
 use crate::runtime::tensor::{Shape, Tensor, TensorData, TensorDataView};
 
 use super::audio;
+use super::audio::{PcmWindows, SliceWindows, WindowSpec};
 use super::bias;
 use super::ctc;
 use super::decode;
@@ -258,6 +259,18 @@ pub(crate) fn chunk_window_samples(ane_encoder: bool) -> usize {
     } else {
         CHUNK_WINDOW_SAMPLES_ORT
     }
+}
+
+/// Long-form window geometry for the active encoder backend: the single-pass
+/// ceiling, the backend's window length, and the fixed inter-window overlap.
+/// Free-standing (like [`chunk_window_samples`]) so the geometry is unit-tested
+/// without a loaded model.
+pub(crate) fn window_spec(ane_encoder: bool) -> WindowSpec {
+    WindowSpec::new(
+        CHUNK_THRESHOLD_SAMPLES,
+        chunk_window_samples(ane_encoder),
+        CHUNK_OVERLAP_SAMPLES,
+    )
 }
 
 /// Default number of session triplets in the pool.
@@ -1916,7 +1929,8 @@ impl Engine {
         triplet: &mut SessionTriplet,
         biaser: Option<&bias::Biaser>,
     ) -> Result<Vec<WordInfo>, GigasttError> {
-        if samples.len() <= CHUNK_THRESHOLD_SAMPLES {
+        let spec = window_spec(self.ane_encoder);
+        if spec.is_single_pass(samples.len()) {
             let (features, num_frames) = self.features.compute(samples);
             tracing::info!("Extracted {} mel frames", num_frames);
             let mut decoder_state = DecoderState::new(self.tokenizer.blank_id());
@@ -1933,7 +1947,14 @@ impl Engine {
                 .map_err(|e| GigasttError::Inference { source: e.into() })?
                 .0)
         } else {
-            self.transcribe_samples_chunked(samples, triplet, biaser)
+            tracing::info!(
+                "Long-form chunked decode: {:.1}s in ~{}s windows ({}s overlap, ane={})",
+                samples.len() as f64 / 16000.0,
+                spec.window() / 16000,
+                spec.overlap() / 16000,
+                self.ane_encoder,
+            );
+            self.decode_words_streaming(&mut SliceWindows::new(samples, spec), triplet, biaser)
         }
     }
 
@@ -1972,43 +1993,32 @@ impl Engine {
         Ok(words)
     }
 
-    /// Long-form decode: split `float_samples` into overlapping windows, encode
-    /// and decode each independently with a fresh [`DecoderState`], offset each
+    /// Long-form decode: pull overlapping windows from `windows`, encode and
+    /// decode each independently with a fresh [`DecoderState`], offset each
     /// chunk's word timestamps by the chunk's absolute start, then stitch the
     /// per-chunk word lists with overlap de-dup via [`stitch_chunk_words`].
     ///
-    /// Peak encoder activation memory is bounded by [`chunk_window_samples`]
-    /// (24s ort / 30s ANE) rather than the full file length. Chunk starts are
-    /// aligned to encoder frame boundaries (multiples of
-    /// `HOP_LENGTH * ENCODER_SUBSAMPLING`) so the per-chunk frame offset is
-    /// exact, matching the streaming path's math.
-    fn transcribe_samples_chunked(
+    /// Peak encoder activation memory is bounded by the source's window length
+    /// (24s ort / 30s ANE, see [`chunk_window_samples`]) rather than the full
+    /// file length. Window starts are aligned to encoder frame boundaries
+    /// (multiples of `HOP_LENGTH * ENCODER_SUBSAMPLING`) so the per-chunk frame
+    /// offset is exact, matching the streaming path's math.
+    ///
+    /// Takes the PCM as a [`PcmWindows`] source rather than a `&[f32]`, so the
+    /// loop makes no assumption that the whole file is in memory.
+    fn decode_words_streaming(
         &self,
-        float_samples: &[f32],
+        windows: &mut dyn PcmWindows,
         triplet: &mut SessionTriplet,
         biaser: Option<&bias::Biaser>,
     ) -> Result<Vec<WordInfo>, GigasttError> {
-        let total = float_samples.len();
-        let window = chunk_window_samples(self.ane_encoder);
-        let stride = window - CHUNK_OVERLAP_SAMPLES;
-        // Align stride to an encoder-frame boundary so each chunk's frame offset
-        // is integral; otherwise the offset would drift by a sub-frame each hop.
+        let overlap = windows.spec().overlap();
         let frame_samples = HOP_LENGTH * ENCODER_SUBSAMPLING;
-        let stride = (stride / frame_samples) * frame_samples;
-        tracing::info!(
-            "Long-form chunked decode: {:.1}s in ~{}s windows ({}s overlap, ane={})",
-            total as f64 / 16000.0,
-            window / 16000,
-            CHUNK_OVERLAP_SAMPLES / 16000,
-            self.ane_encoder,
-        );
 
         let mut merged: Vec<WordInfo> = Vec::new();
-        let mut start = 0usize;
-        while start < total {
-            let end = (start + window).min(total);
-            let chunk = &float_samples[start..end];
-            let (features, num_frames) = self.features.compute(chunk);
+        while let Some(window) = windows.next_window()? {
+            let start = window.start_sample;
+            let (features, num_frames) = self.features.compute(window.samples);
             let frame_offset = start / frame_samples;
             let mut decoder_state = DecoderState::new(self.tokenizer.blank_id());
             let (chunk_words, _endpoint) = self
@@ -2025,13 +2035,8 @@ impl Engine {
 
             // Seam between the previous chunk's window and this one falls at the
             // midpoint of their overlap region, in absolute seconds.
-            let overlap_mid_s = (start as f64 + CHUNK_OVERLAP_SAMPLES as f64 / 2.0) / 16000.0;
+            let overlap_mid_s = (start as f64 + overlap as f64 / 2.0) / 16000.0;
             merged = stitch_chunk_words(merged, chunk_words, overlap_mid_s);
-
-            if end == total {
-                break;
-            }
-            start += stride;
         }
         Ok(merged)
     }
@@ -2274,8 +2279,11 @@ pub(crate) fn stitch_chunk_words(
     }
     // Drop the earlier chunk's tail that reaches past the seam — those words are
     // re-decoded by `next` with more right context, so prefer the later chunk
-    // for the back half of the overlap.
-    merged.retain(|w| w.start <= seam_s);
+    // for the back half of the overlap. `merged` is monotonic in `start`, so the
+    // words to drop are exactly a suffix: binary-search the seam and truncate.
+    // (`retain` would rescan every word merged so far on every chunk — O(chunks
+    // × words) — for a policy that only ever trims the tail.)
+    merged.truncate(merged.partition_point(|w| w.start <= seam_s));
     merged.extend(next.into_iter().filter(|w| w.start > seam_s));
     merged
 }
@@ -2884,6 +2892,29 @@ mod tests {
     }
 
     #[test]
+    fn test_stitch_truncate_matches_retain_predicate() {
+        // `stitch_chunk_words` trims the earlier chunk with
+        // `partition_point` + `truncate` instead of `retain` (which rescanned
+        // every merged word on every chunk). On the monotonic-in-`start` lists
+        // the chunked loop actually produces, the two are the same predicate —
+        // sweep seams on and between every word boundary to show it.
+        let merged: Vec<WordInfo> = (0..40)
+            .map(|i| word(&format!("w{i}"), i as f64 * 0.5, i as f64 * 0.5 + 0.3))
+            .collect();
+        for step in 0..=80 {
+            let seam_s = step as f64 * 0.25;
+            let mut expected = merged.clone();
+            expected.retain(|w| w.start <= seam_s);
+            let got = stitch_chunk_words(merged.clone(), Vec::new(), seam_s);
+            assert_eq!(
+                got.iter().map(|w| w.word.as_str()).collect::<Vec<_>>(),
+                expected.iter().map(|w| w.word.as_str()).collect::<Vec<_>>(),
+                "diverged at seam {seam_s}"
+            );
+        }
+    }
+
+    #[test]
     fn test_stitch_timestamp_offset_math() {
         // The chunked path offsets a chunk's frame indices by
         // start_samples / (HOP_LENGTH * ENCODER_SUBSAMPLING). Verify that a word
@@ -2916,6 +2947,24 @@ mod tests {
         assert!(CHUNK_WINDOW_SAMPLES_ANE > CHUNK_OVERLAP_SAMPLES);
         assert!(CHUNK_THRESHOLD_SAMPLES >= CHUNK_WINDOW_SAMPLES_ORT);
         assert!(CHUNK_THRESHOLD_SAMPLES >= CHUNK_WINDOW_SAMPLES_ANE);
+    }
+
+    #[test]
+    fn test_window_spec_reproduces_legacy_chunk_geometry() {
+        // The long-form loop used to derive its own window/stride and read the
+        // overlap straight off `CHUNK_OVERLAP_SAMPLES`; it now takes all three
+        // from the spec. Any divergence here moves every seam, so pin it.
+        let frame_samples = HOP_LENGTH * ENCODER_SUBSAMPLING;
+        for ane in [false, true] {
+            let window = chunk_window_samples(ane);
+            let legacy_stride = ((window - CHUNK_OVERLAP_SAMPLES) / frame_samples) * frame_samples;
+            let spec = window_spec(ane);
+            assert_eq!(spec.window(), window, "window (ane={ane})");
+            assert_eq!(spec.stride(), legacy_stride, "stride (ane={ane})");
+            assert_eq!(spec.overlap(), CHUNK_OVERLAP_SAMPLES, "overlap (ane={ane})");
+            assert!(spec.is_single_pass(CHUNK_THRESHOLD_SAMPLES));
+            assert!(!spec.is_single_pass(CHUNK_THRESHOLD_SAMPLES + 1));
+        }
     }
 
     #[test]

--- a/crates/gigastt-core/tests/longform_digest.rs
+++ b/crates/gigastt-core/tests/longform_digest.rs
@@ -1,0 +1,165 @@
+//! Bit-identity probe for the file-decode path: prints one digest per input.
+//!
+//! Model-gated (`#[ignore]`, requires the GigaAM model (~850MB) at
+//! `~/.gigastt/models`). It asserts nothing about the digest values — it is the
+//! instrument for an A/B between two revisions, so a change to the decode path
+//! can be shown to leave every transcript and every word timestamp untouched:
+//!
+//! ```sh
+//! # revision A (e.g. the base branch)
+//! git worktree add /tmp/base origin/main
+//! cp crates/gigastt-core/tests/longform_digest.rs \
+//!    /tmp/base/crates/gigastt-core/tests/
+//! (cd /tmp/base && cargo test -p gigastt-core --test longform_digest \
+//!    -- --ignored --nocapture) | tee /tmp/base.txt
+//!
+//! # revision B (the change under review)
+//! cargo test -p gigastt-core --test longform_digest -- --ignored --nocapture \
+//!   | tee /tmp/head.txt
+//!
+//! diff /tmp/base.txt /tmp/head.txt
+//! ```
+//!
+//! The digest covers the transcript text, the word count, and every word's text
+//! plus the **bit patterns** of its start/end timestamps, so a timestamp that
+//! moves by a single ULP changes it.
+//!
+//! No audio is committed for this: the inputs are the tracked `golos_*.wav`
+//! fixtures, used both on their own (each is well under the 30 s single-pass
+//! ceiling) and tiled into one long buffer whose prefixes straddle that ceiling
+//! and the long-form window/stride boundaries.
+
+use gigastt_core::inference::Engine;
+use gigastt_core::inference::audio::{decode_audio_file, encode_wav_pcm16};
+use gigastt_core::inference::{TranscribeResult, WordInfo};
+use gigastt_core::model::default_model_dir;
+
+const FIXTURE_DIR: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../gigastt/tests/fixtures/golos_"
+);
+
+/// Clips digested on their own. Each is a few seconds, so they pin the
+/// single-pass branch.
+const SOLO: [&str; 5] = ["00", "01", "02", "03", "04"];
+
+/// Clips concatenated — repeating from the start once exhausted — into the
+/// buffer the long-form prefixes are cut from.
+const POOL: [&str; 10] = ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09"];
+
+/// Prefix lengths of the tiled pool, in samples @16 kHz: 29.0 s and 29.9 s
+/// (single-pass), 30.0 s (exactly the ceiling, still single-pass), then 30.1 /
+/// 35 / 44.0 / 44.01 / 90 s — the last five chunked, and 704_000 / 704_160 sit
+/// on and just past twice the 22 s stride.
+const PREFIXES: [usize; 8] = [
+    464_000, 478_400, 480_000, 481_600, 560_000, 704_000, 704_160, 1_440_000,
+];
+
+/// Samples at or below this take the single-pass branch (30 s @16 kHz). Spelled
+/// out rather than imported: the point of the probe is to notice if the branch
+/// an input takes ever moves.
+const SINGLE_PASS_MAX: usize = 480_000;
+
+const FNV_OFFSET: u64 = 0xcbf5_1f19_4761_9ec5;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+fn feed(h: &mut u64, bytes: &[u8]) {
+    for b in bytes {
+        *h ^= u64::from(*b);
+        *h = h.wrapping_mul(FNV_PRIME);
+    }
+}
+
+/// FNV-1a over the transcript and every word's text + timestamp bit patterns.
+fn digest(text: &str, words: &[WordInfo]) -> u64 {
+    let mut h = FNV_OFFSET;
+    feed(&mut h, text.as_bytes());
+    feed(&mut h, &words.len().to_le_bytes());
+    for w in words {
+        feed(&mut h, w.word.as_bytes());
+        feed(&mut h, &w.start.to_bits().to_le_bytes());
+        feed(&mut h, &w.end.to_bits().to_le_bytes());
+    }
+    h
+}
+
+fn fixture(id: &str) -> String {
+    format!("{FIXTURE_DIR}{id}.wav")
+}
+
+fn row(label: &str, samples: usize, res: &TranscribeResult) -> u64 {
+    // A silently broken engine would emit empty transcripts, whose digests match
+    // across revisions for the wrong reason. Refuse to report that as evidence.
+    assert!(
+        !res.text.trim().is_empty() && !res.words.is_empty(),
+        "{label}: empty transcript ({} samples) — the probe has nothing to compare",
+        samples
+    );
+    let d = digest(&res.text, &res.words);
+    let branch = if samples <= SINGLE_PASS_MAX {
+        "single-pass"
+    } else {
+        "chunked"
+    };
+    println!(
+        "{label:<14} {samples:>9} {:>8.2}  {branch:<11} {:>5}  {d:016x}",
+        samples as f64 / 16000.0,
+        res.words.len(),
+    );
+    d
+}
+
+#[test]
+#[ignore = "requires the GigaAM model (~850MB) at ~/.gigastt/models"]
+fn longform_transcript_digests() {
+    let model_dir = default_model_dir();
+    let engine = Engine::load(&model_dir).expect("load engine");
+    let mut triplet = engine.pool.checkout_blocking().expect("checkout triplet");
+
+    println!("model dir: {model_dir}");
+    println!(
+        "{:<14} {:>9} {:>8}  {:<11} {:>5}  digest",
+        "input", "samples", "seconds", "branch", "words"
+    );
+
+    let mut all = FNV_OFFSET;
+
+    for id in SOLO {
+        let path = fixture(id);
+        let samples = decode_audio_file(&path).expect("decode fixture");
+        let res = engine
+            .transcribe_file(&path, &mut triplet)
+            .expect("transcribe fixture");
+        feed(
+            &mut all,
+            &row(&format!("golos_{id}"), samples.len(), &res).to_le_bytes(),
+        );
+    }
+
+    // Tile the pool until it covers the longest prefix, so every prefix is a cut
+    // of one deterministic buffer.
+    let longest = PREFIXES.iter().copied().max().unwrap_or(0);
+    let clips: Vec<Vec<f32>> = POOL
+        .iter()
+        .map(|id| decode_audio_file(&fixture(id)).expect("decode fixture"))
+        .collect();
+    let mut pool: Vec<f32> = Vec::with_capacity(longest);
+    while pool.len() < longest {
+        for clip in &clips {
+            pool.extend_from_slice(clip);
+        }
+    }
+
+    for len in PREFIXES {
+        let wav = encode_wav_pcm16(&pool[..len], 16000);
+        let res = engine
+            .transcribe_bytes(&wav, &mut triplet)
+            .expect("transcribe prefix");
+        feed(
+            &mut all,
+            &row(&format!("pool[..{len}]"), len, &res).to_le_bytes(),
+        );
+    }
+
+    println!("combined: {all:016x}");
+}

--- a/crates/gigastt-core/tests/longform_digest.rs
+++ b/crates/gigastt-core/tests/longform_digest.rs
@@ -20,6 +20,14 @@
 //! diff /tmp/base.txt /tmp/head.txt
 //! ```
 //!
+//! Give each side its own `CARGO_TARGET_DIR`. Cargo's freshness check is
+//! mtime-based, so two trees sharing one target directory can silently re-run
+//! the binary built from the *other* tree — which yields a perfect match for
+//! entirely the wrong reason, in the one probe whose whole job is to detect a
+//! silent no-op. If you must share a target dir, check provenance before
+//! believing the result: `tail -2 target/release/deps/longform_digest-*.d`
+//! should name the `CARGO_MANIFEST_DIR` you think you measured.
+//!
 //! The digest covers the transcript text, the word count, and every word's text
 //! plus the **bit patterns** of its start/end timestamps, so a timestamp that
 //! moves by a single ULP changes it.


### PR DESCRIPTION
## Why

Long-form file decode indexes one whole-file `&[f32]` to slice its overlapping windows. That is the
last structural reason the file path must hold the entire decoded buffer in memory: the chunker itself
only ever needs one window at a time. This introduces the seam behind which the PCM source stops being
"the whole file", **without changing behaviour by a single bit** — so the streaming decoder that follows
can be swapped in behind a shape that is already proven.

## What changes

- New internal `audio/stream.rs`: `WindowSpec` (single-pass ceiling, window, frame-aligned stride),
  `PcmWindow`, a lending `PcmWindows` trait, and `SliceWindows` over `&[f32]`. The trait uses
  `next_window(&mut self) -> Result<Option<PcmWindow<'_>>>` rather than `Iterator` because symphonia's
  `decode(&mut self) -> GenericAudioBufferRef<'_>` borrows the decoder — a plain `Iterator` cannot
  express that, GAT or not.
- `transcribe_samples_chunked` becomes `decode_words_streaming(&mut dyn PcmWindows, ...)`; the
  single-pass branch wraps its slice in `SliceWindows`. Both branches, the window geometry and the seam
  policy are untouched.
- `stitch_chunk_words` trims by `partition_point` + `truncate` instead of `retain`, which was a genuine
  O(chunks × words) rescan of the whole accumulated list once per window.

Every item added is `pub(crate)`. **Zero public API change** — `cargo semver-checks` reports 219 checks,
219 pass, "no semver update required", with no override of any kind.

## Proof it is behaviour-preserving

Two independent instruments, because "provably identical" has to mean something:

1. **Oracle test, no model and no audio.** `SliceWindows`' `(start_sample, len)` sequence is compared
   against the loop it replaces for every length in a 4001-step sweep over `0..3× window`, every
   boundary ±1 (0, 640, stride, window, stride+window, 2×stride, the 30 s threshold), and every single
   length in the degenerate band `704000..=704320`.
2. **Bit-identity digest across revisions.** `tests/longform_digest.rs` (model-gated, `#[ignore]`d)
   hashes the transcript, the word count, and every word's text plus the **bit patterns** of its
   start/end timestamps, over 13 inputs spanning both branches — 5 solo clips and 8 prefixes of a tiled
   pool at 29.0 / 29.9 / 30.0 / 30.1 / 35 / 44.0 / 44.01 / 90 s. Base vs HEAD: **13/13 identical**,
   combined digest `e01e4f439d5b7e2f` on both sides. A timestamp moving by one ULP would change it.

The probe hard-fails rather than skips when the model is missing, and fails if any transcript comes back
empty, so an all-empty table can never pass as evidence. Its doc records the two-revision recipe —
including a warning to give each side its own `CARGO_TARGET_DIR`, because a shared one can silently
re-run the other tree's binary and produce a perfect match for the wrong reason (the reviewer hit
exactly that).

Independently: the five seam-predicate characterisation tests that landed on main earlier today pass
unchanged against the rewritten `stitch_chunk_words`.

## Also in this diff

Fixes the stale docs-drift path filter in `.github/workflows/ci.yml`, which still watched
`crates/gigastt-core/src/inference/audio.rs` — a file deleted when that module became a directory, so
the gate was silently skipping code-only changes.

`cargo test -p gigastt-core --lib` → 539 passed. `-p gigastt --lib` → 201 passed. Clippy clean.