### PR TITLE
chore(deps): migrate to ort 2.0.0-rc.13 and version-scope the CoreML cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a wall-clock extrapolation that assumed a fixed RTF of 0.1; it now advances
   from the engine's real per-window processed-sample count. The SSE `progress`
   event shape is unchanged (additive-only).
+- **`ort` moved to exactly `2.0.0-rc.13`.** rc.13 relocated the `CoreML` / `CUDA` /
+  `NNAPI` execution providers behind `ort`'s own Cargo features, so the provider
+  match arms are now gated per feature — a default (CPU) build never names a
+  feature-gated type. The pin stays exact (`=`) so a future rc cannot arrive
+  unannounced. On macOS the CoreML EP behaviour is unchanged (MLProgram format,
+  static input shapes).
+  - **The CoreML compiled-model cache is recompiled once after this upgrade.**
+    The cache (`~/.gigastt/models/coreml_cache/`) is now scoped by ONNX Runtime
+    version (`coreml_cache/ort-<minor>/`), because a bundle compiled by one ONNX
+    Runtime is not loadable by another — loading a stale one made the CoreML EP
+    fail at prediction time and fall back to CPU silently on every run. After the
+    upgrade the first transcription recompiles the graph (a few seconds, a
+    one-time cost); subsequent runs are fast again. The pre-upgrade cache is left
+    on disk; `gigastt cache-gc` now reclaims stale CoreML caches (it previously
+    pruned only `optimized_cache/`).
 
 - **File decode resamples incrementally instead of in one whole-buffer pass.**
   Decoded packets now drain through a stateful resampler in ~1 s staged chunks, so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,9 +2834,9 @@ checksum = "1cc978697f3ada0ad98b323b9d85e85c6b08d478830148636c19b6d5f2ac9b85"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
 dependencies = [
  "libloading 0.9.0",
  "ndarray",
@@ -2848,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -66,7 +66,7 @@ ane = ["dep:tar", "dep:objc2", "dep:objc2-core-ml", "dep:objc2-foundation", "dep
 __internals = []
 
 [dependencies]
-ort = "=2.0.0-rc.12"
+ort = "=2.0.0-rc.13"
 candle-core = { version = "0.11", optional = true }
 candle-nn = { version = "0.11", optional = true }
 safetensors = { version = "0.8", optional = true }

--- a/crates/gigastt-core/src/model/cache.rs
+++ b/crates/gigastt-core/src/model/cache.rs
@@ -13,6 +13,33 @@ use std::path::{Path, PathBuf};
 
 use super::ModelVariant;
 
+/// Version-scoped subdirectory name for the CoreML compiled-model cache:
+/// `ort-<onnxruntime-minor>` (e.g. `ort-27`).
+///
+/// The CoreML EP compiles each session graph to an `.mlmodelc` bundle under
+/// `coreml_cache/`, keyed only by a graph hash — never by the ONNX Runtime build
+/// that produced it. A bundle compiled by one ONNX Runtime is not guaranteed
+/// loadable by another; loading a stale one makes the CoreML EP fail at
+/// prediction time and silently fall back to CPU on every run. Scoping the cache
+/// under the ORT minor version means an ORT upgrade simply misses the old entries
+/// and recompiles once, which is correct and self-healing.
+pub(crate) fn coreml_cache_version_dir() -> String {
+    format!("ort-{}", ort::MINOR_VERSION)
+}
+
+/// Directory the CoreML EP writes its compiled cache into for a model living in
+/// `model_dir`: `model_dir/coreml_cache/ort-<minor>/`. Single source of truth for
+/// both the write path (the `ort` runtime factory) and the GC keep-name
+/// ([`prune_coreml_cache`]). Only the `coreml` build writes the cache, so the
+/// path builder is compiled there; the GC keep-name uses
+/// [`coreml_cache_version_dir`] directly and stays available on every build.
+#[cfg(feature = "coreml")]
+pub(crate) fn coreml_cache_dir(model_dir: &Path) -> PathBuf {
+    model_dir
+        .join("coreml_cache")
+        .join(coreml_cache_version_dir())
+}
+
 /// Basename of the optimized graph ORT would open for `model_path`'s stem:
 /// `{file_stem}_optimized.onnx`.
 pub fn optimized_cache_basename(encoder_path: &Path) -> Option<String> {
@@ -46,6 +73,20 @@ pub struct OptimizedCachePruneReport {
     /// Paths removed (or that would be removed under `dry_run`).
     pub removed: Vec<PathBuf>,
     /// Sum of sizes of `removed` entries.
+    pub freed_bytes: u64,
+    pub dry_run: bool,
+}
+
+/// Result of pruning stale CoreML compiled-model caches under
+/// `model_dir/coreml_cache/`.
+#[derive(Debug, Default, Clone)]
+pub struct CoremlCachePruneReport {
+    /// Current-ORT-version cache dir retained, if it exists on disk.
+    pub kept: Option<PathBuf>,
+    /// Stale cache dirs removed (or that would be under `dry_run`): sibling
+    /// `ort-*` version dirs and legacy pre-versioning hash dirs.
+    pub removed: Vec<PathBuf>,
+    /// Sum of sizes of all files under `removed`.
     pub freed_bytes: u64,
     pub dry_run: bool,
 }
@@ -129,6 +170,86 @@ pub fn prune_optimized_cache(model_dir: &Path, dry_run: bool) -> Result<Optimize
         );
     }
     Ok(report)
+}
+
+/// Remove CoreML compiled-model caches produced by a different ONNX Runtime
+/// build under `model_dir/coreml_cache/`.
+///
+/// Keeps only the current version dir (`ort-<minor>/`, see
+/// [`coreml_cache_dir`]); removes every other subdirectory — sibling `ort-*`
+/// dirs from other ORT versions and legacy hash dirs written directly under
+/// `coreml_cache/` before the cache was version-scoped. Stray files are left
+/// alone (mirrors [`prune_optimized_cache`]). Not feature-gated: a CPU build may
+/// still need to reclaim a `coreml_cache/` left behind by an earlier CoreML
+/// build.
+///
+/// With `dry_run`, reports what would be deleted without removing anything.
+pub fn prune_coreml_cache(model_dir: &Path, dry_run: bool) -> Result<CoremlCachePruneReport> {
+    let mut report = CoremlCachePruneReport {
+        dry_run,
+        ..Default::default()
+    };
+    let cache_root = model_dir.join("coreml_cache");
+    if !cache_root.is_dir() {
+        return Ok(report);
+    }
+
+    let keep_name = coreml_cache_version_dir();
+    for entry in std::fs::read_dir(&cache_root)
+        .with_context(|| format!("failed to read coreml_cache at {}", cache_root.display()))?
+    {
+        let entry = entry.context("failed to read coreml_cache entry")?;
+        let path = entry.path();
+        // Only compiled-model cache subdirectories are ours to manage.
+        if !path.is_dir() {
+            continue;
+        }
+        if entry.file_name().to_string_lossy() == keep_name {
+            report.kept = Some(path);
+            continue;
+        }
+        let size = dir_size_bytes(&path);
+        if !dry_run {
+            std::fs::remove_dir_all(&path).with_context(|| {
+                format!("failed to remove stale coreml cache {}", path.display())
+            })?;
+        }
+        report.removed.push(path);
+        report.freed_bytes = report.freed_bytes.saturating_add(size);
+    }
+
+    if !report.removed.is_empty() {
+        tracing::info!(
+            dry_run,
+            kept = report.kept.is_some(),
+            removed = report.removed.len(),
+            freed_mib = report.freed_bytes / (1024 * 1024),
+            "coreml_cache prune finished"
+        );
+    }
+    Ok(report)
+}
+
+/// Recursively sum the sizes of regular files under `path`. Best-effort:
+/// unreadable entries contribute zero rather than aborting the walk.
+fn dir_size_bytes(path: &Path) -> u64 {
+    let mut total = 0u64;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            match entry.file_type() {
+                Ok(ft) if ft.is_dir() => stack.push(entry.path()),
+                Ok(ft) if ft.is_file() => {
+                    total = total.saturating_add(entry.metadata().map(|m| m.len()).unwrap_or(0));
+                }
+                _ => {}
+            }
+        }
+    }
+    total
 }
 
 /// Hardlink exact duplicate files under `model_dir` (content SHA-256).
