### PR TITLE
feat(core): decode OGG/Opus packet-wise instead of accumulating every channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path.** File decode streams through bounded windows regardless of length,
   so peak memory stays roughly constant — files of any length now transcribe
   fine. The paths that still need the whole decoded buffer in memory (speaker
-  diarization, `channels=split`, and telephony/Opus decoding) keep the
-  ~30-minute safety ceiling to avoid OOM, surfaced as the same
+  diarization, `channels=split`, and the G.722 / raw telephony codecs) keep
+  the ~30-minute safety ceiling to avoid OOM, surfaced as the same
   `audio_too_long` code introduced above.
 
 - **The same cap on the `--vad` file path.** Silence-skipping used to scan and
@@ -45,6 +45,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   therefore the transcript are byte-identical to the batch path — asserted
   against it directly, including a proptest over random probability sequences
   and configs. `--max-audio-secs` still applies verbatim when set.
+
+- **The same cap on OGG/Opus.** Symphonia demuxes Opus but ships no decoder, so
+  packets went through the `opus-rs` fallback, which accumulated every channel
+  of the whole file before anything could be mixed or resampled — leaving the
+  container behind voice messages, browser MediaRecorder captures and WebRTC
+  recordings as the last one that could not stream. A two-hour 24 kbps
+  `.ogg` is 25 MB and was refused outright. Opus now decodes packet-wise into
+  the same window loop as every other container: peak RSS across 5 min / 30 min
+  / 2 h is 780 / 910 / 822 MB — no slope, dominated by the ONNX arena. The
+  samples are identical to the whole-buffer decode, including the mono
+  downmix, which is asserted against it directly; the resampler is still fed in
+  the same fixed-size chunks so its flush boundaries do not move.
 
 ### Changed
 

--- a/crates/gigastt-core/src/inference/audio/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/mod.rs
@@ -30,12 +30,14 @@ pub(crate) use super::{HOP_LENGTH, N_FFT};
 pub(crate) const MAX_BUFFER_SAMPLES: usize = 16000 * 5; // 5 seconds at 16kHz
 /// Explicit, documented safety ceiling (seconds) for the decode paths that must
 /// hold the **whole** decoded buffer in RAM: speaker diarization,
-/// `channels=split`, and the telephony / Opus whole-buffer codecs. The default
+/// `channels=split` (including its per-channel Opus decode), and the G.722 /
+/// raw telephony codecs, which have no packet-wise decoder. The default
 /// file path streams overlapping windows (see `Engine::decode_words_streaming`),
-/// and the VAD file path streams through
-/// [`VadWindows`](super::audio::VadWindows), so both have peak audio memory
-/// O(one window) regardless of length and *no* duration limit; the remaining
-/// paths keep this bound so a multi-hour input refuses with a typed
+/// the VAD file path streams through
+/// [`VadWindows`](super::audio::VadWindows), and OGG/Opus streams packet-wise
+/// through the `opus-rs` fallback, so all three have peak audio memory O(one
+/// window) regardless of length and *no* duration limit; the remaining paths
+/// keep this bound so a multi-hour input refuses with a typed
 /// [`AudioTooLong`](crate::error::GigasttError::AudioTooLong) instead of driving
 /// the process into OOM. Operators can lower the effective limit for every path
 /// (including the streaming one) with `--max-audio-secs`; there is no way to

--- a/crates/gigastt-core/src/inference/audio/opus.rs
+++ b/crates/gigastt-core/src/inference/audio/opus.rs
@@ -8,6 +8,12 @@ use symphonia::core::formats::FormatReader;
 #[cfg(feature = "file-decode")]
 use super::audio_too_long_err;
 
+/// Opus always decodes at 48 kHz regardless of the container's declared input
+/// rate (RFC 7845 §5.1), so this — not the header rate — is the unit the length
+/// budget counts and a duration trip reports.
+#[cfg(feature = "file-decode")]
+pub(super) const OPUS_DECODE_RATE: u32 = 48_000;
+
 /// Maximum decoded samples per channel for one Opus packet: 120 ms at 48 kHz
 /// (RFC 6716 §3.2.5). A packet claiming more is malformed.
 #[cfg(feature = "file-decode")]
