### PR TITLE
feat(server): report an unavailable diarization on async job results too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into a result that is thrown away. Adds a `GigasttError::Cancelled` variant
   (additive; the enum is `#[non_exhaustive]`).
 
+- **`diarization` capability notice on transcription responses.** Asking for
+  diarization and getting none used to be indistinguishable from not asking:
+  HTTP 200, every speaker field empty, no explanation. An additive
+  `diarization` object now appears on the response **only** when
+  `?diarization=true` was requested and speakers could not be labeled, with a
+  `reason` separating the three cases that previously collapsed into the same
+  silence — `no_speaker_model`, `duration_ceiling` (carrying the actual input
+  and ceiling seconds), and `pipeline_error`. Clients that get diarization, or
+  never ask for it, see a byte-identical response. Served on both
+  `POST /v1/transcribe` and `GET /v1/jobs/{id}/result`.
+
+  Live WebSocket sessions deliberately do **not** carry this notice: `ready`
+  already advertises `diarization` as a server capability before any audio is
+  sent, and a `configure` for an unavailable capability is a documented
+  graceful no-op there (the same convention `punctuation` follows). The
+  request/response endpoints have no such handshake, which is why they need it.
+
 ### Removed
 
 - **The 30-minute (1800 s) duration cap on the default file-transcription

--- a/crates/gigastt-core/src/protocol/mod.rs
+++ b/crates/gigastt-core/src/protocol/mod.rs
@@ -21,7 +21,12 @@ pub enum ServerMessage {
         /// Supported input sample rates (omitted from JSON if empty for backward compat).
         #[serde(skip_serializing_if = "Vec::is_empty")]
         supported_rates: Vec<u32>,
-        /// Whether diarization is active for this session. Omitted from JSON when false.
+        /// Whether this server *can* diarize — a speaker model is loaded.
+        /// `Ready` precedes `Configure`, so this is a capability advert, not
+        /// session state: `Configure { diarization: true }` against a `false`
+        /// here is a graceful no-op (same convention as `punctuation`), and
+        /// this field is how a client knows that in advance. Omitted from JSON
+        /// when false.
         #[serde(skip_serializing_if = "std::ops::Not::not")]
         diarization: bool,
         /// Minimum protocol version accepted by this server. Lets clients

--- a/crates/gigastt/src/server/http/jobs_api.rs
+++ b/crates/gigastt/src/server/http/jobs_api.rs
@@ -158,6 +158,10 @@ pub async fn get_job_result(
             "job_not_finished",
         ));
     }
+    // Read before `result` is moved out below; the outcome is `Copy`.
+    let diarization = job
+        .diarization
+        .and_then(super::transcribe::diarization_notice);
     let Some(result) = job.result else {
         tracing::error!(job_id = %id, "Done job is missing result");
         return Err(api_error(
@@ -180,9 +184,7 @@ pub async fn get_job_result(
             duration: result.duration_s,
             confidence: result.confidence,
             segments,
-            // The async jobs surface does not yet carry a diarization outcome
-            // (see `FileTranscribeOpts::diarization_outcome`), so no notice here.
-            diarization: None,
+            diarization,
         })
         .into_response())
     }

