### PR TITLE
feat(server): decode the SSE upload on demand instead of materializing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   decoding) keep the ~30-minute safety ceiling to avoid OOM, surfaced as the
   same `audio_too_long` code introduced above.
 
+- **The same cap on `POST /v1/transcribe/stream` (SSE).** The SSE endpoint drives
+  the streaming recognizer one second at a time, so it never needed the whole
+  buffer — but the eager decode in front of it materialized the upload, which
+  kept it on the whole-buffer ~30-minute ceiling while the single-shot endpoint
+  beside it had none. Uploading a 50-minute file for progressive results was
+  refused with `413 audio_too_long`. It now decodes on demand through the new
+  public `AudioChunks`, which yields the same fixed-size chunk sequence
+  `slice.chunks(n)` gives over a fully decoded buffer, so the recognizer state —
+  and the emitted segments — advance exactly as before. `--max-audio-secs` is
+  honoured verbatim and still answered as a clean `413` before the stream opens
+  for containers that declare a duration.
+
 ### Changed
 
 - **CLI contract change: `gigastt transcribe-batch` no longer fails on long

--- a/crates/gigastt-core/src/inference/audio/chunks.rs
+++ b/crates/gigastt-core/src/inference/audio/chunks.rs
@@ -1,0 +1,94 @@
+//! Fixed-size streaming decode of a container to 16 kHz mono.
+//!
+//! [`FileWindows`] yields the *overlapping* windows the long-form file decode
+//! wants. Callers that drive the **streaming** recognizer instead — SSE file
+//! transcription, and any embedder feeding `Engine::process_chunk` — want plain
+//! consecutive chunks of a fixed length, exactly what `slice.chunks(n)` gives
+//! over a fully decoded buffer, without the fully decoded buffer.
+//!
+//! That is this type. It holds one pull block plus at most one chunk, so peak
+//! audio memory is O(chunk) rather than O(file), and it emits the same sample
+//! sequence in the same chunk boundaries `chunks(n)` would.
+
+use anyhow::Result;
+use bytes::Bytes;
+
+use super::stream::{FileWindows, PcmWindows, WindowSpec};
+
+/// Samples pulled from the container per step, independent of the emitted chunk
+/// size. Frame-aligned so [`WindowSpec`] keeps stride == window.
+const PULL_SAMPLES: usize = 32_000; // 2 s @16 kHz
+
+/// Consecutive fixed-size chunks of 16 kHz mono PCM, decoded on demand.
+///
+/// Yields `chunk_samples` per call until the stream ends; the final chunk is the
+/// remainder and may be shorter — the same shape as `slice.chunks(n)`. An empty
+/// stream yields nothing.
+pub struct AudioChunks {
+    src: FileWindows,
+    /// Decoded-but-not-yet-emitted samples.
+    pending: Vec<f32>,
+    /// Emission buffer, reused across calls so a chunk costs no allocation.
+    chunk: Vec<f32>,
+    chunk_samples: usize,
+    eof: bool,
+}
+
+impl AudioChunks {
+    /// Open `data` for chunked decode. The container is probed here, so an
+    /// unsupported or malformed **header** fails now rather than mid-stream;
+    /// packet decoding is lazy.
+    ///
+    /// `max_audio_secs` is honoured verbatim — `None` means unbounded, since
+    /// peak memory does not scale with length. `chunk_samples` is clamped to at
+    /// least 1.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the container cannot be probed or has no audio track.
+    pub fn from_bytes(
+        data: Bytes,
+        chunk_samples: usize,
+        max_audio_secs: Option<f64>,
+    ) -> Result<Self> {
+        let chunk_samples = chunk_samples.max(1);
+        Ok(Self {
+            src: FileWindows::from_bytes(
+                data,
+                WindowSpec::new(0, PULL_SAMPLES, 0),
+                max_audio_secs,
+            )?,
+            pending: Vec::with_capacity(chunk_samples + PULL_SAMPLES),
+            chunk: Vec::with_capacity(chunk_samples),
+            chunk_samples,
+            eof: false,
+        })
+    }
+
+    /// Total 16 kHz samples decoded so far. Exact once the stream is drained.
+    pub fn total_16k_samples(&self) -> usize {
+        self.src.total_16k_samples()
+    }
+
+    /// Lend the next chunk, or `Ok(None)` once the stream is exhausted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a packet fails to decode or the length budget trips.
+    pub fn next_chunk(&mut self) -> Result<Option<&[f32]>> {
+        while !self.eof && self.pending.len() < self.chunk_samples {
+            match self.src.next_window().map_err(anyhow::Error::from)? {
+                Some(w) => self.pending.extend_from_slice(w.samples),
+                None => self.eof = true,
+            }
+        }
+        if self.pending.is_empty() {
+            return Ok(None);
+        }
+        let take = self.chunk_samples.min(self.pending.len());
+        self.chunk.clear();
+        self.chunk.extend_from_slice(&self.pending[..take]);
+        self.pending.drain(..take);
+        Ok(Some(&self.chunk))
+    }
+}