@@ -86,6 +92,103 @@ pub(super) fn next_demux_packet(
     }
 }
 
+/// Reject channel layouts the `opus-rs` fallback cannot decode. Mono/stereo
+/// covers Telegram voice notes, browser MediaRecorder captures, and `.opus`
+/// files; multistream (>2ch) OGG/Opus is out.
+#[cfg(feature = "file-decode")]
+fn check_opus_channels(channels: usize) -> Result<()> {
+    if !(1..=2).contains(&channels) {
+        anyhow::bail!("Opus with {channels} channels is not supported (mono/stereo only)");
+    }
+    Ok(())
+}
+
+/// Per RFC 7845 the decode rate is always 48 kHz, whatever the container's
+/// declared input rate.
+#[cfg(feature = "file-decode")]
+fn new_opus_decoder(channels: usize) -> Result<opus_rs::OpusDecoder> {
+    opus_rs::OpusDecoder::new(OPUS_DECODE_RATE as i32, channels)
+        .map_err(|e| anyhow::anyhow!("Opus decoder init failed: {e}"))
+}
+
+/// Decode one packet into `pcm` (interleaved, `channels` deep), returning the
+/// per-channel frame count. The single place that knows the packet contract —
+/// the `opus-rs` API takes the exact packet duration rather than a buffer
+/// capacity — shared by the whole-buffer and streaming decoders so they cannot
+/// drift apart.
+#[cfg(feature = "file-decode")]
+fn decode_packet_interleaved(
+    decoder: &mut opus_rs::OpusDecoder,
+    channels: usize,
+    data: &[u8],
+    pcm: &mut Vec<f32>,
+) -> Result<usize> {
+    let frame_size =
+        opus_packet_frame_size(data).ok_or_else(|| anyhow::anyhow!("Malformed Opus packet"))?;
+    pcm.resize(frame_size * channels, 0.0);
+    let decoded = decoder
+        .decode(data, frame_size, pcm)
+        .map_err(|e| anyhow::anyhow!("Opus decode error: {e}"))?
+        .min(frame_size);
+    Ok(decoded)
+}
+
+/// Packet-at-a-time Opus decode, mixed down to mono as it goes.
+///
+/// The streaming counterpart of [`decode_opus_channels`], which has to hold
+/// every channel of the whole file before anything can be mixed or resampled —
+/// the reason the Opus path stayed on the whole-buffer duration ceiling while
+/// every other container streamed. This one holds a single packet.
+///
+/// The mix is the same mean
+/// [`mix_channels_to_mono`](super::decode::mix_channels_to_mono) computes, in
+/// the same summation order, so the samples are identical rather than merely
+/// equivalent.
+#[cfg(feature = "file-decode")]
+pub(super) struct OpusStream {
+    decoder: opus_rs::OpusDecoder,
+    channels: usize,
+    /// Interleaved per-packet scratch, hoisted out of the decode loop.
+    pcm: Vec<f32>,
+}
+
+#[cfg(feature = "file-decode")]
+impl OpusStream {
+    pub(super) fn new(channels: usize) -> Result<Self> {
+        check_opus_channels(channels)?;
+        Ok(Self {
+            decoder: new_opus_decoder(channels)?,
+            channels,
+            pcm: Vec::new(),
+        })
+    }
+
+    /// Decode one packet, appending its mono 48 kHz samples to `out`. Returns
+    /// the number of frames appended.
+    pub(super) fn decode_packet(&mut self, data: &[u8], out: &mut Vec<f32>) -> Result<usize> {
+        let frames =
+            decode_packet_interleaved(&mut self.decoder, self.channels, data, &mut self.pcm)?;
+        push_mono_mix(&self.pcm, self.channels, frames, out);
+        Ok(frames)
+    }
+}
+
+/// Append the mono mix of the first `frames` interleaved frames of `pcm`.
+///
+/// Deliberately the same arithmetic as
+/// [`mix_channels_to_mono`](super::decode::mix_channels_to_mono) over the same
+/// samples de-interleaved — same summation order, same divisor — so mixing
+/// per packet cannot drift from mixing the whole file at once. Pinned against
+/// it in `tests.rs`.
+#[cfg(feature = "file-decode")]
+pub(super) fn push_mono_mix(pcm: &[f32], channels: usize, frames: usize, out: &mut Vec<f32>) {
+    let ch = channels as f32;
+    for frame in 0..frames {
+        let base = frame * channels;
+        out.push(pcm[base..base + channels].iter().sum::<f32>() / ch);
+    }
+}
+
 /// Decode the packets of an Opus track (OGG container) to per-channel f32
 /// samples at 48 kHz.
 ///