--- a/crates/gigastt/src/server/http/transcribe.rs
+++ b/crates/gigastt/src/server/http/transcribe.rs
@@ -81,7 +81,7 @@ pub struct DiarizationNotice {
 /// successful or unrequested diarization leaves the response shape untouched.
 /// Every declined case carries a distinct `reason`, and the duration ceiling
 /// also carries the input and ceiling seconds.
-fn diarization_notice(outcome: DiarizationOutcome) -> Option<DiarizationNotice> {
+pub(super) fn diarization_notice(outcome: DiarizationOutcome) -> Option<DiarizationNotice> {
     match outcome {
         DiarizationOutcome::Applied => None,
         DiarizationOutcome::NoSpeakerModel => Some(DiarizationNotice {

--- a/crates/gigastt/src/server/jobs.rs
+++ b/crates/gigastt/src/server/jobs.rs
@@ -125,6 +125,12 @@ pub struct Job {
     pub attempts: u32,
     /// Populated when status becomes `Done`.
     pub result: Option<gigastt_core::inference::TranscribeResult>,
+    /// Why speakers were or were not labeled, recorded when the run finishes and
+    /// only when `?diarization=true` was submitted. `GET /v1/jobs/{id}/result`
+    /// turns it into the same capability notice the synchronous endpoint
+    /// attaches, so an async job cannot answer with silently empty speaker
+    /// fields either. `None` when diarization was not requested.
+    pub diarization: Option<gigastt_core::inference::DiarizationOutcome>,
     /// Populated when status becomes `Failed`.
     pub error: Option<String>,
     /// Active SSE listeners.
@@ -158,6 +164,7 @@ impl Job {
             total_seconds: 0.0,
             attempts: 0,
             result: None,
+            diarization: None,
             error: None,
             event_channels: Vec::new(),
             abort: None,
@@ -807,6 +814,13 @@ impl JobExecution for RealJobExecutor {
             })
         };
 
+        // Write-once sink for *why* speakers were or were not labeled. Armed
+        // only when diarization was requested, matching the synchronous path:
+        // an unarmed sink makes the engine record nothing.
+        let diar_sink: Option<
+            Arc<std::sync::OnceLock<gigastt_core::inference::DiarizationOutcome>>,
+        > = (params.diarization == Some(true)).then(|| Arc::new(std::sync::OnceLock::new()));
+
         // Check out a triplet from the batch pool and run inference.
         // This is wrapped in its own async block so the progress updater is
         // always cancelled and awaited before the function returns, even on
@@ -833,10 +847,12 @@ impl JobExecution for RealJobExecutor {
                 raw_codec: None,
                 abort: Some(abort.clone()),
                 progress: Some(progress.clone()),
-                // The async jobs surface has the same silent-degradation shape as
-                // the sync path once diarization is requested; it is not wired to
-                // a notice here (out of scope) and keeps its current behaviour.
-                diarization_outcome: None,
+                // Same sink the synchronous endpoint uses, so an async job that
+                // produces no speaker labels can say why instead of returning a
+                // transcript with silently empty speaker fields. Only armed when
+                // diarization was actually requested; otherwise the engine
+                // records nothing and the response shape is untouched.
+                diarization_outcome: diar_sink.clone(),
                 max_audio_secs: limits.max_audio_secs_opt(),
             };
             let handle = tokio::task::spawn_blocking(move || {
@@ -883,6 +899,16 @@ impl JobExecution for RealJobExecutor {
 
         progress_cancel.cancel();
         let _ = progress_handle.await;
+
+        // Record the outcome on the job before returning: the worker stores the
+        // transcript after this call, and `GET /v1/jobs/{id}/result` reads both
+        // together. Written even on a failed run — the sink is empty then, so
+        // this is a no-op rather than a stale value.
+        if let Some(outcome) = diar_sink.as_ref().and_then(|s| s.get().copied()) {
+            let _ = store
+                .update(id, Box::new(move |j| j.diarization = Some(outcome)))
+                .await;
+        }
 
         inference_result
     }

--- a/crates/gigastt/tests/common/mod.rs
+++ b/crates/gigastt/tests/common/mod.rs
@@ -502,3 +502,28 @@ pub fn assert_msg_type(
     );
     v
 }
+
+/// A link-farm of the real model directory with `wespeaker_resnet34.onnx` left
+/// out, so a server started on it loads the recognition model but advertises no
+/// diarization capability.
+///
+/// Lets the "diarization requested but unavailable" path be exercised
+/// deterministically instead of depending on whether a speaker model happens to
+/// be installed on the machine. The returned `TempDir` must outlive the server.
+/// Unix only: it relies on symlinks to avoid copying ~850 MB.
+#[cfg(unix)]
+#[allow(dead_code)]
+pub fn model_dir_without_speaker() -> (tempfile::TempDir, String) {
+    let src = model_dir();
+    let dir = tempfile::tempdir().expect("tempdir");
+    for entry in std::fs::read_dir(&src).expect("read model dir") {
+        let entry = entry.expect("dir entry");
+        let name = entry.file_name();
+        if name.to_string_lossy() == "wespeaker_resnet34.onnx" {
+            continue;
+        }
+        std::os::unix::fs::symlink(entry.path(), dir.path().join(&name)).expect("symlink");
+    }
+    let path = dir.path().to_string_lossy().into_owned();
+    (dir, path)
+}

--- a/crates/gigastt/tests/e2e_jobs.rs
+++ b/crates/gigastt/tests/e2e_jobs.rs
@@ -272,3 +272,75 @@ async fn test_job_invalid_audio_fails_with_sanitized_error() {
 
     let _ = shutdown.send(());
 }
+
+/// Submit → poll → fetch the result, returning the parsed result body.
+async fn run_job_to_result(port: u16, query: &str, wav: Vec<u8>) -> serde_json::Value {
+    let client = reqwest::Client::new();
+    let submit = client
+        .post(format!("http://127.0.0.1:{port}/v1/jobs{query}"))
+        .body(wav)
+        .send()
+        .await
+        .expect("POST /v1/jobs failed");
+    assert_eq!(submit.status(), 202);
+    let body: serde_json::Value =
+        serde_json::from_str(&submit.text().await.expect("submit text")).expect("submit JSON");
+    let job_id = body["job_id"].as_str().expect("job_id").to_string();
+
+    for _ in 0..240 {
+        let status_text = client
+            .get(format!("http://127.0.0.1:{port}/v1/jobs/{job_id}"))
+            .send()
+            .await
+            .expect("GET status failed")
+            .text()
+            .await
+            .expect("status text");
+        let status: serde_json::Value = serde_json::from_str(&status_text).expect("status JSON");
+        if status["status"] == "done" {
+            break;
+        }
+        assert_ne!(status["status"], "failed", "job failed: {status:?}");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    let result = client
+        .get(format!("http://127.0.0.1:{port}/v1/jobs/{job_id}/result"))
+        .send()
+        .await
+        .expect("GET result failed");
+    assert_eq!(result.status(), 200);
+    serde_json::from_str(&result.text().await.expect("result text")).expect("result JSON")
+}
+
+/// A job submitted with `?diarization=true` against a server that has no speaker
+/// model must say why on the result, instead of answering 200 with every speaker
+/// field empty and no explanation — the same notice the synchronous endpoint
+/// attaches. A job that did not ask for diarization keeps the byte-identical
+/// response shape it always had.
+#[cfg(unix)]
+#[ignore = "requires model"]
+#[tokio::test]
+async fn test_job_diarization_unavailable_is_reported() {
+    let (_model_guard, dir) = common::model_dir_without_speaker();
+    let (port, shutdown) = common::start_server_with_jobs(&dir, 1).await;
+
+    let asked = run_job_to_result(port, "?diarization=true", common::generate_wav(2, 16000)).await;
+    assert!(
+        asked["text"].is_string(),
+        "the transcript is still complete: {asked:?}"
+    );
+    assert_eq!(
+        asked["diarization"]["status"], "unavailable",
+        "a job that asked for diarization and got none must say so: {asked:?}"
+    );
+    assert_eq!(asked["diarization"]["reason"], "no_speaker_model");
+
+    let plain = run_job_to_result(port, "", common::generate_wav(2, 16000)).await;
+    assert!(
+        plain.get("diarization").is_none(),
+        "a job that never asked for diarization must keep the old response shape: {plain:?}"
+    );
+
+    let _ = shutdown.send(());
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -468,6 +468,36 @@ them in.
   Actual diarization output requires the speaker-encoder model to be loaded on the
   server (downloaded automatically when the `diarization` feature is enabled).
 
+When `diarization=true` was requested but speakers could **not** be labeled, the
+response carries an additive `diarization` object explaining why, instead of a
+200 with silently empty speaker fields. It is absent when diarization was not
+requested or succeeded, so clients that never ask see the exact same shape. The
+same object appears on `GET /v1/jobs/{id}/result`.
+
+```json
+{
+  "text": "…", "words": [...], "duration": 4200.0,
+  "diarization": {
+    "status": "unavailable",
+    "reason": "duration_ceiling",
+    "message": "diarization skipped: input 4200s exceeds the 3600s single-pass limit; the transcript is complete but has no speaker labels",
+    "input_seconds": 4200.0,
+    "ceiling_seconds": 3600.0
+  }
+}
+```
+
+| `reason` | When |
+|---|---|
+| `no_speaker_model` | No speaker-encoder model is loaded, or the build lacks the `diarization` feature |
+| `duration_ceiling` | The clusterer refused the input; `input_seconds` and `ceiling_seconds` carry the clusterer's own numbers |
+| `pipeline_error` | Diarization was attempted and failed for another reason (logged server-side) |
+
+The transcript itself is complete in every case — only the speaker labels are
+missing. Live WebSocket sessions do not carry this notice: `ready` advertises
+`diarization` as a server capability before any audio is sent, and a `configure`
+requesting an unavailable capability is a graceful no-op there.
+
 When either channel split or diarization produces speaker labels, each word object
 includes a `speaker` integer:
 


### PR DESCRIPTION
> Branched from `main`, independent of #252 / #253 (server surface only, no overlap).

## Why

The capability notice added in 679807b stopped `POST /v1/transcribe` from answering 200 with silently empty speaker fields — but it was wired for the synchronous path only. The async queue kept the old shape. A job submitted with `?diarization=true` against a server with no speaker model returned:

```json
{"duration": 2.0, "text": "…", "words": []}
```

No speaker fields, no explanation, HTTP 200. That is the same defect the sync path had, on the surface most likely to be handed a long recording in the first place. `jobs.rs` even said so in a comment (`diarization_outcome: None`, "not wired here").

## What

The executor arms the same write-once sink, stores the outcome on the `Job` when the run finishes, and `GET /v1/jobs/{id}/result` maps it through the same `diarization_notice`. No new types, no new mapping, no trait signature change — the executor already holds `store` and `id`.

The object appears **only** when diarization was requested and produced no labels, so a job that never asked — or got labels — returns a byte-identical response.

## Correction to the brief: WebSocket is not the same gap

The handoff listed live WebSocket diarization alongside jobs. Reading the protocol, it is materially different and I did **not** add a notice there:

- `ready` advertises `diarization` as a server capability **before any audio is sent**, so a WS client can know in advance. REST and jobs have no handshake — which is exactly why they need the notice.
- `configure` already documents the graceful-no-op convention for unavailable capabilities, explicitly for `punctuation` ("A `true` on a server without a punctuation model is a graceful no-op"). Making diarization the one exception that errors would be inconsistent with the protocol's own rule.

What *was* wrong is `Ready.diarization`'s doc comment: it claimed the field says "whether diarization is active for this session", while `ws.rs` sets it from `has_speaker_encoder()` before `configure` is even received. A client reading that doc would expect it to reflect their `configure`. Fixed to say what it is — a capability advert. Doc-only, no wire change.

## The notice also shipped undocumented

679807b touched no docs and no CHANGELOG. Both are added here: `docs/api.md` gains the response object, an example, the three `reason` values, and the WebSocket carve-out; the CHANGELOG gains the entry it never got.

## Test

`test_job_diarization_unavailable_is_reported` builds a model directory that symlinks everything except `wespeaker_resnet34.onnx`, so "requested but unavailable" is deterministic rather than a function of what happens to be installed on the machine (the new `common::model_dir_without_speaker` helper; symlinks, so no 850 MB copy).

It asserts both directions — the notice appears with `reason: "no_speaker_model"`, and a job that never asked for diarization has no `diarization` key at all.

I checked it actually tests the fix: with the three source files stashed and the test kept, it fails with exactly the silent payload above.

```
assertion `left == right` failed: a job that asked for diarization and got none must say so:
  Object {"duration": Number(2.0), "text": String(""), "words": Array []}
  left: Null
 right: "unavailable"
```

## Verification

- `cargo test --workspace --lib --bins` — all pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p gigastt-core -p gigastt` — clean
- `cargo semver-checks -p gigastt-core --default-features --baseline-rev origin/main` — 219 pass, no bump required
- `scripts/check-docs-drift.py` — no drift
- E2E with the model: `e2e_jobs` 6 passed, `e2e_rest` 46 passed, `e2e_ws` 33 passed