--- a/crates/gigastt-core/src/inference/audio/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/mod.rs
@@ -1,5 +1,7 @@
 //! Audio decoding, resampling, and buffer management utilities.
 
+#[cfg(feature = "file-decode")]
+mod chunks;
 mod decode;
 mod opus;
 mod pcm;
@@ -155,6 +157,11 @@ pub(crate) use stream::{PcmWindows, SliceWindows, WindowSpec};
 // windows from it; the public `decode_audio_*` functions drain it flat.
 #[cfg(feature = "file-decode")]
 pub(crate) use stream::FileWindows;
+// Fixed-size streaming decode for callers driving the streaming recognizer
+// (SSE file transcription, embedders). Public: it is the only way to decode a
+// container without materializing it.
+#[cfg(feature = "file-decode")]
+pub use chunks::AudioChunks;
 
 pub use telephony::TelephonyCodec;
 #[cfg(feature = "file-decode")]

--- a/crates/gigastt-core/src/inference/audio/tests.rs
+++ b/crates/gigastt-core/src/inference/audio/tests.rs
@@ -1823,3 +1823,66 @@ fn test_telephony_raw_streaming_matches_whole_buffer_resample() {
     let streamed = decode_telephony_raw(&encoded, TelephonyCodec::Pcmu, 8_000).unwrap();
     assert_matches_whole_buffer(&streamed, &reference, "pcmu 8k");
 }
+
+// --- AudioChunks (fixed-size streaming decode) ---
+
+/// The chunk sequence must be exactly `slice.chunks(n)` over the flat decode —
+/// same samples, same boundaries — because the streaming recognizer's state
+/// depends on the chunk cadence, so any drift here would change a transcript.
+#[test]
+fn test_audio_chunks_match_flat_decode_chunked() {
+    for &n in &[1usize, 999, 16_000, 16_001, 48_000, 120_000] {
+        for &chunk in &[16_000usize, 640, 7_000] {
+            let src: Vec<f32> = (0..n)
+                .map(|i| 0.4 * ((i as f32) * 0.017).sin() + 0.2 * ((i as f32) * 0.0031).sin())
+                .collect();
+            let wav = bytes::Bytes::from(encode_wav_pcm16(&src, 16000));
+            let flat = decode_audio_bytes(&wav).expect("flat decode");
+
+            let mut chunks = AudioChunks::from_bytes(wav, chunk, None).expect("open chunks");
+            let mut got: Vec<Vec<f32>> = Vec::new();
+            while let Some(c) = chunks.next_chunk().expect("chunk") {
+                got.push(c.to_vec());
+            }
+            let want: Vec<Vec<f32>> = flat.chunks(chunk).map(<[f32]>::to_vec).collect();
+            assert_eq!(got, want, "n={n} chunk={chunk}");
+            assert_eq!(
+                chunks.total_16k_samples(),
+                flat.len(),
+                "n={n} chunk={chunk}"
+            );
+        }
+    }
+}
+
+/// An operator length limit still trips, and as the typed `AudioTooLong` so the
+/// HTTP layer can answer 413 rather than a generic decode failure.
+#[test]
+fn test_audio_chunks_honour_max_audio_secs() {
+    let src = vec![0.1f32; 16_000 * 5];
+    let wav = bytes::Bytes::from(encode_wav_pcm16(&src, 16000));
+    // Unbounded: the whole clip streams.
+    let mut ok = AudioChunks::from_bytes(wav.clone(), 16_000, None).expect("open");
+    let mut total = 0;
+    while let Some(c) = ok.next_chunk().expect("chunk") {
+        total += c.len();
+    }
+    assert_eq!(total, src.len());
+
+    // Bounded below the clip length: the budget trips during the pull.
+    let mut capped = AudioChunks::from_bytes(wav, 16_000, Some(1.0)).expect("open");
+    let err = loop {
+        match capped.next_chunk() {
+            Ok(Some(_)) => continue,
+            Ok(None) => panic!("a 5 s clip must not drain under a 1 s limit"),
+            Err(e) => break e,
+        }
+    };
+    assert!(
+        matches!(
+            err.downcast_ref::<crate::error::GigasttError>(),
+            Some(crate::error::GigasttError::AudioTooLong { .. })
+        ),
+        "expected a typed AudioTooLong, got: {err:#}"
+    );
+}

