### PR TITLE
feat(core): run the file VAD inside the window stream, not over two whole buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The 30-minute (1800 s) duration cap on the default file-transcription
   path.** File decode streams through bounded windows regardless of length,
   so peak memory stays roughly constant — files of any length now transcribe
-  fine. The paths that still need the whole decoded buffer in memory (VAD
-  segmentation, speaker diarization, `channels=split`, and telephony/Opus
-  decoding) keep the ~30-minute safety ceiling to avoid OOM, surfaced as the
-  same `audio_too_long` code introduced above.
+  fine. The paths that still need the whole decoded buffer in memory (speaker
+  diarization, `channels=split`, and telephony/Opus decoding) keep the
+  ~30-minute safety ceiling to avoid OOM, surfaced as the same
+  `audio_too_long` code introduced above.
+
+- **The same cap on the `--vad` file path.** Silence-skipping used to scan and
+  copy two whole-file buffers, which kept the ceiling in place exactly where
+  long files matter most — `--profile edge` turns VAD on by default, so the
+  smallest hosts were the ones still capped. The VAD now runs *inside* the
+  window loop: Silero is causal, so frames are scored as the container decodes
+  and kept audio is released as soon as the bounded look-ahead
+  (`min_speech_ms + min_silence_ms + speech_pad_ms`, ~850 ms at the defaults)
+  has passed. Peak audio memory is one decode window plus that look-ahead,
+  whatever the length. The speech spans, the windows fed to the encoder, and
+  therefore the transcript are byte-identical to the batch path — asserted
+  against it directly, including a proptest over random probability sequences
+  and configs. `--max-audio-secs` still applies verbatim when set.
 
 ### Changed
 

--- a/crates/gigastt-core/proptest-regressions/vad.txt
+++ b/crates/gigastt-core/proptest-regressions/vad.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 82b8bc748ca891b27005e661a67f584119993d80cf15b4486ea2252cb11fb7dd # shrinks to probs = [0.75729066, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4800178], tail = 1, threshold = 0.1, min_silence_ms = 193, min_speech_ms = 225, speech_pad_ms = 0

--- a/crates/gigastt-core/src/inference/audio/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/mod.rs
@@ -6,6 +6,8 @@ mod pcm;
 mod resample;
 mod stream;
 mod telephony;
+#[cfg(feature = "file-decode")]
+mod vad_windows;
 
 #[cfg(test)]
 #[path = "tests.rs"]
@@ -27,12 +29,13 @@ pub(crate) use super::{HOP_LENGTH, N_FFT};
 
 pub(crate) const MAX_BUFFER_SAMPLES: usize = 16000 * 5; // 5 seconds at 16kHz
 /// Explicit, documented safety ceiling (seconds) for the decode paths that must
-/// hold the **whole** decoded buffer in RAM: VAD segmentation, speaker
-/// diarization, `channels=split`, and the telephony / Opus whole-buffer codecs.
-/// The default file path streams overlapping windows (see
-/// `Engine::decode_words_streaming`), so its peak audio memory is O(one window)
-/// regardless of length and it has *no* duration limit; these paths keep this
-/// bound so a multi-hour input refuses with a typed
+/// hold the **whole** decoded buffer in RAM: speaker diarization,
+/// `channels=split`, and the telephony / Opus whole-buffer codecs. The default
+/// file path streams overlapping windows (see `Engine::decode_words_streaming`),
+/// and the VAD file path streams through
+/// [`VadWindows`](super::audio::VadWindows), so both have peak audio memory
+/// O(one window) regardless of length and *no* duration limit; the remaining
+/// paths keep this bound so a multi-hour input refuses with a typed
 /// [`AudioTooLong`](crate::error::GigasttError::AudioTooLong) instead of driving
 /// the process into OOM. Operators can lower the effective limit for every path
 /// (including the streaming one) with `--max-audio-secs`; there is no way to
@@ -155,6 +158,10 @@ pub(crate) use stream::{PcmWindows, SliceWindows, WindowSpec};
 // windows from it; the public `decode_audio_*` functions drain it flat.
 #[cfg(feature = "file-decode")]
 pub(crate) use stream::FileWindows;
+// VAD-compressed window source: same geometry over the silence-free timeline,
+// so the VAD file path is O(one window) too and needs no duration ceiling.
+#[cfg(feature = "file-decode")]
+pub(crate) use vad_windows::VadWindows;
 
 pub use telephony::TelephonyCodec;
 #[cfg(feature = "file-decode")]

--- a/crates/gigastt-core/src/inference/audio/stream.rs
+++ b/crates/gigastt-core/src/inference/audio/stream.rs
@@ -114,6 +114,97 @@ impl WindowSpec {
     }
 }
 
+/// Window-cursor arithmetic for a source that decodes as it goes.
+///
+/// Pure and shared, so every streaming source yields the one window sequence
+/// [`SliceWindows`] would over the same fully-decoded buffer:
+/// [`WindowCursor::fill_target`] says how far the source must decode before the
+/// next window can be decided, and [`WindowCursor::take`] turns "here is what
+/// is available" into that window.
+#[cfg(feature = "file-decode")]
+pub(crate) struct WindowCursor {
+    spec: WindowSpec,
+    /// Absolute start (@16 kHz) of the next window to yield.
+    next_start: usize,
+    /// True until the first window's single-pass-vs-windowed decision is made.
+    first: bool,
+    done: bool,
+}
+
+#[cfg(feature = "file-decode")]
+impl WindowCursor {
+    pub(crate) fn new(spec: WindowSpec) -> Self {
+        Self {
+            spec,
+            next_start: 0,
+            first: true,
+            done: false,
+        }
+    }
+
+    pub(crate) fn is_done(&self) -> bool {
+        self.done
+    }
+
+    pub(crate) fn next_start(&self) -> usize {
+        self.next_start
+    }
+
+    pub(crate) fn spec(&self) -> WindowSpec {
+        self.spec
+    }
+
+    /// Decode at least this many samples before calling [`WindowCursor::take`]:
+    /// one past the window end, so `end == total` is distinguishable from a
+    /// mid-stream boundary, and enough for the first window to decide
+    /// single-pass vs windowed.
+    pub(crate) fn fill_target(&self) -> usize {
+        if self.first {
+            self.spec
+                .single_pass_max()
+                .saturating_add(1)
+                .max(self.spec.window().saturating_add(1))
+        } else {
+            self.next_start + self.spec.window() + 1
+        }
+    }
+
+    /// The next `[start, end)` window given the samples decoded so far
+    /// (`avail_end`) and whether the stream is exhausted, or `None` once every
+    /// window has been yielded.
+    pub(crate) fn take(&mut self, avail_end: usize, eof: bool) -> Option<(usize, usize)> {
+        if self.done {
+            return None;
+        }
+        let start = self.next_start;
+        if self.first {
+            self.first = false;
+            if eof && avail_end <= self.spec.single_pass_max() {
+                // The whole stream fits the single-pass ceiling: one window over
+                // all of it. `decode_words_streaming` then runs one encoder pass
+                // with frame offset 0 and stitches onto an empty list —
+                // byte-identical to `decode_words`' non-windowed branch.
+                self.done = true;
+                return Some((start, avail_end));
+            }
+        }
+        if start >= avail_end {
+            // Reachable only at EOF, once the last window has been yielded.
+            self.done = true;
+            return None;
+        }
+        // Because the caller decoded one sample past `start + window` (or hit
+        // EOF), `end == avail_end` holds only when this window reaches the end.
+        let end = (start + self.spec.window()).min(avail_end);
+        if eof && end == avail_end {
+            self.done = true;
+        } else {
+            self.next_start = start + self.spec.stride();
+        }
+        Some((start, end))
+    }
+}
+
 /// One decode window lent by a [`PcmWindows`] source.
 pub(crate) struct PcmWindow<'a> {
     /// Absolute offset of `samples[0]` in the stream, in samples @16 kHz.
@@ -245,11 +336,7 @@ pub(crate) struct FileWindows {
     /// Total 16 kHz samples decoded so far (== `buf_start_abs + buf.len()`).
     decoded_16k_total: usize,
     spec: WindowSpec,
-    /// Absolute start (@16 kHz) of the next window to yield.
-    next_start: usize,
-    /// True until the first window's single-pass-vs-windowed decision is made.
-    first: bool,
-    done: bool,
+    cursor: WindowCursor,
 }
 
 #[cfg(feature = "file-decode")]
