### PR TITLE
fix(server): stop decoding every job twice and bound the queue by bytes

### DIFF
--- a/crates/gigastt-core/src/inference/audio/decode.rs
+++ b/crates/gigastt-core/src/inference/audio/decode.rs
@@ -225,6 +225,88 @@ pub fn decode_audio_bytes_shared(data: Bytes) -> Result<Vec<f32>> {
     decode_audio_inner(mss, hint, "bytes")
 }
 
+/// Read an audio container's declared duration (seconds) from its header
+/// WITHOUT decoding a single audio packet.
+///
+/// Runs only symphonia's format probe and reads the default audio track's
+/// declared frame count and sample rate — an O(header) read, not the O(T)
+/// decode `decode_audio_bytes_shared` performs. Returns:
+/// - `Ok(Some(secs))` when the container declares a positive frame count and a
+///   plausible sample rate (WAV, FLAC, M4A, and OGG usually do);
+/// - `Ok(None)` when the stream is probeable but declares no usable duration
+///   (a raw MP3 stream typically does not, and neither does a crafted header);
+/// - `Err(_)` when the bytes cannot be probed as a supported container at all.
+///
+/// Use this to size a long job's progress bar without paying for a full decode
+/// whose samples are immediately discarded; fall back to a real decode on
+/// anything other than `Ok(Some(_))`.
+///
+/// ```text
+/// { true }
+/// fn probe_duration_bytes(data: Bytes) -> Result<Option<f64>>
+/// { true }
+/// ```
+#[cfg(feature = "file-decode")]
+pub fn probe_duration_bytes(data: Bytes) -> Result<Option<f64>> {
+    let source = BytesMediaSource::new(data);
+    let mss = MediaSourceStream::new(Box::new(source), Default::default());
+    probe_duration_inner(mss, Hint::new())
+}
+
+/// Path twin of [`probe_duration_bytes`]: read a file's declared duration from
+/// its header without decoding. Seeds the probe hint from the extension exactly
+/// as [`decode_audio_file`] does.
+#[cfg(feature = "file-decode")]
+pub fn probe_duration_file(path: &str) -> Result<Option<f64>> {
+    let file =
+        std::fs::File::open(path).with_context(|| format!("Failed to open audio file: {path}"))?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(ext) = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+    {
+        hint.with_extension(ext);
+    }
+    probe_duration_inner(mss, hint)
+}
+
+/// Shared probe: identify the container and read the default audio track's
+/// declared frame count / sample rate, deriving duration = frames / rate. No
+/// packet is ever decoded, so a container that does not declare its length
+/// yields `Ok(None)` rather than a scanned duration.
+#[cfg(feature = "file-decode")]
+fn probe_duration_inner(mss: MediaSourceStream<'_>, hint: Hint) -> Result<Option<f64>> {
+    let format = symphonia::default::get_probe()
+        .probe(
+            &hint,
+            mss,
+            FormatOptions::default(),
+            MetadataOptions::default(),
+        )
+        .context("Unsupported audio format")?;
+
+    let Some(track) = format.default_track(TrackType::Audio) else {
+        return Ok(None);
+    };
+    let Some(audio_params) = track.codec_params.as_ref().and_then(|p| p.audio()) else {
+        return Ok(None);
+    };
+    let Some(sample_rate) = audio_params.sample_rate else {
+        return Ok(None);
+    };
+    // A crafted / implausible header rate can't be trusted to scale a duration:
+    // report "unknown" and let the caller fall back to a real decode, which
+    // clamps the rate and enforces the duration cap incrementally.
+    if sample_rate == 0 || sample_rate > MAX_SAMPLE_RATE {
+        return Ok(None);
+    }
+    match track.num_frames {
+        Some(n) if n > 0 => Ok(Some(n as f64 / sample_rate as f64)),
+        _ => Ok(None),
+    }
+}
+
 /// Decode an audio file to one f32 sample vector per channel at 16 kHz.
 ///
 /// Same probe/decode/resample pipeline as [`decode_audio_file`], but keeps

