### PR TITLE
feat(server): surface diarization limits instead of empty speaker fields

### DIFF
--- a/crates/gigastt-core/src/inference/diarization.rs
+++ b/crates/gigastt-core/src/inference/diarization.rs
@@ -40,8 +40,10 @@ use parking_lot::Mutex;
 use polyvoice::streaming::StreamingPipeline;
 use polyvoice::{
     ClusterConfig, DiarizationConfig as DiaConfig, EmbeddingError, EmbeddingExtractor, EnergyVad,
-    FbankOnnxExtractor, Pipeline, VadConfig,
+    FbankOnnxExtractor, Pipeline, PipelineError, VadConfig,
 };
+
+use super::DiarizationOutcome;
 
 /// WeSpeaker ResNet34 embedding dimension.
 pub(crate) const SPEAKER_EMBEDDING_DIM: usize = 256;
@@ -203,28 +205,52 @@ pub struct LabeledTurn {
 
 /// Run offline diarization over `samples` (16 kHz mono f32).
 ///
-/// Returns `None` on pipeline failure (already logged). Empty input yields
-/// `Some(vec![])`.
-pub fn run_offline(encoder: &SpeakerEncoder, samples: &[f32]) -> Option<Vec<LabeledTurn>> {
+/// `Ok(turns)` on success (empty input yields `Ok(vec![])`). On failure the
+/// error is *classified* so the caller can tell the client why no speakers were
+/// produced instead of degrading silently:
+/// - [`DiarizationOutcome::DurationCeiling`] when the clusterer refuses the
+///   buffer for exceeding its single-pass duration limit — carrying the real
+///   input and ceiling seconds polyvoice reported — and
+/// - [`DiarizationOutcome::Failed`] for any other pipeline error (still logged).
+pub fn run_offline(
+    encoder: &SpeakerEncoder,
+    samples: &[f32],
+) -> Result<Vec<LabeledTurn>, DiarizationOutcome> {
     let config = DiaConfig::default();
     let vad_config = VadConfig::default();
     let pipeline = Pipeline::new(config, vad_config);
     let mut vad = EnergyVad::new(-40.0, 16000, vad_config.frame_size);
     match pipeline.run(samples, encoder.as_ref(), &mut vad) {
-        Ok(dia_result) => Some(
-            dia_result
-                .turns
-                .into_iter()
-                .map(|t| LabeledTurn {
-                    start: t.time.start,
-                    end: t.time.end,
-                    speaker: t.speaker.0,
-                })
-                .collect(),
-        ),
-        Err(e) => {
-            tracing::warn!("Offline diarization failed: {e:#}");
-            None
+        Ok(dia_result) => Ok(dia_result
+            .turns
+            .into_iter()
+            .map(|t| LabeledTurn {
+                start: t.time.start,
+                end: t.time.end,
+                speaker: t.speaker.0,
+            })
+            .collect()),
+        Err(e) => Err(classify_offline_error(e)),
+    }
+}
+
+/// Map a polyvoice [`PipelineError`] to the client-facing [`DiarizationOutcome`].
+///
+/// The duration ceiling is surfaced with the real numbers polyvoice reported;
+/// every other failure is logged and collapsed to
+/// [`DiarizationOutcome::Failed`].
+fn classify_offline_error(e: PipelineError) -> DiarizationOutcome {
+    match e {
+        PipelineError::AudioTooLong {
+            actual_secs,
+            max_secs,
+        } => DiarizationOutcome::DurationCeiling {
+            input_secs: actual_secs as f64,
+            ceiling_secs: max_secs as f64,
+        },
+        other => {
+            tracing::warn!("Offline diarization failed: {other:#}");
+            DiarizationOutcome::Failed
         }
     }
 }
@@ -242,6 +268,33 @@ pub fn assign_speakers_by_midpoint(turns: &[LabeledTurn], words: &mut [super::Wo
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // A duration-ceiling refusal must surface the *real* numbers polyvoice
+    // reported (not a re-derived guess) so the client sees both the input and
+    // the ceiling. This is the sole case that carries numbers.
+    #[test]
+    fn test_classify_offline_error_duration_ceiling_carries_numbers() {
+        let outcome = classify_offline_error(PipelineError::AudioTooLong {
+            actual_secs: 5400.0,
+            max_secs: 3600.0,
+        });
+        assert_eq!(
+            outcome,
+            DiarizationOutcome::DurationCeiling {
+                input_secs: 5400.0,
+                ceiling_secs: 3600.0,
+            }
+        );
+    }
+
+    // Every other pipeline error collapses to `Failed` (logged, no numbers).
+    #[test]
+    fn test_classify_offline_error_other_is_failed() {
+        assert_eq!(
+            classify_offline_error(PipelineError::NoSpeech),
+            DiarizationOutcome::Failed
+        );
+    }
 
     // Model-free guard for the WeSpeaker rank-3 fbank fix: `load_speaker_encoder`
     // must stay wired to polyvoice's `FbankOnnxExtractor` (rank-3 fbank input) via

--- a/crates/gigastt-core/src/inference/engine.rs
+++ b/crates/gigastt-core/src/inference/engine.rs
@@ -23,9 +23,9 @@ use super::state::{
 };
 use super::tokenizer::{self, Tokenizer};
 use super::types::{
-    DEFAULT_HOTWORDS_BOOST, HotwordError, HotwordOverride, MAX_HOTWORD_PHRASE_CHARS,
-    MAX_HOTWORDS_PER_REQUEST, OverrideError, TranscribeOverrides, TranscribeRequest,
-    TranscribeResult, TranscribeSource, merge_channel_results,
+    DEFAULT_HOTWORDS_BOOST, DiarizationOutcome, HotwordError, HotwordOverride,
+    MAX_HOTWORD_PHRASE_CHARS, MAX_HOTWORDS_PER_REQUEST, OverrideError, TranscribeOverrides,
+    TranscribeRequest, TranscribeResult, TranscribeSource, merge_channel_results,
 };
 use super::{ENCODER_SUBSAMPLING, HOP_LENGTH, N_FFT, N_MELS, SECONDS_PER_FRAME, now_timestamp};
 
@@ -1643,6 +1643,7 @@ impl Engine {
                         &req.overrides,
                         req.hotwords,
                         req.diarization,
+                        req.diarization_outcome.as_deref(),
                         ctl,
                     )
                 }
@@ -1668,6 +1669,7 @@ impl Engine {
                         &req.overrides,
                         req.hotwords,
                         req.diarization,
+                        req.diarization_outcome.as_deref(),
                         ctl,
                     )
                 }
@@ -1678,6 +1680,7 @@ impl Engine {
                 &req.overrides,
                 req.hotwords,
                 req.diarization,
+                req.diarization_outcome.as_deref(),
                 ctl,
             ),
             TranscribeSource::Channels(channels) => self.transcribe_channels_inner(
@@ -2006,6 +2009,7 @@ impl Engine {
     /// validated by [`Engine::validate_overrides`] — an on-request with the
     /// resource missing degrades gracefully (VAD absent → whole-buffer decode)
     /// rather than erroring here.
+    #[allow(clippy::too_many_arguments)] // overrides + diarization sink + controls; bundle later if it grows again
     fn transcribe_samples_with_overrides(
         &self,
         float_samples: &[f32],
@@ -2013,14 +2017,13 @@ impl Engine {
         overrides: &TranscribeOverrides,
         hotwords: Option<&HotwordOverride>,
         diarize: bool,
+        diar_sink: Option<&std::sync::OnceLock<DiarizationOutcome>>,
         ctl: DecodeControls,
     ) -> Result<TranscribeResult, GigasttError> {
         // `diarize` is opt-in per request: offline speaker diarization only runs
         // when the caller asked for it (REST `?diarization=true`). A plain
         // transcript — and the `channels=split` dual-mono fallback — must carry no
         // speaker labels, so the default paths pass `false`.
-        #[cfg(not(feature = "diarization"))]
-        let _ = diarize;
         let wall_start = std::time::Instant::now();
         let duration_s = float_samples.len() as f64 / 16000.0;
 
@@ -2028,15 +2031,34 @@ impl Engine {
         let mut words =
             self.decode_words_for_samples(float_samples, triplet, overrides, hotwords, ctl)?;
 
+        // Record *why* speakers were or were not labeled into the caller's sink
+        // so a `?diarization=true` request that produced no labels can be
+        // surfaced with a reason instead of an all-empty-speaker transcript.
         #[cfg(feature = "diarization")]
-        if diarize
-            && let Some(enc) = self
+        if diarize {
+            let outcome = match self
                 .speaker_encoder
                 .as_ref()
                 .and_then(|lazy| lazy.get_or_load())
-            && let Some(turns) = diarization::run_offline(&enc, float_samples)
-        {
-            diarization::assign_speakers_by_midpoint(&turns, &mut words);
+            {
+                None => DiarizationOutcome::NoSpeakerModel,
+                Some(enc) => match diarization::run_offline(&enc, float_samples) {
+                    Ok(turns) => {
+                        diarization::assign_speakers_by_midpoint(&turns, &mut words);
+                        DiarizationOutcome::Applied
+                    }
+                    Err(declined) => declined,
+                },
+            };
+            if let Some(sink) = diar_sink {
+                let _ = sink.set(outcome);
+            }
+        }
+        // A build compiled without the `diarization` feature can never label
+        // speakers; report that per request rather than silently dropping the flag.
+        #[cfg(not(feature = "diarization"))]
+        if diarize && let Some(sink) = diar_sink {
+            let _ = sink.set(DiarizationOutcome::NoSpeakerModel);
         }
 
         let result = self.finish_transcribe_result(words, duration_s, overrides);
@@ -5451,11 +5473,40 @@ vocab = "pack_vocab.txt"
                     },
                     None,
                     false,
+                    None,
                     super::super::DecodeControls::default(),
                 )
                 .expect("vad-off decode");
             assert_eq!(baseline.text, with_vad_off.text);
             assert_eq!(baseline.words.len(), with_vad_off.words.len());
+        }
+
+        #[test]
+        fn test_diarization_requested_without_speaker_model_records_notice() {
+            use crate::inference::{DiarizationOutcome, TranscribeRequest, TranscribeSource};
+            use std::sync::{Arc, OnceLock};
+
+            // A `?diarization=true` request against an engine with no speaker
+            // model must record `NoSpeakerModel` in the outcome sink so the
+            // server can surface it, instead of silently returning an
+            // all-empty-speaker transcript. Model-free: the tiny mock engine
+            // never ships a WeSpeaker model, and a build without the
+            // `diarization` feature reports the same outcome via the same sink.
+            let (engine, _tmp) = tiny_mock_engine();
+            let mut guard = engine.pool.checkout_blocking().expect("checkout");
+            let samples = vec![0.0f32; 100];
+            let sink: Arc<OnceLock<DiarizationOutcome>> = Arc::new(OnceLock::new());
+            let req = TranscribeRequest::new(TranscribeSource::Samples(&samples))
+                .with_diarization(true)
+                .with_diarization_outcome(Some(sink.clone()));
+            engine
+                .transcribe_request(req, &mut guard)
+                .expect("decode should succeed");
+            assert_eq!(
+                sink.get().copied(),
+                Some(DiarizationOutcome::NoSpeakerModel),
+                "diarization requested without a model must be reported, not silent"
+            );
         }
 
         #[test]

--- a/crates/gigastt-core/src/inference/mod.rs
+++ b/crates/gigastt-core/src/inference/mod.rs
@@ -41,9 +41,9 @@ pub use state::{
     TranscriptAssembler, TranscriptSegment, WordInfo,
 };
 pub use types::{
-    DEFAULT_HOTWORDS_BOOST, HotwordError, HotwordOverride, MAX_HOTWORD_PHRASE_CHARS,
-    MAX_HOTWORDS_PER_REQUEST, OverrideError, TranscribeOverrides, TranscribeRequest,
-    TranscribeResult, TranscribeSource, merge_channel_results,
+    DEFAULT_HOTWORDS_BOOST, DiarizationOutcome, HotwordError, HotwordOverride,
+    MAX_HOTWORD_PHRASE_CHARS, MAX_HOTWORDS_PER_REQUEST, OverrideError, TranscribeOverrides,
+    TranscribeRequest, TranscribeResult, TranscribeSource, merge_channel_results,
 };
 
 /// Number of mel frequency bins used for spectrogram features.

--- a/crates/gigastt-core/src/inference/types.rs
+++ b/crates/gigastt-core/src/inference/types.rs
@@ -1,8 +1,8 @@
 //! File-transcription result types and per-request overrides.
 
 use serde::Serialize;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::{Arc, OnceLock};
 
 use super::state::{WordInfo, aggregate_confidence};
 
@@ -209,6 +209,41 @@ pub fn merge_channel_results(per_channel: Vec<TranscribeResult>) -> TranscribeRe
     }
 }
 
+/// Outcome of an offline speaker-diarization attempt for a file-transcription
+/// request.
+///
+/// Recorded into the caller-supplied [`TranscribeRequest::diarization_outcome`]
+/// sink so a `?diarization=true` request that ends up with no speaker labels can
+/// be surfaced *with a reason* instead of returning an all-empty-speaker
+/// transcript silently (HTTP 200 today). The sink is written only when
+/// diarization was requested; a plain transcript leaves it untouched.
+///
+/// A new variant is additive: the enum is `#[non_exhaustive]`, and downstream
+/// mappers already need a catch-all arm.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub enum DiarizationOutcome {
+    /// Speaker turns were produced and each word labeled.
+    Applied,
+    /// Requested, but no speaker encoder is available — the model file is
+    /// absent or failed to load, or this build lacks the `diarization` feature.
+    /// Server capability is advertised on `/health` and the WebSocket `Ready`
+    /// message; this reports it per request.
+    NoSpeakerModel,
+    /// The clusterer refused the input because it exceeds the maximum duration
+    /// it can process in a single global pass. Both fields are seconds of audio,
+    /// as reported by the clusterer (not re-derived here).
+    DurationCeiling {
+        /// Length of the submitted audio.
+        input_secs: f64,
+        /// The clusterer's single-pass ceiling.
+        ceiling_secs: f64,
+    },
+    /// Attempted but the diarization pipeline failed for another reason (already
+    /// logged); no numbers to report.
+    Failed,
+}
+
 /// Input audio for a single file-transcription request.
 ///
 /// Prefer constructing a [`TranscribeRequest`] and calling
@@ -269,6 +304,13 @@ pub struct TranscribeRequest<'a> {
     /// it both to reset its no-progress deadline and to drive a real per-window
     /// job progress bar. `None` (the default) reports nothing.
     pub progress: Option<Arc<AtomicU64>>,
+    /// Optional write-once sink for the offline speaker-diarization outcome.
+    /// When set and [`diarization`](Self::diarization) is true, the engine
+    /// records why speakers were or were not labeled ([`DiarizationOutcome`])
+    /// so the caller can surface a capability notice on the response instead of
+    /// returning an all-empty-speaker transcript silently. `None` (the default)
+    /// records nothing, reproducing the historical behaviour.
+    pub diarization_outcome: Option<Arc<OnceLock<DiarizationOutcome>>>,
 }
 
 impl<'a> TranscribeRequest<'a> {
@@ -281,6 +323,7 @@ impl<'a> TranscribeRequest<'a> {
             diarization: false,
             abort: None,
             progress: None,
+            diarization_outcome: None,
         }
     }
 
@@ -315,6 +358,16 @@ impl<'a> TranscribeRequest<'a> {
     /// 16 kHz samples after each long-form window. `None` reports nothing.
     pub fn with_progress(mut self, progress: Option<Arc<AtomicU64>>) -> Self {
         self.progress = progress;
+        self
+    }
+
+    /// Attach a write-once sink that receives the offline-diarization
+    /// [`DiarizationOutcome`] for this request. `None` records nothing.
+    pub fn with_diarization_outcome(
+        mut self,
+        sink: Option<Arc<OnceLock<DiarizationOutcome>>>,
+    ) -> Self {
+        self.diarization_outcome = sink;
         self
     }
 }

--- a/crates/gigastt/src/server/file_transcribe.rs
+++ b/crates/gigastt/src/server/file_transcribe.rs
@@ -31,6 +31,13 @@ pub(crate) struct FileTranscribeOpts {
     /// count of processed 16 kHz samples. The server watchdog reads it to reset
     /// its no-progress deadline and to drive a real job progress bar.
     pub progress: Option<Arc<AtomicU64>>,
+    /// Write-once sink for the offline-diarization outcome. When set (with
+    /// `diarization = true`), the engine records why speakers were or were not
+    /// labeled so a surface can turn a `?diarization=true` request that produced
+    /// no labels into a capability notice instead of an all-empty-speaker
+    /// transcript. `None` records nothing.
+    pub diarization_outcome:
+        Option<Arc<std::sync::OnceLock<gigastt_core::inference::DiarizationOutcome>>>,
 }
 
 /// Sets a shared abort flag when dropped. Held in the REST handler's async
@@ -180,6 +187,7 @@ pub(crate) fn run_file_transcribe_blocking(
                 .with_overrides(opts.overrides)
                 .with_hotwords(opts.hotwords.as_ref())
                 .with_diarization(opts.diarization)
+                .with_diarization_outcome(opts.diarization_outcome.clone())
                 .with_abort(opts.abort.clone())
                 .with_progress(opts.progress.clone()),
             reservation,

--- a/crates/gigastt/src/server/http/jobs_api.rs
+++ b/crates/gigastt/src/server/http/jobs_api.rs
@@ -180,6 +180,9 @@ pub async fn get_job_result(
             duration: result.duration_s,
             confidence: result.confidence,
             segments,
+            // The async jobs surface does not yet carry a diarization outcome
+            // (see `FileTranscribeOpts::diarization_outcome`), so no notice here.
+            diarization: None,
         })
         .into_response())
     }