@@ -360,6 +481,63 @@ mod tests {
         assert!(report.kept.is_empty());
         assert!(report.removed.is_empty());
         assert!(zombie.exists());
+    }
+
+    #[test]
+    fn test_prune_coreml_cache_keeps_current_version_drops_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let root = dir.join("coreml_cache");
+        // Current-version dir (must survive) with a compiled bundle inside.
+        let keep = root.join(coreml_cache_version_dir());
+        write_file(
+            &keep.join("0_static_mlprogram").join("model.mil"),
+            &[1u8; 100],
+        );
+        // A sibling from a different ORT version (stale).
+        let stale_ver = root.join("ort-1");
+        write_file(&stale_ver.join("model.txt"), &[2u8; 200]);
+        // Legacy pre-versioning hash dirs written directly under coreml_cache/.
+        let legacy_a = root.join("3716630788028257604");
+        write_file(&legacy_a.join("model.txt"), &[3u8; 300]);
+        let legacy_b = root.join("9059995084551308172");
+        write_file(&legacy_b.join("weights.bin"), &[4u8; 400]);
+        // Stray file must be left alone.
+        write_file(&root.join("README"), b"keep me");
+
+        let report = prune_coreml_cache(dir, false).unwrap();
+        assert_eq!(report.kept, Some(keep.clone()));
+        assert_eq!(report.removed.len(), 3);
+        assert!(keep.exists());
+        assert!(!stale_ver.exists());
+        assert!(!legacy_a.exists());
+        assert!(!legacy_b.exists());
+        assert!(root.join("README").exists());
+        assert_eq!(report.freed_bytes, 200 + 300 + 400);
+    }
+
+    #[test]
+    fn test_prune_coreml_cache_dry_run_does_not_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let legacy = dir.join("coreml_cache").join("17316774604053445175");
+        write_file(&legacy.join("model.txt"), &[7u8; 512]);
+
+        let report = prune_coreml_cache(dir, true).unwrap();
+        assert!(report.dry_run);
+        assert!(report.kept.is_none());
+        assert_eq!(report.removed.len(), 1);
+        assert!(legacy.exists(), "dry_run must not delete");
+        assert_eq!(report.freed_bytes, 512);
+    }
+
+    #[test]
+    fn test_prune_coreml_cache_absent_dir_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let report = prune_coreml_cache(tmp.path(), false).unwrap();
+        assert!(report.kept.is_none());
+        assert!(report.removed.is_empty());
+        assert_eq!(report.freed_bytes, 0);
     }
 
     #[test]

