### PR TITLE
feat(core): decode file audio into windows instead of one whole-file buffer

### DIFF
--- a/crates/gigastt-core/src/inference/audio/decode.rs
+++ b/crates/gigastt-core/src/inference/audio/decode.rs
@@ -29,7 +29,7 @@ use super::opus::{decode_opus_channels, next_demux_packet};
 #[cfg(feature = "file-decode")]
 use super::resample::{RESAMPLE_STAGING_FRAMES, ResampleTo16k, SampleRate};
 #[cfg(feature = "file-decode")]
-use super::telephony::{sniffs_as_g722_wav, try_decode_g722_wav};
+use super::stream::FileWindows;
 
 /// A [`MediaSource`] that borrows its data from a reference-counted [`Bytes`]
 /// buffer instead of cloning into a `Vec<u8>`.
@@ -138,39 +138,11 @@ impl MediaSource for BytesMediaSource {
 /// ```
 #[cfg(feature = "file-decode")]
 pub fn decode_audio_file(path: &str) -> Result<Vec<f32>> {
-    // G.722-in-WAV (format tag 0x0064) has no symphonia decoder: sniff the
-    // first chunk headers, and only when they declare G.722 read the file
-    // fully and decode it here. Other inputs stream through symphonia as
-    // before, so plain WAVs keep their from-disk memory profile.
-    if sniffs_as_g722_wav(path)? {
-        let bytes =
-            std::fs::read(path).with_context(|| format!("Failed to read audio file: {path}"))?;
-        if let Some(result) = try_decode_g722_wav(&bytes) {
-            return result;
-        }
-    }
-
-    let file =
-        std::fs::File::open(path).with_context(|| format!("Failed to open audio file: {path}"))?;
-    let mss = MediaSourceStream::new(Box::new(file), Default::default());
-
-    let mut hint = Hint::new();
-    if let Some(ext) = std::path::Path::new(path)
-        .extension()
-        .and_then(|e| e.to_str())
-    {
-        hint.with_extension(ext);
-    }
-
-    let source_label = format!(
-        "format={}",
-        std::path::Path::new(path)
-            .extension()
-            .unwrap_or_default()
-            .to_string_lossy()
-    );
-
-    decode_audio_inner(mss, hint, &source_label)
+    // Flat drain of the windowed decoder: byte-identical to the whole-buffer
+    // decode it replaced, including the G.722-in-WAV telephony sniff. Callers
+    // that want peak memory independent of duration go through
+    // `Engine::transcribe_request`, which pulls windows instead of draining.
+    FileWindows::decode_file(path)
 }
 
 /// Decode audio from raw bytes in memory (no temp file needed).
@@ -214,15 +186,8 @@ pub fn decode_audio_bytes(data: &[u8]) -> Result<Vec<f32>> {
 /// ```
 #[cfg(feature = "file-decode")]
 pub fn decode_audio_bytes_shared(data: Bytes) -> Result<Vec<f32>> {
-    // G.722-in-WAV (format tag 0x0064) has no symphonia decoder; detect it
-    // before the generic probe and decode via the telephony fallback.
-    if let Some(result) = try_decode_g722_wav(&data) {
-        return result;
-    }
-    let source = BytesMediaSource::new(data);
-    let mss = MediaSourceStream::new(Box::new(source), Default::default());
-    let hint = Hint::new();
-    decode_audio_inner(mss, hint, "bytes")
+    // Flat drain of the windowed decoder (G.722 telephony sniff included).
+    FileWindows::decode_bytes(data)
 }
 
 /// Read an audio container's declared duration (seconds) from its header
@@ -544,153 +509,4 @@ fn normalized_correlation(a: &[f32], b: &[f32]) -> f64 {
         return 0.0;
     }
     cov / denom
-}
-
-/// Shared decode logic: probe → format → decode → mono mix → duration check → resample.
-#[cfg(feature = "file-decode")]
-fn decode_audio_inner<'s>(
-    mss: MediaSourceStream<'s>,
-    hint: Hint,
-    source_label: &str,
-) -> Result<Vec<f32>> {
-    let mut format = symphonia::default::get_probe()
-        .probe(
-            &hint,
-            mss,
-            FormatOptions::default(),
-            MetadataOptions::default(),
-        )
-        .context("Unsupported audio format")?;
-
-    let track = format
-        .default_track(TrackType::Audio)
-        .context("No audio track found")?;
-    let track_id = track.id;
-    let audio_params = track
-        .codec_params
-        .as_ref()
-        .and_then(|p| p.audio())
-        .context("No audio codec parameters")?;
-    let sample_rate = audio_params.sample_rate.context("Unknown sample rate")?;
-    if sample_rate == 0 || sample_rate > MAX_SAMPLE_RATE {
-        anyhow::bail!("Unsupported sample rate: {sample_rate}Hz");
-    }
-    let channels = audio_params
-        .channels
-        .as_ref()
-        .map(|c| c.count())
-        .unwrap_or(1);
-    // Some formats (WAV, FLAC) publish the total frame count in the track;
-    // reserve up-front to avoid `Vec` reallocation thrash for large uploads.
-    // Streaming codecs (MP3) leave this as None and we fall back to the
-    // default growth strategy.
-    let n_frames_hint = track.num_frames;
-
-    tracing::info!("Audio ({source_label}): {sample_rate}Hz, {channels}ch");
-
-    // Sample budget from a CLAMPED rate (header `sample_rate` capped at
-    // MAX_DECODE_SAMPLE_RATE), so a crafted header cannot inflate the duration
-    // cap or the capacity hint. Computed before the capacity match so the hint
-    // is bounded by the same budget.
-    let max_samples: usize = max_decode_samples(sample_rate);
-
-    // Decoded packets are staged at the source rate and drained to 16 kHz as
-    // they fill, so peak memory is O(one staging chunk) instead of O(file).
-    let mut acc = ResampleTo16k::new(
-        SampleRate(sample_rate),
-        match n_frames_hint {
-            Some(n) if n > 0 && n <= max_samples as u64 => Some(n as usize),
-            _ => None,
-        },
-    );
-    // Source-rate frame count, tracked separately because the accumulator now
-    // holds 16 kHz samples while the duration cap is expressed in source-rate
-    // frames.
-    let mut source_frames: usize = 0;
-
-    // Symphonia demuxes OGG/Opus but ships no Opus decoder, so Opus packets
-    // go through the `opus-rs` fallback (mono mix included) and rejoin the
-    // shared duration-log / resample tail.
-    if audio_params.codec == CODEC_ID_OPUS {
-        let mono = mix_channels_to_mono(&decode_opus_channels(
-            &mut *format,
-            track_id,
-            channels,
-            max_samples,
-        )?);
-        source_frames = mono.len();
-        for piece in mono.chunks(RESAMPLE_STAGING_FRAMES) {
-            acc.stage().extend_from_slice(piece);
-            acc.flush_full()?;
-        }
-    } else {
-        let mut decoder = symphonia::default::get_codecs()
-            .make_audio_decoder(audio_params, &AudioDecoderOptions::default())
-            .context("Unsupported audio codec")?;
-
-        loop {
-            let have_pcm = source_frames > 0;
-            let Some(packet) = next_demux_packet(&mut *format, have_pcm)? else {
-                break;
-            };
-
-            if packet.track_id != track_id {
-                continue;
-            }
-
-            let decoded = decoder.decode(&packet).context("Decode error")?;
-            let spec = decoded.spec().clone();
-            let num_frames = decoded.frames();
-            let ch = spec.channels().count();
-
-            // Mix to mono if multi-channel
-            if ch > 1 {
-                let mut interleaved: Vec<f32> = Vec::with_capacity(num_frames * ch);
-                decoded.copy_to_vec_interleaved(&mut interleaved);
-                let stage = acc.stage();
-                for frame in 0..num_frames {
-                    let mut sum = 0.0_f32;
-                    for c in 0..ch {
-                        sum += interleaved[frame * ch + c];
-                    }
-                    stage.push(sum / ch as f32);
-                }
-            } else {
-                let stage = acc.stage();
-                let offset = stage.len();
-                stage.resize(offset + num_frames, 0.0);
-                decoded.copy_to_slice_interleaved(&mut stage[offset..]);
-            }
-            source_frames += num_frames;
-
-            // Incremental duration cap: abort before the next packet is decoded
-            // if the accumulated buffer already exceeds the duration budget.
-            // This prevents a crafted upload from allocating hundreds of MiB of
-            // PCM before the post-loop guard gets a chance to run.
-            if source_frames > max_samples {
-                let observed_s = source_frames as f64 / sample_rate as f64;
-                anyhow::bail!(
-                    "Audio file too long ({:.0}s). Maximum supported: {MAX_DURATION_S:.0}s.",
-                    observed_s
-                );
-            }
-
-            acc.flush_full()?;
-        }
-    }
-
-    let duration_s = source_frames as f64 / sample_rate as f64;
-    tracing::info!(
-        "Decoded {} samples at {}Hz ({:.1}s)",
-        source_frames,
-        sample_rate,
-        duration_s
-    );
-
-    let all_samples = acc.finish()?;
-    if sample_rate != 16000 {
-        tracing::info!("Resampled to 16kHz: {} samples", all_samples.len());
-    }
-
-    Ok(all_samples)
 }