@@ -394,9 +481,7 @@ impl FileWindows {
                     buf_start_abs: 0,
                     decoded_16k_total: 0,
                     spec,
-                    next_start: 0,
-                    first: true,
-                    done: false,
+                    cursor: WindowCursor::new(spec),
                 })
             }
         }
@@ -413,9 +498,7 @@ impl FileWindows {
             buf_start_abs: 0,
             decoded_16k_total: total,
             spec,
-            next_start: 0,
-            first: true,
-            done: false,
+            cursor: WindowCursor::new(spec),
         }
     }
 
@@ -532,7 +615,7 @@ impl PcmWindows for FileWindows {
     }
 
     fn next_window(&mut self) -> Result<Option<PcmWindow<'_>>, GigasttError> {
-        if self.done {
+        if self.cursor.is_done() {
             return Ok(None);
         }
 
@@ -540,7 +623,8 @@ impl PcmWindows for FileWindows {
         // forward, so everything before `next_start` is dead. This is what keeps
         // the resident buffer at one window plus look-ahead.
         let drop = self
-            .next_start
+            .cursor
+            .next_start()
             .saturating_sub(self.buf_start_abs)
             .min(self.buf.len());
         if drop > 0 {
@@ -548,50 +632,12 @@ impl PcmWindows for FileWindows {
             self.buf_start_abs += drop;
         }
 
-        // Decode one sample past the window end so `end == total` is
-        // distinguishable from a mid-stream boundary; the first window also needs
-        // enough to decide single-pass vs windowed.
-        let target = if self.first {
-            (self.spec.single_pass_max() + 1).max(self.spec.window() + 1)
-        } else {
-            self.next_start + self.spec.window() + 1
-        };
-        self.fill_to(target).map_err(decode_error)?;
+        self.fill_to(self.cursor.fill_target())
+            .map_err(decode_error)?;
 
-        let avail_end = self.decoded_16k_total;
-        let start = self.next_start;
-
-        if self.first {
-            self.first = false;
-            if self.eof && avail_end <= self.spec.single_pass_max() {
-                // The whole stream fits the single-pass ceiling: yield exactly one
-                // window over all of it. `decode_words_streaming` then runs one
-                // encoder pass with frame offset 0 and stitches onto an empty list
-                // — byte-identical to `decode_words`' non-windowed branch.
-                self.done = true;
-                let e = avail_end - self.buf_start_abs;
-                return Ok(Some(PcmWindow {
-                    start_sample: start,
-                    samples: &self.buf[..e],
-                }));
-            }
-        }
-
-        if start >= avail_end {
-            // Reachable only at EOF, once the last window has been yielded.
-            self.done = true;
+        let Some((start, end)) = self.cursor.take(self.decoded_16k_total, self.eof) else {
             return Ok(None);
-        }
-
-        // Standard overlapping geometry, matching `SliceWindows` exactly. Because
-        // `fill_to` decoded one sample past `start + window` (or hit EOF),
-        // `end == avail_end` holds only when this window reaches the true end.
-        let end = (start + self.spec.window()).min(avail_end);
-        if self.eof && end == avail_end {
-            self.done = true;
-        } else {
-            self.next_start = start + self.spec.stride();
-        }
+        };
         let s = start - self.buf_start_abs;
         let e = end - self.buf_start_abs;
         Ok(Some(PcmWindow {

--- a/crates/gigastt-core/src/inference/audio/vad_windows.rs
+++ b/crates/gigastt-core/src/inference/audio/vad_windows.rs
@@ -1,0 +1,470 @@
+//! Windowed PCM source for the VAD file path.
+//!
+//! The batch VAD path decodes the whole file, scans every frame for speech, and
+//! copies the kept spans into a second whole-file buffer — two O(file)
+//! allocations, which is why that path alone still enforced a duration ceiling
+//! while the plain file path had none. [`VadWindows`] replaces both with a
+//! stream: [`FileWindows`] feeds the container in fixed blocks, [`VadSegmenter`]
+//! scores them causally and releases kept audio as soon as its bounded
+//! look-ahead allows, and this source hands the result to the decode loop as the
+//! same overlapping windows [`SliceWindows`](super::SliceWindows) would yield
+//! over the fully compressed buffer.
+//!
+//! Peak audio memory is one decode window plus well under a second of retained
+//! PCM, regardless of file length. The windows themselves are unchanged, so the
+//! transcript is too.
+
+use crate::error::GigasttError;
+use crate::vad::{SileroVad, VadConfig, VadSegmenter};
+
+use super::stream::{FileWindows, PcmWindow, PcmWindows, WindowCursor, WindowSpec};
+
+/// Block size (@16 kHz) pulled from the container per VAD step. A multiple of
+/// the encoder frame stride, large enough to amortize the per-block work and
+/// small enough that the retained PCM stays negligible.
+const PULL_SAMPLES: usize = 32_000; // 2 s
+
+/// Poll the abort flag every this many pulled blocks (~30 s of audio), matching
+/// the batch scan's cadence: interruptible on a multi-hour file without an
+/// atomic load per block.
+const ABORT_POLL_BLOCKS: usize = 16;
+
+/// [`PcmWindows`] over the silence-free timeline of a streamed container.
+pub(crate) struct VadWindows<'a> {
+    raw: FileWindows,
+    vad: &'a SileroVad,
+    seg: VadSegmenter,
+    abort: Option<&'a dyn Fn() -> bool>,
+    /// Rolling compressed buffer holding `[buf_start_abs, compressed_total)`.
+    buf: Vec<f32>,
+    /// Absolute sample index (on the compressed timeline) of `buf[0]`.
+    buf_start_abs: usize,
+    /// Total compressed samples released so far.
+    compressed_total: usize,
+    /// True once the container is drained and the segmenter has been closed.
+    eof: bool,
+    /// Set when the VAD model itself failed mid-stream; the caller re-decodes
+    /// without VAD rather than returning a truncated transcript.
+    vad_failed: bool,
+    blocks: usize,
+    cursor: WindowCursor,
+}
+
+impl<'a> VadWindows<'a> {
+    /// Wrap an open container in the VAD stream. `spec` is the decode geometry
+    /// applied to the *compressed* timeline — the same one the no-VAD path uses.
+    pub(crate) fn new(
+        raw: FileWindows,
+        vad: &'a SileroVad,
+        cfg: &VadConfig,
+        spec: WindowSpec,
+        abort: Option<&'a dyn Fn() -> bool>,
+    ) -> Self {
+        Self {
+            raw,
+            vad,
+            seg: VadSegmenter::new(cfg),
+            abort,
+            buf: Vec::new(),
+            buf_start_abs: 0,
+            compressed_total: 0,
+            eof: false,
+            vad_failed: false,
+            blocks: 0,
+            cursor: WindowCursor::new(spec),
+        }
+    }
+
+    /// Window geometry for the flat container reads this source performs:
+    /// consecutive, non-overlapping blocks covering the stream exactly once.
+    pub(crate) fn pull_spec() -> WindowSpec {
+        WindowSpec::new(0, PULL_SAMPLES, 0)
+    }
+
+    /// Kept speech spans on the **original** timeline, in order. Complete once
+    /// the source is drained; used to map decoded word timestamps back off the
+    /// compressed timeline.
+    pub(crate) fn regions(&self) -> &[(usize, usize)] {
+        self.seg.regions()
+    }
+
+    /// Total 16 kHz samples read from the container. Exact once drained — this
+    /// is the clip's real duration, not the compressed one.
+    pub(crate) fn total_16k_samples(&self) -> usize {
+        self.raw.total_16k_samples()
+    }
+
+    /// True when the caller must re-decode without VAD: either the model failed
+    /// mid-stream, or the scan found no speech at all in a non-empty clip (a bad
+    /// threshold against continuous speech or a pure tone). Both cases fall back
+    /// to the full/chunked decode rather than returning an empty transcript.
+    pub(crate) fn needs_fallback(&self) -> bool {
+        self.vad_failed || (self.regions().is_empty() && self.total_16k_samples() > 0)
+    }
+
+    /// Decode and score until `target` compressed samples are available (or the
+    /// stream ends).
+    fn fill_to(&mut self, target: usize) -> Result<(), GigasttError> {
+        let Self {
+            raw,
+            vad,
+            seg,
+            abort,
+            buf,
+            compressed_total,
+            eof,
+            vad_failed,
+            blocks,
+            ..
+        } = self;
+        while !*eof && *compressed_total < target {
+            if let Some(abort) = abort {
+                *blocks += 1;
+                if *blocks >= ABORT_POLL_BLOCKS {
+                    *blocks = 0;
+                    if abort() {
+                        return Err(GigasttError::Cancelled);
+                    }
+                }
+            }
+            let before = buf.len();
+            let scanned = match raw.next_window()? {
+                Some(w) => seg.push(vad, w.samples, buf),
+                None => {
+                    *eof = true;
+                    seg.finish(vad, raw.total_16k_samples(), buf)
+                }
+            };
+            if let Err(e) = scanned {
+                // Same policy as the batch path: a VAD failure never fails the
+                // request, it drops VAD for this clip.
+                tracing::warn!("VAD failed mid-stream, decoding full audio: {e:#}");
+                *vad_failed = true;
+                *eof = true;
+                buf.truncate(before);
+                return Ok(());
+            }
+            *compressed_total += buf.len() - before;
+        }
+        Ok(())
+    }
+}
+
+impl PcmWindows for VadWindows<'_> {
+    fn spec(&self) -> WindowSpec {
+        self.cursor.spec()
+    }
+
+    fn next_window(&mut self) -> Result<Option<PcmWindow<'_>>, GigasttError> {
+        if self.cursor.is_done() {
+            return Ok(None);
+        }
+
+        // Reclaim the previous window's consumed prefix; windows only move
+        // forward, so everything before `next_start` is dead.
+        let drop = self
+            .cursor
+            .next_start()
+            .saturating_sub(self.buf_start_abs)
+            .min(self.buf.len());
+        if drop > 0 {
+            self.buf.drain(0..drop);
+            self.buf_start_abs += drop;
+        }
+
+        self.fill_to(self.cursor.fill_target())?;
+
+        // Nothing survived the VAD: yield no window rather than an empty one.
+        // The batch path returns early on empty regions for the same reason —
+        // a zero-length encoder run is not a decode.
+        if self.eof && self.compressed_total == 0 {
+            return Ok(None);
+        }
+
+        let Some((start, end)) = self.cursor.take(self.compressed_total, self.eof) else {
+            return Ok(None);
+        };
+        let s = start - self.buf_start_abs;
+        let e = end - self.buf_start_abs;
+        Ok(Some(PcmWindow {
+            start_sample: start,
+            samples: &self.buf[s..e],
+        }))
+    }
+}
+
+/// Byte-identity tests against the batch VAD path.
+///
+/// The Silero session is scripted through the mock runtime, so a whole
+/// probability sequence — and therefore a whole speech/silence layout — can be
+/// pinned without the model on disk. That makes the comparison that matters run
+/// in CI: the same clip, the same config, batch versus streaming, window for
+/// window.
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::inference::audio::{SliceWindows, encode_wav_pcm16};
+    use crate::runtime::mock::{MockFactory, MockSession};
+    use crate::runtime::tensor::{Shape, Tensor, TensorData};
+    use crate::vad::{VAD_FRAME_SAMPLES, regions_from_probs};
+    use bytes::Bytes;
+
+    /// One decode window, owned: `(start on the compressed timeline, samples)`.
+    type OwnedWindow = (usize, Vec<f32>);
+
+    /// The ort long-form geometry, matching `Engine::window_spec` (CPU backend).
+    fn ort_spec() -> WindowSpec {
+        WindowSpec::new(16000 * 30, 16000 * 24, 16000 * 2)
+    }
+
+    /// A [`SileroVad`] whose session replays `probs`, one per frame, so the VAD
+    /// file path runs without the model. Shapes match the real graph, so the
+    /// output-by-shape identification in `run_frame` is exercised too.
+    fn scripted_vad(probs: &[f32]) -> SileroVad {
+        let script: Vec<Vec<Tensor>> = probs
+            .iter()
+            .map(|&p| {
+                vec![
+                    Tensor::new_checked(Shape::new(vec![1]), TensorData::F32(vec![p])),
+                    Tensor::new_checked(
+                        Shape::new(vec![2, 1, 128]),
+                        TensorData::F32(vec![0.0; 2 * 128]),
+                    ),
+                ]
+            })
+            .collect();
+        let session = MockSession::new(
+            vec![
+                Shape::new(vec![1, VAD_FRAME_SAMPLES]),
+                Shape::new(vec![2, 1, 128]),
+                Shape::new(vec![1]),
+            ],
+            Vec::new(),
+        )
+        .with_script(script);
+        let factory = MockFactory::new(HashMap::from([(
+            "silero_vad".to_string(),
+            Arc::new(session),
+        )]));
+        SileroVad::load_with_factory(std::path::Path::new("silero_vad.onnx"), &factory)
+            .expect("scripted vad")
+    }
+
+    /// Deterministic signal in [-1, 1) that survives PCM16 quantization.
+    fn signal(n: usize) -> Vec<f32> {
+        (0..n)
+            .map(|i| 0.4 * ((i as f32 * 0.017).sin() + 0.5 * (i as f32 * 0.0031).sin()))
+            .collect()
+    }
+
+    /// `(start, samples)` pairs from any window source.
+    fn drain(src: &mut dyn PcmWindows) -> Vec<OwnedWindow> {
+        let mut out = Vec::new();
+        while let Some(w) = src.next_window().expect("window") {
+            out.push((w.start_sample, w.samples.to_vec()));
+        }
+        out
+    }
+
+    /// What the batch path feeds the decoder: `speech_regions` over the whole
+    /// buffer, the kept spans concatenated, then the standard geometry (one
+    /// whole-buffer window under the single-pass ceiling).
+    fn batch(
+        samples: &[f32],
+        probs: &[f32],
+        cfg: &VadConfig,
+    ) -> (Vec<(usize, usize)>, Vec<OwnedWindow>) {
+        let regions = regions_from_probs(probs, VAD_FRAME_SAMPLES, samples.len(), cfg);
+        let compressed: Vec<f32> = regions
+            .iter()
+            .flat_map(|&(s, e)| samples[s..e].iter().copied())
+            .collect();
+        let spec = ort_spec();
+        let windows = if compressed.is_empty() {
+            // The batch path returns before touching the decoder when no region
+            // survives, and falls back to a full decode instead.
+            Vec::new()
+        } else if compressed.len() <= spec.single_pass_max() {
+            vec![(0, compressed.clone())]
+        } else {
+            drain(&mut SliceWindows::new(&compressed, spec))
+        };
+        (regions, windows)
+    }
+
+    /// Probabilities covering `n` samples: `on_frames` speech then `off_frames`
+    /// silence, repeating.
+    fn alternating(n: usize, on_frames: usize, off_frames: usize) -> Vec<f32> {
+        let period = on_frames + off_frames;
+        (0..n.div_ceil(VAD_FRAME_SAMPLES))
+            .map(|i| if i % period < on_frames { 0.9 } else { 0.1 })
+            .collect()
+    }
+
+    fn assert_matches_batch(n: usize, probs: &[f32], cfg: &VadConfig) {
+        let samples = signal(n);
+        let wav = Bytes::from(encode_wav_pcm16(&samples, 16000));
+        // 16 kHz PCM16 is the passthrough path, so the decoded buffer is the
+        // quantized `samples` — take it from the decoder to compare like for like.
+        let decoded = FileWindows::from_bytes(wav.clone(), WindowSpec::flat(), None)
+            .expect("open flat")
+            .drain_to_vec()
+            .expect("drain");
+        let (want_regions, want_windows) = batch(&decoded, probs, cfg);
+
+        let vad = scripted_vad(probs);
+        let mut src = VadWindows::new(
+            FileWindows::from_bytes(wav, VadWindows::pull_spec(), None).expect("open pull"),
+            &vad,
+            cfg,
+            ort_spec(),
+            None,
+        );
+        let got_windows = drain(&mut src);
+        assert_eq!(src.regions(), want_regions, "regions diverged at n={n}");
+        assert_eq!(got_windows, want_windows, "windows diverged at n={n}");
+        assert_eq!(src.total_16k_samples(), decoded.len());
+        // Both paths hand the clip back to the full decode on an empty result.
+        assert_eq!(src.needs_fallback(), want_regions.is_empty());
+    }
+
+    #[test]
+    fn test_vad_windows_match_batch_below_single_pass() {
+        // 20 s: the compressed buffer stays under the single-pass ceiling, so
+        // both paths must yield exactly one whole-buffer window.
+        let n = 16000 * 20;
+        assert_matches_batch(n, &alternating(n, 20, 40), &VadConfig::default());
+    }
+
+    #[test]
+    fn test_vad_windows_match_batch_in_the_chunked_regime() {
+        // 90 s with ~2/3 speech: the compressed buffer is well past the ceiling,
+        // so the overlapping geometry is exercised over compressed time.
+        let n = 16000 * 90;
+        assert_matches_batch(n, &alternating(n, 60, 30), &VadConfig::default());
+    }
+
+    #[test]
+    fn test_vad_windows_match_batch_on_sparse_speech() {
+        // Long silences between short bursts: many regions, heavy compression.
+        let n = 16000 * 75;
+        assert_matches_batch(n, &alternating(n, 12, 100), &VadConfig::default());
+    }
+
+    #[test]
+    fn test_vad_windows_match_batch_across_configs() {
+        let n = 16000 * 45;
+        let probs = alternating(n, 25, 25);
+        for cfg in [
+            VadConfig {
+                threshold: 0.5,
+                min_silence_ms: 0,
+                min_speech_ms: 0,
+                speech_pad_ms: 0,
+            },
+            VadConfig {
+                threshold: 0.5,
+                min_silence_ms: 100,
+                min_speech_ms: 1000,
+                speech_pad_ms: 300,
+            },
+            VadConfig {
+                threshold: 0.5,
+                min_silence_ms: 2000,
+                min_speech_ms: 100,
+                speech_pad_ms: 50,
+            },
+        ] {
+            assert_matches_batch(n, &probs, &cfg);
+        }
+    }
+
+    #[test]
+    fn test_vad_windows_all_speech_is_the_plain_stream() {
+        // Every frame speech: the compressed timeline is the raw one, so the
+        // windows must equal what `FileWindows` alone would yield.
+        let n = 16000 * 70;
+        let samples = signal(n);
+        let wav = Bytes::from(encode_wav_pcm16(&samples, 16000));
+        let probs = vec![0.9f32; n.div_ceil(VAD_FRAME_SAMPLES)];
+        let vad = scripted_vad(&probs);
+        let cfg = VadConfig::default();
+        let mut src = VadWindows::new(
+            FileWindows::from_bytes(wav.clone(), VadWindows::pull_spec(), None).expect("pull"),
+            &vad,
+            &cfg,
+            ort_spec(),
+            None,
+        );
+        let got = drain(&mut src);
+        let want = drain(&mut FileWindows::from_bytes(wav, ort_spec(), None).expect("plain"));
+        assert_eq!(src.regions(), &[(0, n)]);
+        assert_eq!(got, want);
+        assert!(!src.needs_fallback());
+    }
+
+    #[test]
+    fn test_vad_windows_no_speech_asks_for_fallback() {
+        let n = 16000 * 40;
+        let samples = signal(n);
+        let wav = Bytes::from(encode_wav_pcm16(&samples, 16000));
+        let probs = vec![0.1f32; n.div_ceil(VAD_FRAME_SAMPLES)];
+        let vad = scripted_vad(&probs);
+        let cfg = VadConfig::default();
+        let mut src = VadWindows::new(
+            FileWindows::from_bytes(wav, VadWindows::pull_spec(), None).expect("pull"),
+            &vad,
+            &cfg,
+            ort_spec(),
+            None,
+        );
+        assert!(drain(&mut src).is_empty());
+        assert!(src.regions().is_empty());
+        assert!(
+            src.needs_fallback(),
+            "a clip with no detected speech must fall back, not transcribe to nothing"
+        );
+    }
+
+    #[test]
+    fn test_vad_windows_empty_clip_needs_no_fallback() {
+        let wav = Bytes::from(encode_wav_pcm16(&[], 16000));
+        let vad = scripted_vad(&[0.1]);
+        let cfg = VadConfig::default();
+        let mut src = VadWindows::new(
+            FileWindows::from_bytes(wav, VadWindows::pull_spec(), None).expect("pull"),
+            &vad,
+            &cfg,
+            ort_spec(),
+            None,
+        );
+        drain(&mut src);
+        assert_eq!(src.total_16k_samples(), 0);
+        assert!(!src.needs_fallback());
+    }
+
+    #[test]
+    fn test_vad_windows_cancellation_stops_the_scan() {
+        let n = 16000 * 600; // 10 min: many pull blocks, so the poll is reached
+        let samples = signal(n);
+        let wav = Bytes::from(encode_wav_pcm16(&samples, 16000));
+        let probs = vec![0.9f32; n.div_ceil(VAD_FRAME_SAMPLES)];
+        let vad = scripted_vad(&probs);
+        let cfg = VadConfig::default();
+        let flag = || true;
+        let mut src = VadWindows::new(
+            FileWindows::from_bytes(wav, VadWindows::pull_spec(), None).expect("pull"),
+            &vad,
+            &cfg,
+            ort_spec(),
+            Some(&flag),
+        );
+        assert!(matches!(
+            src.next_window(),
+            Err(crate::error::GigasttError::Cancelled)
+        ));
+    }
+}

--- a/crates/gigastt-core/src/inference/engine.rs
+++ b/crates/gigastt-core/src/inference/engine.rs
@@ -1631,14 +1631,17 @@ impl Engine {
         match req.source {
             #[cfg(feature = "file-decode")]
             TranscribeSource::Path(path) => {
-                if self.stream_eligible(&req.overrides, req.diarization) {
-                    let windows = audio::FileWindows::open(
-                        path,
-                        window_spec(self.ane_encoder),
-                        max_audio_secs,
+                if self.stream_eligible(req.diarization) {
+                    self.transcribe_stream_file(
+                        |spec| {
+                            audio::FileWindows::open(path, spec, max_audio_secs)
+                                .map_err(audio::decode_error)
+                        },
+                        triplet,
+                        &req.overrides,
+                        req.hotwords,
+                        ctl,
                     )
-                    .map_err(audio::decode_error)?;
-                    self.transcribe_stream_mono(windows, triplet, &req.overrides, req.hotwords, ctl)
                 } else {
                     let float_samples = audio::decode_audio_file_bounded(path, max_audio_secs)
                         .map_err(audio::decode_error)?;
@@ -1655,14 +1658,17 @@ impl Engine {
             }
             #[cfg(feature = "file-decode")]
             TranscribeSource::Bytes(data) => {
-                if self.stream_eligible(&req.overrides, req.diarization) {
-                    let windows = audio::FileWindows::from_bytes(
-                        data,
-                        window_spec(self.ane_encoder),
-                        max_audio_secs,
+                if self.stream_eligible(req.diarization) {
+                    self.transcribe_stream_file(
+                        |spec| {
+                            audio::FileWindows::from_bytes(data.clone(), spec, max_audio_secs)
+                                .map_err(audio::decode_error)
+                        },
+                        triplet,
+                        &req.overrides,
+                        req.hotwords,
+                        ctl,
                     )
-                    .map_err(audio::decode_error)?;
-                    self.transcribe_stream_mono(windows, triplet, &req.overrides, req.hotwords, ctl)
                 } else {
                     let float_samples =
                         audio::decode_audio_bytes_shared_bounded(data, max_audio_secs)
@@ -1701,15 +1707,88 @@ impl Engine {
     /// streaming decode, whose peak audio memory is O(one window) rather than
     /// O(file).
     ///
-    /// VAD scans the whole 16 kHz buffer for speech regions and diarization
-    /// embeds the whole buffer; neither can run against a stream that is never
-    /// fully resident, so both fall back to the whole-buffer decode. `diarize`
-    /// only matters with the `diarization` feature compiled in.
+    /// Diarization embeds the whole clip in a second pass, so it cannot run
+    /// against a stream that is never fully resident: it still forces the
+    /// whole-buffer decode, and with it the duration ceiling. VAD does not — it
+    /// is causal, and [`VadWindows`](audio::VadWindows) runs it inside the
+    /// stream. `diarize` only matters with the `diarization` feature compiled
+    /// in.
     #[cfg(feature = "file-decode")]
-    fn stream_eligible(&self, overrides: &TranscribeOverrides, diarize: bool) -> bool {
+    fn stream_eligible(&self, diarize: bool) -> bool {
+        !(cfg!(feature = "diarization") && diarize)
+    }
+
+    /// Streaming mono file transcription, with the VAD stage in front when one
+    /// is attached and the request did not opt out.
+    ///
+    /// `open` builds a fresh window source for a given geometry. It is called
+    /// once, or twice when the VAD stage declines — the model failed mid-stream,
+    /// or the scan found no speech at all in a non-empty clip — in which case
+    /// the clip is decoded whole, exactly as the batch path did.
+    #[cfg(feature = "file-decode")]
+    fn transcribe_stream_file(
+        &self,
+        open: impl Fn(WindowSpec) -> Result<audio::FileWindows, GigasttError>,
+        triplet: &mut SessionTriplet,
+        overrides: &TranscribeOverrides,
+        hotwords: Option<&HotwordOverride>,
+        ctl: DecodeControls,
+    ) -> Result<TranscribeResult, GigasttError> {
         let use_vad = self.vad.is_some() && overrides.vad.unwrap_or(true);
-        let will_diarize = cfg!(feature = "diarization") && diarize;
-        !use_vad && !will_diarize
+        if let (true, Some(vad)) = (use_vad, &self.vad) {
+            let wall_start = std::time::Instant::now();
+            let request_biaser = hotwords.and_then(|hw| self.build_request_biaser(hw));
+            let biaser: Option<&bias::Biaser> = match hotwords {
+                None => self.biaser.as_ref(),
+                Some(_) => request_biaser.as_ref(),
+            };
+            let mut windows = audio::VadWindows::new(
+                open(audio::VadWindows::pull_spec())?,
+                vad,
+                &self.vad_config,
+                window_spec(self.ane_encoder),
+                ctl.abort,
+            );
+            let mut words = self.decode_words_streaming(&mut windows, triplet, biaser, ctl)?;
+            if !windows.needs_fallback() {
+                // Words are decoded on the compressed (silence-removed)
+                // timeline; put them back on the clip's own.
+                let regions = windows.regions();
+                for w in &mut words {
+                    w.start = crate::vad::remap_compressed_seconds(w.start, regions, 16000.0);
+                    w.end = crate::vad::remap_compressed_seconds(w.end, regions, 16000.0);
+                }
+                let duration_s = windows.total_16k_samples() as f64 / 16000.0;
+                let wall_s = wall_start.elapsed().as_secs_f64();
+                tracing::info!(
+                    audio_s = format_args!("{duration_s:.2}"),
+                    wall_s = format_args!("{wall_s:.2}"),
+                    rtf = format_args!(
+                        "{:.3}",
+                        if duration_s > 0.0 {
+                            wall_s / duration_s
+                        } else {
+                            0.0
+                        }
+                    ),
+                    regions = regions.len(),
+                    "transcribe complete (streaming windows, vad)"
+                );
+                return Ok(self.finish_transcribe_result(words, duration_s, overrides));
+            }
+            // Either the VAD found no speech at all — tone or continuous speech
+            // against a bad threshold — or the model failed mid-stream (already
+            // logged with the cause). Both re-read the clip and decode it whole
+            // rather than returning an empty transcript.
+            tracing::warn!("VAD produced no usable speech regions; decoding full audio");
+        }
+        self.transcribe_stream_mono(
+            open(window_spec(self.ane_encoder))?,
+            triplet,
+            overrides,
+            hotwords,
+            ctl,
+        )
     }
 
     /// Mono file-transcription tail that pulls windows straight from the

--- a/crates/gigastt-core/src/vad.rs
+++ b/crates/gigastt-core/src/vad.rs
@@ -351,6 +351,310 @@ pub fn remap_compressed_seconds(
     end as f64 / sample_rate
 }
 
+/// Causal, bounded-memory form of the file-VAD pipeline: the frame scan of
+/// [`SileroVad::speech_regions`] plus the silence-free concatenation the engine
+/// builds from its output.
+///
+/// The batch pair needs the whole 16 kHz buffer resident — once to score every
+/// frame, once to copy the kept spans out — which is what pinned the VAD file
+/// path to a duration ceiling. Silero is already causal (its recurrent state
+/// carries frame to frame), and every decision [`regions_from_probs`] makes is
+/// settled by a *bounded* look-ahead: a region can still absorb the next speech
+/// run for `min_silence_ms`, can still be dropped for falling short of
+/// `min_speech_ms`, and can still merge with its neighbour across
+/// `2 × speech_pad_ms`. So samples go in, whole frames are scored as they
+/// complete, and kept audio is released as soon as the look-ahead that decides
+/// it has passed — roughly `min_speech_ms + min_silence_ms + speech_pad_ms` of
+/// PCM held at a time (~850 ms at the defaults), whatever the file's length.
+///
+/// The result is byte-identical to the batch path, not merely equivalent:
+/// [`VadSegmenter::regions`] after `finish` equals [`regions_from_probs`] over
+/// the same frames, and the samples appended to `out` are exactly that
+/// concatenation. Both are asserted directly, including a proptest over random
+/// probability sequences and configs.
+///
+/// Only the file path needs it, so it is gated on `file-decode`: a lean build
+/// has no file VAD at all, only [`VadEndpointer`] for streams.
+#[cfg(feature = "file-decode")]
+pub(crate) struct VadSegmenter {
+    threshold: f32,
+    min_silence: usize,
+    min_speech: usize,
+    pad: usize,
+    /// Silero recurrent state, carried across pushes.
+    state: [f32; VAD_STATE_LEN],
+    /// Retained 16 kHz samples; `raw[0]` is absolute sample `raw_start`.
+    raw: Vec<f32>,
+    raw_start: usize,
+    /// Absolute index one past the last scored frame.
+    pos: usize,
+    /// Inside a raw (thresholded) speech run.
+    in_run: bool,
+    /// Merged region under construction: `(start, end of its last speech frame)`.
+    merged: Option<(usize, usize)>,
+    /// Index in `regions` of the entry the open region extends, set once that
+    /// region is long enough that the `min_speech_ms` drop can no longer take it.
+    open_idx: Option<usize>,
+    /// Kept, padded spans in order. Only the last one can still grow.
+    regions: Vec<(usize, usize)>,
+    /// Next `regions` entry to release samples from.
+    out_idx: usize,
+    /// Absolute index already copied into the caller's compressed buffer.
+    copied_to: usize,
+}
+
+#[cfg(feature = "file-decode")]
+impl VadSegmenter {
+    /// New segmenter for `cfg`, at absolute sample 0.
+    pub(crate) fn new(cfg: &VadConfig) -> Self {
+        Self {
+            threshold: cfg.threshold,
+            min_silence: VadConfig::ms_to_samples(cfg.min_silence_ms),
+            min_speech: VadConfig::ms_to_samples(cfg.min_speech_ms),
+            pad: VadConfig::ms_to_samples(cfg.speech_pad_ms),
+            state: [0.0; VAD_STATE_LEN],
+            raw: Vec::new(),
+            raw_start: 0,
+            pos: 0,
+            in_run: false,
+            merged: None,
+            open_idx: None,
+            regions: Vec::new(),
+            out_idx: 0,
+            copied_to: 0,
+        }
+    }
+
+    /// Kept spans as `[start, end)` on the **original** timeline, in order.
+    /// Complete only after [`VadSegmenter::finish`]; before that the last entry
+    /// can still grow.
+    pub(crate) fn regions(&self) -> &[(usize, usize)] {
+        &self.regions
+    }
+
+    /// Feed the next contiguous block of 16 kHz samples, appending everything
+    /// the VAD has committed to keeping to `out`.
+    pub(crate) fn push(
+        &mut self,
+        vad: &SileroVad,
+        samples: &[f32],
+        out: &mut Vec<f32>,
+    ) -> Result<()> {
+        self.push_with(samples, out, |frame, state| vad.run_frame(frame, state))
+    }
+
+    /// Close the stream at `total` absolute samples and release the rest.
+    pub(crate) fn finish(
+        &mut self,
+        vad: &SileroVad,
+        total: usize,
+        out: &mut Vec<f32>,
+    ) -> Result<()> {
+        self.finish_with(total, out, |frame, state| vad.run_frame(frame, state))
+    }
+
+    /// [`VadSegmenter::push`] with the per-frame scorer injected, so the pure
+    /// decision logic can be driven from a probability sequence in tests
+    /// without loading Silero.
+    fn push_with<F>(&mut self, samples: &[f32], out: &mut Vec<f32>, mut score: F) -> Result<()>
+    where
+        F: FnMut(&[f32], &mut [f32; VAD_STATE_LEN]) -> Result<f32>,
+    {
+        self.raw.extend_from_slice(samples);
+        let avail = self.raw_start + self.raw.len();
+        while self.pos + VAD_FRAME_SAMPLES <= avail {
+            let off = self.pos - self.raw_start;
+            let prob = score(&self.raw[off..off + VAD_FRAME_SAMPLES], &mut self.state)?;
+            self.step(prob, self.pos + VAD_FRAME_SAMPLES);
+        }
+        self.flush(out);
+        self.trim();
+        Ok(())
+    }
+
+    /// [`VadSegmenter::finish`] with the per-frame scorer injected.
+    fn finish_with<F>(&mut self, total: usize, out: &mut Vec<f32>, mut score: F) -> Result<()>
+    where
+        F: FnMut(&[f32], &mut [f32; VAD_STATE_LEN]) -> Result<f32>,
+    {
+        // `frame_probs` scores a trailing partial window zero-padded; so does
+        // this. That frame's timeline stops at `total`, not at the padded frame
+        // boundary — `regions_from_probs` measures the last run against
+        // `total_samples` the same way, and a region released early must not be
+        // credited with samples the signal does not have.
+        while self.pos < total {
+            let off = self.pos - self.raw_start;
+            let end = (off + VAD_FRAME_SAMPLES).min(self.raw.len());
+            let prob = score(&self.raw[off..end], &mut self.state)?;
+            self.step(prob, (self.pos + VAD_FRAME_SAMPLES).min(total));
+        }
+        self.close(total);
+        self.flush(out);
+        Ok(())
+    }
+
+    /// Settle the tail: a run still open at EOF ends at the true signal length
+    /// (not at the padded frame boundary), the open region is finalized, and
+    /// every span is clamped to `total` — exactly what `regions_from_probs`
+    /// does with its `total_samples` argument.
+    fn close(&mut self, total: usize) {
+        if self.in_run
+            && let Some(m) = self.merged.as_mut()
+        {
+            m.1 = total;
+            self.in_run = false;
+        }
+        if let Some((ms, me)) = self.merged.take() {
+            self.finalize(ms, me);
+        }
+        for r in &mut self.regions {
+            r.1 = r.1.min(total);
+        }
+        self.pos = self.pos.max(total);
+    }
+
+    /// Advance the timeline to `end` with the scored frame's speech probability
+    /// `prob`. `end` is the frame boundary except for the trailing partial
+    /// frame, where it is the true signal length.
+    fn step(&mut self, prob: f32, end: usize) {
+        let start = self.pos;
+        if prob >= self.threshold {
+            if !self.in_run {
+                match self.merged {
+                    // A gap shorter than `min_silence` does not split a region.
+                    Some((_, me)) if start.saturating_sub(me) < self.min_silence => {}
+                    Some((ms, me)) => {
+                        self.finalize(ms, me);
+                        self.merged = None;
+                    }
+                    None => {}
+                }
+                if self.merged.is_none() {
+                    self.merged = Some((start, start));
+                }
+                self.in_run = true;
+            }
+            if let Some(m) = self.merged.as_mut() {
+                m.1 = end;
+            }
+            // Once the region clears `min_speech` the drop can no longer take
+            // it, so its audio is released without waiting for it to close —
+            // this is what keeps an hour of unbroken speech from being buffered.
+            if let Some((ms, me)) = self.merged {
+                match self.open_idx {
+                    Some(i) => self.regions[i].1 = self.regions[i].1.max(me),
+                    None if me - ms >= self.min_speech => {
+                        self.open_idx = Some(self.push_padded(ms.saturating_sub(self.pad), me));
+                    }
+                    None => {}
+                }
+            }
+        } else {
+            self.in_run = false;
+            // The earliest a later run can start is `end`, so once that is
+            // `min_silence` past the region's end nothing can merge into it.
+            if let Some((ms, me)) = self.merged
+                && end.saturating_sub(me) >= self.min_silence
+            {
+                self.finalize(ms, me);
+                self.merged = None;
+            }
+        }
+        self.pos = end;
+    }
+
+    /// Append a padded span, merging it into the previous one when the padding
+    /// makes them touch. Mirrors step 4 of [`regions_from_probs`]; returns the
+    /// index of the entry that now covers `[ps, pe)`.
+    fn push_padded(&mut self, ps: usize, pe: usize) -> usize {
+        match self.regions.last_mut() {
+            Some(last) if ps <= last.1 => last.1 = last.1.max(pe),
+            _ => self.regions.push((ps, pe)),
+        }
+        self.regions.len() - 1
+    }
+
+    /// Commit a closed merged region `[ms, me)`: dropped when shorter than
+    /// `min_speech`, otherwise padded and merged into the output list.
+    fn finalize(&mut self, ms: usize, me: usize) {
+        let idx = self.open_idx.take();
+        if me - ms < self.min_speech {
+            return;
+        }
+        let pe = me + self.pad;
+        match idx {
+            Some(i) => self.regions[i].1 = self.regions[i].1.max(pe),
+            None => {
+                self.push_padded(ms.saturating_sub(self.pad), pe);
+            }
+        }
+    }
+
+    /// Absolute index up to which membership in `regions` is final.
+    fn decided_to(&self) -> usize {
+        let base = self.regions.last().map_or(0, |r| r.1);
+        let bound = match self.merged {
+            // The open region is certain to survive and `regions.last()` already
+            // tracks how far it reaches.
+            Some(_) if self.open_idx.is_some() => base,
+            // Still undecided from its padded start on.
+            Some((ms, _)) => base.max(ms.saturating_sub(self.pad)),
+            // Silence: a later region's padded start is at least `pos - pad`.
+            None => base.max(self.pos.saturating_sub(self.pad)),
+        };
+        bound.min(self.pos)
+    }
+
+    /// Copy every decided, not-yet-released kept sample into `out`.
+    fn flush(&mut self, out: &mut Vec<f32>) {
+        let decided = self.decided_to().min(self.raw_start + self.raw.len());
+        while self.out_idx < self.regions.len() {
+            let (s, e) = self.regions[self.out_idx];
+            let from = self.copied_to.max(s);
+            let to = e.min(decided);
+            if to > from {
+                // `trim` only ever drops PCM below what a still-growing span can
+                // reach back to; if that ever stops holding, say so here rather
+                // than underflowing into an opaque index panic.
+                debug_assert!(
+                    from >= self.raw_start,
+                    "released PCM at {from} below the retained start {}",
+                    self.raw_start
+                );
+                out.extend_from_slice(&self.raw[from - self.raw_start..to - self.raw_start]);
+                self.copied_to = to;
+            }
+            if self.out_idx + 1 < self.regions.len() {
+                self.out_idx += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Drop the retained PCM that can no longer be needed. Everything below the
+    /// decided watermark has been released already; an undecided open region
+    /// still needs its padded start.
+    fn trim(&mut self) {
+        let decided = self.decided_to();
+        let keep_from = match self.merged {
+            Some((ms, _)) if self.open_idx.is_none() => decided.min(ms.saturating_sub(self.pad)),
+            _ => decided,
+        };
+        let drop = keep_from.saturating_sub(self.raw_start).min(self.raw.len());
+        if drop > 0 {
+            self.raw.drain(..drop);
+            self.raw_start += drop;
+        }
+    }
+
+    /// Retained PCM, in samples. Test-only: the bound on this is the whole point.
+    #[cfg(test)]
+    fn retained(&self) -> usize {
+        self.raw.len()
+    }
+}
+
 /// Streaming endpoint detector: feeds streamed audio through the VAD in fixed
 /// frames, tracks trailing silence, and reports when an utterance has ended
 /// (≥ `min_silence_ms` of silence *after* speech was seen).
@@ -590,6 +894,195 @@ mod tests {
         assert!(!h.update(0.9, 512));
         assert!(!h.update(0.1, 512)); // 512
         assert!(h.update(0.1, 512)); // 1024 → fire #2
+    }
+
+    /// Streaming-segmenter equivalence. Gated with the segmenter itself:
+    /// a lean build has no file VAD to compare against.
+    #[cfg(feature = "file-decode")]
+    mod segmenter {
+        use super::*;
+
+        /// Drive a [`VadSegmenter`] from a probability sequence instead of the
+        /// model, in deliberately irregular chunks so the frame-buffering seam is
+        /// exercised. Returns the regions it settled on, the samples it released,
+        /// and the high-water mark of retained PCM.
+        ///
+        /// Sample `i` carries the value `i as f32`, so a released sample names its
+        /// own absolute index and the concatenation can be compared element-wise.
+        fn stream(
+            probs: &[f32],
+            total: usize,
+            cfg: &VadConfig,
+        ) -> (Vec<(usize, usize)>, Vec<f32>, usize) {
+            let raw: Vec<f32> = (0..total).map(|i| i as f32).collect();
+            let mut seg = VadSegmenter::new(cfg);
+            let mut out = Vec::new();
+            let mut it = probs.iter().copied();
+            let mut peak = 0usize;
+            let mut i = 0usize;
+            let mut chunk = 1usize;
+            while i < total {
+                let end = (i + chunk).min(total);
+                seg.push_with(&raw[i..end], &mut out, |_, _| Ok(it.next().unwrap_or(0.0)))
+                    .expect("push");
+                peak = peak.max(seg.retained());
+                i = end;
+                chunk = chunk % 977 + 1;
+            }
+            seg.finish_with(total, &mut out, |_, _| Ok(it.next().unwrap_or(0.0)))
+                .expect("finish");
+            (seg.regions().to_vec(), out, peak)
+        }
+
+        /// The batch pair the streamer must reproduce: `regions_from_probs` plus the
+        /// silence-free concatenation `Engine::decode_speech_regions` builds.
+        fn batch(probs: &[f32], total: usize, cfg: &VadConfig) -> (Vec<(usize, usize)>, Vec<f32>) {
+            let regions = regions_from_probs(probs, VAD_FRAME_SAMPLES, total, cfg);
+            let out = regions
+                .iter()
+                .flat_map(|&(s, e)| (s..e).map(|i| i as f32))
+                .collect();
+            (regions, out)
+        }
+
+        fn assert_stream_matches_batch(probs: &[f32], total: usize, cfg: &VadConfig) {
+            let (got_regions, got_samples, _) = stream(probs, total, cfg);
+            let (want_regions, want_samples) = batch(probs, total, cfg);
+            assert_eq!(
+                got_regions, want_regions,
+                "regions diverged (total={total})"
+            );
+            assert_eq!(
+                got_samples, want_samples,
+                "compressed buffer diverged (total={total})"
+            );
+        }
+
+        /// Probability sequence covering `total` samples at the production frame size.
+        fn probs_for(total: usize, f: impl Fn(usize) -> f32) -> Vec<f32> {
+            (0..total.div_ceil(VAD_FRAME_SAMPLES)).map(f).collect()
+        }
+
+        #[test]
+        fn test_segmenter_matches_batch_on_shaped_sequences() {
+            let c = VadConfig::default();
+            let fs = VAD_FRAME_SAMPLES;
+            // Alternating speech/silence blocks of many different periods, plus the
+            // degenerate all-speech / all-silence ends.
+            for period in [1usize, 2, 3, 5, 8, 16, 20, 31, 64] {
+                let total = 200 * fs + 137; // deliberately not frame-aligned
+                let probs = probs_for(total, |i| if (i / period) % 2 == 0 { 0.9 } else { 0.1 });
+                assert_stream_matches_batch(&probs, total, &c);
+            }
+            for level in [0.1f32, 0.9] {
+                let total = 97 * fs;
+                let probs = probs_for(total, |_| level);
+                assert_stream_matches_batch(&probs, total, &c);
+            }
+        }
+
+        #[test]
+        fn test_segmenter_matches_batch_on_degenerate_configs() {
+            let fs = VAD_FRAME_SAMPLES;
+            let total = 120 * fs + 11;
+            let probs = probs_for(total, |i| if (i / 7) % 3 == 0 { 0.9 } else { 0.1 });
+            // Padding wider than the silence gap is the config where step 2 and
+            // step 4 of `regions_from_probs` can both merge the same pair.
+            for c in [
+                cfg(0.5, 0, 0, 0),
+                cfg(0.5, 0, 0, 200),
+                cfg(0.5, 10, 0, 500),
+                cfg(0.5, 1000, 2000, 100),
+                cfg(0.5, 40, 40, 40),
+            ] {
+                assert_stream_matches_batch(&probs, total, &c);
+            }
+        }
+
+        #[test]
+        fn test_segmenter_matches_batch_on_short_and_empty_inputs() {
+            let c = VadConfig::default();
+            for total in [
+                0usize,
+                1,
+                2,
+                VAD_FRAME_SAMPLES - 1,
+                VAD_FRAME_SAMPLES,
+                VAD_FRAME_SAMPLES + 1,
+            ] {
+                for level in [0.1f32, 0.9] {
+                    assert_stream_matches_batch(&probs_for(total, |_| level), total, &c);
+                }
+            }
+        }
+
+        // Excluded under Miri: each case drives thousands of frames through the
+        // segmenter and the batch oracle, orders of magnitude too slow for the
+        // interpreter. The same property runs natively on every `cargo test`.
+        #[cfg(not(miri))]
+        proptest::proptest! {
+            #![proptest_config(proptest::prelude::ProptestConfig::with_cases(256))]
+            /// The load-bearing claim: for *any* probability sequence and *any*
+            /// config, the causal segmenter settles on the same spans and releases
+            /// the same samples as the batch pipeline it replaces.
+            #[test]
+            fn prop_segmenter_matches_batch(
+                probs in proptest::collection::vec(0.0f32..=1.0, 1..60),
+                tail in 1usize..=VAD_FRAME_SAMPLES,
+                threshold in 0.1f32..0.9,
+                min_silence_ms in 0u32..800,
+                min_speech_ms in 0u32..500,
+                speech_pad_ms in 0u32..400,
+            ) {
+                let total = (probs.len() - 1) * VAD_FRAME_SAMPLES + tail;
+                let c = cfg(threshold, min_silence_ms, min_speech_ms, speech_pad_ms);
+                let (got_regions, got_samples, _) = stream(&probs, total, &c);
+                let (want_regions, want_samples) = batch(&probs, total, &c);
+                proptest::prop_assert_eq!(got_regions, want_regions);
+                proptest::prop_assert_eq!(got_samples, want_samples);
+            }
+        }
+
+        #[test]
+        fn test_segmenter_retains_bounded_pcm_on_unbroken_speech() {
+            // An hour of unbroken speech: the region never closes, so a segmenter
+            // that waited for it would hold the whole hour. Released early, the
+            // retained PCM stays inside the look-ahead the config implies.
+            let c = VadConfig::default();
+            let total = 16000 * 3600;
+            let probs = probs_for(total, |_| 0.9);
+            let (regions, out, peak) = stream(&probs, total, &c);
+            assert_eq!(regions, vec![(0, total)]);
+            assert_eq!(out.len(), total);
+            let bound =
+                VadConfig::ms_to_samples(c.min_speech_ms + c.min_silence_ms + c.speech_pad_ms)
+                    + VAD_FRAME_SAMPLES
+                    + 977; // + the largest test chunk
+            assert!(
+                peak <= bound,
+                "retained {peak} samples, expected at most {bound}"
+            );
+        }
+
+        #[test]
+        fn test_segmenter_retains_bounded_pcm_on_sparse_speech() {
+            // Three hours of mostly silence with periodic speech: the same bound
+            // must hold when regions open and close throughout.
+            let c = VadConfig::default();
+            let total = 16000 * 3600 * 3;
+            let probs = probs_for(total, |i| if (i / 40) % 5 == 0 { 0.9 } else { 0.1 });
+            let (regions, out, peak) = stream(&probs, total, &c);
+            assert!(!regions.is_empty());
+            assert_eq!(out.len(), regions.iter().map(|(s, e)| e - s).sum::<usize>());
+            let bound =
+                VadConfig::ms_to_samples(c.min_speech_ms + c.min_silence_ms + c.speech_pad_ms)
+                    + VAD_FRAME_SAMPLES
+                    + 977;
+            assert!(
+                peak <= bound,
+                "retained {peak} samples, expected at most {bound}"
+            );
+        }
     }
 
     #[test]

--- a/docs/api.md
+++ b/docs/api.md
@@ -633,10 +633,11 @@ default 50 MiB ≈ 26 min of 16 kHz mono WAV); raise it for larger single files.
 Operators who want an explicit duration limit can start the server with
 `--max-audio-secs <N>` (env `GIGASTT_MAX_AUDIO_SECS`, default `0` = unlimited);
 audio longer than `N` seconds is rejected with `413 Payload Too Large` and code
-`audio_too_long` before any inference runs. VAD segmentation, speaker
-diarization, `channels=split`, and telephony/Opus decoding hold the whole
-decoded buffer in memory, so those paths always enforce a fixed ~30-minute
-safety ceiling regardless of `--max-audio-secs`, returning the same
+`audio_too_long` before any inference runs. `?vad=true` streams too — the VAD
+runs causally inside the window loop — so it carries no ceiling of its own.
+Speaker diarization, `channels=split`, and telephony/Opus decoding still hold
+the whole decoded buffer in memory, so those paths always enforce a fixed
+~30-minute safety ceiling regardless of `--max-audio-secs`, returning the same
 `audio_too_long` code. A batch worker should gate on `GET /ready` (not just
 `/health`) so it backs off on `503` pool saturation instead of failing
 mid-job.
@@ -655,7 +656,7 @@ mid-job.
 | 409 | `job_not_finished` | `GET /v1/jobs/{id}/result` called before the job is done |
 | 409 | `job_not_cancellable` | `DELETE /v1/jobs/{id}` called on a terminal job |
 | 413 | `payload_too_large` | Body exceeds `--body-limit-bytes` (default 50 MiB) |
-| 413 | `audio_too_long` | Audio exceeds `--max-audio-secs` (opt-in, env `GIGASTT_MAX_AUDIO_SECS`, default unlimited), or a whole-buffer path (VAD/diarization/`channels=split`/telephony) hit its ~30-minute safety ceiling |
+| 413 | `audio_too_long` | Audio exceeds `--max-audio-secs` (opt-in, env `GIGASTT_MAX_AUDIO_SECS`, default unlimited), or a whole-buffer path (diarization/`channels=split`/telephony) hit its ~30-minute safety ceiling |
 | 422 | `invalid_audio` | Audio could not be decoded (unsupported/corrupt format) |
 | 422 | `transcription_error` | Audio decoded but inference failed |
 | 429 | `queue_full` | In-memory job store is full; `Retry-After` header included |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,11 +126,11 @@ gigastt serve [OPTIONS]
   --jobs-ttl-secs <N>           TTL for finished/failed/cancelled jobs before eviction
                                 [default: 3600]. Env: GIGASTT_JOBS_TTL_SECS.
   --max-audio-secs <N>          Reject audio longer than N seconds on every path; 0 leaves
-                                the streaming file path unlimited [default: 0]. Paths that
-                                still need the whole buffer (VAD, diarization,
-                                channels=split, telephony) keep their own 1800 s ceiling
-                                regardless. Over the limit returns 413 audio_too_long.
-                                Env: GIGASTT_MAX_AUDIO_SECS.
+                                the streaming file path unlimited [default: 0], with or
+                                without --vad. Paths that still need the whole buffer
+                                (diarization, channels=split, telephony) keep their own
+                                1800 s ceiling regardless. Over the limit returns
+                                413 audio_too_long. Env: GIGASTT_MAX_AUDIO_SECS.
   --jobs-max <N>                Max jobs kept in memory; POST /v1/jobs returns 429 when
                                 full [default: 100]. Env: GIGASTT_JOBS_MAX.
   --jobs-max-bytes <N>          Max total bytes of buffered job uploads kept in memory;

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -259,8 +259,8 @@ gigastt serve --vad --pool-size 1
 
 | Path | When | Behaviour |
 |------|------|-----------|
-| **Speech regions (`--vad`)** | VAD loaded and not overridden off | Silero `speech_regions` → decode speech-only buffer; word times remapped to original timeline. Peak RSS drops on pause-rich / multi-utt files. |
-| **Empty VAD regions** | VAD returns zero spans (e.g. tone) | **Fallback** to full / fixed-window decode (does not return empty text). |
+| **Speech regions (`--vad`)** | VAD loaded and not overridden off | Silero scores the stream causally, kept audio is decoded in the same overlapping windows as the plain path, word times remapped to the original timeline. Peak audio memory is O(one window) — no duration ceiling. |
+| **Empty VAD regions** | VAD returns zero spans (e.g. tone), or the model fails mid-stream | **Fallback** to full / fixed-window decode (does not return empty text); the clip is re-read from the source. |
 | **Fixed-window chunking** | File ≳ 30 s and no usable VAD path | Overlapping ~24 s windows (30 s on ANE), stitch words at overlap midpoints — bounds encoder activation memory. |
 
 There is no separate client-side stitch API: operators use **`--vad`** for


### PR DESCRIPTION
## Why

Dropping the duration cap left one path behind. `--vad` scanned the whole decoded clip for speech regions, then copied the kept spans into a second whole-file buffer — two O(file) allocations — so `stream_eligible` sent it down the whole-buffer branch, where `whole_buffer_limit_secs` clamps to 1800 s. `--profile edge` turns VAD on by default, so the ceiling sat exactly on the hosts that need long files most.

On `main` (0ceb98d), clean machine:

```
$ gigastt transcribe --vad /tmp/gigastt_fx_3h.wav
Error: audio too long: 1800s exceeds the maximum of 1800s
        2.16 real   862 MB peak RSS
```

## What

`VadSegmenter` (`vad.rs`) is the causal form of `regions_from_probs` plus the silence-free concatenation the engine builds from it. Silero is already causal (its recurrent state carries frame to frame), and every decision the batch function makes is settled by a **bounded** look-ahead: a region can still absorb the next speech run for `min_silence_ms`, can still be dropped for falling short of `min_speech_ms`, and can still merge with its neighbour across `2 × speech_pad_ms`. Frames are scored as the container decodes, and kept audio is released as soon as the look-ahead that decides it has passed.

The non-obvious part: a region whose length has already cleared `min_speech_ms` can no longer be dropped, so its samples are released **without waiting for the region to close**. Without that, an hour of unbroken speech would still be buffered whole.

`VadWindows` (`inference/audio/vad_windows.rs`) is a `PcmWindows` source over the compressed timeline: `FileWindows` feeds the container in 2 s blocks, the segmenter scores them, and windows come out with the same geometry `SliceWindows` would yield over the fully compressed buffer. The window arithmetic moved out of `FileWindows` into a shared `WindowCursor` rather than being duplicated — the subtle EOF/single-pass logic now has one home.

`stream_eligible` now disqualifies only diarization.

## Memory gate: 3 h with `--vad` within 2× of the same clip without it

Clean machine, release, CPU EP, `rnnt` INT8, 3 h fixture.

| run | `main` (0ceb98d) | this branch |
|---|---|---|
| 3 h `--vad` | **refuses at 1800 s**, 862 MB | **878.8 MB**, 78.3 s |
| 3 h no VAD | 865.4 MB, 399.0 s | 863.8 MB, 416.3 s |

**878.8 / 865.4 = 1.015×** against a 2× gate. Peak no longer tracks duration: one decode window (~1.5 MB) plus the look-ahead (`min_speech + min_silence + pad` ≈ 850 ms of PCM ≈ 56 KB).

## Quality gate: the transcript is byte-identical, checked not assumed

- **20/20** real continuous podlodka recordings with `--vad`: byte-identical.
- 25 min fixture with `--vad`: byte-identical.
- 1700 s fixture, right at the old ceiling, with `--vad`: byte-identical.
- 3 h fixture without VAD: byte-identical — this one covers the `WindowCursor` extraction.
- **proptest (256 cases)** over random probability sequences and random configs asserts both the span list and the released samples against the batch pipeline, plus shaped/degenerate suites and two retention-bound tests.
- `vad_windows.rs` scripts Silero through the mock runtime, so the batch-versus-stream comparison — same clip, same config, window for window — runs in CI **with no model on disk**.

The proptest earned its keep: it found a real defect (seed checked in). A region released early was credited with the last *padded* frame, whose end reaches past the true signal length, so at EOF it could retroactively fail `min_speech_ms` after its audio had already gone out. Fixed by clamping the trailing frame's end to the signal length — which is also exactly what `regions_from_probs` does with `total_samples`.

## Cost

hyperfine, 8 runs, 25 min with `--vad`: this branch **22.94 s ± 1.56**, `main` **30.62 s ± 13.42** (min 21.9, max 56.7). User time is the same (79.1 vs 80.3 s) — same work; the batch path just has a long tail from allocating two whole-file buffers. Honest reading: **wall time did not grow**, and the spread collapsed.

## Scope

Diarization, `channels=split`, and the telephony / Opus codecs still need the whole buffer and keep the ceiling. SSE `/v1/transcribe/stream` materializes its buffer before chunking by design and is unchanged. `--max-audio-secs` still applies verbatim when set.

## Verification

- `cargo test -p gigastt-core --lib` — 570 passed
- `cargo test -p gigastt --lib` — 215 passed
- `cargo clippy --all-targets` — clean
- `cargo fmt --all -- --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p gigastt-core` — clean
- `cargo semver-checks -p gigastt-core --default-features --baseline-rev origin/main` — 219 checks pass, no semver update required
- `scripts/check-docs-drift.py` — no drift
- E2E with the model, `--ignored --test-threads=1 --no-fail-fast`: 119 passed, 1 failed — `cli_download_json_emits_quantize_phase`, which **fails identically on `main`** and is unrelated (model download / quantize phase events)