### PR TITLE
feat(server): cooperative cancellation and a no-progress inference watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cooperative cancellation reaches the running transcription.** A client
+  disconnect or shutdown on `POST /v1/transcribe`, and `DELETE /v1/jobs/{id}` on
+  an in-flight job, now flip an abort flag that the engine's per-window decode
+  loop — and the VAD scan — observe at the next window boundary, releasing the
+  pooled session within one window instead of transcribing the rest of the file
+  into a result that is thrown away. Adds a `GigasttError::Cancelled` variant
+  (additive; the enum is `#[non_exhaustive]`).
+
 ### Changed
+
+- **`--inference-timeout-secs` is now a no-progress watchdog, not a total
+  wall-clock cap.** The deadline resets every time a decode window completes, so
+  a long file that keeps making progress no longer trips it — previously the
+  600 s default was a hidden ceiling on audio duration (roughly `timeout ÷ RTF`,
+  about 100 minutes at RTF 0.1). The flag name, the default (600 s), and the
+  `inference_timeout` error code are unchanged, and a short file that genuinely
+  hangs still trips at the same moment; on a trip the run is aborted so its
+  pooled triplet is freed within one window rather than staying wedged for the
+  rest of the file.
+
+- **`/v1/jobs` progress reflects audio actually decoded.** The progress bar was
+  a wall-clock extrapolation that assumed a fixed RTF of 0.1; it now advances
+  from the engine's real per-window processed-sample count. The SSE `progress`
+  event shape is unchanged (additive-only).
 
 - **File decode resamples incrementally instead of in one whole-buffer pass.**
   Decoded packets now drain through a stateful resampler in ~1 s staged chunks, so

--- a/crates/gigastt-core/src/error.rs
+++ b/crates/gigastt-core/src/error.rs
@@ -115,6 +115,14 @@ pub enum GigasttError {
     /// Invalid user-supplied parameter or option (not audio-specific).
     #[error("invalid input: {message}")]
     InvalidInput { message: String },
+    /// The run was cancelled cooperatively before it finished (client
+    /// disconnect, `DELETE /v1/jobs/{id}`, a fired shutdown signal, or the
+    /// no-progress inference watchdog). The decode loop observes the abort
+    /// signal at a window boundary and returns this so the pooled session is
+    /// released promptly instead of running to completion. Additive: the enum
+    /// is `#[non_exhaustive]`.
+    #[error("cancelled")]
+    Cancelled,
 }
 
 impl GigasttError {
@@ -129,6 +137,7 @@ impl GigasttError {
             GigasttError::InvalidAudio { .. } => "invalid_audio",
             GigasttError::Io(_) => "io_error",
             GigasttError::InvalidInput { .. } => "invalid_input",
+            GigasttError::Cancelled => "cancelled",
         }
     }
 }
@@ -186,6 +195,12 @@ mod tests {
             .code(),
             "invalid_input"
         );
+        assert_eq!(GigasttError::Cancelled.code(), "cancelled");
+    }
+
+    #[test]
+    fn test_cancelled_display() {
+        assert_eq!(GigasttError::Cancelled.to_string(), "cancelled");
     }
 
     #[test]

--- a/crates/gigastt-core/src/inference/engine.rs
+++ b/crates/gigastt-core/src/inference/engine.rs
@@ -32,6 +32,48 @@ use super::{ENCODER_SUBSAMPLING, HOP_LENGTH, N_FFT, N_MELS, SECONDS_PER_FRAME, n
 #[cfg(feature = "diarization")]
 use super::diarization::{self, LazySpeakerEncoder};
 
+/// Cooperative-run hooks threaded through the decode call chain.
+///
+/// Both fields are `None` on the historical path, in which case every decode
+/// function behaves byte-for-byte as before — the hooks are only ever consulted
+/// through `if let Some(_)` guards, adding no work when absent. `abort` is
+/// polled at window boundaries so a cancelled run releases its pooled session
+/// within one window; `on_progress` receives the cumulative count of processed
+/// 16 kHz samples after each long-form window so a server watchdog can reset its
+/// no-progress deadline and drive a real progress bar.
+#[derive(Clone, Copy, Default)]
+struct DecodeControls<'a> {
+    abort: Option<&'a dyn Fn() -> bool>,
+    on_progress: Option<&'a dyn Fn(u64)>,
+}
+
+impl DecodeControls<'_> {
+    /// True once the caller has requested cancellation.
+    #[inline]
+    fn aborted(&self) -> bool {
+        self.abort.is_some_and(|a| a())
+    }
+
+    /// Report cumulative processed 16 kHz samples, if a sink is attached.
+    #[inline]
+    fn report(&self, processed_16k_samples: u64) {
+        if let Some(on_progress) = self.on_progress {
+            on_progress(processed_16k_samples);
+        }
+    }
+
+    /// Drop the progress sink but keep the abort hook. Used for the
+    /// `channels=split` path, where each channel restarts the sample clock and a
+    /// shared monotonic progress counter would go backwards.
+    #[inline]
+    fn abort_only(&self) -> Self {
+        Self {
+            abort: self.abort,
+            on_progress: None,
+        }
+    }
+}
+
 /// Parse a cgroup memory limit file body (`memory.max` v2 or
 /// `memory.limit_in_bytes` v1). Returns `None` for missing/unbounded/`max`.
 /// Pure so unit tests can feed strings without a real cgroup mount.