--- a/crates/gigastt-core/src/inference/audio/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/mod.rs
@@ -83,6 +83,11 @@ pub use resample::{SampleRate, resample, resample_with_cache};
 // Long-form window source. Crate-internal: the file-decode loop is the only
 // consumer today, and the streaming source lands behind the same trait.
 pub(crate) use stream::{PcmWindows, SliceWindows, WindowSpec};
+// Streaming container-backed window source: keeps peak audio memory O(one
+// window) regardless of file duration. `Engine::transcribe_request` pulls
+// windows from it; the public `decode_audio_*` functions drain it flat.
+#[cfg(feature = "file-decode")]
+pub(crate) use stream::FileWindows;
 
 pub use telephony::TelephonyCodec;
 #[cfg(feature = "file-decode")]

--- a/crates/gigastt-core/src/inference/audio/resample.rs
+++ b/crates/gigastt-core/src/inference/audio/resample.rs
@@ -274,6 +274,40 @@ impl ResampleTo16k {
         Ok(self.out)
     }
 
+    /// Move the 16 kHz samples produced so far into `dst`, leaving the
+    /// accumulator ready to keep decoding.
+    ///
+    /// For a resampling rate these are the samples already flushed to `out` (the
+    /// partial staging chunk stays until it fills or [`Self::finish_into`] runs);
+    /// for the 16 kHz passthrough the staged samples ARE the output, so they move
+    /// directly. The windowed streaming source calls this after every packet so
+    /// peak memory stays O(one window) rather than O(file); the flat
+    /// [`Self::finish`] path never touches it. The concatenation of every
+    /// `drain_ready_into` plus a final [`Self::finish_into`] is byte-identical to
+    /// one [`Self::finish`], because the staged chunk sequence — and therefore
+    /// every cached-resampler call — is unchanged.
+    pub(super) fn drain_ready_into(&mut self, dst: &mut Vec<f32>) {
+        let ready = if self.from_rate.0 == 16_000 {
+            &mut self.stage
+        } else {
+            &mut self.out
+        };
+        dst.append(ready);
+    }
+
+    /// Flush any staged remainder through the resampler and move all remaining
+    /// 16 kHz output into `dst`. The streaming counterpart of [`Self::finish`];
+    /// idempotent once drained, so an end-of-stream poll may call it repeatedly.
+    pub(super) fn finish_into(&mut self, dst: &mut Vec<f32>) -> Result<()> {
+        if self.from_rate.0 == 16_000 {
+            dst.append(&mut self.stage);
+            return Ok(());
+        }
+        self.drain()?;
+        dst.append(&mut self.out);
+        Ok(())
+    }
+
     fn drain(&mut self) -> Result<()> {
         if self.stage.is_empty() {
             return Ok(());

--- a/crates/gigastt-core/src/inference/audio/stream.rs
+++ b/crates/gigastt-core/src/inference/audio/stream.rs
@@ -15,6 +15,34 @@
 use crate::error::GigasttError;
 use crate::inference::{ENCODER_SUBSAMPLING, HOP_LENGTH};
 
+#[cfg(feature = "file-decode")]
+use anyhow::{Context, Result};
+#[cfg(feature = "file-decode")]
+use bytes::Bytes;
+#[cfg(feature = "file-decode")]
+use symphonia::core::codecs::audio::well_known::CODEC_ID_OPUS;
+#[cfg(feature = "file-decode")]
+use symphonia::core::codecs::audio::{AudioDecoder, AudioDecoderOptions};
+#[cfg(feature = "file-decode")]
+use symphonia::core::formats::probe::Hint;
+#[cfg(feature = "file-decode")]
+use symphonia::core::formats::{FormatOptions, FormatReader, TrackType};
+#[cfg(feature = "file-decode")]
+use symphonia::core::io::MediaSourceStream;
+#[cfg(feature = "file-decode")]
+use symphonia::core::meta::MetadataOptions;
+
+#[cfg(feature = "file-decode")]
+use super::decode::{BytesMediaSource, mix_channels_to_mono};
+#[cfg(feature = "file-decode")]
+use super::opus::{decode_opus_channels, next_demux_packet};
+#[cfg(feature = "file-decode")]
+use super::resample::{RESAMPLE_STAGING_FRAMES, ResampleTo16k, SampleRate};
+#[cfg(feature = "file-decode")]
+use super::telephony::{sniffs_as_g722_wav, try_decode_g722_wav};
+#[cfg(feature = "file-decode")]
+use super::{MAX_DURATION_S, MAX_SAMPLE_RATE, max_decode_samples};
+
 /// Samples per encoder output frame (`HOP_LENGTH * ENCODER_SUBSAMPLING`,
 /// 640 @16 kHz). Window starts are multiples of this so each window's frame
 /// offset is integral.
@@ -57,6 +85,12 @@ impl WindowSpec {
         self.stride
     }
 
+    /// Largest total (samples @16 kHz) that stays on the single-pass branch — one
+    /// encoder Run over the whole buffer rather than overlapping windows.
+    pub(crate) fn single_pass_max(&self) -> usize {
+        self.single_pass_max
+    }
+
     /// Samples shared by two consecutive windows (`window - stride`). Equals the
     /// requested overlap whenever that overlap is already frame-aligned.
     pub(crate) fn overlap(&self) -> usize {
@@ -67,6 +101,14 @@ impl WindowSpec {
     /// encoder Run over the whole buffer) branch.
     pub(crate) fn is_single_pass(&self, total: usize) -> bool {
         total <= self.single_pass_max
+    }
+
+    /// Sentinel geometry for flat (`drain_to_vec`) decode, which never windows.
+    /// Its window/stride are never read; only [`FileWindows::drain_to_vec`] uses
+    /// a `FileWindows` built with it.
+    #[cfg(feature = "file-decode")]
+    pub(crate) fn flat() -> Self {
+        Self::new(usize::MAX, usize::MAX, 0)
     }
 }
 
@@ -133,6 +175,405 @@ impl PcmWindows for SliceWindows<'_> {
         Ok(Some(PcmWindow {
             start_sample: start,
             samples: &self.samples[start..end],
+        }))
+    }
+}
+
+/// The decode engine behind [`FileWindows`]: a streaming symphonia loop, or an
+/// already-materialized buffer for the formats that cannot stream.
+#[cfg(feature = "file-decode")]
+enum Source {
+    /// Container decoded packet-by-packet, resampled to 16 kHz as it goes.
+    Streaming {
+        format: Box<dyn FormatReader>,
+        decoder: Box<dyn AudioDecoder>,
+        track_id: u32,
+        /// Source (container) sample rate — the units the duration cap counts.
+        sample_rate: u32,
+        /// Running SOURCE-rate frame count, tracked separately from the 16 kHz
+        /// accumulator because the duration cap is expressed in source frames.
+        source_frames: usize,
+        /// Source-rate frame budget from a clamped rate (see [`max_decode_samples`]).
+        max_samples: usize,
+        /// Boxed: it carries the heavyweight rubato FIR state, so keeping it
+        /// behind a pointer keeps the `Streaming` variant small.
+        resampler: Box<ResampleTo16k>,
+        /// Per-packet interleaved scratch, hoisted out of the decode loop.
+        interleaved: Vec<f32>,
+    },
+    /// The whole 16 kHz stream is already in [`FileWindows::buf`]. Used by the
+    /// Opus fallback (it still accumulates per channel — streaming it is out of
+    /// scope) and the G.722-in-WAV telephony path (no symphonia decoder).
+    Eager,
+}
+
+/// A [`PcmWindows`] source that pulls overlapping decode windows straight from an
+/// audio container, so peak audio memory is O(one window) rather than O(file).
+///
+/// It holds only a rolling 16 kHz buffer — one window plus a packet of
+/// look-ahead — and drops each window's consumed prefix before decoding the
+/// next, so a three-hour file costs the same resident audio memory as a
+/// thirty-second one. The window sequence is byte-identical to
+/// [`SliceWindows`] over the same fully-decoded buffer:
+///
+/// - a stream that fits the single-pass ceiling yields exactly one window over
+///   the whole buffer, matching `Engine::decode_words`' non-windowed branch;
+/// - a longer stream yields the standard overlapping geometry.
+///
+/// [`FileWindows::drain_to_vec`] runs the same decode flat (no windowing) and is
+/// byte-identical to the whole-buffer decoder the public `decode_audio_*`
+/// wrappers used to call.
+#[cfg(feature = "file-decode")]
+pub(crate) struct FileWindows {
+    src: Source,
+    /// True once the container is exhausted (or eagerly materialized).
+    eof: bool,
+    /// True once the resampler's staged remainder has been flushed at EOF.
+    finished: bool,
+    /// Rolling 16 kHz buffer holding `[buf_start_abs, decoded_16k_total)`.
+    buf: Vec<f32>,
+    /// Absolute sample index (@16 kHz) of `buf[0]`.
+    buf_start_abs: usize,
+    /// Total 16 kHz samples decoded so far (== `buf_start_abs + buf.len()`).
+    decoded_16k_total: usize,
+    spec: WindowSpec,
+    /// Absolute start (@16 kHz) of the next window to yield.
+    next_start: usize,
+    /// True until the first window's single-pass-vs-windowed decision is made.
+    first: bool,
+    done: bool,
+}
+
+#[cfg(feature = "file-decode")]
+impl FileWindows {
+    /// Open a file for windowed decode. Mirrors `decode_audio_file`'s probe/hint
+    /// setup, including the G.722-in-WAV telephony sniff.
+    pub(crate) fn open(path: &str, spec: WindowSpec) -> Result<Self> {
+        if sniffs_as_g722_wav(path)? {
+            let bytes = std::fs::read(path)
+                .with_context(|| format!("Failed to read audio file: {path}"))?;
+            if let Some(result) = try_decode_g722_wav(&bytes) {
+                return Ok(Self::eager(result?, spec));
+            }
+        }
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("Failed to open audio file: {path}"))?;
+        let mss = MediaSourceStream::new(Box::new(file), Default::default());
+        let mut hint = Hint::new();
+        if let Some(ext) = std::path::Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+        {
+            hint.with_extension(ext);
+        }
+        Self::from_mss(mss, hint, spec)
+    }
+
+    /// Open a shared [`Bytes`] buffer for windowed decode. `BytesMediaSource` is
+    /// seekable, so the isomp4 demuxer's trailing-`moov` seek works; no spool.
+    pub(crate) fn from_bytes(data: Bytes, spec: WindowSpec) -> Result<Self> {
+        if let Some(result) = try_decode_g722_wav(&data) {
+            return Ok(Self::eager(result?, spec));
+        }
+        let source = BytesMediaSource::new(data);
+        let mss = MediaSourceStream::new(Box::new(source), Default::default());
+        Self::from_mss(mss, Hint::new(), spec)
+    }
+
+    /// Probe the container and either set up the streaming decoder or, for Opus /
+    /// G.722, eagerly materialize the whole 16 kHz buffer. Scalar params are
+    /// copied out (and the non-Opus decoder built) inside one borrow scope so the
+    /// `FormatReader` is free to move or be driven afterwards — the same shape as
+    /// the whole-buffer `decode_audio_inner`.
+    fn from_mss(mss: MediaSourceStream<'static>, hint: Hint, spec: WindowSpec) -> Result<Self> {
+        let mut format = symphonia::default::get_probe()
+            .probe(
+                &hint,
+                mss,
+                FormatOptions::default(),
+                MetadataOptions::default(),
+            )
+            .context("Unsupported audio format")?;
+
+        let (track_id, sample_rate, channels, decoder_opt) = {
+            let track = format
+                .default_track(TrackType::Audio)
+                .context("No audio track found")?;
+            let track_id = track.id;
+            let audio_params = track
+                .codec_params
+                .as_ref()
+                .and_then(|p| p.audio())
+                .context("No audio codec parameters")?;
+            let sample_rate = audio_params.sample_rate.context("Unknown sample rate")?;
+            if sample_rate == 0 || sample_rate > MAX_SAMPLE_RATE {
+                anyhow::bail!("Unsupported sample rate: {sample_rate}Hz");
+            }
+            let channels = audio_params
+                .channels
+                .as_ref()
+                .map(|c| c.count())
+                .unwrap_or(1);
+            // Opus is demuxed by symphonia but has no symphonia decoder; the
+            // `opus-rs` fallback needs the `FormatReader`, so build no decoder
+            // here and take the eager branch below.
+            let decoder_opt = if audio_params.codec == CODEC_ID_OPUS {
+                None
+            } else {
+                Some(
+                    symphonia::default::get_codecs()
+                        .make_audio_decoder(audio_params, &AudioDecoderOptions::default())
+                        .context("Unsupported audio codec")?,
+                )
+            };
+            (track_id, sample_rate, channels, decoder_opt)
+        };
+
+        let max_samples = max_decode_samples(sample_rate);
+
+        match decoder_opt {
+            None => {
+                let mono = mix_channels_to_mono(&decode_opus_channels(
+                    &mut *format,
+                    track_id,
+                    channels,
+                    max_samples,
+                )?);
+                let mut resampler = ResampleTo16k::new(SampleRate(sample_rate), None);
+                for piece in mono.chunks(RESAMPLE_STAGING_FRAMES) {
+                    resampler.stage().extend_from_slice(piece);
+                    resampler.flush_full()?;
+                }
+                let mut buf = Vec::new();
+                resampler.finish_into(&mut buf)?;
+                tracing::info!("Audio (opus): {sample_rate}Hz, {channels}ch (eager)");
+                Ok(Self::eager(buf, spec))
+            }
+            Some(decoder) => {
+                tracing::info!("Audio: {sample_rate}Hz, {channels}ch (streaming windows)");
+                Ok(Self {
+                    src: Source::Streaming {
+                        format,
+                        decoder,
+                        track_id,
+                        sample_rate,
+                        source_frames: 0,
+                        max_samples,
+                        // No length hint: the windowed path never materializes the
+                        // whole 16 kHz stream, so it must not reserve for it.
+                        resampler: Box::new(ResampleTo16k::new(SampleRate(sample_rate), None)),
+                        interleaved: Vec::new(),
+                    },
+                    eof: false,
+                    finished: false,
+                    buf: Vec::new(),
+                    buf_start_abs: 0,
+                    decoded_16k_total: 0,
+                    spec,
+                    next_start: 0,
+                    first: true,
+                    done: false,
+                })
+            }
+        }
+    }
+
+    /// Build an eager source over an already-decoded 16 kHz buffer.
+    fn eager(buf: Vec<f32>, spec: WindowSpec) -> Self {
+        let total = buf.len();
+        Self {
+            src: Source::Eager,
+            eof: true,
+            finished: true,
+            buf,
+            buf_start_abs: 0,
+            decoded_16k_total: total,
+            spec,
+            next_start: 0,
+            first: true,
+            done: false,
+        }
+    }
+
+    /// Total 16 kHz samples decoded. Exact once the stream is drained (every
+    /// window consumed), matching the whole-buffer decoder's sample count.
+    pub(crate) fn total_16k_samples(&self) -> usize {
+        self.decoded_16k_total
+    }
+
+    /// Decode the whole stream flat (no windowing) to one 16 kHz mono buffer.
+    ///
+    /// Byte-identical to the whole-buffer `decode_audio_inner`: the same packet
+    /// loop, the same per-packet resampler flush cadence, the same final drain.
+    pub(crate) fn drain_to_vec(mut self) -> Result<Vec<f32>> {
+        self.fill_to(usize::MAX)?;
+        Ok(std::mem::take(&mut self.buf))
+    }
+
+    /// Flat-decode a file to 16 kHz mono. The window geometry is irrelevant to
+    /// `drain_to_vec`, so a sentinel spec is used.
+    pub(crate) fn decode_file(path: &str) -> Result<Vec<f32>> {
+        Self::open(path, WindowSpec::flat())?.drain_to_vec()
+    }
+
+    /// Flat-decode a shared byte buffer to 16 kHz mono.
+    pub(crate) fn decode_bytes(data: Bytes) -> Result<Vec<f32>> {
+        Self::from_bytes(data, WindowSpec::flat())?.drain_to_vec()
+    }
+
+    /// Decode until `decoded_16k_total >= target` (or EOF), appending 16 kHz
+    /// samples to `buf`. Enforces the source-rate duration cap incrementally with
+    /// the exact same error string as the whole-buffer path.
+    fn fill_to(&mut self, target: usize) -> Result<()> {
+        let Source::Streaming {
+            format,
+            decoder,
+            track_id,
+            sample_rate,
+            source_frames,
+            max_samples,
+            resampler,
+            interleaved,
+        } = &mut self.src
+        else {
+            return Ok(()); // Eager: the whole buffer is already resident.
+        };
+
+        while !self.eof && self.decoded_16k_total < target {
+            let have_pcm = *source_frames > 0;
+            let packet = match next_demux_packet(&mut **format, have_pcm)? {
+                Some(p) => p,
+                None => {
+                    self.eof = true;
+                    break;
+                }
+            };
+            if packet.track_id != *track_id {
+                continue;
+            }
+
+            let decoded = decoder.decode(&packet).context("Decode error")?;
+            let num_frames = decoded.frames();
+            let ch = decoded.spec().channels().count();
+
+            if ch > 1 {
+                interleaved.clear();
+                decoded.copy_to_vec_interleaved(interleaved);
+                let stage = resampler.stage();
+                for frame in 0..num_frames {
+                    let mut sum = 0.0_f32;
+                    for c in 0..ch {
+                        sum += interleaved[frame * ch + c];
+                    }
+                    stage.push(sum / ch as f32);
+                }
+            } else {
+                let stage = resampler.stage();
+                let offset = stage.len();
+                stage.resize(offset + num_frames, 0.0);
+                decoded.copy_to_slice_interleaved(&mut stage[offset..]);
+            }
+            *source_frames += num_frames;
+
+            if *source_frames > *max_samples {
+                let observed_s = *source_frames as f64 / *sample_rate as f64;
+                anyhow::bail!(
+                    "Audio file too long ({:.0}s). Maximum supported: {MAX_DURATION_S:.0}s.",
+                    observed_s
+                );
+            }
+
+            resampler.flush_full()?;
+            let before = self.buf.len();
+            resampler.drain_ready_into(&mut self.buf);
+            self.decoded_16k_total += self.buf.len() - before;
+        }
+
+        if self.eof && !self.finished {
+            let before = self.buf.len();
+            resampler.finish_into(&mut self.buf)?;
+            self.decoded_16k_total += self.buf.len() - before;
+            self.finished = true;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "file-decode")]
+impl PcmWindows for FileWindows {
+    fn spec(&self) -> WindowSpec {
+        self.spec
+    }
+
+    fn next_window(&mut self) -> Result<Option<PcmWindow<'_>>, GigasttError> {
+        if self.done {
+            return Ok(None);
+        }
+
+        // Reclaim the previous window's consumed prefix: windows only move
+        // forward, so everything before `next_start` is dead. This is what keeps
+        // the resident buffer at one window plus look-ahead.
+        let drop = self
+            .next_start
+            .saturating_sub(self.buf_start_abs)
+            .min(self.buf.len());
+        if drop > 0 {
+            self.buf.drain(0..drop);
+            self.buf_start_abs += drop;
+        }
+
+        // Decode one sample past the window end so `end == total` is
+        // distinguishable from a mid-stream boundary; the first window also needs
+        // enough to decide single-pass vs windowed.
+        let target = if self.first {
+            (self.spec.single_pass_max() + 1).max(self.spec.window() + 1)
+        } else {
+            self.next_start + self.spec.window() + 1
+        };
+        self.fill_to(target)
+            .map_err(|e| GigasttError::InvalidAudio {
+                reason: format!("{e:#}"),
+            })?;
+
+        let avail_end = self.decoded_16k_total;
+        let start = self.next_start;
+
+        if self.first {
+            self.first = false;
+            if self.eof && avail_end <= self.spec.single_pass_max() {
+                // The whole stream fits the single-pass ceiling: yield exactly one
+                // window over all of it. `decode_words_streaming` then runs one
+                // encoder pass with frame offset 0 and stitches onto an empty list
+                // — byte-identical to `decode_words`' non-windowed branch.
+                self.done = true;
+                let e = avail_end - self.buf_start_abs;
+                return Ok(Some(PcmWindow {
+                    start_sample: start,
+                    samples: &self.buf[..e],
+                }));
+            }
+        }
+
+        if start >= avail_end {
+            // Reachable only at EOF, once the last window has been yielded.
+            self.done = true;
+            return Ok(None);
+        }
+
+        // Standard overlapping geometry, matching `SliceWindows` exactly. Because
+        // `fill_to` decoded one sample past `start + window` (or hit EOF),
+        // `end == avail_end` holds only when this window reaches the true end.
+        let end = (start + self.spec.window()).min(avail_end);
+        if self.eof && end == avail_end {
+            self.done = true;
+        } else {
+            self.next_start = start + self.spec.stride();
+        }
+        let s = start - self.buf_start_abs;
+        let e = end - self.buf_start_abs;
+        Ok(Some(PcmWindow {
+            start_sample: start,
+            samples: &self.buf[s..e],
         }))
     }
 }