--- a/crates/gigastt/src/server/http/openai_api.rs
+++ b/crates/gigastt/src/server/http/openai_api.rs
@@ -43,7 +43,8 @@ pub async fn openai_transcriptions(
     if req.options.stream {
         return openai_transcriptions_stream(state, req.file).await;
     }
-    let result = run_file_transcription(&state, req.file, &ExportParams::default()).await?;
+    // The OpenAI-compatible alias does not expose diarization, so no outcome sink.
+    let result = run_file_transcription(&state, req.file, &ExportParams::default(), None).await?;
     Ok(super::super::openai::render_openai_response(
         &result,
         &req.options,

--- a/crates/gigastt/src/server/http/tests.rs
+++ b/crates/gigastt/src/server/http/tests.rs
@@ -46,6 +46,7 @@ fn test_transcribe_response_serialization() {
         duration: 1.5,
         confidence: None,
         segments: None,
+        diarization: None,
     };
     let json = serde_json::to_string(&resp).unwrap();
     let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -1034,6 +1035,7 @@ fn test_transcribe_response_omits_segments_when_none() {
         duration: 1.5,
         confidence: None,
         segments: None,
+        diarization: None,
     };
     let v = serde_json::to_value(&resp).unwrap();
     assert!(v.get("segments").is_none());
@@ -1052,6 +1054,7 @@ fn test_transcribe_response_confidence_present_only_when_some() {
         duration: 1.5,
         confidence: Some(0.87),
         segments: None,
+        diarization: None,
     };
     let v = serde_json::to_value(&with).unwrap();
     let c = v["confidence"].as_f64().expect("numeric confidence");
@@ -1063,6 +1066,7 @@ fn test_transcribe_response_confidence_present_only_when_some() {
         duration: 0.0,
         confidence: None,
         segments: None,
+        diarization: None,
     };
     let v = serde_json::to_value(&without).unwrap();
     assert!(v.get("confidence").is_none());
@@ -1082,6 +1086,7 @@ fn test_transcribe_response_includes_segments_when_present() {
         duration: 1.0,
         confidence: None,
         segments: Some(to_segments(&words, 80, 14)),
+        diarization: None,
     };
     let v = serde_json::to_value(&resp).unwrap();
     let segments = v["segments"].as_array().unwrap();

--- a/crates/gigastt/src/server/http/transcribe.rs
+++ b/crates/gigastt/src/server/http/transcribe.rs
@@ -6,13 +6,13 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use serde::Serialize;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64};
+use std::sync::{Arc, OnceLock};
 
 use super::super::config::RuntimeLimits;
 use super::super::metrics::MetricsRegistry;
 use gigastt_core::export::Segment;
-use gigastt_core::inference::Engine;
+use gigastt_core::inference::{DiarizationOutcome, Engine};
 
 use super::error::{
     ApiError, api_error, api_inference_timeout_error, api_pool_closed_error, api_timeout_error,
@@ -42,6 +42,80 @@ pub struct TranscribeResponse {
     /// so existing clients that read `text` / `words` / `duration` are unaffected.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub segments: Option<Vec<Segment>>,
+    /// Present only when `?diarization=true` was requested and speakers could
+    /// **not** be labeled — the transcript is still complete, but the client
+    /// would otherwise see empty speaker fields with no explanation. Additive:
+    /// absent when diarization was not requested or succeeded, so existing
+    /// clients see the exact same shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diarization: Option<DiarizationNotice>,
+}
+
+/// Capability notice attached to a transcription response when a
+/// `?diarization=true` request produced no speaker labels. Makes the reason
+/// visible to the client instead of returning an all-empty-speaker transcript
+/// with HTTP 200 and no explanation.
+#[derive(Serialize)]
+pub struct DiarizationNotice {
+    /// Always `"unavailable"` — the notice only appears when diarization was
+    /// requested and did not label speakers.
+    pub status: &'static str,
+    /// Machine-readable cause: `"duration_ceiling"`, `"no_speaker_model"`, or
+    /// `"pipeline_error"`.
+    pub reason: &'static str,
+    /// Human-readable, non-sensitive explanation.
+    pub message: String,
+    /// Length of the submitted audio in seconds — present only for the duration
+    /// ceiling, so the client can see what was too long.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_seconds: Option<f64>,
+    /// The clusterer's single-pass ceiling in seconds — present only for the
+    /// duration ceiling.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ceiling_seconds: Option<f64>,
+}
+
+/// Map a [`DiarizationOutcome`] to the client-facing [`DiarizationNotice`].
+///
+/// `Applied` (and any future success) yields `None` — no notice, so a
+/// successful or unrequested diarization leaves the response shape untouched.
+/// Every declined case carries a distinct `reason`, and the duration ceiling
+/// also carries the input and ceiling seconds.
+fn diarization_notice(outcome: DiarizationOutcome) -> Option<DiarizationNotice> {
+    match outcome {
+        DiarizationOutcome::Applied => None,
+        DiarizationOutcome::NoSpeakerModel => Some(DiarizationNotice {
+            status: "unavailable",
+            reason: "no_speaker_model",
+            message: "diarization was requested but no speaker model is loaded".to_string(),
+            input_seconds: None,
+            ceiling_seconds: None,
+        }),
+        DiarizationOutcome::DurationCeiling {
+            input_secs,
+            ceiling_secs,
+        } => Some(DiarizationNotice {
+            status: "unavailable",
+            reason: "duration_ceiling",
+            message: format!(
+                "diarization skipped: input {input_secs:.0}s exceeds the {ceiling_secs:.0}s \
+                 single-pass limit; the transcript is complete but has no speaker labels"
+            ),
+            input_seconds: Some(input_secs),
+            ceiling_seconds: Some(ceiling_secs),
+        }),
+        DiarizationOutcome::Failed => Some(DiarizationNotice {
+            status: "unavailable",
+            reason: "pipeline_error",
+            message: "diarization failed; the transcript is complete but has no speaker labels"
+                .to_string(),
+            input_seconds: None,
+            ceiling_seconds: None,
+        }),
+        // `DiarizationOutcome` is `#[non_exhaustive]`; a future variant should
+        // add its own notice above. Until then, prefer silence over a wrong one.
+        _ => None,
+    }
 }
 
 /// Resolve the `?codec=` / `?sample_rate=` query pair into a raw-decode recipe.
@@ -136,6 +210,7 @@ pub(super) async fn run_file_transcription(
     state: &AppState,
     body: Bytes,
     params: &ExportParams,
+    diar_sink: Option<Arc<OnceLock<DiarizationOutcome>>>,
 ) -> Result<gigastt_core::inference::TranscribeResult, ApiError> {
     if body.is_empty() {
         return Err(api_error(
@@ -235,6 +310,7 @@ pub(super) async fn run_file_transcription(
         raw_codec,
         abort: Some(abort.clone()),
         progress: Some(progress.clone()),
+        diarization_outcome: diar_sink,
     };
 
     // A client disconnect drops this handler future before it returns, dropping
@@ -355,8 +431,15 @@ pub async fn transcribe(
     Query(params): Query<ExportParams>,
     body: Bytes,
 ) -> Result<Response, ApiError> {
-    let result = run_file_transcription(&state, body, &params).await?;
+    // Only sink the diarization outcome when diarization was requested, so a
+    // `?diarization=true` request that produces no speaker labels can be turned
+    // into a visible notice instead of an all-empty-speaker transcript.
+    let diar_sink: Option<Arc<OnceLock<DiarizationOutcome>>> =
+        (params.diarization == Some(true)).then(|| Arc::new(OnceLock::new()));
+    let result = run_file_transcription(&state, body, &params, diar_sink.clone()).await?;
     if let Some(rendered) = render_export_response(&result, &params)? {
+        // Export formats (SRT/VTT/TSV/plain text) have no field for a capability
+        // notice; it surfaces on the JSON path below.
         Ok(rendered)
     } else {
         // Default JSON response. `?segments=true` adds a cue-grouped
@@ -368,13 +451,89 @@ pub async fn transcribe(
         } else {
             None
         };
+        // Attach a diarization notice only when diarization was requested and
+        // declined (ceiling / no model / pipeline error); `Applied` and the
+        // not-requested case leave the field absent.
+        let diarization = diar_sink
+            .as_ref()
+            .and_then(|sink| sink.get().copied())
+            .and_then(diarization_notice);
         Ok(Json(TranscribeResponse {
             text: result.text,
             words: result.words,
             duration: result.duration_s,
             confidence: result.confidence,
             segments,
+            diarization,
         })
         .into_response())
+    }
+}
+
+#[cfg(test)]
+mod diarization_notice_tests {
+    use super::*;
+
+    #[test]
+    fn test_applied_yields_no_notice() {
+        // A successful diarization needs no notice: speakers ride on the words.
+        assert!(diarization_notice(DiarizationOutcome::Applied).is_none());
+    }
+
+    #[test]
+    fn test_duration_ceiling_carries_numbers_and_reason() {
+        let notice = diarization_notice(DiarizationOutcome::DurationCeiling {
+            input_secs: 5400.0,
+            ceiling_secs: 3600.0,
+        })
+        .expect("a declined ceiling must produce a notice");
+        assert_eq!(notice.status, "unavailable");
+        assert_eq!(notice.reason, "duration_ceiling");
+        assert_eq!(notice.input_seconds, Some(5400.0));
+        assert_eq!(notice.ceiling_seconds, Some(3600.0));
+
+        // The wire JSON carries both numbers and the machine-readable reason.
+        let json = serde_json::to_value(&notice).expect("serialize");
+        assert_eq!(json["reason"], "duration_ceiling");
+        assert_eq!(json["input_seconds"], 5400.0);
+        assert_eq!(json["ceiling_seconds"], 3600.0);
+    }
+
+    #[test]
+    fn test_no_speaker_model_reason_without_numbers() {
+        let notice = diarization_notice(DiarizationOutcome::NoSpeakerModel).expect("notice");
+        assert_eq!(notice.reason, "no_speaker_model");
+        assert!(notice.input_seconds.is_none());
+        assert!(notice.ceiling_seconds.is_none());
+        // `skip_serializing_if` keeps the number fields out of the JSON entirely.
+        let json = serde_json::to_value(&notice).expect("serialize");
+        assert!(json.get("input_seconds").is_none());
+        assert!(json.get("ceiling_seconds").is_none());
+    }
+
+    #[test]
+    fn test_failed_maps_to_pipeline_error() {
+        let notice = diarization_notice(DiarizationOutcome::Failed).expect("notice");
+        assert_eq!(notice.reason, "pipeline_error");
+        assert!(notice.input_seconds.is_none());
+    }
+
+    #[test]
+    fn test_response_omits_diarization_field_when_absent() {
+        // The default (not-requested / succeeded) response must be byte-shape
+        // compatible: no `diarization` key at all.
+        let resp = TranscribeResponse {
+            text: "hi".to_string(),
+            words: Vec::new(),
+            duration: 1.0,
+            confidence: None,
+            segments: None,
+            diarization: None,
+        };
+        let json = serde_json::to_value(&resp).expect("serialize");
+        assert!(
+            json.get("diarization").is_none(),
+            "diarization must be omitted when there is no notice"
+        );
     }
 }

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -820,6 +820,10 @@ impl JobExecution for RealJobExecutor {
                 raw_codec: None,
                 abort: Some(abort.clone()),
                 progress: Some(progress.clone()),
+                // The async jobs surface has the same silent-degradation shape as
+                // the sync path once diarization is requested; it is not wired to
+                // a notice here (out of scope) and keeps its current behaviour.
+                diarization_outcome: None,
             };
             let handle = tokio::task::spawn_blocking(move || {
                 let _enter = span.enter();


### PR DESCRIPTION
## The problem

Ask for `?diarization=true` on a long recording and you got **HTTP 200 with every speaker field empty**
and nothing else — the feature simply evaporated. `run_offline` returns `None` with a `warn!` when
polyvoice's internal 3600 s ceiling refuses the buffer, and the caller carried on as if diarization had
never been requested.

That is bad today. It becomes indefensible the moment the product says files have no maximum length, so
it is fixed before that lands. A documented ceiling is a defensible engineering position; a silent one
is not.

## Wire shape

An additive `diarization` object on the transcribe response, `skip_serializing_if = None`, so it is
absent unless diarization was requested **and** speakers could not be labelled. Clients that get
diarization, or never ask for it, see a byte-identical response.

```json
"diarization": {
  "status": "unavailable", "reason": "duration_ceiling",
  "message": "...", "input_seconds": 5400, "ceiling_seconds": 3600
}
```

`reason` is one of `duration_ceiling`, `no_speaker_model`, `pipeline_error` — three genuinely different
situations that previously collapsed into the same silence. Only the ceiling case carries numbers, and
they are the values polyvoice actually reports rather than a re-derived guess.

## Semver

`cargo semver-checks` — 219 checks, 219 pass, no bump required. `TranscribeResult` was deliberately
**not** grown: it is the one type in this family without `#[non_exhaustive]`, so a field there would be
a major break. The wire field lives on the binary's response type; core carries the outcome out through
a write-once sink on the already-`#[non_exhaustive]` `TranscribeRequest`, plus a new
`#[non_exhaustive] DiarizationOutcome`.

## Correction to the original premise

The "no speaker model" case was assumed to 409 at the handler. It does not — `has_speaker_encoder()` is
only read by `/health` and the WebSocket `Ready` message, so that case silently no-ops exactly like the
ceiling. Rather than turn an existing 200 into a client-breaking 409, it is surfaced through the same
notice.

## Known remaining silence

`/v1/jobs` and live WebSocket diarization have the same shape and are **not** wired here — reported,
out of scope, not papered over.

Core 553 tests, binary 214, clippy clean in both feature configurations.