@@ -1562,6 +1604,25 @@ impl Engine {
         req: TranscribeRequest<'_>,
         triplet: &mut SessionTriplet,
     ) -> Result<TranscribeResult, GigasttError> {
+        use std::sync::atomic::Ordering::Relaxed;
+        // Bridge the request's shared cancellation / progress handles into the
+        // lightweight closures the decode chain consults. Both own a clone of
+        // the `Arc`, so they outlive the borrow of `req` and stay valid for the
+        // whole call. Absent handles leave `ctl` all-`None`, and every decode
+        // function then runs its historical, byte-identical path.
+        let abort_fn: Option<Box<dyn Fn() -> bool>> = req.abort.as_ref().map(|flag| {
+            let flag = flag.clone();
+            Box::new(move || flag.load(Relaxed)) as Box<dyn Fn() -> bool>
+        });
+        let progress_fn: Option<Box<dyn Fn(u64)>> = req.progress.as_ref().map(|counter| {
+            let counter = counter.clone();
+            Box::new(move |n: u64| counter.store(n, Relaxed)) as Box<dyn Fn(u64)>
+        });
+        let ctl = DecodeControls {
+            abort: abort_fn.as_deref(),
+            on_progress: progress_fn.as_deref(),
+        };
+
         match req.source {
             #[cfg(feature = "file-decode")]
             TranscribeSource::Path(path) => {
@@ -1570,7 +1631,7 @@ impl Engine {
                         .map_err(|e| GigasttError::InvalidAudio {
                             reason: format!("{e:#}"),
                         })?;
-                    self.transcribe_stream_mono(windows, triplet, &req.overrides, req.hotwords)
+                    self.transcribe_stream_mono(windows, triplet, &req.overrides, req.hotwords, ctl)
                 } else {
                     let float_samples =
                         audio::decode_audio_file(path).map_err(|e| GigasttError::InvalidAudio {
@@ -1582,6 +1643,7 @@ impl Engine {
                         &req.overrides,
                         req.hotwords,
                         req.diarization,
+                        ctl,
                     )
                 }
             }
@@ -1593,7 +1655,7 @@ impl Engine {
                             .map_err(|e| GigasttError::InvalidAudio {
                                 reason: format!("{e:#}"),
                             })?;
-                    self.transcribe_stream_mono(windows, triplet, &req.overrides, req.hotwords)
+                    self.transcribe_stream_mono(windows, triplet, &req.overrides, req.hotwords, ctl)
                 } else {
                     let float_samples = audio::decode_audio_bytes_shared(data).map_err(|e| {
                         GigasttError::InvalidAudio {
@@ -1606,6 +1668,7 @@ impl Engine {
                         &req.overrides,
                         req.hotwords,
                         req.diarization,
+                        ctl,
                     )
                 }
             }
@@ -1615,10 +1678,15 @@ impl Engine {
                 &req.overrides,
                 req.hotwords,
                 req.diarization,
+                ctl,
             ),
-            TranscribeSource::Channels(channels) => {
-                self.transcribe_channels_inner(channels, triplet, &req.overrides, req.hotwords)
-            }
+            TranscribeSource::Channels(channels) => self.transcribe_channels_inner(
+                channels,
+                triplet,
+                &req.overrides,
+                req.hotwords,
+                ctl.abort_only(),
+            ),
         }
     }
 
@@ -1654,6 +1722,7 @@ impl Engine {
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
         hotwords: Option<&HotwordOverride>,
+        ctl: DecodeControls,
     ) -> Result<TranscribeResult, GigasttError> {
         let wall_start = std::time::Instant::now();
 
@@ -1668,7 +1737,7 @@ impl Engine {
             Some(_) => request_biaser.as_ref(),
         };
 
-        let words = self.decode_words_streaming(&mut windows, triplet, biaser)?;
+        let words = self.decode_words_streaming(&mut windows, triplet, biaser, ctl)?;
         // Exact once every window is consumed (the loop above drains to EOF).
         let duration_s = windows.total_16k_samples() as f64 / 16000.0;
         let result = self.finish_transcribe_result(words, duration_s, overrides);
@@ -1881,6 +1950,7 @@ impl Engine {
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
         hotwords: Option<&HotwordOverride>,
+        ctl: DecodeControls,
     ) -> Result<TranscribeResult, GigasttError> {
         if channels.is_empty() {
             return Ok(TranscribeResult {
@@ -1894,7 +1964,7 @@ impl Engine {
         let mut per_channel = Vec::with_capacity(channels.len());
         for channel_samples in channels {
             let words =
-                self.decode_words_for_samples(channel_samples, triplet, overrides, hotwords)?;
+                self.decode_words_for_samples(channel_samples, triplet, overrides, hotwords, ctl)?;
             let duration_s = channel_samples.len() as f64 / 16000.0;
             per_channel.push(TranscribeResult {
                 confidence: aggregate_confidence(&words),
@@ -1943,6 +2013,7 @@ impl Engine {
         overrides: &TranscribeOverrides,
         hotwords: Option<&HotwordOverride>,
         diarize: bool,
+        ctl: DecodeControls,
     ) -> Result<TranscribeResult, GigasttError> {
         // `diarize` is opt-in per request: offline speaker diarization only runs
         // when the caller asked for it (REST `?diarization=true`). A plain
@@ -1955,7 +2026,7 @@ impl Engine {
 
         #[cfg_attr(not(feature = "diarization"), allow(unused_mut))]
         let mut words =
-            self.decode_words_for_samples(float_samples, triplet, overrides, hotwords)?;
+            self.decode_words_for_samples(float_samples, triplet, overrides, hotwords, ctl)?;
 
         #[cfg(feature = "diarization")]
         if diarize
@@ -2012,13 +2083,20 @@ impl Engine {
         samples: &[f32],
         triplet: &mut SessionTriplet,
         biaser: Option<&bias::Biaser>,
+        ctl: DecodeControls,
     ) -> Result<Vec<WordInfo>, GigasttError> {
         let spec = window_spec(self.ane_encoder);
         if spec.is_single_pass(samples.len()) {
+            // A single-pass decode is one encoder Run with no window loop to
+            // check between, so honour cancellation before starting it. The
+            // caller's watchdog treats this whole clip as one "window".
+            if ctl.aborted() {
+                return Err(GigasttError::Cancelled);
+            }
             let (features, num_frames) = self.features.compute(samples);
             tracing::info!("Extracted {} mel frames", num_frames);
             let mut decoder_state = DecoderState::new(self.tokenizer.blank_id());
-            Ok(self
+            let words = self
                 .run_inference(
                     triplet,
                     &features,
@@ -2029,7 +2107,9 @@ impl Engine {
                     biaser,
                 )
                 .map_err(|e| GigasttError::Inference { source: e.into() })?
-                .0)
+                .0;
+            ctl.report(samples.len() as u64);
+            Ok(words)
         } else {
             tracing::info!(
                 "Long-form chunked decode: {:.1}s in ~{}s windows ({}s overlap, ane={})",
@@ -2038,7 +2118,7 @@ impl Engine {
                 spec.overlap() / 16000,
                 self.ane_encoder,
             );
-            self.decode_words_streaming(&mut SliceWindows::new(samples, spec), triplet, biaser)
+            self.decode_words_streaming(&mut SliceWindows::new(samples, spec), triplet, biaser, ctl)
         }
     }
 
@@ -2053,6 +2133,7 @@ impl Engine {
         regions: &[(usize, usize)],
         triplet: &mut SessionTriplet,
         biaser: Option<&bias::Biaser>,
+        ctl: DecodeControls,
     ) -> Result<Vec<WordInfo>, GigasttError> {
         if regions.is_empty() {
             tracing::info!("VAD found no speech; skipping decode");
@@ -2069,7 +2150,7 @@ impl Engine {
             float_samples.len(),
             regions.len()
         );
-        let mut words = self.decode_words(&speech, triplet, biaser)?;
+        let mut words = self.decode_words(&speech, triplet, biaser, ctl)?;
         for w in &mut words {
             w.start = crate::vad::remap_compressed_seconds(w.start, regions, 16000.0);
             w.end = crate::vad::remap_compressed_seconds(w.end, regions, 16000.0);
@@ -2095,13 +2176,25 @@ impl Engine {
         windows: &mut dyn PcmWindows,
         triplet: &mut SessionTriplet,
         biaser: Option<&bias::Biaser>,
+        ctl: DecodeControls,
     ) -> Result<Vec<WordInfo>, GigasttError> {
         let overlap = windows.spec().overlap();
         let frame_samples = HOP_LENGTH * ENCODER_SUBSAMPLING;
 
         let mut merged: Vec<WordInfo> = Vec::new();
         while let Some(window) = windows.next_window()? {
+            // Cooperative cancellation checkpoint: a flipped abort flag ends the
+            // run at this window boundary, so a cancelled request (client
+            // disconnect, `DELETE /v1/jobs/{id}`, shutdown, or the no-progress
+            // watchdog) frees its pooled session within one window instead of
+            // decoding the rest of the file.
+            if ctl.aborted() {
+                return Err(GigasttError::Cancelled);
+            }
             let start = window.start_sample;
+            // Window ends advance monotonically, so this doubles as the
+            // cumulative processed-sample count reported below.
+            let win_end = start + window.samples.len();
             let (features, num_frames) = self.features.compute(window.samples);
             let frame_offset = start / frame_samples;
             let mut decoder_state = DecoderState::new(self.tokenizer.blank_id());
@@ -2121,6 +2214,11 @@ impl Engine {
             // midpoint of their overlap region, in absolute seconds.
             let overlap_mid_s = (start as f64 + overlap as f64 / 2.0) / 16000.0;
             merged = stitch_chunk_words(merged, chunk_words, overlap_mid_s);
+
+            // A completed window is one unit of real progress: it resets the
+            // server's no-progress deadline and advances a job's bar by the
+            // seconds of audio just decoded (`win_end / 16000`).
+            ctl.report(win_end as u64);
         }
         Ok(merged)
     }
@@ -2144,6 +2242,7 @@ impl Engine {
         triplet: &mut SessionTriplet,
         overrides: &TranscribeOverrides,
         hotwords: Option<&HotwordOverride>,
+        ctl: DecodeControls,
     ) -> Result<Vec<WordInfo>, GigasttError> {
         // Build a temporary biaser only when the request supplies hotwords.
         // Owned here so the `Option<&Biaser>` passed into decode stays valid
@@ -2159,23 +2258,33 @@ impl Engine {
 
         let use_vad = self.vad.is_some() && overrides.vad.unwrap_or(true);
         match (use_vad, &self.vad) {
-            (true, Some(vad)) => match vad.speech_regions(float_samples, &self.vad_config) {
-                Ok(regions) if regions.is_empty() => {
-                    // Tone / continuous speech can yield zero regions on a bad
-                    // threshold; fall back to fixed-window / full decode rather
-                    // than returning an empty transcript (lab T-045).
-                    tracing::warn!(
-                        "VAD found no speech regions; falling back to full/chunked decode"
-                    );
-                    self.decode_words(float_samples, triplet, biaser)
+            (true, Some(vad)) => {
+                match vad.speech_regions_with_abort(float_samples, &self.vad_config, ctl.abort) {
+                    Ok(regions) if regions.is_empty() => {
+                        // Tone / continuous speech can yield zero regions on a bad
+                        // threshold; fall back to fixed-window / full decode rather
+                        // than returning an empty transcript (lab T-045).
+                        tracing::warn!(
+                            "VAD found no speech regions; falling back to full/chunked decode"
+                        );
+                        self.decode_words(float_samples, triplet, biaser, ctl)
+                    }
+                    Ok(regions) => {
+                        self.decode_speech_regions(float_samples, &regions, triplet, biaser, ctl)
+                    }
+                    Err(e) => {
+                        // A flipped abort flag stops the VAD scan too; surface it
+                        // as cancellation instead of silently re-decoding the whole
+                        // file, which would ignore the cancel and keep the triplet.
+                        if ctl.aborted() {
+                            return Err(GigasttError::Cancelled);
+                        }
+                        tracing::warn!("VAD failed, decoding full audio: {e:#}");
+                        self.decode_words(float_samples, triplet, biaser, ctl)
+                    }
                 }
-                Ok(regions) => self.decode_speech_regions(float_samples, &regions, triplet, biaser),
-                Err(e) => {
-                    tracing::warn!("VAD failed, decoding full audio: {e:#}");
-                    self.decode_words(float_samples, triplet, biaser)
-                }
-            },
-            _ => self.decode_words(float_samples, triplet, biaser),
+            }
+            _ => self.decode_words(float_samples, triplet, biaser, ctl),
         }
     }
 
@@ -5342,6 +5451,7 @@ vocab = "pack_vocab.txt"
                     },
                     None,
                     false,
+                    super::super::DecodeControls::default(),
                 )
                 .expect("vad-off decode");
             assert_eq!(baseline.text, with_vad_off.text);

--- a/crates/gigastt-core/src/inference/types.rs
+++ b/crates/gigastt-core/src/inference/types.rs
@@ -1,6 +1,8 @@
 //! File-transcription result types and per-request overrides.
 
 use serde::Serialize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 
 use super::state::{WordInfo, aggregate_confidence};
 
@@ -252,6 +254,21 @@ pub struct TranscribeRequest<'a> {
     /// encoder / `diarization` feature). Ignored for
     /// [`TranscribeSource::Channels`].
     pub diarization: bool,
+    /// Optional cooperative-cancellation flag. When set and flipped to `true`
+    /// by another thread (client disconnect, `DELETE /v1/jobs/{id}`, shutdown,
+    /// or the no-progress inference watchdog), the decode loop observes it at a
+    /// window boundary and returns
+    /// [`GigasttError::Cancelled`](crate::error::GigasttError::Cancelled),
+    /// releasing the pooled session within one window instead of running to
+    /// completion. `None` (the default) is the historical, non-cancellable
+    /// behaviour.
+    pub abort: Option<Arc<AtomicBool>>,
+    /// Optional progress sink. When set, the long-form decode stores the number
+    /// of 16 kHz samples processed so far (monotonically increasing, ending at
+    /// the decoded length) after each window completes. A server watchdog reads
+    /// it both to reset its no-progress deadline and to drive a real per-window
+    /// job progress bar. `None` (the default) reports nothing.
+    pub progress: Option<Arc<AtomicU64>>,
 }
 
 impl<'a> TranscribeRequest<'a> {
@@ -262,6 +279,8 @@ impl<'a> TranscribeRequest<'a> {
             overrides: TranscribeOverrides::default(),
             hotwords: None,
             diarization: false,
+            abort: None,
+            progress: None,
         }
     }
 
@@ -280,6 +299,22 @@ impl<'a> TranscribeRequest<'a> {
     /// Enable or disable offline speaker diarization for mono sources.
     pub fn with_diarization(mut self, diarization: bool) -> Self {
         self.diarization = diarization;
+        self
+    }
+
+    /// Attach a cooperative-cancellation flag. Flipping the shared
+    /// [`AtomicBool`] to `true` from another thread makes the decode return
+    /// [`GigasttError::Cancelled`](crate::error::GigasttError::Cancelled) at the
+    /// next window boundary. `None` restores the non-cancellable default.
+    pub fn with_abort(mut self, abort: Option<Arc<AtomicBool>>) -> Self {
+        self.abort = abort;
+        self
+    }
+
+    /// Attach a progress sink that receives the cumulative count of processed
+    /// 16 kHz samples after each long-form window. `None` reports nothing.
+    pub fn with_progress(mut self, progress: Option<Arc<AtomicU64>>) -> Self {
+        self.progress = progress;
         self
     }
 }

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -185,10 +185,37 @@ impl SileroVad {
     /// Speech probability for every non-overlapping 512-sample window of
     /// `samples` (the trailing partial window, if any, is included zero-padded).
     pub fn frame_probs(&self, samples: &[f32]) -> Result<Vec<f32>> {
+        self.frame_probs_with_abort(samples, None)
+    }
+
+    /// Like [`SileroVad::frame_probs`] but polls `abort` while scanning so a
+    /// VAD pass over a whole long file can bail out cooperatively (a
+    /// no-progress inference watchdog or a client cancellation flips the flag).
+    /// Returns an error — which the caller maps to
+    /// [`GigasttError::Cancelled`](crate::error::GigasttError::Cancelled) — when
+    /// `abort` fires. With `abort = None` it is byte-for-byte `frame_probs`.
+    pub(crate) fn frame_probs_with_abort(
+        &self,
+        samples: &[f32],
+        abort: Option<&dyn Fn() -> bool>,
+    ) -> Result<Vec<f32>> {
         let mut state = [0.0f32; VAD_STATE_LEN];
         let mut probs = Vec::with_capacity(samples.len() / VAD_FRAME_SAMPLES + 1);
         let mut i = 0;
+        let mut since_check = 0usize;
         while i < samples.len() {
+            // Poll the abort flag roughly every ~2 s of audio (64 × 512
+            // samples) rather than once per 32 ms frame: interruptible on a
+            // multi-minute scan without an atomic load in the inner loop.
+            if let Some(abort) = abort {
+                since_check += 1;
+                if since_check >= 64 {
+                    since_check = 0;
+                    if abort() {
+                        anyhow::bail!("cancelled");
+                    }
+                }
+            }
             let end = (i + VAD_FRAME_SAMPLES).min(samples.len());
             probs.push(self.run_frame(&samples[i..end], &mut state)?);
             i = end;
@@ -201,7 +228,19 @@ impl SileroVad {
     ///
     /// Empty when no frame clears `cfg.threshold`.
     pub fn speech_regions(&self, samples: &[f32], cfg: &VadConfig) -> Result<Vec<(usize, usize)>> {
-        let probs = self.frame_probs(samples)?;
+        self.speech_regions_with_abort(samples, cfg, None)
+    }
+
+    /// Like [`SileroVad::speech_regions`] but threads an `abort` poll into the
+    /// underlying frame scan. With `abort = None` it is byte-for-byte
+    /// `speech_regions`.
+    pub(crate) fn speech_regions_with_abort(
+        &self,
+        samples: &[f32],
+        cfg: &VadConfig,
+        abort: Option<&dyn Fn() -> bool>,
+    ) -> Result<Vec<(usize, usize)>> {
+        let probs = self.frame_probs_with_abort(samples, abort)?;
         Ok(regions_from_probs(
             &probs,
             VAD_FRAME_SAMPLES,

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -78,6 +78,9 @@ uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]
 tempfile = "3"
+# `test-util` (paused clock) is test-only; it unifies with the production tokio
+# dependency's features only when building tests, keeping it out of the binary.
+tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread"] }
 tokio-tungstenite = "0.30"
 proptest = "1"
 reqwest = { version = "0.13", features = ["stream"] }

--- a/crates/gigastt/src/server/config.rs
+++ b/crates/gigastt/src/server/config.rs
@@ -130,12 +130,20 @@ pub struct RuntimeLimits {
     /// long for a free session triplet before returning 503 / `timeout`.
     /// The `Retry-After` hint echoes the same value. Default: 30.
     pub pool_checkout_timeout_secs: u64,
-    /// Per-request inference timeout (seconds). A `spawn_blocking` ONNX run
-    /// exceeding this returns a typed `inference_timeout` to the client so a
-    /// hung run can't block it indefinitely. `0` disables the timeout.
-    /// Default: 600 — generous enough to transcribe a worst-case in-spec
-    /// 10-minute (600 s audio) file on the CPU EP without tripping, while
-    /// still bounding a genuinely wedged run.
+    /// Per-request **no-progress** inference watchdog (seconds). The deadline
+    /// resets every time a decode window completes, so a file that keeps making
+    /// progress never trips — only a run that stalls for this many seconds
+    /// without finishing a window returns a typed `inference_timeout` (504 on
+    /// REST, a job failure on `/v1/jobs`). On a trip the run's abort flag is
+    /// flipped, so the pooled triplet is released within one window instead of
+    /// staying wedged for the rest of the file. `0` disables the watchdog.
+    /// Default: 600.
+    ///
+    /// This was a *total* wall-clock cap in earlier releases; the flag name,
+    /// the default, and the `inference_timeout` error code are unchanged, and a
+    /// short file that genuinely hangs still trips at the same moment — but the
+    /// hidden ceiling on audio duration (roughly `timeout ÷ RTF`) is gone, so
+    /// long files are no longer capped by this limit.
     pub inference_timeout_secs: u64,
     /// Whether the asynchronous `/v1/jobs` API is enabled. Off by default so
     /// existing single-user installs see no change.

--- a/crates/gigastt/src/server/file_transcribe.rs
+++ b/crates/gigastt/src/server/file_transcribe.rs
@@ -10,6 +10,8 @@ use gigastt_core::inference::{
     Engine, HotwordOverride, OwnedReservation, SessionTriplet, TranscribeOverrides,
     TranscribeRequest, TranscribeResult, TranscribeSource,
 };
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// Options for a single file-transcription run after request validation.
 #[derive(Clone, Default)]
@@ -21,6 +23,90 @@ pub(crate) struct FileTranscribeOpts {
     /// When set, decode the body as a raw telephony stream and re-wrap as WAV
     /// before the engine path. REST-only today; jobs do not expose `?codec=`.
     pub raw_codec: Option<(gigastt_core::inference::audio::TelephonyCodec, u32)>,
+    /// Cooperative-cancellation flag threaded into the engine's per-window
+    /// decode loop. Flipping it (client disconnect, `DELETE /v1/jobs/{id}`,
+    /// shutdown, or the no-progress watchdog) ends the run at the next window.
+    pub abort: Option<Arc<AtomicBool>>,
+    /// Progress sink the engine advances after each window with the cumulative
+    /// count of processed 16 kHz samples. The server watchdog reads it to reset
+    /// its no-progress deadline and to drive a real job progress bar.
+    pub progress: Option<Arc<AtomicU64>>,
+}
+
+/// Sets a shared abort flag when dropped. Held in the REST handler's async
+/// scope so that a client disconnect — which drops the handler future before it
+/// returns — flips the flag, and the detached blocking decode observes it at the
+/// next window boundary and releases its pooled triplet. On the normal return
+/// path the flag is set after the result is already in hand, so it is a no-op.
+pub(crate) struct AbortOnDrop(pub Arc<AtomicBool>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Outcome of awaiting a blocking transcription under the no-progress watchdog.
+pub(crate) enum WatchdogOutcome<T> {
+    /// The blocking task finished; carries the raw join result.
+    Joined(Result<T, tokio::task::JoinError>),
+    /// No window completed within the inference timeout. `abort` was set so the
+    /// run cancels at its next window boundary and frees the triplet.
+    TimedOut,
+}
+
+/// Await a blocking transcription `handle`, redefining `inference_timeout_secs`
+/// from a total wall-clock cap into a **no-progress watchdog**: the deadline
+/// resets every time `progress` advances (i.e. a window completes), so a long
+/// file that keeps making progress never trips, while a genuinely stalled run
+/// trips at the same moment it always did. `timeout_secs == 0` disables the
+/// watchdog. A fired `shutdown` also flips `abort`, so SIGTERM cancels the run
+/// at its next window instead of blocking the drain for the whole file.
+pub(crate) async fn await_transcription_watchdog<T>(
+    mut handle: tokio::task::JoinHandle<T>,
+    progress: &AtomicU64,
+    abort: &AtomicBool,
+    timeout_secs: u64,
+    shutdown: &tokio_util::sync::CancellationToken,
+) -> WatchdogOutcome<T> {
+    let mut shutdown_fired = false;
+
+    if timeout_secs == 0 {
+        // No watchdog: still link shutdown -> abort so a drain cancels promptly.
+        loop {
+            tokio::select! {
+                joined = &mut handle => return WatchdogOutcome::Joined(joined),
+                _ = shutdown.cancelled(), if !shutdown_fired => {
+                    shutdown_fired = true;
+                    abort.store(true, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    let timeout = std::time::Duration::from_secs(timeout_secs);
+    let mut last_progress = progress.load(Ordering::Relaxed);
+    let mut deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        tokio::select! {
+            joined = &mut handle => return WatchdogOutcome::Joined(joined),
+            _ = shutdown.cancelled(), if !shutdown_fired => {
+                shutdown_fired = true;
+                abort.store(true, Ordering::Relaxed);
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                let cur = progress.load(Ordering::Relaxed);
+                if cur > last_progress {
+                    // A window completed since the last check: reset the deadline.
+                    last_progress = cur;
+                    deadline = tokio::time::Instant::now() + timeout;
+                } else {
+                    abort.store(true, Ordering::Relaxed);
+                    return WatchdogOutcome::TimedOut;
+                }
+            }
+        }
+    }
 }
 
 /// Decode raw telephony bytes to an in-memory PCM16 WAV for engine paths.
@@ -75,12 +161,15 @@ pub(crate) fn run_file_transcribe_blocking(
                 "channels=split requested but {reason} detected; falling back to mono transcription"
             );
             engine.transcribe_request(
-                TranscribeRequest::new(TranscribeSource::Bytes(body)),
+                TranscribeRequest::new(TranscribeSource::Bytes(body))
+                    .with_abort(opts.abort.clone())
+                    .with_progress(opts.progress.clone()),
                 reservation,
             )
         } else {
             engine.transcribe_request(
-                TranscribeRequest::new(TranscribeSource::Channels(&channels)),
+                TranscribeRequest::new(TranscribeSource::Channels(&channels))
+                    .with_abort(opts.abort.clone()),
                 reservation,
             )
         }
@@ -90,7 +179,9 @@ pub(crate) fn run_file_transcribe_blocking(
             TranscribeRequest::new(TranscribeSource::Bytes(body))
                 .with_overrides(opts.overrides)
                 .with_hotwords(opts.hotwords.as_ref())
-                .with_diarization(opts.diarization),
+                .with_diarization(opts.diarization)
+                .with_abort(opts.abort.clone())
+                .with_progress(opts.progress.clone()),
             reservation,
         )
     }
@@ -124,6 +215,113 @@ mod tests {
         match err {
             GigasttError::InvalidAudio { .. } => {}
             other => panic!("expected InvalidAudio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_abort_on_drop_sets_flag() {
+        let flag = Arc::new(AtomicBool::new(false));
+        {
+            let _guard = AbortOnDrop(flag.clone());
+            assert!(!flag.load(Ordering::Relaxed), "flag is clear while held");
+        }
+        assert!(
+            flag.load(Ordering::Relaxed),
+            "drop must flip the abort flag"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_watchdog_times_out_and_aborts_without_progress() {
+        // A run that never advances `progress` past the timeout must trip and
+        // flip `abort` (so the real decode would cancel at its next window).
+        let progress = Arc::new(AtomicU64::new(0));
+        let abort = Arc::new(AtomicBool::new(false));
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = tokio::task::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            0u32
+        });
+        let outcome = await_transcription_watchdog(handle, &progress, &abort, 1, &shutdown).await;
+        assert!(matches!(outcome, WatchdogOutcome::TimedOut));
+        assert!(abort.load(Ordering::Relaxed), "a trip must flip abort");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_watchdog_resets_on_progress_and_joins() {
+        // A run that reports a window every 0.5 s never exhausts the 1 s
+        // no-progress budget, so it joins normally and is not aborted.
+        let progress = Arc::new(AtomicU64::new(0));
+        let abort = Arc::new(AtomicBool::new(false));
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = tokio::task::spawn({
+            let progress = progress.clone();
+            async move {
+                for window in 1..=4u64 {
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    progress.store(window * 16_000, Ordering::Relaxed);
+                }
+                42u32
+            }
+        });
+        let outcome = await_transcription_watchdog(handle, &progress, &abort, 1, &shutdown).await;
+        match outcome {
+            WatchdogOutcome::Joined(Ok(v)) => assert_eq!(v, 42),
+            other => panic!("expected Joined(Ok(42)), got {}", label(&other)),
+        }
+        assert!(
+            !abort.load(Ordering::Relaxed),
+            "a steadily-progressing run must not be aborted"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_watchdog_disabled_never_times_out() {
+        // `timeout_secs == 0` disables the watchdog: even a long, silent run
+        // joins without tripping and without abort.
+        let progress = Arc::new(AtomicU64::new(0));
+        let abort = Arc::new(AtomicBool::new(false));
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = tokio::task::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            5u32
+        });
+        let outcome = await_transcription_watchdog(handle, &progress, &abort, 0, &shutdown).await;
+        assert!(matches!(outcome, WatchdogOutcome::Joined(Ok(5))));
+        assert!(!abort.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_watchdog_shutdown_flips_abort() {
+        // A fired shutdown must flip `abort` so the run cancels at its next
+        // window; the watchdog then joins the (now-cancelled) task.
+        let progress = Arc::new(AtomicU64::new(0));
+        let abort = Arc::new(AtomicBool::new(false));
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let handle = tokio::task::spawn({
+            let abort = abort.clone();
+            async move {
+                loop {
+                    if abort.load(Ordering::Relaxed) {
+                        break 9u32;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            }
+        });
+        shutdown.cancel();
+        // A generous timeout that must not be what ends the run.
+        let outcome = await_transcription_watchdog(handle, &progress, &abort, 600, &shutdown).await;
+        assert!(matches!(outcome, WatchdogOutcome::Joined(Ok(9))));
+        assert!(abort.load(Ordering::Relaxed), "shutdown must flip abort");
+    }
+
+    /// Human-readable tag for a `WatchdogOutcome` in test panics.
+    fn label<T>(outcome: &WatchdogOutcome<T>) -> &'static str {
+        match outcome {
+            WatchdogOutcome::Joined(Ok(_)) => "Joined(Ok)",
+            WatchdogOutcome::Joined(Err(_)) => "Joined(Err)",
+            WatchdogOutcome::TimedOut => "TimedOut",
         }
     }
 }

--- a/crates/gigastt/src/server/http/jobs_api.rs
+++ b/crates/gigastt/src/server/http/jobs_api.rs
@@ -206,6 +206,14 @@ pub async fn cancel_job(
             Box::new(|j| {
                 if matches!(j.status, JobStatus::Queued | JobStatus::Processing) {
                     j.status = JobStatus::Cancelled;
+                    // Flip the in-flight run's abort flag (set by the executor
+                    // while Processing) so the engine stops at its next window
+                    // and releases its pooled triplet in bounded time, rather
+                    // than transcribing the rest of the file into a result the
+                    // worker will discard. `None` for a still-queued job.
+                    if let Some(abort) = &j.abort {
+                        abort.store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
                 }
             }),
         )

--- a/crates/gigastt/src/server/http/transcribe.rs
+++ b/crates/gigastt/src/server/http/transcribe.rs
@@ -7,6 +7,7 @@ use axum::response::{IntoResponse, Json, Response};
 use serde::Serialize;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 
 use super::super::config::RuntimeLimits;
 use super::super::metrics::MetricsRegistry;
@@ -218,13 +219,29 @@ pub(super) async fn run_file_transcription(
     let mut reservation =
         reserve_batch_slot(&engine, &limits, state.metrics_registry.as_ref()).await?;
 
+    // Cooperative cancellation + real-progress plumbing, shared with the jobs
+    // path. `abort` lets a client disconnect, a fired shutdown, or the
+    // no-progress watchdog stop the detached ONNX run at its next window;
+    // `progress` carries per-window processed-sample counts back to the watchdog
+    // so a long file that keeps advancing never trips the timeout.
+    let abort = Arc::new(AtomicBool::new(false));
+    let progress = Arc::new(AtomicU64::new(0));
+
     let file_opts = super::super::file_transcribe::FileTranscribeOpts {
         overrides,
         hotwords,
         split_channels,
         diarization: request_diarization,
         raw_codec,
+        abort: Some(abort.clone()),
+        progress: Some(progress.clone()),
     };
+
+    // A client disconnect drops this handler future before it returns, dropping
+    // the guard and flipping `abort`; the detached blocking run then cancels at
+    // its next window and returns the triplet. On the normal return path the
+    // guard fires after the result is already in hand, so it is a harmless no-op.
+    let _abort_guard = super::super::file_transcribe::AbortOnDrop(abort.clone());
 
     let inference_start = std::time::Instant::now();
     let span = tracing::Span::current();
@@ -255,28 +272,33 @@ pub(super) async fn run_file_transcription(
         // reservation dropped here automatically returns the triplet to the pool
     });
 
-    // Guard the blocking ONNX run with the per-request inference timeout
-    // (`0` disables). `spawn_blocking` can't be cancelled, so the detached task
-    // keeps the triplet and returns the slot to the pool only when the run
-    // finishes; the client gets a typed `inference_timeout` (504) immediately.
+    // The per-request inference timeout is now a no-progress watchdog: the
+    // deadline resets whenever a window completes, so a long file streaming
+    // steady progress never trips it, while a genuinely stalled run still trips
+    // at the same moment and returns a typed `inference_timeout` (504). On a
+    // trip — and on shutdown — the watchdog flips `abort`, so the detached run
+    // releases its triplet within one window instead of staying wedged for the
+    // whole file. `0` disables the watchdog (shutdown still cancels).
     let inference_timeout_secs = limits.inference_timeout_secs;
-    let result = if inference_timeout_secs == 0 {
-        handle.await
-    } else {
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(inference_timeout_secs),
-            handle,
-        )
-        .await
-        {
-            Ok(r) => r,
-            Err(_elapsed) => {
-                if let Some(ref reg) = state.metrics_registry {
-                    reg.counter_inc("gigastt_inference_timeouts_total", &[], 1);
-                }
-                tracing::error!("REST inference exceeded {inference_timeout_secs}s — aborting");
-                return Err(api_inference_timeout_error());
+    let outcome = super::super::file_transcribe::await_transcription_watchdog(
+        handle,
+        &progress,
+        &abort,
+        inference_timeout_secs,
+        &state.shutdown,
+    )
+    .await;
+
+    let result = match outcome {
+        super::super::file_transcribe::WatchdogOutcome::Joined(r) => r,
+        super::super::file_transcribe::WatchdogOutcome::TimedOut => {
+            if let Some(ref reg) = state.metrics_registry {
+                reg.counter_inc("gigastt_inference_timeouts_total", &[], 1);
             }
+            tracing::error!(
+                "REST inference made no progress for {inference_timeout_secs}s — aborting"
+            );
+            return Err(api_inference_timeout_error());
         }
     };
     if let Some(ref reg) = state.metrics_registry {
@@ -289,6 +311,16 @@ pub(super) async fn run_file_transcription(
 
     match result {
         Ok(Ok(result)) => Ok(result),
+        Ok(Err(gigastt_core::error::GigasttError::Cancelled)) => {
+            // Reached only when a shutdown cancelled the run while the client was
+            // still connected (a disconnect drops this future before here). Be
+            // honest that the server is going away rather than faking success.
+            Err(api_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Server is shutting down",
+                "cancelled",
+            ))
+        }
         Ok(Err(e)) => {
             tracing::error!("Transcription error: {e}");
             Err(api_error(

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -12,6 +12,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use parking_lot::Mutex;
 
@@ -128,6 +129,12 @@ pub struct Job {
     pub error: Option<String>,
     /// Active SSE listeners.
     pub event_channels: Vec<tokio::sync::mpsc::UnboundedSender<JobEvent>>,
+    /// Cooperative-cancellation flag for the in-flight run. The executor sets it
+    /// when it begins inference; `DELETE /v1/jobs/{id}` flips it so the engine
+    /// releases its pooled triplet within one window instead of transcribing the
+    /// whole file. `None` while queued and after a terminal state. Purely
+    /// in-memory (never serialized): it is a live handle, not job metadata.
+    pub abort: Option<Arc<AtomicBool>>,
 }
 
 /// Upper bound on simultaneous SSE listeners per job. Dead channels are
@@ -153,6 +160,7 @@ impl Job {
             result: None,
             error: None,
             event_channels: Vec::new(),
+            abort: None,
         }
     }
 
@@ -623,15 +631,24 @@ fn sanitize_job_error(e: &anyhow::Error) -> String {
 pub struct RealJobExecutor {
     engine: Arc<ArcSwap<gigastt_core::inference::Engine>>,
     limits: Arc<ArcSwap<RuntimeLimits>>,
+    /// Server shutdown signal. A fired token flips the per-run abort flag so an
+    /// in-flight job releases its triplet at the next window during a drain.
+    shutdown: tokio_util::sync::CancellationToken,
 }
 
 impl RealJobExecutor {
-    /// Create an executor bound to the live engine and runtime limits.
+    /// Create an executor bound to the live engine, runtime limits, and the
+    /// server shutdown token.
     pub fn new(
         engine: Arc<ArcSwap<gigastt_core::inference::Engine>>,
         limits: Arc<ArcSwap<RuntimeLimits>>,
+        shutdown: tokio_util::sync::CancellationToken,
     ) -> Self {
-        Self { engine, limits }
+        Self {
+            engine,
+            limits,
+            shutdown,
+        }
     }
 }
 
@@ -712,16 +729,41 @@ impl JobExecution for RealJobExecutor {
             return Err(anyhow::anyhow!("Invalid input: {}", e.message()));
         }
 
-        // Timer-based progress updater. Assumes RTF ≈ 0.1 (10 s audio / 1 s wall).
+        // Cooperative cancellation + real progress. `abort` is flipped by
+        // `DELETE /v1/jobs/{id}` or a shutdown drain; `progress` carries the
+        // engine's cumulative processed 16 kHz sample count out of the blocking
+        // decode. Register `abort` on the job so the cancel handler can reach it.
+        let abort = Arc::new(AtomicBool::new(false));
+        let progress = Arc::new(AtomicU64::new(0));
+        let _ = store
+            .update(id, {
+                let abort = abort.clone();
+                Box::new(move |j| {
+                    // Honour a cancel that raced in between the worker marking
+                    // this job Processing and this registration: seed the flag
+                    // from the current status so the run still stops at its first
+                    // window instead of ignoring the already-recorded cancel.
+                    if matches!(j.status, JobStatus::Cancelled) {
+                        abort.store(true, Ordering::Relaxed);
+                    }
+                    j.abort = Some(abort);
+                })
+            })
+            .await;
+        let shutdown = self.shutdown.clone();
+
+        // Real per-window progress updater: mirrors the engine's processed-sample
+        // count into the store and SSE stream every 500 ms. No RTF guess — the
+        // bar tracks audio actually decoded, monotonically. Same interval and
+        // `JobEvent` shape as before, so the SSE wire contract is unchanged.
         let progress_cancel = tokio_util::sync::CancellationToken::new();
         let progress_handle = {
             let store = store.clone();
             let id = id.to_string();
             let cancel = progress_cancel.clone();
             let total = total_seconds;
+            let progress = progress.clone();
             tokio::spawn(async move {
-                let start = std::time::Instant::now();
-                let rtf = 0.1_f64;
                 let mut interval = tokio::time::interval(std::time::Duration::from_millis(500));
                 interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
                 loop {
@@ -729,12 +771,12 @@ impl JobExecution for RealJobExecutor {
                     if cancel.is_cancelled() {
                         break;
                     }
-                    let elapsed = start.elapsed().as_secs_f64();
-                    let processed = (elapsed / rtf).min(total);
+                    let processed =
+                        (progress.load(Ordering::Relaxed) as f64 / TARGET_SAMPLE_RATE).min(total);
                     let percent = if total > 0.0 {
                         ((processed / total) * 100.0) as u32
                     } else {
-                        100
+                        0
                     };
                     let _ = store
                         .update(&id, Box::new(move |j| j.processed_seconds = processed))
@@ -748,9 +790,6 @@ impl JobExecution for RealJobExecutor {
                         },
                     )
                     .await;
-                    if processed >= total {
-                        break;
-                    }
                 }
             })
         };
@@ -779,6 +818,8 @@ impl JobExecution for RealJobExecutor {
                 split_channels: params.channels.as_deref() == Some("split"),
                 diarization: params.diarization == Some(true),
                 raw_codec: None,
+                abort: Some(abort.clone()),
+                progress: Some(progress.clone()),
             };
             let handle = tokio::task::spawn_blocking(move || {
                 let _enter = span.enter();
@@ -798,22 +839,25 @@ impl JobExecution for RealJobExecutor {
                 }
             });
 
-            if inference_timeout_secs == 0 {
-                handle
-                    .await
+            // The inference timeout is a no-progress watchdog (shared with the
+            // REST path): the deadline resets on each completed window, so a long
+            // file making steady progress never trips, while a genuinely stalled
+            // run still fails with the deterministic `inference_timeout` marker.
+            // A fired shutdown also flips `abort`, freeing the triplet mid-drain.
+            match super::file_transcribe::await_transcription_watchdog(
+                handle,
+                &progress,
+                &abort,
+                inference_timeout_secs,
+                &shutdown,
+            )
+            .await
+            {
+                super::file_transcribe::WatchdogOutcome::Joined(r) => r
                     .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
-                    .map_err(anyhow::Error::from)
-            } else {
-                match tokio::time::timeout(
-                    std::time::Duration::from_secs(inference_timeout_secs),
-                    handle,
-                )
-                .await
-                {
-                    Ok(r) => r
-                        .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e}"))?
-                        .map_err(anyhow::Error::from),
-                    Err(_) => Err(anyhow::anyhow!("inference_timeout")),
+                    .map_err(anyhow::Error::from),
+                super::file_transcribe::WatchdogOutcome::TimedOut => {
+                    Err(anyhow::anyhow!("inference_timeout"))
                 }
             }
         }

--- a/crates/gigastt/src/server/mod.rs
+++ b/crates/gigastt/src/server/mod.rs
@@ -403,7 +403,11 @@ pub async fn run_with_config_listener_reloadable(
             max_retries,
             shutdown_root.clone(),
         );
-        let executor = jobs::RealJobExecutor::new(engine_swap.clone(), limits_swap.clone());
+        let executor = jobs::RealJobExecutor::new(
+            engine_swap.clone(),
+            limits_swap.clone(),
+            shutdown_root.clone(),
+        );
         queue.spawn(executor);
         tracing::info!(
             concurrency,

--- a/crates/gigastt/tests/common/mod.rs
+++ b/crates/gigastt/tests/common/mod.rs
@@ -219,6 +219,42 @@ pub async fn start_server_with_limits(
     (port, shutdown_tx)
 }
 
+/// Start the server with both an explicit session-pool size and custom
+/// `RuntimeLimits`. Used by the cancellation / watchdog e2e tests that need a
+/// single deterministic pool slot *and* a short `inference_timeout_secs`.
+pub async fn start_server_with_pool_and_limits(
+    model_dir: &str,
+    pool_size: usize,
+    limits: gigastt::server::RuntimeLimits,
+) -> (u16, oneshot::Sender<()>) {
+    let (port, listener) = free_port().await;
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let engine = gigastt::inference::Engine::load_with_pool_size(model_dir, pool_size).unwrap();
+    let config = gigastt::server::ServerConfig {
+        port,
+        host: "127.0.0.1".into(),
+        origin_policy: gigastt::server::OriginPolicy::loopback_only(),
+        limits,
+        metrics_enabled: false,
+        metrics_listen: gigastt::server::config::default_metrics_listen(),
+        trust_proxy: false,
+        config_path: None,
+        // Batch pool falls back to the interactive pool, so `pool_size` is the
+        // single effective slot the `/v1/transcribe` batch path draws from.
+        batch_pool_size: 0,
+    };
+    tokio::spawn(gigastt::server::run_with_config_listener(
+        engine,
+        config,
+        Some(shutdown_rx),
+        listener,
+    ));
+
+    wait_for_ready(port, Duration::from_secs(30)).await;
+    (port, shutdown_tx)
+}
+
 /// Start the server with the asynchronous `/v1/jobs` API enabled. Uses a
 /// dedicated batch pool of size `batch_pool_size` (minimum 1) so job workers do
 /// not contend with the interactive pool used by WebSocket / synchronous REST.

--- a/crates/gigastt/tests/e2e_errors.rs
+++ b/crates/gigastt/tests/e2e_errors.rs
@@ -390,3 +390,168 @@ async fn test_ws_idle_timeout() {
 
     let _ = shutdown.send(());
 }
+
+// ─── Cooperative cancellation / no-progress watchdog ────────────────────────
+
+/// A run that makes no progress within `inference_timeout_secs` returns 504 AND
+/// releases its pooled triplet within roughly one window — the whole point of
+/// the change. With a single pool slot and a 1 s no-progress budget, a long
+/// file trips the watchdog before its first ~24 s encoder window completes; the
+/// follow-up request must then acquire the slot in far less time than the full
+/// file would take to decode, proving the timed-out run was actually cancelled
+/// rather than left wedged.
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[tokio::test]
+async fn test_inference_watchdog_frees_pool_slot_within_one_window() {
+    let model_dir = common::model_dir();
+    let limits = gigastt::server::RuntimeLimits {
+        inference_timeout_secs: 1,
+        ..Default::default()
+    };
+    let (port, shutdown) = common::start_server_with_pool_and_limits(&model_dir, 1, limits).await;
+
+    // ~5 minutes of audio: a full decode is tens of seconds, so if the slot were
+    // NOT freed on timeout the follow-up would block far past one window. 16 kHz
+    // keeps the body ~9.6 MB, under the 50 MiB limit.
+    let long = common::generate_wav(300, 16000);
+    let short = common::generate_wav(1, 16000);
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/v1/transcribe"))
+        .body(long)
+        .send()
+        .await
+        .expect("long request");
+    assert_eq!(
+        resp.status().as_u16(),
+        504,
+        "a stalled run must trip the no-progress watchdog with 504"
+    );
+
+    // Measure how long the single freed slot takes to serve a fresh request.
+    let reclaim_start = std::time::Instant::now();
+    let resp2 = tokio::time::timeout(
+        Duration::from_secs(20),
+        client
+            .post(format!("http://127.0.0.1:{port}/v1/transcribe"))
+            .body(short)
+            .send(),
+    )
+    .await
+    .expect("follow-up returned before the test timeout")
+    .expect("follow-up request");
+    let reclaimed = reclaim_start.elapsed();
+    assert!(
+        resp2.status().is_success(),
+        "follow-up must get the freed slot, got {}",
+        resp2.status()
+    );
+    assert!(
+        reclaimed < Duration::from_secs(15),
+        "slot should free within ~one window; follow-up took {reclaimed:?}"
+    );
+    eprintln!("pool slot reclaimed + short decode in {reclaimed:?}");
+
+    let _ = shutdown.send(());
+}
+
+/// `DELETE /v1/jobs/{id}` on a processing job frees its triplet in bounded time:
+/// with a single job worker, a queued follow-up job can only run once the
+/// cancelled one releases the slot. If cancellation reached the engine, the
+/// follow-up completes in far less time than the cancelled job's full decode.
+#[ignore = "requires the GigaAM model (~850MB)"]
+#[tokio::test]
+async fn test_delete_job_frees_triplet_in_bounded_time() {
+    let model_dir = common::model_dir();
+    let (port, shutdown) = common::start_server_with_jobs(&model_dir, 1).await;
+    let client = reqwest::Client::new();
+
+    // Submit a long job and wait until it is Processing (holding the only slot).
+    let long = common::generate_wav(300, 16000);
+    let submit_text = client
+        .post(format!("http://127.0.0.1:{port}/v1/jobs"))
+        .body(long)
+        .send()
+        .await
+        .expect("submit long job")
+        .text()
+        .await
+        .expect("submit response body");
+    let submit: serde_json::Value =
+        serde_json::from_str(&submit_text).expect("submit response json");
+    let id = submit["job_id"].as_str().expect("job_id").to_string();
+
+    let mut processing = false;
+    for _ in 0..100 {
+        let status_text = client
+            .get(format!("http://127.0.0.1:{port}/v1/jobs/{id}"))
+            .send()
+            .await
+            .expect("poll job")
+            .text()
+            .await
+            .expect("status body");
+        let status: serde_json::Value = serde_json::from_str(&status_text).expect("status json");
+        if status["status"] == "processing" {
+            processing = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(processing, "long job must reach processing");
+
+    // Cancel it, then time how long a fresh short job takes to finish — it can
+    // only start once the cancelled run releases its triplet.
+    let del = client
+        .delete(format!("http://127.0.0.1:{port}/v1/jobs/{id}"))
+        .send()
+        .await
+        .expect("delete job");
+    assert_eq!(del.status().as_u16(), 204, "cancel returns 204");
+
+    let reclaim_start = std::time::Instant::now();
+    let short = common::generate_wav(2, 16000);
+    let submit2_text = client
+        .post(format!("http://127.0.0.1:{port}/v1/jobs"))
+        .body(short)
+        .send()
+        .await
+        .expect("submit short job")
+        .text()
+        .await
+        .expect("submit2 body");
+    let submit2: serde_json::Value = serde_json::from_str(&submit2_text).expect("submit2 json");
+    let id2 = submit2["job_id"].as_str().expect("job_id2").to_string();
+
+    let mut done = false;
+    for _ in 0..200 {
+        let status_text = client
+            .get(format!("http://127.0.0.1:{port}/v1/jobs/{id2}"))
+            .send()
+            .await
+            .expect("poll job2")
+            .text()
+            .await
+            .expect("status2 body");
+        let status: serde_json::Value = serde_json::from_str(&status_text).expect("status2 json");
+        match status["status"].as_str() {
+            Some("done") => {
+                done = true;
+                break;
+            }
+            Some("failed") => panic!("follow-up job failed: {status:?}"),
+            _ => {}
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let reclaimed = reclaim_start.elapsed();
+    assert!(done, "follow-up job must complete once the slot is freed");
+    assert!(
+        reclaimed < Duration::from_secs(15),
+        "DELETE must free the triplet promptly; follow-up took {reclaimed:?}"
+    );
+    eprintln!("triplet freed + follow-up job done in {reclaimed:?}");
+
+    let _ = shutdown.send(());
+}


### PR DESCRIPTION
## Why this gates removing the duration cap

Nothing could stop a running transcription. `spawn_blocking` is not cancellable, and the code said so
in a comment: client disconnect, `DELETE /v1/jobs/{id}` and SIGTERM all failed to free the pooled
triplet, and process exit waited for the run to finish. With `DEFAULT_POOL_SIZE = 2`, lifting the
duration cap on top of that would have converted a fast, clear rejection into a 504 ten minutes later
with a pool slot wedged for hours.

Measured on a single-slot server against a 300 s job (full decode ~30 s), both cases previously wedged
for the entire run:

| | slot reclaimed |
|---|---|
| `DELETE /v1/jobs/{id}` | **1.05 s** — follow-up job completes |
| watchdog at `--inference-timeout-secs 1` | **2.94 s** — 504 to the client, fresh decode completes (≈ one 24 s window) |

## How

An abort predicate (`Option<&dyn Fn() -> bool>`, not `CancellationToken` — gigastt-core has no
tokio-util and tokio is optional there) is threaded into the per-window loop of
`decode_words_streaming` and into `SileroVad::frame_probs`. On a flipped flag the loop returns the new
`GigasttError::Cancelled` at the next window boundary. REST wires it to client disconnect via a drop
guard plus shutdown; jobs register it on the `Job` and `DELETE` flips it.

## `inference_timeout_secs` stops being a hidden duration cap

It was 600 s of wall clock — roughly `timeout / RTF` seconds of audio, i.e. a hardware-dependent ceiling
of about 100 minutes. Removing `MAX_DURATION_S` while that stood would have traded one cap for a worse
one. It is now a **no-progress watchdog**: the deadline resets on each completed window, so a long file
making steady progress never trips it, while a genuinely stalled run trips at exactly the same moment as
before. Flag name, default and the `inference_timeout` error code are unchanged.

Job progress is now the engine's real per-window processed-sample count instead of the fabricated
`rtf = 0.1` extrapolation. The SSE event shape is unchanged — additive only.

## No behaviour change when nothing is cancelled

The `longform_digest` probe — transcripts plus the bit patterns of every word timestamp — is identical
on both sides, combined hash `e01e4f439d5b7e2f`, each run with its own `CARGO_TARGET_DIR`.
`cargo semver-checks` reports 219 pass, no bump required: `Cancelled` and the two request fields are
additive on `#[non_exhaustive]` types.

Regression suites: `e2e_shutdown` 8/8 including the SIGTERM drain, `e2e_jobs` 5/5, plus two new e2e
cancellation gates. Core lib 547 passed, server lib 209 passed, clippy clean.

One internal signature moves — `RealJobExecutor::new` takes a shutdown token; single caller, not part of
any published API. The SSE `/v1/transcribe/stream` path already self-cancels per 1 s chunk and is
untouched.