@@ -272,5 +713,248 @@ mod tests {
         for (start, _) in &seq {
             assert_eq!(start % FRAME_SAMPLES, 0);
         }
+    }
+}
+
+/// [`FileWindows`] streaming-decode tests: prove that pulling windows from the
+/// container yields byte-identical geometry to [`SliceWindows`] over the same
+/// fully-decoded buffer — and, below the single-pass ceiling, exactly one window
+/// over the whole buffer (matching `Engine::decode_words`' non-windowed branch).
+/// No model is required.
+#[cfg(all(test, feature = "file-decode"))]
+mod file_windows_tests {
+    use super::*;
+    use crate::inference::audio::encode_wav_pcm16;
+    use bytes::Bytes;
+
+    /// The ort long-form geometry, matching `Engine::window_spec` (CPU backend).
+    fn ort_spec() -> WindowSpec {
+        WindowSpec::new(16000 * 30, 16000 * 24, 16000 * 2)
+    }
+
+    /// Deterministic, PCM16-quantization-exercising signal in [-1, 1).
+    fn signal(n: usize, seed: f32) -> Vec<f32> {
+        (0..n)
+            .map(|i| {
+                let t = i as f32;
+                0.4 * ((t * 0.017 + seed).sin() + 0.5 * (t * 0.0031 + seed).sin())
+            })
+            .collect()
+    }
+
+    /// Minimal interleaved-stereo PCM16 WAV (symphonia decodes this to two
+    /// channels, exercising the mono-mix branch of the streaming decode).
+    fn stereo_wav_pcm16(left: &[f32], right: &[f32], rate: u32) -> Vec<u8> {
+        let frames = left.len().min(right.len());
+        let data_bytes = (frames * 2 * 2) as u32;
+        let byte_rate = rate * 2 * 2;
+        let mut w = Vec::with_capacity(44 + data_bytes as usize);
+        w.extend_from_slice(b"RIFF");
+        w.extend_from_slice(&(36 + data_bytes).to_le_bytes());
+        w.extend_from_slice(b"WAVE");
+        w.extend_from_slice(b"fmt ");
+        w.extend_from_slice(&16u32.to_le_bytes());
+        w.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        w.extend_from_slice(&2u16.to_le_bytes()); // channels
+        w.extend_from_slice(&rate.to_le_bytes());
+        w.extend_from_slice(&byte_rate.to_le_bytes());
+        w.extend_from_slice(&4u16.to_le_bytes()); // block align
+        w.extend_from_slice(&16u16.to_le_bytes()); // bits
+        w.extend_from_slice(b"data");
+        w.extend_from_slice(&data_bytes.to_le_bytes());
+        let q = |s: f32| (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+        for i in 0..frames {
+            w.extend_from_slice(&q(left[i]).to_le_bytes());
+            w.extend_from_slice(&q(right[i]).to_le_bytes());
+        }
+        w
+    }
+
+    /// Drain the whole windowed source into owned `(start, samples)` pairs.
+    fn window_seq(mut fw: FileWindows) -> Vec<(usize, Vec<f32>)> {
+        let mut out = Vec::new();
+        while let Some(w) = fw.next_window().expect("window") {
+            out.push((w.start_sample, w.samples.to_vec()));
+        }
+        out
+    }
+
+    /// The [`SliceWindows`] sequence over a materialized buffer — the oracle for
+    /// the windowed (`> single_pass_max`) regime.
+    fn slice_seq(buf: &[f32], spec: WindowSpec) -> Vec<(usize, Vec<f32>)> {
+        let mut sw = SliceWindows::new(buf, spec);
+        let mut out = Vec::new();
+        while let Some(w) = sw.next_window().expect("slice window") {
+            out.push((w.start_sample, w.samples.to_vec()));
+        }
+        out
+    }
+
+    /// What `Engine::decode_words` would feed for a fully-decoded buffer: one
+    /// whole-buffer window at/under the single-pass ceiling, else the standard
+    /// overlapping geometry.
+    fn expected_seq(flat: &[f32], spec: WindowSpec) -> Vec<(usize, Vec<f32>)> {
+        if flat.len() <= spec.single_pass_max() {
+            vec![(0, flat.to_vec())]
+        } else {
+            slice_seq(flat, spec)
+        }
+    }
+
+    #[test]
+    fn test_file_windows_16k_geometry_matches_decode_words() {
+        let spec = ort_spec();
+        // Lengths straddling the single-pass ceiling (480_000 @16 kHz) and the
+        // window/stride grid.
+        for &n in &[1usize, 8_000, 480_000, 480_001, 560_000, 900_000] {
+            let src = signal(n, 1.0);
+            let wav = encode_wav_pcm16(&src, 16000);
+            let flat = FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec)
+                .expect("open flat")
+                .drain_to_vec()
+                .expect("drain");
+            // 16 kHz is the passthrough path: no resampler, so the decoded length
+            // is exact.
+            assert_eq!(flat.len(), n, "passthrough length changed at n={n}");
+            let got = window_seq(
+                FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec).expect("open windows"),
+            );
+            assert_eq!(got, expected_seq(&flat, spec), "geometry mismatch at n={n}");
+        }
+    }
+
+    #[test]
+    fn test_file_windows_48k_stereo_matches_slice_over_drain() {
+        let spec = ort_spec();
+        // 40 s @48 kHz stereo → ~40 s @16 kHz mono, above the single-pass ceiling,
+        // so the windowed geometry (not a single window) is exercised, through the
+        // resampler and the mono-mix branch.
+        let n = 48_000 * 40;
+        let left = signal(n, 0.3);
+        let right = signal(n, 2.1);
+        let wav = stereo_wav_pcm16(&left, &right, 48_000);
+        let flat = FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec)
+            .expect("open flat")
+            .drain_to_vec()
+            .expect("drain");
+        assert!(
+            flat.len() > spec.single_pass_max(),
+            "expected the chunked regime, got {} samples",
+            flat.len()
+        );
+        let got = window_seq(
+            FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec).expect("open windows"),
+        );
+        // Incremental resample + windowing is byte-identical to whole-buffer
+        // resample + SliceWindows: the staged chunk sequence is the same either
+        // way, so every resampled sample matches.
+        assert_eq!(got, slice_seq(&flat, spec));
+    }
+
+    #[test]
+    fn test_file_windows_single_pass_yields_one_window() {
+        let spec = ort_spec();
+        let src = signal(10_000, 0.7);
+        let wav = encode_wav_pcm16(&src, 16000);
+        let got = window_seq(
+            FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec).expect("open"),
+        );
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].0, 0);
+        assert_eq!(got[0].1.len(), 10_000);
+    }
+
+    #[test]
+    fn test_file_windows_total_16k_samples_is_exact_at_16k() {
+        let spec = ort_spec();
+        let n = 700_000; // chunked
+        let src = signal(n, 1.3);
+        let wav = encode_wav_pcm16(&src, 16000);
+        let mut fw =
+            FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec).expect("open");
+        while fw.next_window().expect("window").is_some() {}
+        assert_eq!(fw.total_16k_samples(), n);
+    }
+
+    /// Peak-RSS instrument (decode-only, no model). Writes an `N`-second 48 kHz
+    /// stereo WAV to a temp file, streams every window discarding the samples,
+    /// and asserts the total is right. Run it under a peak-RSS meter at several
+    /// `GIGASTT_PEAK_SECONDS` values — the slope of peak RSS per audio-second is
+    /// the memory claim:
+    ///
+    /// ```sh
+    /// for s in 60 300 1200; do GIGASTT_PEAK_SECONDS=$s /usr/bin/time -l \
+    ///   cargo test -p gigastt-core --lib \
+    ///   file_windows_tests::zzz_streaming_decode_peak_instrument \
+    ///   -- --ignored --exact --nocapture 2>&1 | grep -E 'maximum resident'; done
+    /// ```
+    #[test]
+    #[ignore = "decode-only peak-RSS instrument; drive with GIGASTT_PEAK_SECONDS under /usr/bin/time"]
+    fn zzz_streaming_decode_peak_instrument() {
+        let secs: usize = std::env::var("GIGASTT_PEAK_SECONDS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(5);
+        let path = std::env::temp_dir().join(format!("gigastt_peak_{secs}s.wav"));
+
+        // Stream the synthetic WAV to disk one second at a time so generating it
+        // never holds more than a second of audio in RAM — the decode is what we
+        // are measuring, not the fixture.
+        {
+            use std::io::Write;
+            let rate = 48_000u32;
+            let frames = secs * rate as usize;
+            let data_bytes = (frames * 2 * 2) as u32;
+            let f = std::fs::File::create(&path).expect("create temp wav");
+            let mut w = std::io::BufWriter::new(f);
+            w.write_all(b"RIFF").unwrap();
+            w.write_all(&(36 + data_bytes).to_le_bytes()).unwrap();
+            w.write_all(b"WAVE").unwrap();
+            w.write_all(b"fmt ").unwrap();
+            w.write_all(&16u32.to_le_bytes()).unwrap();
+            w.write_all(&1u16.to_le_bytes()).unwrap();
+            w.write_all(&2u16.to_le_bytes()).unwrap();
+            w.write_all(&rate.to_le_bytes()).unwrap();
+            w.write_all(&(rate * 4).to_le_bytes()).unwrap();
+            w.write_all(&4u16.to_le_bytes()).unwrap();
+            w.write_all(&16u16.to_le_bytes()).unwrap();
+            w.write_all(b"data").unwrap();
+            w.write_all(&data_bytes.to_le_bytes()).unwrap();
+            for sec in 0..secs {
+                let base = (sec * rate as usize) as f32;
+                for i in 0..rate as usize {
+                    let t = base + i as f32;
+                    let s = (0.4 * (t * 0.02).sin() * i16::MAX as f32) as i16;
+                    w.write_all(&s.to_le_bytes()).unwrap();
+                    w.write_all(&s.to_le_bytes()).unwrap();
+                }
+            }
+            w.flush().unwrap();
+        }
+
+        let p = path.to_str().unwrap();
+        // `GIGASTT_PEAK_MODE=drain` measures the old whole-buffer decode (peak
+        // grows with duration) for a same-build A/B against the default windowed
+        // path (peak bounded by one window).
+        let total = if std::env::var("GIGASTT_PEAK_MODE").as_deref() == Ok("drain") {
+            FileWindows::decode_file(p).expect("drain").len()
+        } else {
+            let mut fw = FileWindows::open(p, ort_spec()).expect("open temp wav");
+            let mut counted = 0usize;
+            while let Some(win) = fw.next_window().expect("window") {
+                counted += win.samples.len();
+            }
+            // Overlapping windows re-count their overlap, so the summed window
+            // length exceeds the (bounded) true total.
+            assert!(counted >= fw.total_16k_samples());
+            fw.total_16k_samples()
+        };
+        let _ = std::fs::remove_file(&path);
+
+        let expected = secs * 16_000;
+        assert!(
+            (total as i64 - expected as i64).unsigned_abs() < 16_000,
+            "total {total} not within 1 s of {expected}"
+        );
     }
 }