--- a/crates/gigastt-core/src/inference/audio/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/mod.rs
@@ -70,7 +70,7 @@ pub(crate) use decode::BytesMediaSource;
 #[cfg(feature = "file-decode")]
 pub use decode::{
     decode_audio_bytes, decode_audio_bytes_shared, decode_audio_bytes_shared_channels,
-    decode_audio_file, load_audio_channels,
+    decode_audio_file, load_audio_channels, probe_duration_bytes, probe_duration_file,
 };
 pub use decode::{is_dual_mono, mix_channels_to_mono};
 

--- a/crates/gigastt-core/src/inference/audio/tests.rs
+++ b/crates/gigastt-core/src/inference/audio/tests.rs
@@ -307,6 +307,46 @@ fn test_decode_audio_bytes_wav() {
     assert!((samples.len() as i64 - 16000).unsigned_abs() <= 100);
 }
 
+#[test]
+fn test_probe_duration_wav_reports_declared_seconds() {
+    // A WAV header declares its frame count, so the probe returns the duration
+    // without decoding a single packet.
+    let wav = make_wav_bytes(&vec![0i16; 16000], 16000); // exactly 1.0 s
+    let probed = probe_duration_bytes(Bytes::from(wav)).unwrap();
+    assert!(
+        matches!(probed, Some(s) if (s - 1.0).abs() < 1e-6),
+        "expected ~1.0 s, got {probed:?}"
+    );
+}
+
+#[test]
+fn test_probe_duration_agrees_with_decoded_length() {
+    // The probe's declared duration must match the decoded sample count: the
+    // job executor uses the two interchangeably to size the progress bar, so a
+    // divergence would move the bar when the probe fast-path kicks in.
+    let wav = make_wav_bytes(&vec![0i16; 24000], 16000); // 1.5 s at 16 kHz
+    let probed = probe_duration_bytes(Bytes::from(wav.clone()))
+        .unwrap()
+        .expect("WAV declares its duration");
+    let decoded_s = decode_audio_bytes_shared(Bytes::from(wav)).unwrap().len() as f64 / 16_000.0;
+    assert!(
+        (probed - decoded_s).abs() < 1e-3,
+        "probe {probed} vs decode {decoded_s}"
+    );
+}
+
+#[test]
+fn test_probe_duration_non_container_does_not_claim_duration() {
+    // Bytes that are not a supported container must not panic and must never
+    // report a duration — the caller falls back to a real decode, which
+    // surfaces the proper "invalid audio" error.
+    let r = probe_duration_bytes(Bytes::from_static(b"definitely not audio"));
+    assert!(
+        r.is_err() || matches!(r, Ok(None)),
+        "garbage bytes must be Err or Ok(None), got {r:?}"
+    );
+}
+
 // --- BytesMediaSource tests ---
 
 use std::io::{Read, Seek, SeekFrom};

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -359,8 +359,16 @@ enum Commands {
         #[arg(long, env = "GIGASTT_JOBS_MAX")]
         jobs_max: Option<usize>,
 
-        /// Maximum retry attempts for a job that hits inference_timeout or panics
-        /// [default: 3]. Env: GIGASTT_JOBS_RETRY.
+        /// Maximum total bytes of buffered job uploads kept in memory across the
+        /// queue (queued + processing). Bounds RAM independently of --jobs-max,
+        /// which counts jobs but not their size; a submission over budget gets
+        /// 429 + Retry-After [default: 536870912 = 512 MiB].
+        /// Env: GIGASTT_JOBS_MAX_BYTES.
+        #[arg(long, env = "GIGASTT_JOBS_MAX_BYTES")]
+        jobs_max_bytes: Option<usize>,
+
+        /// Maximum retry attempts for a job that panics [default: 3].
+        /// Env: GIGASTT_JOBS_RETRY.
         #[arg(long, env = "GIGASTT_JOBS_RETRY")]
         jobs_retry: Option<u32>,
 
@@ -763,6 +771,7 @@ fn build_limits(
     jobs_enabled: Option<bool>,
     jobs_ttl_secs: Option<u64>,
     jobs_max: Option<usize>,
+    jobs_max_bytes: Option<usize>,
     jobs_retry: Option<u32>,
 ) -> anyhow::Result<RuntimeLimits> {
     let mut limits = if let Some(path) = config_path {
@@ -808,6 +817,9 @@ fn build_limits(
     }
     if let Some(v) = jobs_max {
         limits.jobs_max = v;
+    }
+    if let Some(v) = jobs_max_bytes {
+        limits.jobs_max_bytes = v;
     }
     if let Some(v) = jobs_retry {
         limits.jobs_retry = v;
@@ -1022,6 +1034,7 @@ async fn main() -> anyhow::Result<()> {
             enable_jobs,
             jobs_ttl_secs,
             jobs_max,
+            jobs_max_bytes,
             jobs_retry,
             encoder_intra_threads,
             bind_all,
@@ -1074,6 +1087,7 @@ async fn main() -> anyhow::Result<()> {
                 Some(enable_jobs),
                 jobs_ttl_secs,
                 jobs_max,
+                jobs_max_bytes,
                 jobs_retry,
             )?;
             let metrics_listen =
@@ -2191,6 +2205,7 @@ mod tests {
     fn test_build_limits_defaults_when_no_config() {
         let limits = build_limits(
             None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+            None,
         )
         .unwrap();
         assert_eq!(limits.idle_timeout_secs, 300);
@@ -2213,12 +2228,14 @@ mod tests {
             Some(true),
             Some(7200),
             Some(50),
+            Some(2 * 1024 * 1024),
             Some(5),
         )
         .unwrap();
         assert!(limits.jobs_enabled);
         assert_eq!(limits.jobs_ttl_secs, 7200);
         assert_eq!(limits.jobs_max, 50);
+        assert_eq!(limits.jobs_max_bytes, 2 * 1024 * 1024);
         assert_eq!(limits.jobs_retry, 5);
     }
 
@@ -2232,6 +2249,8 @@ mod tests {
             "7200",
             "--jobs-max",
             "50",
+            "--jobs-max-bytes",
+            "1048576",
             "--jobs-retry",
             "5",
         ]);
@@ -2240,12 +2259,14 @@ mod tests {
                 enable_jobs,
                 jobs_ttl_secs,
                 jobs_max,
+                jobs_max_bytes,
                 jobs_retry,
                 ..
             } => {
                 assert!(enable_jobs);
                 assert_eq!(jobs_ttl_secs, Some(7200));
                 assert_eq!(jobs_max, Some(50));
+                assert_eq!(jobs_max_bytes, Some(1048576));
                 assert_eq!(jobs_retry, Some(5));
             }
             _ => panic!("expected Serve"),
@@ -2289,6 +2310,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(limits.idle_timeout_secs, 600);
@@ -2308,6 +2330,7 @@ mod tests {
         std::fs::write(tmp.path(), b"idle_timeout_secs = 123\n").unwrap();
         let limits = build_limits(
             Some(tmp.path().to_str().unwrap()),
+            None,
             None,
             None,
             None,
@@ -2345,6 +2368,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(result.is_err());
     }
@@ -2358,6 +2382,7 @@ mod tests {
             None,
             Some(30),
             Some(0),
+            None,
             None,
             None,
             None,
@@ -2381,6 +2406,7 @@ mod tests {
             None,
             Some(0),
             Some(0),
+            None,
             None,
             None,
             None,

--- a/crates/gigastt/src/server/config.rs
+++ b/crates/gigastt/src/server/config.rs
@@ -146,8 +146,16 @@ pub struct RuntimeLimits {
     /// Maximum number of jobs kept in memory (queued + finished). When full,
     /// POST /v1/jobs returns 429 + Retry-After. Default: 100.
     pub jobs_max: usize,
-    /// Maximum retry attempts for a job that hits inference_timeout or panics.
-    /// Default: 3.
+    /// Maximum total bytes of buffered uploads held across all in-memory jobs
+    /// (queued + processing; a terminal job releases its body). The count cap
+    /// (`jobs_max`) alone can't bound RAM — each queued job holds its full
+    /// upload as `Bytes`, so `jobs_max` × `body_limit_bytes` (default 100 × 50
+    /// MiB ≈ 5 GiB) could sit in memory while the queue is "not full" by count.
+    /// A submission that would push the live total over this budget gets the
+    /// same 429 + `Retry-After` backpressure as a count-full queue. Default:
+    /// 512 MiB.
+    pub jobs_max_bytes: usize,
+    /// Maximum retry attempts for a job that panics. Default: 3.
     pub jobs_retry: u32,
 }
 
@@ -166,6 +174,7 @@ impl Default for RuntimeLimits {
             jobs_enabled: false,
             jobs_ttl_secs: 3600,
             jobs_max: 100,
+            jobs_max_bytes: 512 * 1024 * 1024,
             jobs_retry: 3,
         }
     }
@@ -201,7 +210,9 @@ pub struct RuntimeLimitsConfig {
     pub jobs_ttl_secs: u64,
     /// Maximum number of jobs kept in memory.
     pub jobs_max: usize,
-    /// Maximum retry attempts for inference-timeout / panic.
+    /// Maximum total bytes of buffered job uploads kept in memory.
+    pub jobs_max_bytes: usize,
+    /// Maximum retry attempts for a panicking job.
     pub jobs_retry: u32,
 }
 
@@ -221,6 +232,7 @@ impl Default for RuntimeLimitsConfig {
             jobs_enabled: d.jobs_enabled,
             jobs_ttl_secs: d.jobs_ttl_secs,
             jobs_max: d.jobs_max,
+            jobs_max_bytes: d.jobs_max_bytes,
             jobs_retry: d.jobs_retry,
         }
     }
@@ -241,6 +253,7 @@ impl From<RuntimeLimitsConfig> for RuntimeLimits {
             jobs_enabled: cfg.jobs_enabled,
             jobs_ttl_secs: cfg.jobs_ttl_secs,
             jobs_max: cfg.jobs_max,
+            jobs_max_bytes: cfg.jobs_max_bytes,
             jobs_retry: cfg.jobs_retry,
         }
     }
@@ -332,6 +345,7 @@ mod tests {
         assert!(!limits.jobs_enabled);
         assert_eq!(limits.jobs_ttl_secs, 3600);
         assert_eq!(limits.jobs_max, 100);
+        assert_eq!(limits.jobs_max_bytes, 512 * 1024 * 1024);
         assert_eq!(limits.jobs_retry, 3);
     }
 

--- a/crates/gigastt/src/server/http/transcribe.rs
+++ b/crates/gigastt/src/server/http/transcribe.rs
@@ -228,7 +228,11 @@ pub(super) async fn run_file_transcription(
 
     let inference_start = std::time::Instant::now();
     let span = tracing::Span::current();
-    let handle = tokio::task::spawn_blocking(move || {
+    // Route through the shared TaskTracker (like the WS / SSE paths) so a
+    // SIGTERM drain can wait for an in-flight REST transcription up to
+    // `--shutdown-drain-secs`; a bare `tokio::task::spawn_blocking` is untracked
+    // and would be abandoned on shutdown, cutting the response mid-run.
+    let handle = state.tracker.spawn_blocking(move || {
         let _enter = span.enter();
         // catch_unwind ensures triplet is returned to pool even on panic
         let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -223,6 +223,25 @@ impl InMemoryJobStore {
             queue.retain(|x| x != &id);
         }
     }
+
+    /// Total bytes of buffered uploads currently resident across all jobs.
+    /// Terminal jobs release their body (`Bytes::new()`), so this is the live
+    /// upload footprint — the quantity `jobs_max_bytes` bounds. O(jobs), and
+    /// `jobs_max` already caps the count, so this is a short walk.
+    fn resident_body_bytes(jobs: &HashMap<String, Job>) -> usize {
+        jobs.values().map(|j| j.body.len()).sum()
+    }
+
+    /// Whether the store is at capacity by count OR by resident upload bytes.
+    /// Folding the byte budget in here means an over-budget queue produces the
+    /// exact same 429 + `Retry-After` backpressure as a count-full one, with no
+    /// new error type. Bounds live upload RAM to `jobs_max_bytes` plus at most
+    /// one `body_limit_bytes` (the job that crosses the line is admitted, the
+    /// next is refused), mirroring how the count cap admits exactly `jobs_max`.
+    fn at_capacity(&self, jobs: &HashMap<String, Job>) -> bool {
+        jobs.len() >= self.limits.jobs_max
+            || Self::resident_body_bytes(jobs) >= self.limits.jobs_max_bytes
+    }
 }
 
 impl JobStore for InMemoryJobStore {
@@ -231,7 +250,10 @@ impl JobStore for InMemoryJobStore {
             let mut jobs = self.jobs.lock();
             let mut queue = self.queue.lock();
             self.evict_expired_locked(&mut jobs, &mut queue);
-            if jobs.len() >= self.limits.jobs_max {
+            // Race backstop behind the `is_full` gate in `submit_job` (which
+            // returns 429 + Retry-After): rejects on either the count or the
+            // byte budget so two concurrent submits can't both slip past the gate.
+            if self.at_capacity(&jobs) {
                 return Err(anyhow::anyhow!("job store is full"));
             }
             let id = job.id.clone();
@@ -296,7 +318,7 @@ impl JobStore for InMemoryJobStore {
             let mut jobs = self.jobs.lock();
             let mut queue = self.queue.lock();
             self.evict_expired_locked(&mut jobs, &mut queue);
-            jobs.len() >= self.limits.jobs_max
+            self.at_capacity(&jobs)
         })
     }
 }
@@ -572,8 +594,16 @@ pub(crate) async fn broadcast_event(store: &dyn JobStore, id: &str, event: JobEv
 }
 
 fn is_retryable_error(e: &anyhow::Error) -> bool {
+    // Only a panic in the inference thread is transient: the triplet is
+    // recovered via catch_unwind and the same input may well succeed on a fresh
+    // worker, so it is worth another attempt.
+    //
+    // An `inference_timeout` is deliberately NOT retryable. A file that is too
+    // slow for the limit will be exactly as slow next time, so retrying it just
+    // burns (max_retries + 1) × the timeout on a job that can never pass while
+    // the rest of the queue waits behind it. Fail it once instead.
     let s = format!("{e:#}");
-    s.contains("inference_timeout") || s.contains("panicked")
+    s.contains("panicked")
 }
 
 fn sanitize_job_error(e: &anyhow::Error) -> String {
@@ -616,26 +646,48 @@ impl JobExecution for RealJobExecutor {
         let engine = self.engine.load_full();
         let limits = self.limits.load();
 
-        // Decode audio (blocking) once to estimate duration for progress.
-        // Wrap the decoder in catch_unwind so a malformed file cannot be
-        // retried as a transient inference panic.
-        let samples = tokio::task::spawn_blocking({
+        // Size the progress bar from the container header when it declares a
+        // duration (WAV / FLAC / M4A / OGG do). A probe reads O(header) bytes
+        // and decodes nothing, so we skip the full O(T) decode this used to run
+        // purely to throw the samples away — the engine re-decodes `body` for
+        // the actual transcript below. That eliminates one wasted full decode
+        // per job: its wall time and its transient f32 buffer (measured ~0.9 s
+        // and ~73 MB on a 20-min 48 kHz file). Peak RSS is roughly unchanged —
+        // the old pre-decode buffer was already freed before the engine decode,
+        // so the two never coexisted — but the redundant CPU pass is gone.
+        const TARGET_SAMPLE_RATE: f64 = 16_000.0;
+        let probed = tokio::task::spawn_blocking({
             let body = body.clone();
-            move || {
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    gigastt_core::inference::audio::decode_audio_bytes_shared(body)
-                }))
-            }
+            move || gigastt_core::inference::audio::probe_duration_bytes(body)
         })
         .await
-        .map_err(|e| anyhow::anyhow!("audio decode task panicked: {e}"))?
-        .map_err(|_| anyhow::anyhow!("Invalid audio: decoder panicked"))?
-        .map_err(|e| anyhow::anyhow!("Invalid audio: {e:#}"))?;
+        .map_err(|e| anyhow::anyhow!("audio probe task panicked: {e}"))?
+        .ok()
+        .flatten();
 
-        const TARGET_SAMPLE_RATE: f64 = 16_000.0;
-        let total_seconds = samples.len() as f64 / TARGET_SAMPLE_RATE;
-        // Only the duration was needed here; the engine re-decodes from `body`.
-        drop(samples);
+        let total_seconds = match probed {
+            Some(seconds) => seconds,
+            None => {
+                // The header declares no usable duration (often a raw MP3
+                // stream): fall back to the full decode so the job keeps its
+                // progress bar. Wrap the decoder in catch_unwind so a malformed
+                // file cannot be retried as a transient inference panic; the
+                // samples are only used for their count and then dropped.
+                let samples = tokio::task::spawn_blocking({
+                    let body = body.clone();
+                    move || {
+                        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            gigastt_core::inference::audio::decode_audio_bytes_shared(body)
+                        }))
+                    }
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("audio decode task panicked: {e}"))?
+                .map_err(|_| anyhow::anyhow!("Invalid audio: decoder panicked"))?
+                .map_err(|e| anyhow::anyhow!("Invalid audio: {e:#}"))?;
+                samples.len() as f64 / TARGET_SAMPLE_RATE
+            }
+        };
         let _ = store
             .update(id, Box::new(move |j| j.total_seconds = total_seconds))
             .await;
@@ -873,6 +925,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_store_byte_budget_backpressures_under_count_limit() {
+        // Count limit is generous (10) but the byte budget is tiny: a store
+        // holding one upload already at/over the byte budget must report full
+        // and reject the next submission, even though it holds 1 << 10 jobs.
+        let limits = RuntimeLimits {
+            jobs_max: 10,
+            jobs_max_bytes: 8,
+            ..test_limits()
+        };
+        let store = InMemoryJobStore::new(limits);
+        // First upload (11 bytes) is admitted: like the count cap admitting the
+        // Nth job, the budget is checked against the bytes already resident (0).
+        store
+            .create(Job::queued(
+                Bytes::from_static(b"audio-bytes"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        // 11 resident bytes now exceed the 8-byte budget, so the store is full
+        // by bytes despite being far below jobs_max, and the next create fails.
+        assert!(store.is_full().await);
+        let result = store
+            .create(Job::queued(
+                Bytes::from_static(b"more"),
+                ExportParams::default(),
+            ))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_store_byte_budget_released_when_job_terminal() {
+        // A terminal job releases its body, so those bytes stop counting against
+        // the budget and the queue accepts new work again.
+        let limits = RuntimeLimits {
+            jobs_max: 10,
+            jobs_max_bytes: 8,
+            ..test_limits()
+        };
+        let store = InMemoryJobStore::new(limits);
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"audio-bytes"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+        assert!(store.is_full().await);
+        // Release the body the way the worker does at a terminal state.
+        store
+            .update(
+                &id,
+                Box::new(|j| {
+                    j.status = JobStatus::Done;
+                    j.body = Bytes::new();
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(!store.is_full().await);
+    }
+
+    #[tokio::test]
     async fn test_store_is_full_evicts_expired() {
         let limits = RuntimeLimits {
             jobs_ttl_secs: 1,
@@ -1021,10 +1137,12 @@ mod tests {
         };
         let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(limits));
         let executor = MockExecutor {
+            // Panic is the retryable failure class (inference_timeout is not),
+            // so the retry path is exercised with a panic marker.
             results: Arc::new(Mutex::new(vec![
-                Err(anyhow::anyhow!("inference_timeout")),
-                Err(anyhow::anyhow!("inference_timeout")),
-                Err(anyhow::anyhow!("inference_timeout")),
+                Err(anyhow::anyhow!("worker thread panicked")),
+                Err(anyhow::anyhow!("worker thread panicked")),
+                Err(anyhow::anyhow!("worker thread panicked")),
             ])),
             delay_ms: 0,
         };
@@ -1139,10 +1257,12 @@ mod tests {
 
     #[test]
     fn test_is_retryable_error_recognizes_transient_failures() {
-        assert!(is_retryable_error(&anyhow::anyhow!("inference_timeout")));
+        // A panic is transient — a fresh worker may succeed. An inference_timeout
+        // is deterministic, so it is NOT retryable. A decode error never is.
         assert!(is_retryable_error(&anyhow::anyhow!(
             "worker thread panicked"
         )));
+        assert!(!is_retryable_error(&anyhow::anyhow!("inference_timeout")));
         assert!(!is_retryable_error(&anyhow::anyhow!("Invalid audio")));
     }
 
@@ -1282,6 +1402,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_queue_timeout_fails_once() {
+        // A deterministic inference_timeout must fail on its first and only
+        // attempt — even with retry budget to spare — so a too-slow file can't
+        // burn (max_retries + 1) × the timeout while the queue waits.
+        let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(test_limits()));
+        let executor = MockExecutor {
+            // Second result is queued but must never be consumed: no retry.
+            results: Arc::new(Mutex::new(vec![
+                Err(anyhow::anyhow!("inference_timeout")),
+                ok_result(),
+            ])),
+            delay_ms: 0,
+        };
+        // Generous retry budget (3) — the point is that timeout ignores it.
+        let queue = JobQueue::new(
+            store.clone(),
+            1,
+            3,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        queue.spawn(executor);
+
+        let id = store
+            .create(Job::queued(
+                Bytes::from_static(b"x"),
+                ExportParams::default(),
+            ))
+            .await
+            .unwrap();
+
+        for _ in 0..50 {
+            let job = store.get(&id).await.unwrap().unwrap();
+            if matches!(job.status, JobStatus::Failed) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        let job = store.get(&id).await.unwrap().unwrap();
+        assert!(matches!(job.status, JobStatus::Failed));
+        assert_eq!(
+            job.attempts, 1,
+            "inference_timeout must fail once, not retry"
+        );
+    }
+
+    #[tokio::test]
     async fn test_queue_retry_boundary_exhausted_after_max_retries() {
         // max_retries=1 means one retry is allowed: attempts 1 (retry), 2 (fail).
         let limits = RuntimeLimits {
@@ -1290,9 +1457,11 @@ mod tests {
         };
         let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(limits));
         let executor = MockExecutor {
+            // Retry path is exercised with a panic marker (the retryable class);
+            // inference_timeout is deterministic and fails once.
             results: Arc::new(Mutex::new(vec![
-                Err(anyhow::anyhow!("inference_timeout")),
-                Err(anyhow::anyhow!("inference_timeout")),
+                Err(anyhow::anyhow!("worker thread panicked")),
+                Err(anyhow::anyhow!("worker thread panicked")),
             ])),
             delay_ms: 0,
         };
@@ -1389,7 +1558,9 @@ mod tests {
             _params: ExportParams,
         ) -> anyhow::Result<gigastt_core::inference::TranscribeResult> {
             self.lens.lock().push(body.len());
-            Err(anyhow::anyhow!("inference_timeout"))
+            // Retryable failure class, so the body must survive to the next
+            // attempt and only be released at the terminal state.
+            Err(anyhow::anyhow!("worker thread panicked"))
         }
     }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,8 +127,13 @@ gigastt serve [OPTIONS]
                                 [default: 3600]. Env: GIGASTT_JOBS_TTL_SECS.
   --jobs-max <N>                Max jobs kept in memory; POST /v1/jobs returns 429 when
                                 full [default: 100]. Env: GIGASTT_JOBS_MAX.
-  --jobs-retry <N>              Max retries for a job on inference_timeout or panic
-                                [default: 3]. Env: GIGASTT_JOBS_RETRY.
+  --jobs-max-bytes <N>          Max total bytes of buffered job uploads kept in memory;
+                                bounds RAM independently of --jobs-max, a submission over
+                                budget returns 429 [default: 536870912 = 512 MiB].
+                                Env: GIGASTT_JOBS_MAX_BYTES.
+  --jobs-retry <N>              Max retries for a job that panics (a deterministic
+                                inference_timeout is not retried) [default: 3].
+                                Env: GIGASTT_JOBS_RETRY.
   --inference-timeout-secs <N>  Per-request inference timeout; a run exceeding it returns
                                 inference_timeout (REST 504 / WS close). 0 disables
                                 [default: 600]. Env: GIGASTT_INFERENCE_TIMEOUT_SECS.


### PR DESCRIPTION
## Why

`/v1/jobs` is where hour-long files will land, and it was the least careful path in the tree. Four
defects, all verified against the code before touching it.

## 1. Every upload was decoded twice

`RealJobExecutor::execute` ran a full `decode_audio_bytes_shared` purely to compute `total_seconds` for
the progress bar, discarded the samples, and then the engine decoded the same bytes again.

New `probe_duration_bytes` / `probe_duration_file` run only symphonia's format probe and derive the
duration from the declared frame count and rate. Jobs probe first; only `None` (container declares no
frame count) or an error falls back to the old full decode, so no job loses its progress bar.

Measured, release, 20-minute 48 kHz mono: the eliminated decode was **926 ms** of wall time and a
**73 MB** transient buffer; the probe that replaces it takes **0.011 ms** and allocates essentially
nothing. A job now reaches inference ~0.9 s sooner.

To be precise about what this is *not*: peak RSS is essentially unchanged, because the old pre-decode
buffer was dropped before the engine's decode began — the two never coexisted. The win is one full O(T)
decode of CPU per job and 73 MB less allocator churn, not a peak-memory halving.

Two additive `pub fn`s in `gigastt-core`; `cargo semver-checks` reports 219 checks, 219 pass, no bump
required.

## 2. The queue was bounded by job COUNT, not bytes

Each `Job` holds its entire upload as `Bytes`. With the default 50 MiB body limit, a queue that is "not
full" by count could be gigabytes of RAM. Adds `jobs_max_bytes` (default 512 MiB) to `RuntimeLimits`,
the TOML config, `--jobs-max-bytes` and `GIGASTT_JOBS_MAX_BYTES`, folded into a shared `at_capacity()`
used by both `is_full` and `create`. Live upload RAM is now bounded by `jobs_max_bytes` plus at most one
`body_limit_bytes`, mirroring how the count cap admits exactly `jobs_max`.

Over-budget submissions hit the queue's **existing** 429 `queue_full` + `Retry-After` response — no new
error type, no new wire shape.

## 3. A deterministic timeout was retried three more times

`is_retryable_error` treated `inference_timeout` as retryable. A file that is simply too slow for the
limit never becomes fast, so one worker burned 4 × the timeout on it while the queue waited. The timeout
arm is gone; panics stay retryable. New test asserts a timing-out job records exactly one attempt with
retry budget to spare, and the three existing retry-path tests were repointed at a panic marker so they
still exercise the retry loop.

## 4. REST transcription could not be drained on shutdown

`http/transcribe.rs` used a bare `tokio::task::spawn_blocking`, so the task was untracked and
`--shutdown-drain-secs` could not wait for it. Now routed through `state.tracker.spawn_blocking`, the
same pattern the WebSocket and SSE paths already use.

## Behaviour note

One narrow, deliberate change: a file whose container header is valid but whose audio data is corrupt
now fails at the engine decode ("Transcription failed.") rather than at the pre-decode ("Failed to
decode audio file."). Same non-retryable Failed job, same wire shape — only the free-text message
differs, and only for that case. Unreadable containers still fail early through the fallback exactly as
before.

`docs/cli.md` gains the new flag (the docs-drift gate cross-checks every clap flag against it) and the
`--jobs-retry` line is corrected to say panic-only.

`cargo test -p gigastt-core --lib` → 534 passed. `-p gigastt --lib` → 204 passed, `--bins` → 76 passed.
Clippy clean, docs-drift 10/10.