@@ -107,11 +210,8 @@ pub(super) fn decode_opus_channels(
     max_samples: usize,
     limit_secs: f64,
 ) -> Result<Vec<Vec<f32>>> {
-    if !(1..=2).contains(&channels) {
-        anyhow::bail!("Opus with {channels} channels is not supported (mono/stereo only)");
-    }
-    let mut decoder = opus_rs::OpusDecoder::new(48_000, channels)
-        .map_err(|e| anyhow::anyhow!("Opus decoder init failed: {e}"))?;
+    check_opus_channels(channels)?;
+    let mut decoder = new_opus_decoder(channels)?;
     let mut per_channel: Vec<Vec<f32>> = (0..channels).map(|_| Vec::new()).collect();
     let mut pcm: Vec<f32> = Vec::new();
     loop {
@@ -122,13 +222,7 @@ pub(super) fn decode_opus_channels(
         if packet.track_id != track_id {
             continue;
         }
-        let frame_size = opus_packet_frame_size(&packet.data)
-            .ok_or_else(|| anyhow::anyhow!("Malformed Opus packet"))?;
-        pcm.resize(frame_size * channels, 0.0);
-        let decoded = decoder
-            .decode(&packet.data, frame_size, &mut pcm)
-            .map_err(|e| anyhow::anyhow!("Opus decode error: {e}"))?
-            .min(frame_size);
+        let decoded = decode_packet_interleaved(&mut decoder, channels, &packet.data, &mut pcm)?;
         if channels == 1 {
             per_channel[0].extend_from_slice(&pcm[..decoded]);
         } else {
@@ -141,7 +235,11 @@ pub(super) fn decode_opus_channels(
         // Incremental length budget, same as the symphonia decode loops.
         let decoded_len = per_channel.first().map(|v| v.len()).unwrap_or(0);
         if decoded_len > max_samples {
-            return Err(audio_too_long_err(decoded_len, 48_000, limit_secs));
+            return Err(audio_too_long_err(
+                decoded_len,
+                OPUS_DECODE_RATE,
+                limit_secs,
+            ));
         }
     }
     Ok(per_channel)

--- a/crates/gigastt-core/src/inference/audio/stream.rs
+++ b/crates/gigastt-core/src/inference/audio/stream.rs
@@ -33,17 +33,15 @@ use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 
 #[cfg(feature = "file-decode")]
-use super::decode::{BytesMediaSource, mix_channels_to_mono};
+use super::decode::BytesMediaSource;
 #[cfg(feature = "file-decode")]
-use super::opus::{decode_opus_channels, next_demux_packet};
+use super::opus::{OPUS_DECODE_RATE, OpusStream, next_demux_packet};
 #[cfg(feature = "file-decode")]
 use super::resample::{RESAMPLE_STAGING_FRAMES, ResampleTo16k, SampleRate};
 #[cfg(feature = "file-decode")]
 use super::telephony::{sniffs_as_g722_wav, try_decode_g722_wav};
 #[cfg(feature = "file-decode")]
-use super::{
-    MAX_SAMPLE_RATE, audio_too_long_err, decode_error, resolve_budget, whole_buffer_limit_secs,
-};
+use super::{MAX_SAMPLE_RATE, audio_too_long_err, decode_error, resolve_budget};
 
 /// Samples per encoder output frame (`HOP_LENGTH * ENCODER_SUBSAMPLING`,
 /// 640 @16 kHz). Window starts are multiples of this so each window's frame
@@ -300,9 +298,30 @@ enum Source {
         /// Per-packet interleaved scratch, hoisted out of the decode loop.
         interleaved: Vec<f32>,
     },
+    /// OGG/Opus: symphonia demuxes it but ships no decoder, so packets go
+    /// through the `opus-rs` fallback ([`OpusStream`]) and are mixed to mono
+    /// and resampled as they arrive — same shape as `Streaming`, different
+    /// decoder.
+    Opus {
+        format: Box<dyn FormatReader>,
+        track_id: u32,
+        /// Boxed: it carries libopus decoder state.
+        stream: Box<OpusStream>,
+        /// Running decoded frame count at the Opus decode rate (48 kHz), which
+        /// is what the budget below counts and what a trip reports.
+        decoded_48k: usize,
+        max_samples: usize,
+        limit_secs: f64,
+        resampler: Box<ResampleTo16k>,
+        /// Decoded mono samples not yet staged. The whole-buffer path fed the
+        /// resampler in exact [`RESAMPLE_STAGING_FRAMES`] chunks; holding the
+        /// remainder here reproduces that chunk sequence packet-by-packet, so
+        /// the flush boundaries — and with them the resampled output — do not
+        /// move. Bounded by one chunk plus one packet.
+        pending: Vec<f32>,
+    },
     /// The whole 16 kHz stream is already in [`FileWindows::buf`]. Used by the
-    /// Opus fallback (it still accumulates per channel — streaming it is out of
-    /// scope) and the G.722-in-WAV telephony path (no symphonia decoder).
+    /// G.722-in-WAV telephony path (no symphonia decoder).
     Eager,
 }
 
@@ -390,7 +409,7 @@ impl FileWindows {
         spec: WindowSpec,
         max_audio_secs: Option<f64>,
     ) -> Result<Self> {
-        let mut format = symphonia::default::get_probe()
+        let format = symphonia::default::get_probe()
             .probe(
                 &hint,
                 mss,
@@ -437,27 +456,31 @@ impl FileWindows {
 
         match decoder_opt {
             None => {
-                // Opus is accumulated whole-buffer (the fallback decoder does not
-                // stream), so it must stay under the whole-buffer safety ceiling
-                // even when the caller left the streaming budget unbounded.
-                let (opus_max, opus_limit) =
-                    resolve_budget(Some(whole_buffer_limit_secs(max_audio_secs)), sample_rate);
-                let mono = mix_channels_to_mono(&decode_opus_channels(
-                    &mut *format,
-                    track_id,
-                    channels,
-                    opus_max,
-                    opus_limit,
-                )?);
-                let mut resampler = ResampleTo16k::new(SampleRate(sample_rate), None);
-                for piece in mono.chunks(RESAMPLE_STAGING_FRAMES) {
-                    resampler.stage().extend_from_slice(piece);
-                    resampler.flush_full()?;
-                }
-                let mut buf = Vec::new();
-                resampler.finish_into(&mut buf)?;
-                tracing::info!("Audio (opus): {sample_rate}Hz, {channels}ch (eager)");
-                Ok(Self::eager(buf, spec))
+                // The budget counts at the Opus decode rate (48 kHz), which is
+                // what the decoder actually emits and what a trip reports —
+                // the container's declared input rate is not necessarily the
+                // same number. No whole-buffer clamp: this path streams now.
+                let (max_samples, limit_secs) = resolve_budget(max_audio_secs, OPUS_DECODE_RATE);
+                tracing::info!("Audio (opus): {sample_rate}Hz, {channels}ch (streaming windows)");
+                Ok(Self {
+                    src: Source::Opus {
+                        format,
+                        track_id,
+                        stream: Box::new(OpusStream::new(channels)?),
+                        decoded_48k: 0,
+                        max_samples,
+                        limit_secs,
+                        resampler: Box::new(ResampleTo16k::new(SampleRate(sample_rate), None)),
+                        pending: Vec::with_capacity(RESAMPLE_STAGING_FRAMES),
+                    },
+                    eof: false,
+                    finished: false,
+                    buf: Vec::new(),
+                    buf_start_abs: 0,
+                    decoded_16k_total: 0,
+                    spec,
+                    cursor: WindowCursor::new(spec),
+                })
             }
             Some(decoder) => {
                 tracing::info!("Audio: {sample_rate}Hz, {channels}ch (streaming windows)");
@@ -533,6 +556,16 @@ impl FileWindows {
     /// samples to `buf`. Enforces the source-rate length budget incrementally with
     /// the exact same error string as the whole-buffer path.
     fn fill_to(&mut self, target: usize) -> Result<()> {
+        match self.src {
+            Source::Streaming { .. } => self.fill_streaming(target),
+            Source::Opus { .. } => self.fill_opus(target),
+            // The whole buffer is already resident.
+            Source::Eager => Ok(()),
+        }
+    }
+
+    /// [`FileWindows::fill_to`] for a container symphonia can decode itself.
+    fn fill_streaming(&mut self, target: usize) -> Result<()> {
         let Source::Streaming {
             format,
             decoder,
@@ -599,6 +632,74 @@ impl FileWindows {
         }
 
         if self.eof && !self.finished {
+            let before = self.buf.len();
+            resampler.finish_into(&mut self.buf)?;
+            self.decoded_16k_total += self.buf.len() - before;
+            self.finished = true;
+        }
+        Ok(())
+    }
+
+    /// [`FileWindows::fill_to`] for OGG/Opus, decoded through the `opus-rs`
+    /// fallback. Same loop as [`FileWindows::fill_streaming`]: one packet at a
+    /// time, budget checked incrementally, resampler drained into `buf`.
+    fn fill_opus(&mut self, target: usize) -> Result<()> {
+        let Source::Opus {
+            format,
+            track_id,
+            stream,
+            decoded_48k,
+            max_samples,
+            limit_secs,
+            resampler,
+            pending,
+        } = &mut self.src
+        else {
+            return Ok(());
+        };
+
+        while !self.eof && self.decoded_16k_total < target {
+            let have_pcm = *decoded_48k > 0;
+            let packet = match next_demux_packet(&mut **format, have_pcm)? {
+                Some(p) => p,
+                None => {
+                    self.eof = true;
+                    break;
+                }
+            };
+            if packet.track_id != *track_id {
+                continue;
+            }
+
+            *decoded_48k += stream.decode_packet(&packet.data, pending)?;
+            if *decoded_48k > *max_samples {
+                return Err(audio_too_long_err(
+                    *decoded_48k,
+                    OPUS_DECODE_RATE,
+                    *limit_secs,
+                ));
+            }
+
+            // Stage in exact `RESAMPLE_STAGING_FRAMES` chunks, keeping the
+            // remainder in `pending`: that is the chunk sequence the
+            // whole-buffer path produced, and the resampler drains whatever is
+            // staged, so any other cadence would move the flush boundaries and
+            // with them the output samples.
+            while pending.len() >= RESAMPLE_STAGING_FRAMES {
+                resampler
+                    .stage()
+                    .extend_from_slice(&pending[..RESAMPLE_STAGING_FRAMES]);
+                pending.drain(..RESAMPLE_STAGING_FRAMES);
+                resampler.flush_full()?;
+            }
+            let before = self.buf.len();
+            resampler.drain_ready_into(&mut self.buf);
+            self.decoded_16k_total += self.buf.len() - before;
+        }
+
+        if self.eof && !self.finished {
+            resampler.stage().extend_from_slice(pending);
+            pending.clear();
             let before = self.buf.len();
             resampler.finish_into(&mut self.buf)?;
             self.decoded_16k_total += self.buf.len() - before;

--- a/crates/gigastt-core/src/inference/audio/tests.rs
+++ b/crates/gigastt-core/src/inference/audio/tests.rs
@@ -1287,6 +1287,136 @@ fn test_decode_audio_bytes_g722_wav_ffmpeg_fixture_matches_reference() {
 
 // --- Opus (OGG container, pure-Rust opus-rs fallback decoder) ---
 
+/// The whole-buffer Opus pipeline as it stood before the streaming source:
+/// decode every channel of the whole file, mix to mono, then feed the resampler
+/// in exact `RESAMPLE_STAGING_FRAMES` chunks. Kept here verbatim as the oracle
+/// the streaming decode must reproduce sample for sample.
+#[cfg(feature = "file-decode")]
+fn eager_opus_reference(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
+    use symphonia::core::formats::probe::Hint;
+    use symphonia::core::formats::{FormatOptions, TrackType};
+    use symphonia::core::io::MediaSourceStream;
+    use symphonia::core::meta::MetadataOptions;
+
+    let source = BytesMediaSource::new(bytes::Bytes::copy_from_slice(bytes));
+    let mss = MediaSourceStream::new(Box::new(source), Default::default());
+    let mut format = symphonia::default::get_probe().probe(
+        &Hint::new(),
+        mss,
+        FormatOptions::default(),
+        MetadataOptions::default(),
+    )?;
+    let (track_id, sample_rate, channels) = {
+        let track = format
+            .default_track(TrackType::Audio)
+            .ok_or_else(|| anyhow::anyhow!("no audio track"))?;
+        let p = track
+            .codec_params
+            .as_ref()
+            .and_then(|p| p.audio())
+            .ok_or_else(|| anyhow::anyhow!("no audio params"))?;
+        (
+            track.id,
+            p.sample_rate.ok_or_else(|| anyhow::anyhow!("no rate"))?,
+            p.channels.as_ref().map(|c| c.count()).unwrap_or(1),
+        )
+    };
+    let mono = mix_channels_to_mono(&super::opus::decode_opus_channels(
+        &mut *format,
+        track_id,
+        channels,
+        usize::MAX,
+        f64::INFINITY,
+    )?);
+    let mut resampler = super::resample::ResampleTo16k::new(SampleRate(sample_rate), None);
+    for piece in mono.chunks(super::resample::RESAMPLE_STAGING_FRAMES) {
+        resampler.stage().extend_from_slice(piece);
+        resampler.flush_full()?;
+    }
+    let mut out = Vec::new();
+    resampler.finish_into(&mut out)?;
+    Ok(out)
+}
+
+#[test]
+fn test_opus_streaming_decode_matches_whole_buffer() {
+    // Opus used to be the one container that could not stream: the fallback
+    // decoder accumulated every channel of the whole file before anything was
+    // mixed or resampled, which is what kept it on the duration ceiling. It
+    // decodes packet-by-packet now — and must yield the same samples, not
+    // merely close ones.
+    for (name, bytes) in [
+        (
+            "opus_tone.ogg",
+            &include_bytes!("../../../tests/fixtures/opus/opus_tone.ogg")[..],
+        ),
+        (
+            "opus_tone_no_eos.ogg",
+            &include_bytes!("../../../tests/fixtures/opus/opus_tone_no_eos.ogg")[..],
+        ),
+    ] {
+        let streamed = decode_audio_bytes(bytes).expect("streaming decode");
+        let eager = eager_opus_reference(bytes).expect("whole-buffer decode");
+        assert!(!streamed.is_empty(), "{name} decoded to nothing");
+        assert_eq!(streamed, eager, "{name}: streaming decode diverged");
+    }
+}
+
+#[test]
+fn test_opus_streaming_windows_match_slice_over_flat_decode() {
+    // The windowed source over an Opus stream must yield exactly what
+    // `SliceWindows` yields over the same flat decode — the same guarantee the
+    // symphonia-backed source carries.
+    let bytes =
+        bytes::Bytes::from_static(include_bytes!("../../../tests/fixtures/opus/opus_tone.ogg"));
+    // A window shorter than the clip so the overlapping geometry is exercised.
+    let spec = WindowSpec::new(16_000, 16_000, 3_200);
+    let flat = FileWindows::from_bytes(bytes.clone(), WindowSpec::flat(), None)
+        .expect("open flat")
+        .drain_to_vec()
+        .expect("drain");
+    let mut src = FileWindows::from_bytes(bytes, spec, None).expect("open windows");
+    let mut got = Vec::new();
+    while let Some(w) = src.next_window().expect("window") {
+        got.push((w.start_sample, w.samples.to_vec()));
+    }
+    let mut want = Vec::new();
+    let mut sw = SliceWindows::new(&flat, spec);
+    while let Some(w) = sw.next_window().expect("slice window") {
+        want.push((w.start_sample, w.samples.to_vec()));
+    }
+    assert!(
+        got.len() > 1,
+        "expected the windowed regime, got {}",
+        got.len()
+    );
+    assert_eq!(got, want);
+    assert_eq!(src.total_16k_samples(), flat.len());
+}
+
+#[test]
+fn test_push_mono_mix_matches_mix_channels_to_mono() {
+    // The streaming decode mixes per packet; the whole-buffer one mixed the
+    // finished per-channel buffers. Same arithmetic, pinned.
+    for channels in [1usize, 2] {
+        let frames = 97;
+        let pcm: Vec<f32> = (0..frames * channels)
+            .map(|i| ((i as f32) * 0.37).sin() * 0.8 - 0.13)
+            .collect();
+        let mut got = Vec::new();
+        super::opus::push_mono_mix(&pcm, channels, frames, &mut got);
+
+        let per_channel: Vec<Vec<f32>> = (0..channels)
+            .map(|c| (0..frames).map(|f| pcm[f * channels + c]).collect())
+            .collect();
+        assert_eq!(
+            got,
+            mix_channels_to_mono(&per_channel),
+            "channels={channels}"
+        );
+    }
+}
+
 #[test]
 fn test_is_recoverable_packet_eof_matches_unexpected_eof_only() {
     use std::io::{Error as IoError, ErrorKind};

--- a/docs/api.md
+++ b/docs/api.md
@@ -634,8 +634,9 @@ Operators who want an explicit duration limit can start the server with
 `--max-audio-secs <N>` (env `GIGASTT_MAX_AUDIO_SECS`, default `0` = unlimited);
 audio longer than `N` seconds is rejected with `413 Payload Too Large` and code
 `audio_too_long` before any inference runs. `?vad=true` streams too — the VAD
-runs causally inside the window loop — so it carries no ceiling of its own.
-Speaker diarization, `channels=split`, and telephony/Opus decoding still hold
+runs causally inside the window loop — so it carries no ceiling of its own, and
+OGG/Opus uploads stream packet-wise like every other container. Speaker
+diarization, `channels=split`, and the G.722 / raw telephony codecs still hold
 the whole decoded buffer in memory, so those paths always enforce a fixed
 ~30-minute safety ceiling regardless of `--max-audio-secs`, returning the same
 `audio_too_long` code. A batch worker should gate on `GET /ready` (not just


### PR DESCRIPTION
> Stacked on #252 (`feat/streaming-vad`). Review that one first; this diff is the top commit only.

## Why

Opus was the last container that could not stream. Symphonia demuxes it but ships no decoder, so packets go through the `opus-rs` fallback, which built one `Vec<f32>` per channel over the **whole file** before anything could be mixed or resampled. That forced the eager branch of `FileWindows`, and with it the whole-buffer duration ceiling — on the container behind Telegram/WhatsApp voice messages, browser MediaRecorder captures and WebRTC recordings, where two hours at 24 kbps is 25 MB and trivially produced.

```
$ gigastt transcribe gigastt_2h.opus.ogg          # on feat/streaming-vad
Error: audio too long: 1800s exceeds the maximum of 1800s
        4.93 real   802.9 MB peak RSS
```

## After

```
$ gigastt transcribe gigastt_2h.opus.ogg          # this branch
transcribe complete (streaming windows) audio_s=7200.02 wall_s=263.75 rtf=0.037
      265.59 real   805.3 MB peak RSS
```

Peak RSS across a 24× duration range, same binary, same fixture source:

| duration | peak RSS |
|---|---|
| 5 min | 780.2 MB |
| 30 min | 909.5 MB |
| 2 h | 821.8 MB |

Non-monotonic — there is no duration slope left. The ONNX arena dominates and the decode no longer contributes. (For scale, the old path needed ~1.4 GB just for the per-channel buffer of a 2 h mono file, before the mono mix and the 16 kHz output.)

## How the samples stay identical

`OpusStream` decodes one packet at a time and mixes to mono as it goes, so nothing per-channel is retained. Two details are what make this byte-identical rather than merely close, and both are pinned by tests:

- **The mono downmix** is the same mean `mix_channels_to_mono` computes, in the same summation order — extracted as `push_mono_mix` and asserted against `mix_channels_to_mono` directly, for mono and stereo.
- **The resampler is still fed in exact `RESAMPLE_STAGING_FRAMES` chunks**, with the remainder held in `pending`. `flush_full` drains whatever is staged, so staging per packet instead would move the flush boundaries — and at a non-integer rate ratio that moves the output samples. This is the one thing that would have silently changed the transcript.

`decode_packet_interleaved` is now the single place that knows the packet contract, shared by the whole-buffer and streaming decoders so they cannot drift apart.

## Budget

The length budget now counts at the Opus decode rate (48 kHz per RFC 7845), which is what the decoder actually emits and what a duration trip already reported. The container's declared input-rate field is not necessarily the same number, so the previous mix of the two — budget in header-rate units, error in 48 kHz units — was inconsistent under `--max-audio-secs`. Unbounded by default, as on every other streaming path.

## Scope

`decode_opus_channels` stays: `channels=split` still needs per-channel output and remains a whole-buffer path with the ceiling, along with diarization and the G.722 / raw telephony codecs.

## Verification

- `test_opus_streaming_decode_matches_whole_buffer` — the streaming decode equals the previous whole-buffer pipeline **sample for sample** on both core fixtures. The oracle is the old code, kept verbatim in the test.
- `test_opus_streaming_windows_match_slice_over_flat_decode` — windowed geometry over an Opus stream matches `SliceWindows` over the flat decode.
- `test_push_mono_mix_matches_mix_channels_to_mono` — mono and stereo.
- The existing independent `test_decode_audio_bytes_opus_ogg_matches_ffmpeg_reference` (libopus via ffmpeg) still passes, as do the soft-EOF / missing-EOS tests.
- End to end: all three real-speech Opus fixtures — 16 kHz-source OGG, Telegram-style, and the stereo `.opus` — transcribe **byte-identically** to the base branch.
- `cargo test --workspace --lib --bins` — 573 core + 215 server, all pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `scripts/check-docs-drift.py` — clean
- `cargo semver-checks -p gigastt-core --default-features --baseline-rev origin/main` — 219 pass, no semver update required
- `cargo build -p gigastt-core --no-default-features` — same 3 pre-existing warnings, none added
- E2E with the model: `e2e_rest` 46 passed (covers the Opus fixtures over HTTP), `e2e_cli` 11 passed / 1 failed — `cli_download_json_emits_quantize_phase`, which **fails identically on `main`** and is unrelated