--- a/crates/gigastt-core/src/inference/audio/stream.rs
+++ b/crates/gigastt-core/src/inference/audio/stream.rs
@@ -856,9 +856,8 @@ mod file_windows_tests {
         let spec = ort_spec();
         let src = signal(10_000, 0.7);
         let wav = encode_wav_pcm16(&src, 16000);
-        let got = window_seq(
-            FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec).expect("open"),
-        );
+        let got =
+            window_seq(FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec).expect("open"));
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].0, 0);
         assert_eq!(got[0].1.len(), 10_000);
@@ -870,8 +869,7 @@ mod file_windows_tests {
         let n = 700_000; // chunked
         let src = signal(n, 1.3);
         let wav = encode_wav_pcm16(&src, 16000);
-        let mut fw =
-            FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec).expect("open");
+        let mut fw = FileWindows::from_bytes(Bytes::copy_from_slice(&wav), spec).expect("open");
         while fw.next_window().expect("window").is_some() {}
         assert_eq!(fw.total_16k_samples(), n);
     }

--- a/crates/gigastt-core/src/inference/engine.rs
+++ b/crates/gigastt-core/src/inference/engine.rs
@@ -1565,32 +1565,48 @@ impl Engine {
         match req.source {
             #[cfg(feature = "file-decode")]
             TranscribeSource::Path(path) => {
-                let float_samples =
-                    audio::decode_audio_file(path).map_err(|e| GigasttError::InvalidAudio {
-                        reason: format!("{e:#}"),
-                    })?;
-                self.transcribe_samples_with_overrides(
-                    &float_samples,
-                    triplet,
-                    &req.overrides,
-                    req.hotwords,
-                    req.diarization,
-                )
+                if self.stream_eligible(&req.overrides, req.diarization) {
+                    let windows = audio::FileWindows::open(path, window_spec(self.ane_encoder))
+                        .map_err(|e| GigasttError::InvalidAudio {
+                            reason: format!("{e:#}"),
+                        })?;
+                    self.transcribe_stream_mono(windows, triplet, &req.overrides, req.hotwords)
+                } else {
+                    let float_samples =
+                        audio::decode_audio_file(path).map_err(|e| GigasttError::InvalidAudio {
+                            reason: format!("{e:#}"),
+                        })?;
+                    self.transcribe_samples_with_overrides(
+                        &float_samples,
+                        triplet,
+                        &req.overrides,
+                        req.hotwords,
+                        req.diarization,
+                    )
+                }
             }
             #[cfg(feature = "file-decode")]
             TranscribeSource::Bytes(data) => {
-                let float_samples = audio::decode_audio_bytes_shared(data).map_err(|e| {
-                    GigasttError::InvalidAudio {
-                        reason: format!("{e:#}"),
-                    }
-                })?;
-                self.transcribe_samples_with_overrides(
-                    &float_samples,
-                    triplet,
-                    &req.overrides,
-                    req.hotwords,
-                    req.diarization,
-                )
+                if self.stream_eligible(&req.overrides, req.diarization) {
+                    let windows = audio::FileWindows::from_bytes(data, window_spec(self.ane_encoder))
+                        .map_err(|e| GigasttError::InvalidAudio {
+                            reason: format!("{e:#}"),
+                        })?;
+                    self.transcribe_stream_mono(windows, triplet, &req.overrides, req.hotwords)
+                } else {
+                    let float_samples = audio::decode_audio_bytes_shared(data).map_err(|e| {
+                        GigasttError::InvalidAudio {
+                            reason: format!("{e:#}"),
+                        }
+                    })?;
+                    self.transcribe_samples_with_overrides(
+                        &float_samples,
+                        triplet,
+                        &req.overrides,
+                        req.hotwords,
+                        req.diarization,
+                    )
+                }
             }
             TranscribeSource::Samples(samples) => self.transcribe_samples_with_overrides(
                 samples,
@@ -1603,6 +1619,73 @@ impl Engine {
                 self.transcribe_channels_inner(channels, triplet, &req.overrides, req.hotwords)
             }
         }
+    }
+
+    /// True when a `Path` / `Bytes` request can be served by the windowed
+    /// streaming decode, whose peak audio memory is O(one window) rather than
+    /// O(file).
+    ///
+    /// VAD scans the whole 16 kHz buffer for speech regions and diarization
+    /// embeds the whole buffer; neither can run against a stream that is never
+    /// fully resident, so both fall back to the whole-buffer decode. `diarize`
+    /// only matters with the `diarization` feature compiled in.
+    #[cfg(feature = "file-decode")]
+    fn stream_eligible(&self, overrides: &TranscribeOverrides, diarize: bool) -> bool {
+        let use_vad = self.vad.is_some() && overrides.vad.unwrap_or(true);
+        let will_diarize = cfg!(feature = "diarization") && diarize;
+        !use_vad && !will_diarize
+    }
+
+    /// Mono file-transcription tail that pulls windows straight from the
+    /// container instead of decoding the whole file first.
+    ///
+    /// Equivalent to [`Engine::transcribe_samples_with_overrides`] on the
+    /// no-VAD, no-diarization path: [`FileWindows`](audio::FileWindows) yields
+    /// exactly the geometry [`SliceWindows`] would over the fully-decoded buffer
+    /// (one window for a single-pass-length stream, overlapping windows beyond),
+    /// so [`Engine::decode_words_streaming`] produces the same words — but peak
+    /// audio memory no longer scales with duration. The duration cap and its
+    /// exact error string are enforced inside the decode as before.
+    #[cfg(feature = "file-decode")]
+    fn transcribe_stream_mono(
+        &self,
+        mut windows: audio::FileWindows,
+        triplet: &mut SessionTriplet,
+        overrides: &TranscribeOverrides,
+        hotwords: Option<&HotwordOverride>,
+    ) -> Result<TranscribeResult, GigasttError> {
+        let wall_start = std::time::Instant::now();
+
+        // Hotword biaser selection, mirroring `decode_words_for_samples`:
+        // engine boot biaser, a temporary per-request biaser, or off.
+        let request_biaser = match hotwords {
+            Some(hw) => self.build_request_biaser(hw),
+            None => None,
+        };
+        let biaser: Option<&bias::Biaser> = match hotwords {
+            None => self.biaser.as_ref(),
+            Some(_) => request_biaser.as_ref(),
+        };
+
+        let words = self.decode_words_streaming(&mut windows, triplet, biaser)?;
+        // Exact once every window is consumed (the loop above drains to EOF).
+        let duration_s = windows.total_16k_samples() as f64 / 16000.0;
+        let result = self.finish_transcribe_result(words, duration_s, overrides);
+
+        let wall_s = wall_start.elapsed().as_secs_f64();
+        let rtf = if duration_s > 0.0 {
+            wall_s / duration_s
+        } else {
+            0.0
+        };
+        tracing::info!(
+            audio_s = format_args!("{duration_s:.2}"),
+            wall_s = format_args!("{wall_s:.2}"),
+            rtf = format_args!("{rtf:.3}"),
+            "transcribe complete (streaming windows)"
+        );
+
+        Ok(result)
     }
 
     /// Transcribe an audio file to text (supports WAV, MP3, M4A/AAC, OGG, FLAC).

--- a/crates/gigastt-core/src/inference/engine.rs
+++ b/crates/gigastt-core/src/inference/engine.rs
@@ -1588,10 +1588,11 @@ impl Engine {
             #[cfg(feature = "file-decode")]
             TranscribeSource::Bytes(data) => {
                 if self.stream_eligible(&req.overrides, req.diarization) {
-                    let windows = audio::FileWindows::from_bytes(data, window_spec(self.ane_encoder))
-                        .map_err(|e| GigasttError::InvalidAudio {
-                            reason: format!("{e:#}"),
-                        })?;
+                    let windows =
+                        audio::FileWindows::from_bytes(data, window_spec(self.ane_encoder))
+                            .map_err(|e| GigasttError::InvalidAudio {
+                                reason: format!("{e:#}"),
+                            })?;
                     self.transcribe_stream_mono(windows, triplet, &req.overrides, req.hotwords)
                 } else {
                     let float_samples = audio::decode_audio_bytes_shared(data).map_err(|e| {


### PR DESCRIPTION
## The number

Decode-only peak RSS on a 20-minute 48 kHz stereo WAV, same binary, same file, both paths measured
against each other:

| path | 60 s | 1200 s | slope |
|---|---|---|---|
| windowed (this PR) | 19.8 MB | 18.4 MB | **≈ 0** (measured −1.2 KB/s, i.e. noise) |
| whole-buffer (today) | — | 95.6 MB | ~64 KB/s — the 16 kHz output itself |

Peak audio memory no longer scales with duration at all. For reference, before this wave started the
same measurement was 706 MiB and 564 KB per second of audio; the staged resampler took it to ~82 MB
with a 64 KB/s slope, and this removes the slope.

## What changed

`FileWindows` in `audio/stream.rs` — a symphonia packet loop feeding the stateful `ResampleTo16k`,
keeping one rolling window and dropping the consumed prefix. `Engine::transcribe_request` routes
`TranscribeSource::Path` and `::Bytes` through it. The three mono decode functions drain it flat and
keep byte-stable signatures; `decode_audio_inner` is gone.

VAD and diarization still take the whole-buffer decode, because both are non-causal and genuinely need
the entire buffer — that is tracked separately, not papered over here.

## Equivalence

- The committed digest probe — transcripts plus the **bit patterns** of every word timestamp, 13 inputs
  spanning both the single-pass and chunked branches — is **bit-identical** against `main`, combined
  hash `e01e4f439d5b7e2f` on both sides, each run with its own `CARGO_TARGET_DIR`.
- 48 kHz and 44.1 kHz come out **bit-identical**, not merely within the one-encoder-frame tolerance the
  spec allowed. A model-free decode A/B matches to the bit at both rates, mono and stereo.
- A new unit test proves the windowed geometry equals `SliceWindows` over the flat drain at 48 kHz
  stereo, with no model involved.

## Traps handled

Constant staging chunk so the rubato cache never splits; 16 kHz sources build no resampler at all and
stay zero-copy; the duration cap still counts source-rate frames and emits the exact same error string;
`Bytes` is seekable so no temp-file spool is introduced and no network-socket streaming is attempted
(symphonia's isomp4 needs the moov atom, which ffmpeg puts at EOF).

## Not in scope

The Opus fallback still materializes per channel before windowing; `channels=split`, VAD, diarization
and the duration cap itself are untouched. Two channel-decode functions stay on the old inner path
since split-channel is out of scope.

`gigastt-core --lib` 546 pass, `gigastt --lib` 204 pass, clippy clean, `cargo semver-checks` 219 pass —
no version bump required, no public signature changed.