--- a/crates/gigastt-core/src/model/cache.rs
+++ b/crates/gigastt-core/src/model/cache.rs
@@ -176,7 +176,7 @@ pub fn prune_optimized_cache(model_dir: &Path, dry_run: bool) -> Result<Optimize
 /// build under `model_dir/coreml_cache/`.
 ///
 /// Keeps only the current version dir (`ort-<minor>/`, see
-/// [`coreml_cache_dir`]); removes every other subdirectory — sibling `ort-*`
+/// `coreml_cache_dir`); removes every other subdirectory — sibling `ort-*`
 /// dirs from other ORT versions and legacy hash dirs written directly under
 /// `coreml_cache/` before the cache was version-scoped. Stray files are left
 /// alone (mirrors [`prune_optimized_cache`]). Not feature-gated: a CPU build may

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -13,7 +13,12 @@
 mod cache;
 mod manifest;
 
-pub use cache::{DedupeReport, OptimizedCachePruneReport, dedupe_model_dir, prune_optimized_cache};
+#[cfg(feature = "coreml")]
+pub(crate) use cache::coreml_cache_dir;
+pub use cache::{
+    CoremlCachePruneReport, DedupeReport, OptimizedCachePruneReport, dedupe_model_dir,
+    prune_coreml_cache, prune_optimized_cache,
+};
 pub use manifest::{MANIFEST_FILE, ManifestFiles, ModelManifest};
 
 #[cfg(feature = "net")]

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -36,7 +36,7 @@ impl OrtExecutionProvider {
     /// Returns the execution-provider list to register when loading a session.
     ///
     /// `model_path` is used to derive provider-specific cache directories (e.g.
-    /// CoreML's `coreml_cache/` next to the model).
+    /// CoreML's version-scoped `coreml_cache/ort-<minor>/` next to the model).
     pub(crate) fn execution_providers(
         self,
         model_path: &Path,
@@ -52,10 +52,15 @@ impl OrtExecutionProvider {
             Self::Cpu => vec![ort::ep::CPU::default().build()],
             #[cfg(feature = "coreml")]
             Self::CoreML => {
-                let cache_dir = model_path
-                    .parent()
-                    .map(|p| p.join("coreml_cache"))
-                    .unwrap_or_else(|| PathBuf::from("coreml_cache"));
+                // Version-scoped: `coreml_cache/ort-<minor>/`. The CoreML EP keys
+                // its compiled bundles by graph hash only, so an ORT upgrade would
+                // otherwise load a bundle a different ONNX Runtime compiled and
+                // fail into a silent CPU fallback. Scoping by ORT version makes the
+                // upgrade miss the stale entry and recompile once (self-healing).
+                let cache_dir = match model_path.parent() {
+                    Some(p) => crate::model::coreml_cache_dir(p),
+                    None => crate::model::coreml_cache_dir(Path::new(".")),
+                };
                 let coreml_ep = ort::ep::CoreML::default()
                     .with_model_format(ort::ep::coreml::ModelFormat::MLProgram)
                     .with_static_input_shapes(true)

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -14,11 +14,21 @@ use super::session::OrtRuntime;
 compile_error!("features `coreml` and `cuda` are mutually exclusive");
 
 /// `ort` execution provider selector.
+///
+/// As of `ort` 2.0.0-rc.13 the CoreML / CUDA / NNAPI providers live behind
+/// `ort`'s own `coreml` / `cuda` / `nnapi` Cargo features, so the variants that
+/// name them are compiled in only when our matching feature (which enables the
+/// upstream one) is on. A default CPU build carries only `Cpu`. This type is
+/// crate-internal (`pub(crate) mod runtime`), so the feature-conditional variant
+/// set is not part of the public API.
 #[derive(Clone, Copy)]
 pub enum OrtExecutionProvider {
     Cpu,
+    #[cfg(feature = "coreml")]
     CoreML,
+    #[cfg(feature = "cuda")]
     Cuda,
+    #[cfg(feature = "nnapi")]
     Nnapi,
 }
 
@@ -31,8 +41,16 @@ impl OrtExecutionProvider {
         self,
         model_path: &Path,
     ) -> Vec<ort::ep::ExecutionProviderDispatch> {
+        // Each non-CPU arm names a provider type that `ort` 2.0.0-rc.13 gates
+        // behind its own feature, so the arm is gated on the matching feature —
+        // the default build compiles a single `Cpu` arm and never references a
+        // type that is configured out. `model_path` is only read by the CoreML
+        // arm; the `let _` below keeps it accounted for on builds without it.
+        #[cfg(not(feature = "coreml"))]
+        let _ = model_path;
         match self {
             Self::Cpu => vec![ort::ep::CPU::default().build()],
+            #[cfg(feature = "coreml")]
             Self::CoreML => {
                 let cache_dir = model_path
                     .parent()
@@ -49,10 +67,12 @@ impl OrtExecutionProvider {
                     .build();
                 vec![coreml_ep, ort::ep::CPU::default().build()]
             }
+            #[cfg(feature = "cuda")]
             Self::Cuda => vec![
                 ort::ep::CUDA::default().build(),
                 ort::ep::CPU::default().build(),
             ],
+            #[cfg(feature = "nnapi")]
             Self::Nnapi => vec![
                 ort::ep::NNAPI::default().build(),
                 ort::ep::CPU::default().build(),
@@ -86,14 +106,17 @@ impl OrtFactory {
         Self::with_provider(OrtExecutionProvider::Cpu)
     }
 
+    #[cfg(feature = "coreml")]
     pub fn coreml() -> Self {
         Self::with_provider(OrtExecutionProvider::CoreML)
     }
 
+    #[cfg(feature = "cuda")]
     pub fn cuda() -> Self {
         Self::with_provider(OrtExecutionProvider::Cuda)
     }
 
+    #[cfg(feature = "nnapi")]
     pub fn nnapi() -> Self {
         Self::with_provider(OrtExecutionProvider::Nnapi)
     }
@@ -160,15 +183,28 @@ pub fn default_factory() -> Box<dyn RuntimeFactory> {
     {
         Box::new(crate::runtime::coreml::factory::AneFactory::new())
     }
+    // Select the provider with `#[cfg]`, not a runtime `cfg!()`: since rc.13 the
+    // accelerated constructors don't exist unless their feature is on, so a
+    // `cfg!()` branch that merely evaluates false at runtime would still have to
+    // compile a call to a function that isn't there. The `not(...)` guards keep
+    // exactly one block active for any feature combination (coreml precedes cuda
+    // precedes nnapi; coreml+cuda is already a `compile_error!`).
     #[cfg(not(any(feature = "candle", all(feature = "ane", target_os = "macos"))))]
     {
-        if cfg!(feature = "coreml") {
+        #[cfg(feature = "coreml")]
+        {
             Box::new(OrtFactory::coreml())
-        } else if cfg!(feature = "cuda") {
+        }
+        #[cfg(all(feature = "cuda", not(feature = "coreml")))]
+        {
             Box::new(OrtFactory::cuda())
-        } else if cfg!(feature = "nnapi") {
+        }
+        #[cfg(all(feature = "nnapi", not(feature = "coreml"), not(feature = "cuda")))]
+        {
             Box::new(OrtFactory::nnapi())
-        } else {
+        }
+        #[cfg(not(any(feature = "coreml", feature = "cuda", feature = "nnapi")))]
+        {
             Box::new(OrtFactory::cpu())
         }
     }
@@ -248,11 +284,17 @@ pub(crate) fn production_factory_variant(
     }
     let _ = backend;
 
-    let factory = if cfg!(feature = "coreml") {
-        OrtFactory::coreml()
-    } else if cfg!(feature = "cuda") {
-        OrtFactory::cuda()
-    } else {
+    // `#[cfg]` rather than a runtime `cfg!()` for the same reason as
+    // `default_factory`: the accelerated constructors are compiled out without
+    // their feature. Only the CPU branch reads `model_dir`, so it is marked used
+    // on the accelerated builds. This path selects coreml/cuda/cpu only — nnapi
+    // is a mobile target reached through `default_factory`, not the server.
+    #[cfg(feature = "coreml")]
+    let factory = OrtFactory::coreml();
+    #[cfg(all(feature = "cuda", not(feature = "coreml")))]
+    let factory = OrtFactory::cuda();
+    #[cfg(not(any(feature = "coreml", feature = "cuda")))]
+    let factory = {
         // Shared PrepackedWeights across every session this factory creates.
         // ORT still materializes per-session initializers for most graphs; the
         // container shares prepacked kernel buffers when the EP supports it.
@@ -263,6 +305,8 @@ pub(crate) fn production_factory_variant(
             .with_optimized_cache_dir(model_dir.join("optimized_cache"))
             .with_prepacked_weights(prepacked)
     };
+    #[cfg(any(feature = "coreml", feature = "cuda"))]
+    let _ = model_dir;
     Box::new(factory)
 }
 

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -548,9 +548,10 @@ enum Commands {
         force: bool,
     },
 
-    /// Prune stale ONNX Runtime optimized graphs (and optionally hardlink
-    /// exact duplicate files) under the model directory. Reclaims disk on
-    /// multi-head / FP32-polluted installs without changing accuracy.
+    /// Prune stale ONNX Runtime optimized graphs and stale CoreML compiled-model
+    /// caches (and optionally hardlink exact duplicate files) under the model
+    /// directory. Reclaims disk on multi-head / FP32-polluted installs and after
+    /// an ONNX Runtime upgrade, without changing accuracy.
     CacheGc {
         /// Model directory
         #[arg(long, default_value_t = model::default_model_dir())]
@@ -1294,6 +1295,21 @@ async fn main() -> anyhow::Result<()> {
                 prune.freed_bytes as f64 / (1024.0 * 1024.0),
             );
             for p in &prune.removed {
+                println!("  - {}", p.display());
+            }
+            let coreml = model::prune_coreml_cache(dir, dry_run)?;
+            println!(
+                "coreml_cache: kept {}, removed {} stale ({} {:.1} MiB)",
+                if coreml.kept.is_some() {
+                    "current"
+                } else {
+                    "none"
+                },
+                coreml.removed.len(),
+                action,
+                coreml.freed_bytes as f64 / (1024.0 * 1024.0),
+            );
+            for p in &coreml.removed {
                 println!("  - {}", p.display());
             }
             if dedupe {


### PR DESCRIPTION
## Why now

`ort 2.0.0-rc.13` moved the `CoreML` / `CUDA` / `NNAPI` providers behind its own Cargo features. Our
`execution_providers` named them from ungated match arms, so the default build stopped compiling with
six `E0433` errors — which broke the published crate for anyone resolving without our lockfile. main
carries an exact pin to rc.12 as a stopgap; this is the real migration.

## The migration

Mechanical, but the defect was structural: the gating sat on the *variant selection* (`cfg!()` at
runtime) rather than on the provider code itself, so the types were still named in a build that lacks
the features. Now the enum variants, their match arms and the provider constructors are all `#[cfg]`-
gated per feature. The enum is `pub(crate)`, so no public API moves. Pin is exact — a caret is what
caused the incident.

CoreML's configuration surface is unchanged: MLProgram, static input shapes, cache layout.

## The part that is not mechanical

The CoreML compiled-model cache is keyed by model/graph hash only, **not** by ORT version, so it is not
invalidated across this bump. First run on rc.13 against a pre-upgrade cache failed with
`Feature _Gather_1_output_0 is required but not specified` and fell back to CPU — gracefully, with a
WARN, and then on **every subsequent run** too. Shipping the bump alone would have handed every existing
macOS CoreML user a silent 3-5× slowdown until they discovered a directory they have never heard of.

Fixed here, not deferred: the cache is now scoped as `coreml_cache/ort-<minor>/`, derived from
`ort::MINOR_VERSION` (24 → 27 across this bump) with a single source of truth in `model/cache.rs`. An
upgrade simply misses the old entries and recompiles once — self-healing rather than poisoned.

Old directories are left in place at runtime (deleting user data at startup would be surprising, and the
versioned path already prevents poisoning), but they were dead weight the GC never reclaimed —
`cache-gc` only pruned `optimized_cache/`. It now keeps the current `ort-<minor>/` tree and reclaims
stale siblings and legacy directories. Reclamation stays opt-in; dry-run against the real cache on this
machine reported 6 stale directories, 26.4 MiB.

## Verification

- **CoreML executed for real**, not merely compiled: `golos_00.wav` transcribed with
  `encoder=int8/coreml`, the warmup probe (which runs the encoder through CoreML) passed, and there is
  no `falling back to CPU execution provider` line.
- **Proven with the stale cache present**: 6 legacy hash directories on disk, `ort-27/` created fresh,
  correct transcript, no fallback — so the new path demonstrably does not reach the poisoned entry.
- Feature matrix clean: default, coreml, cuda, nnapi, diarization, and the lean
  `--no-default-features --features file-decode` path.
- The out-of-tree fresh-resolve check (added earlier today) resolves rc.13 and compiles all three crates.

CHANGELOG notes the one-time recompile after upgrade, so an operator seeing a slow first run knows it is
expected.