--- a/crates/gigastt/src/server/http/stream.rs
+++ b/crates/gigastt/src/server/http/stream.rs
@@ -12,6 +12,11 @@ use super::error::{ApiError, api_error};
 use super::state::AppState;
 use super::transcribe::reserve_batch_slot;
 
+/// Samples per `process_chunk` call on the SSE path: one second at 16 kHz.
+/// Frame-aligned, and pinned because the streaming recognizer's state — and so
+/// the emitted segments — depend on the chunk cadence.
+const SSE_CHUNK_SAMPLES: usize = 16_000;
+
 /// Per-segment error carried over the SSE channel: a stable machine-readable
 /// code plus a sanitized message, mirroring the WebSocket error contract so
 /// SSE clients get the same codes (`inference_error`, `inference_panic`,
@@ -101,21 +106,46 @@ pub async fn transcribe_stream(
     // bump and `decode_audio_bytes_shared` reads the upload buffer in place. On a
     // decode error the early `?` return drops `reservation`, returning the
     // triplet to the pool.
-    // SSE materializes the whole buffer before chunking, so it is a whole-buffer
-    // path: bounded by the operator `--max-audio-secs` (or the fixed safety
-    // ceiling when unset), consistent with the single-shot REST path.
+    // SSE drives the *streaming* recognizer one second at a time, so it never
+    // needed the whole buffer — only the eager decode in front of it did, and
+    // that is what pinned this endpoint to the whole-buffer duration ceiling
+    // while the single-shot path had none. `AudioChunks` probes the container
+    // here (so an unsupported or malformed header still fails as a clean HTTP
+    // status, before the stream opens) and decodes packets on demand.
     let max_audio_secs = limits.max_audio_secs_opt();
-    let samples = tokio::task::spawn_blocking(move || {
+    let body_for_probe = body.clone();
+    let chunks = tokio::task::spawn_blocking(move || {
         // catch_unwind mirrors the REST handler: a panic inside the blocking
-        // decode (e.g. a crafted container that trips an upstream arithmetic
+        // probe (e.g. a crafted container that trips an upstream arithmetic
         // panic) is absorbed and surfaced as a normal decode error instead of a
         // `JoinError`, so the SSE path returns a clean 422 rather than a 500.
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            gigastt_core::inference::audio::decode_audio_bytes_shared_bounded(body, max_audio_secs)
+            // Enforce an operator length limit up front where the container
+            // declares its duration (WAV / FLAC / M4A / OGG), so `--max-audio-secs`
+            // keeps answering a clean 413 instead of tripping mid-stream. The
+            // incremental budget inside the decode remains the backstop for
+            // containers that declare nothing.
+            if let Some(limit) = max_audio_secs
+                && let Ok(Some(declared)) =
+                    gigastt_core::inference::audio::probe_duration_bytes(body_for_probe.clone())
+                && declared > limit
+            {
+                return Err(anyhow::Error::from(
+                    gigastt_core::error::GigasttError::AudioTooLong {
+                        observed_secs: declared,
+                        limit_secs: limit,
+                    },
+                ));
+            }
+            gigastt_core::inference::audio::AudioChunks::from_bytes(
+                body_for_probe,
+                SSE_CHUNK_SAMPLES,
+                max_audio_secs,
+            )
         })) {
             Ok(inner) => inner,
             Err(_) => {
-                tracing::error!("Panic in SSE audio decode — treated as decode error");
+                tracing::error!("Panic in SSE audio probe — treated as decode error");
                 Err(anyhow::anyhow!("Audio decode thread panicked"))
             }
         }
@@ -168,13 +198,36 @@ pub async fn transcribe_stream(
         // catch_unwind ensures the triplet is returned to the pool even on panic.
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut stream_state = engine.create_state(false);
-            let chunk_size = 16000; // 1 second at 16 kHz
+            let mut chunks = chunks;
 
-            for chunk in samples.chunks(chunk_size) {
+            // Same chunk sequence `samples.chunks(SSE_CHUNK_SAMPLES)` produced —
+            // fixed-size, last one short — so the streaming state advances
+            // exactly as before; only where the samples come from changed.
+            loop {
                 if cancel.is_cancelled() {
                     tracing::info!("SSE transcription cancelled by shutdown");
                     return;
                 }
+                let chunk = match chunks.next_chunk() {
+                    Ok(Some(c)) => c,
+                    Ok(None) => break,
+                    Err(e) => {
+                        // A decode failure past the header (corrupt packet, or a
+                        // length budget tripping on a container that declared no
+                        // duration) can no longer be an HTTP status — the stream
+                        // is already open — so it ends the stream with the same
+                        // machine-readable code the status would have carried.
+                        let code = e
+                            .downcast_ref::<gigastt_core::error::GigasttError>()
+                            .map_or("invalid_audio", |g| g.code());
+                        tracing::error!("SSE audio decode error: {e:#}");
+                        let _ = tx.blocking_send(Err(StreamError {
+                            code,
+                            message: "Failed to decode audio file. Check format (WAV, MP3, M4A, OGG, FLAC supported).".into(),
+                        }));
+                        return;
+                    }
+                };
                 match engine.process_chunk(chunk, &mut stream_state, &mut reservation) {
                     Ok(segs) => {
                         for seg in segs {

--- a/crates/gigastt/tests/e2e_rest.rs
+++ b/crates/gigastt/tests/e2e_rest.rs
@@ -1726,3 +1726,47 @@ async fn test_openai_transcriptions_missing_file_returns_400() {
 
     let _ = shutdown.send(());
 }
+
+/// The SSE path used to decode the whole upload before chunking it, so it
+/// refused anything past the whole-buffer ~30 min ceiling with `413
+/// audio_too_long` while the single-shot endpoint next to it had no limit at
+/// all. It decodes on demand now, and the only length limit left is the
+/// operator's own `--max-audio-secs` — which must still be answered as a clean
+/// status *before* the stream opens, not as an error event once it has.
+///
+/// (The "long audio actually streams" half is a multi-hour-scale check that
+/// belongs with the local-only load tests, not in CI; this pins the contract
+/// that the fix had to preserve.)
+#[ignore = "requires model"]
+#[tokio::test]
+async fn test_transcribe_stream_sse_operator_limit_is_a_clean_413() {
+    let limits = gigastt::server::RuntimeLimits {
+        max_audio_secs: 2,
+        ..Default::default()
+    };
+    let (port, shutdown) = common::start_server_with_limits(&common::model_dir(), limits).await;
+
+    let resp = tokio::time::timeout(Duration::from_secs(60), async {
+        reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/v1/transcribe/stream"))
+            .body(common::generate_wav(10, 16000))
+            .send()
+            .await
+            .expect("POST /v1/transcribe/stream failed")
+    })
+    .await
+    .expect("POST /v1/transcribe/stream timed out");
+
+    assert_eq!(
+        resp.status(),
+        413,
+        "an operator length limit must trip before the stream opens"
+    );
+    let body = resp.text().await.expect("error body");
+    assert!(
+        body.contains("audio_too_long"),
+        "expected the audio_too_long code, got: {body}"
+    );
+
+    let _ = shutdown.send(());
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -633,10 +633,11 @@ default 50 MiB ≈ 26 min of 16 kHz mono WAV); raise it for larger single files.
 Operators who want an explicit duration limit can start the server with
 `--max-audio-secs <N>` (env `GIGASTT_MAX_AUDIO_SECS`, default `0` = unlimited);
 audio longer than `N` seconds is rejected with `413 Payload Too Large` and code
-`audio_too_long` before any inference runs. VAD segmentation, speaker
-diarization, `channels=split`, and telephony/Opus decoding hold the whole
-decoded buffer in memory, so those paths always enforce a fixed ~30-minute
-safety ceiling regardless of `--max-audio-secs`, returning the same
+`audio_too_long` before any inference runs. `POST /v1/transcribe/stream` (SSE)
+decodes on demand as it emits, so it carries no ceiling of its own either. VAD
+segmentation, speaker diarization, `channels=split`, and telephony/Opus decoding
+hold the whole decoded buffer in memory, so those paths always enforce a fixed
+~30-minute safety ceiling regardless of `--max-audio-secs`, returning the same
 `audio_too_long` code. A batch worker should gate on `GET /ready` (not just
 `/health`) so it backs off on `503` pool saturation instead of failing
 mid-job.


### PR DESCRIPTION
Toward #236. Branched from `main`, independent of #252 / #253 / #254.

## Why

The reporter in #236 could not transcribe a ~50 minute file. The single-shot endpoint lost its cap earlier in this wave — but `POST /v1/transcribe/stream` still refused:

```
413 {"code":"audio_too_long","error":"audio too long: 1800s exceeds the maximum of 1800s"}
```

That is the surface you would actually reach for on a 50 minute file, because it is the one that reports progress while it works.

I audited every surface with the reporter's own 50 min file before touching anything:

| surface | before |
|---|---|
| CLI `transcribe` | ok |
| `POST /v1/transcribe` (body limit raised) | ok |
| `POST /v1/jobs` | ok |
| **`POST /v1/transcribe/stream` (SSE)** | **413 `audio_too_long`** |
| `?diarization=true` | 413 (known, separate) |
| `?channels=split` | 413 (known, separate) |
| `POST /v1/transcribe` at the **default** 50 MiB body limit | rejected — a 50 min 16 kHz WAV is 91 MiB |

## What

SSE never needed the whole buffer: it drives the streaming recognizer one second at a time. Only the eager decode in front of it did. It now pulls from `AudioChunks`, a new public primitive that decodes a container into fixed-size 16 kHz mono chunks, holding one pull block plus one chunk.

The chunk sequence is exactly what `slice.chunks(n)` produced over the fully decoded buffer — same samples, same boundaries. That matters: the recognizer's state, and therefore which segments get emitted when, depends on the chunk cadence. Asserted directly across several lengths and chunk sizes, not assumed.

The container is still probed up front, so an unsupported or malformed header still fails as a clean HTTP status before the stream opens. `--max-audio-secs` is also still enforced up front where the container declares a duration, so it keeps answering `413` instead of tripping mid-stream; the incremental budget inside the decode is the backstop for containers that declare nothing, and a trip past the header ends the stream with the same machine-readable code the status would have carried.

## After

Release binary, 50 minute WAV:

```
HTTP/1.1 200 OK
1376 SSE events, 0 error events
last word at 2957.56 s of a 3000 s file
5:05 wall
```

## What this does not claim

Peak RSS on the SSE path is **not** flat in duration. Measured through tiny Opus bodies so the upload is out of the picture:

| duration | peak RSS |
|---|---|
| 5 min | 270 MiB |
| 25 min | 275 MiB |
| 50 min | ~510 MiB |

Flat to 25 minutes and then a step — so it is not a per-second leak, and it sits in the pre-existing streaming recognizer, not in this change. But removing the cap is what lets a request get there, so I would rather name it than let "no ceiling" imply "no growth". Worth a separate look; 510 MiB for a 50 minute SSE request is workable meanwhile.

## Test

The "long audio actually streams" half is a multi-hour-scale check that belongs with the local-only load tests, not CI — an in-process `#[tokio::test]` driving 30+ minutes through a current-thread runtime pegged a core and never finished, which is a harness artifact (the release binary handles the same input fine, above). So CI gets:

- two unit tests pinning `AudioChunks` against the flat decode chunked, across lengths and chunk sizes, plus the typed `AudioTooLong` on a budget trip;
- an e2e test that `--max-audio-secs` still trips as a clean `413` **before** the stream opens — the contract the fix had to preserve.

## Verification

- `cargo test --workspace --lib --bins` — all pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `scripts/check-docs-drift.py` — clean
- `cargo semver-checks -p gigastt-core --default-features --baseline-rev origin/main` — 219 pass; `AudioChunks` is additive
- E2E with the model: `e2e_rest` 47 passed, `e2e_http_cov` 4 passed