### PR TITLE
perf(cli): drop the WAV round trip from the raw telephony path

### DIFF
--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -1371,7 +1371,7 @@ async fn main() -> anyhow::Result<()> {
             let mut guard = engine.pool.checkout().await?;
             let result = if let Some(codec_name) = codec.as_deref() {
                 // Raw headerless telephony input: decode via the codec tables
-                // and re-wrap as an in-memory WAV, bypassing container sniffing.
+                // straight to mono 16 kHz f32 and hand the samples to the engine.
                 let telephony_codec = inference::audio::TelephonyCodec::from_name(codec_name)
                     .ok_or_else(|| {
                         anyhow::anyhow!(
@@ -1387,9 +1387,31 @@ async fn main() -> anyhow::Result<()> {
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
                 let raw = std::fs::read(&file)
                     .with_context(|| format!("Failed to open audio file: {file}"))?;
-                let samples = inference::audio::decode_telephony_raw(&raw, telephony_codec, rate)?;
-                let wav = inference::audio::encode_wav_pcm16(&samples, 16000);
-                engine.transcribe_bytes(&wav, &mut guard)
+                let mut samples =
+                    inference::audio::decode_telephony_raw(&raw, telephony_codec, rate)?;
+                // NOT a no-op: preserve transcript byte-identity. The former path
+                // encoded these samples into an in-memory WAV and let the engine
+                // decode it back, which snapped every value to 16-bit PCM. Passing
+                // the raw f32 straight through would change the transcript (measured:
+                // 153 token edits on a 9-minute call), so reproduce that quantization
+                // in place — clamp to [-1, 1], round via 32767, normalise via 32768,
+                // matching `encode_wav_pcm16` and the PCM decode path. Whether
+                // full-precision f32 is better is an open WER question tracked in
+                // roadmap/ (telephony precision); do not silently drop this snap.
+                for s in samples.iter_mut() {
+                    let v = if s.is_finite() {
+                        s.clamp(-1.0, 1.0)
+                    } else {
+                        0.0
+                    };
+                    *s = (v * 32767.0).round() as i16 as f32 / 32768.0;
+                }
+                engine.transcribe_request(
+                    inference::TranscribeRequest::new(inference::TranscribeSource::Samples(
+                        &samples,
+                    )),
+                    &mut guard,
+                )
             } else if stereo_speakers {
                 let channels = inference::audio::load_audio_channels(&file)?;
                 let fallback_reason = match channels.len() {


### PR DESCRIPTION
The CLI's `--codec` path decoded the raw telephony stream, re-encoded the samples into an in-memory WAV,
copied that into `Bytes`, and handed it to the engine — which decoded it again. The engine already
accepts pre-decoded samples, so the round trip performed a full redundant decode per file.

It was **not** entirely redundant, which is the interesting part. `encode_wav_pcm16` requantizes the
resampled f32 to 16-bit, and that snap is load-bearing: feeding full-precision f32 straight through
changes the transcript by 153 token edits on a 9-minute file. So the fix preserves the quantization
explicitly (clamp/round to 16-bit in place) and then uses `TranscribeSource::Samples`. Both the commit
message and a code comment mark the snap as deliberate, so a future reader does not "clean up" a
quantization step that looks pointless and silently reintroduce the drift.

**Byte-identical**: transcripts before and after are sha256-identical, same 1368 words, same word
timings, measured back-to-back in one environment (an earlier baseline from a different environment was
discarded as an invalid control rather than reported).

**Memory**: peak RSS median 824.7 → 821.0 MiB, −3.4 MiB. That is far below the ~35 MiB predicted, and
the measurement is reported over the prediction: the peak is the ONNX arena, not the transient audio
buffers, so removing them barely moves it. Wall time is a wash — inference dominates at RTF ~0.035.
The change earns its place on removing a redundant decode pass with provable byte-identity, not on
memory.

Whether full-precision f32 would actually be *better* than the 16-bit snap is a real question with a
153-edit magnitude, and it is a WER call — logged in the tracker with a measurement plan rather than
decided inside a plumbing cleanup.

The server's `?codec=` path keeps its WAV form: its `Bytes` feed shared container decoding downstream
(`channels=split`, the mono fallback), so the same fix does not apply there.

Core lib 553, server lib 214, bins 76, clippy clean.