### PR TITLE
feat(server): stream channels=split instead of decoding every channel whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   decoding) keep the ~30-minute safety ceiling to avoid OOM, surfaced as the
   same `audio_too_long` code introduced above.
 
+- **The same cap on `?channels=split`.** Splitting stereo into two speakers
+  decoded every channel of the whole file up front, and decided *whether* to
+  split by correlating the two channels end to end — so a 35-minute call was
+  refused with `413 audio_too_long`. Both halves stream now: the decision comes
+  from `scan_channels`, which is header-only unless the file is exactly stereo
+  and otherwise a single pass over six accumulators, and each channel is then
+  pulled through the windowed decode in turn via the additive
+  `TranscribeSource::ChannelStreams`. A 35-minute stereo upload transcribes in
+  578 MiB peak with both speakers labeled. `channels=split` on a VAD-enabled
+  server keeps the whole-buffer path (and its ceiling) until the VAD itself
+  runs inside the window loop.
+
 ### Changed
 
 - **CLI contract change: `gigastt transcribe-batch` no longer fails on long

--- a/crates/gigastt-core/src/inference/audio/decode.rs
+++ b/crates/gigastt-core/src/inference/audio/decode.rs
@@ -371,6 +371,7 @@ pub struct ChannelScan {
     pub dual_mono: bool,
 }
 
+#[cfg(feature = "file-decode")]
 impl ChannelScan {
     /// Whether `channels=split` should fall back to the mono mix, and why.
     /// `None` means genuine stereo: split it.

--- a/crates/gigastt-core/src/inference/audio/decode.rs
+++ b/crates/gigastt-core/src/inference/audio/decode.rs
@@ -359,6 +359,175 @@ pub fn decode_audio_bytes_shared_channels_bounded(
     decode_audio_inner_channels(mss, Hint::new(), "bytes", max_audio_secs)
 }
 
+/// What a one-pass scan of a container's channels found.
+#[cfg(feature = "file-decode")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelScan {
+    /// Channels the container declares.
+    pub channels: usize,
+    /// True only when there are exactly two and they are near-identical — a PBX
+    /// that recorded the same mix to both. Transcribing those as two speakers
+    /// would duplicate every word.
+    pub dual_mono: bool,
+}
+
+impl ChannelScan {
+    /// Whether `channels=split` should fall back to the mono mix, and why.
+    /// `None` means genuine stereo: split it.
+    pub fn mono_fallback_reason(&self) -> Option<&'static str> {
+        match self.channels {
+            0 => Some("no channels"),
+            1 => Some("mono audio"),
+            2 if self.dual_mono => Some("dual-mono audio"),
+            2 => None,
+            _ => Some("more than two channels"),
+        }
+    }
+}
+
+/// Decide how `channels=split` should treat `data` **without materializing it**.
+///
+/// The split path used to answer this by decoding every channel of the whole
+/// file and correlating the two in full, which is what pinned it to a duration
+/// ceiling. Almost all of the answer is in the header: anything that is not
+/// exactly two channels falls back to the mono mix, and that needs no decode at
+/// all. Only the two-channel case has to look at the audio, and
+/// [`DualMonoDetector`] does that in one pass over six accumulators.
+///
+/// The correlation is taken on the **16 kHz resampled** channels, on the same
+/// per-packet staging cadence the whole-buffer decode used, so it is the same
+/// statistic on the same numbers — the verdict does not move.
+///
+/// OGG/Opus is the exception: it has no packet-wise decoder here, so it keeps
+/// the whole-buffer decode (and its ceiling) for this decision.
+#[cfg(feature = "file-decode")]
+pub fn scan_channels(data: Bytes, max_audio_secs: Option<f64>) -> Result<ChannelScan> {
+    let source = BytesMediaSource::new(data.clone());
+    let mss = MediaSourceStream::new(Box::new(source), Default::default());
+    let mut format = symphonia::default::get_probe()
+        .probe(
+            &Hint::new(),
+            mss,
+            FormatOptions::default(),
+            MetadataOptions::default(),
+        )
+        .context("Unsupported audio format")?;
+
+    let (track_id, sample_rate, channels, is_opus) = {
+        let track = format
+            .default_track(TrackType::Audio)
+            .context("No audio track found")?;
+        let params = track
+            .codec_params
+            .as_ref()
+            .and_then(|p| p.audio())
+            .context("No audio codec parameters")?;
+        let sample_rate = params.sample_rate.context("Unknown sample rate")?;
+        if sample_rate == 0 || sample_rate > MAX_SAMPLE_RATE {
+            anyhow::bail!("Unsupported sample rate: {sample_rate}Hz");
+        }
+        (
+            track.id,
+            sample_rate,
+            params.channels.as_ref().map(|c| c.count()).unwrap_or(1),
+            params.codec == CODEC_ID_OPUS,
+        )
+    };
+
+    // Header-only verdict: no decode, whatever the file's length.
+    if channels != 2 {
+        return Ok(ChannelScan {
+            channels,
+            dual_mono: false,
+        });
+    }
+
+    if is_opus {
+        let decoded = decode_audio_bytes_shared_channels_bounded(data, max_audio_secs)?;
+        return Ok(ChannelScan {
+            channels: decoded.len(),
+            dual_mono: is_dual_mono(&decoded),
+        });
+    }
+
+    let (max_samples, limit_secs) = resolve_budget(max_audio_secs, sample_rate);
+    let mut decoder = {
+        let track = format
+            .default_track(TrackType::Audio)
+            .context("No audio track found")?;
+        let params = track
+            .codec_params
+            .as_ref()
+            .and_then(|p| p.audio())
+            .context("No audio codec parameters")?;
+        symphonia::default::get_codecs()
+            .make_audio_decoder(params, &AudioDecoderOptions::default())
+            .context("Unsupported audio codec")?
+    };
+
+    // One resampler per channel, fed on the same cadence the whole-buffer
+    // decode used, so the 16 kHz samples reaching the detector are the ones it
+    // would have correlated.
+    let mut acc: Vec<ResampleTo16k> = (0..2)
+        .map(|_| ResampleTo16k::new(SampleRate(sample_rate), None))
+        .collect();
+    let mut detector = DualMonoDetector::new();
+    let mut ready: [Vec<f32>; 2] = [Vec::new(), Vec::new()];
+    let mut interleaved: Vec<f32> = Vec::new();
+    let mut source_frames: usize = 0;
+
+    loop {
+        let Some(packet) = next_demux_packet(&mut *format, source_frames > 0)? else {
+            break;
+        };
+        if packet.track_id != track_id {
+            continue;
+        }
+        let decoded = decoder.decode(&packet).context("Decode error")?;
+        let num_frames = decoded.frames();
+        let ch = decoded.spec().channels().count();
+        if ch < 2 {
+            // A mid-stream drop to mono makes the pair meaningless; treat the
+            // stream as not dual-mono and let the split path decide per channel.
+            break;
+        }
+        interleaved.clear();
+        decoded.copy_to_vec_interleaved(&mut interleaved);
+        for (c, chan) in acc.iter_mut().enumerate() {
+            let stage = chan.stage();
+            for frame in 0..num_frames {
+                stage.push(interleaved[frame * ch + c]);
+            }
+        }
+        source_frames += num_frames;
+        if source_frames > max_samples {
+            return Err(audio_too_long_err(source_frames, sample_rate, limit_secs));
+        }
+        for (c, chan) in acc.iter_mut().enumerate() {
+            chan.flush_full()?;
+            chan.drain_ready_into(&mut ready[c]);
+        }
+        let (left, right) = ready.split_at_mut(1);
+        detector.push(&left[0], &right[0]);
+        ready[0].clear();
+        ready[1].clear();
+    }
+
+    for (c, chan) in acc.into_iter().enumerate() {
+        let mut tail = Vec::new();
+        let mut chan = chan;
+        chan.finish_into(&mut tail)?;
+        ready[c] = tail;
+    }
+    let (left, right) = ready.split_at_mut(1);
+    detector.push(&left[0], &right[0]);
+
+    Ok(ChannelScan {
+        channels: 2,
+        dual_mono: detector.is_dual_mono(),
+    })
+}
+
 /// Shared non-mixing decode: probe → format → decode → per-channel resample.
 #[cfg(feature = "file-decode")]
 fn decode_audio_inner_channels<'s>(

--- a/crates/gigastt-core/src/inference/audio/decode.rs
+++ b/crates/gigastt-core/src/inference/audio/decode.rs
@@ -536,6 +536,80 @@ pub fn is_dual_mono(channels: &[Vec<f32>]) -> bool {
     normalized_correlation(&left[..len], &right[..len]) > DUAL_MONO_CORRELATION_THRESHOLD
 }
 
+/// Streaming form of the dual-mono correlation, for the `channels=split` path
+/// over a container that is never fully resident.
+///
+/// [`is_dual_mono`] needs both channels end to end, which is the only reason
+/// channel splitting had to hold the whole decode. The same statistic is
+/// computable in one pass with Welford's co-moment recurrence, so this keeps
+/// six `f64` accumulators instead of two whole channels.
+///
+/// The recurrence is used rather than raw power sums (`Σab − ΣaΣb/n`) on
+/// purpose: the naive form loses the covariance to cancellation once `n` is in
+/// the tens of millions, exactly the regime long files put it in, and the
+/// decision it feeds is a knife-edge threshold. Agreement with the batch
+/// function is asserted in `tests.rs`, on the value and on the decision.
+#[derive(Debug, Default, Clone)]
+pub struct DualMonoDetector {
+    n: f64,
+    mean_a: f64,
+    mean_b: f64,
+    /// Co-moment Σ(a−ā)(b−b̄).
+    c_ab: f64,
+    m2_a: f64,
+    m2_b: f64,
+}
+
+impl DualMonoDetector {
+    /// New detector with no samples observed.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed the next block of two channels. Only the overlapping prefix counts,
+    /// matching [`is_dual_mono`]'s `min(len)` truncation.
+    pub fn push(&mut self, a: &[f32], b: &[f32]) {
+        for (&x, &y) in a.iter().zip(b) {
+            let (x, y) = (x as f64, y as f64);
+            self.n += 1.0;
+            let dx = x - self.mean_a;
+            let dy = y - self.mean_b;
+            self.mean_a += dx / self.n;
+            self.mean_b += dy / self.n;
+            self.c_ab += dx * (y - self.mean_b);
+            self.m2_a += dx * (x - self.mean_a);
+            self.m2_b += dy * (y - self.mean_b);
+        }
+    }
+
+    /// Normalized correlation of everything observed so far, on the same scale
+    /// [`is_dual_mono`] thresholds. `0.0` when either channel is silent.
+    pub fn correlation(&self) -> f64 {
+        if self.n == 0.0 {
+            return 0.0;
+        }
+        let denom = self.m2_a.sqrt() * self.m2_b.sqrt();
+        if denom < 1e-12 {
+            return 0.0;
+        }
+        self.c_ab / denom
+    }
+
+    /// Whether the two channels are near-identical — the same verdict
+    /// [`is_dual_mono`] returns for a fully materialized pair. `false` when no
+    /// samples were observed.
+    pub fn is_dual_mono(&self) -> bool {
+        self.n > 0.0 && self.correlation() > DUAL_MONO_CORRELATION_THRESHOLD
+    }
+}
+
+/// Test-only alias so the streaming detector can be pinned against the exact
+/// batch statistic it replaces.
+#[cfg(test)]
+pub(super) fn normalized_correlation_for_test(a: &[f32], b: &[f32]) -> f64 {
+    normalized_correlation(a, b)
+}
+
 fn normalized_correlation(a: &[f32], b: &[f32]) -> f64 {
     let n = a.len();
     if n == 0 || n != b.len() {

--- a/crates/gigastt-core/src/inference/audio/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/mod.rs
@@ -140,7 +140,7 @@ pub use decode::{
 // buffers itself; the path variant is engine-only.
 #[cfg(feature = "file-decode")]
 pub(crate) use decode::decode_audio_file_bounded;
-pub use decode::{is_dual_mono, mix_channels_to_mono};
+pub use decode::{DualMonoDetector, is_dual_mono, mix_channels_to_mono};
 
 pub(crate) use pcm::{consume_audio_buffer, prepare_audio_buffer};
 pub use pcm::{parse_pcm16_with_carry, parse_pcm16_with_carry_into};

--- a/crates/gigastt-core/src/inference/audio/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/mod.rs
@@ -129,6 +129,8 @@ pub(crate) fn audio_too_long_err(
 #[cfg(test)]
 pub(crate) use decode::BytesMediaSource;
 #[cfg(feature = "file-decode")]
+pub use decode::scan_channels;
+#[cfg(feature = "file-decode")]
 pub use decode::{
     decode_audio_bytes, decode_audio_bytes_shared, decode_audio_bytes_shared_bounded,
     decode_audio_bytes_shared_channels, decode_audio_bytes_shared_channels_bounded,
@@ -140,7 +142,7 @@ pub use decode::{
 // buffers itself; the path variant is engine-only.
 #[cfg(feature = "file-decode")]
 pub(crate) use decode::decode_audio_file_bounded;
-pub use decode::{DualMonoDetector, is_dual_mono, mix_channels_to_mono};
+pub use decode::{ChannelScan, DualMonoDetector, is_dual_mono, mix_channels_to_mono};
 
 pub(crate) use pcm::{consume_audio_buffer, prepare_audio_buffer};
 pub use pcm::{parse_pcm16_with_carry, parse_pcm16_with_carry_into};

--- a/crates/gigastt-core/src/inference/audio/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/mod.rs
@@ -129,7 +129,7 @@ pub(crate) fn audio_too_long_err(
 #[cfg(test)]
 pub(crate) use decode::BytesMediaSource;
 #[cfg(feature = "file-decode")]
-pub use decode::scan_channels;
+pub use decode::{ChannelScan, scan_channels};
 #[cfg(feature = "file-decode")]
 pub use decode::{
     decode_audio_bytes, decode_audio_bytes_shared, decode_audio_bytes_shared_bounded,
@@ -142,7 +142,7 @@ pub use decode::{
 // buffers itself; the path variant is engine-only.
 #[cfg(feature = "file-decode")]
 pub(crate) use decode::decode_audio_file_bounded;
-pub use decode::{ChannelScan, DualMonoDetector, is_dual_mono, mix_channels_to_mono};
+pub use decode::{DualMonoDetector, is_dual_mono, mix_channels_to_mono};
 
 pub(crate) use pcm::{consume_audio_buffer, prepare_audio_buffer};
 pub use pcm::{parse_pcm16_with_carry, parse_pcm16_with_carry_into};

--- a/crates/gigastt-core/src/inference/audio/stream.rs
+++ b/crates/gigastt-core/src/inference/audio/stream.rs
@@ -125,9 +125,6 @@ pub(crate) enum ChannelSelect {
     /// Mean of every channel present in the packet.
     Mono,
     /// A single channel, by zero-based index.
-    // Exercised by the equivalence tests; the `channels=split` call site that
-    // makes it live in a non-test build lands with the per-channel decode.
-    #[allow(dead_code)]
     One(usize),
 }
 

--- a/crates/gigastt-core/src/inference/audio/stream.rs
+++ b/crates/gigastt-core/src/inference/audio/stream.rs
@@ -114,6 +114,23 @@ impl WindowSpec {
     }
 }
 
+/// Which channel a windowed decode yields.
+///
+/// The default file pipeline wants the mono mix; `channels=split` wants each
+/// channel on its own, and needs it *streamed* — materializing every channel of
+/// the whole file is what pinned that path to a duration ceiling.
+#[cfg(feature = "file-decode")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChannelSelect {
+    /// Mean of every channel present in the packet.
+    Mono,
+    /// A single channel, by zero-based index.
+    // Exercised by the equivalence tests; the `channels=split` call site that
+    // makes it live in a non-test build lands with the per-channel decode.
+    #[allow(dead_code)]
+    One(usize),
+}
+
 /// One decode window lent by a [`PcmWindows`] source.
 pub(crate) struct PcmWindow<'a> {
     /// Absolute offset of `samples[0]` in the stream, in samples @16 kHz.
@@ -245,6 +262,8 @@ pub(crate) struct FileWindows {
     /// Total 16 kHz samples decoded so far (== `buf_start_abs + buf.len()`).
     decoded_16k_total: usize,
     spec: WindowSpec,
+    /// Which channel the packet loop keeps.
+    channel: ChannelSelect,
     /// Absolute start (@16 kHz) of the next window to yield.
     next_start: usize,
     /// True until the first window's single-pass-vs-windowed decision is made.
@@ -274,7 +293,7 @@ impl FileWindows {
         {
             hint.with_extension(ext);
         }
-        Self::from_mss(mss, hint, spec, max_audio_secs)
+        Self::from_mss(mss, hint, spec, max_audio_secs, ChannelSelect::Mono)
     }
 
     /// Open a shared [`Bytes`] buffer for windowed decode. `BytesMediaSource` is
@@ -289,7 +308,7 @@ impl FileWindows {
         }
         let source = BytesMediaSource::new(data);
         let mss = MediaSourceStream::new(Box::new(source), Default::default());
-        Self::from_mss(mss, Hint::new(), spec, max_audio_secs)
+        Self::from_mss(mss, Hint::new(), spec, max_audio_secs, ChannelSelect::Mono)
     }
 
     /// Probe the container and either set up the streaming decoder or, for Opus /
@@ -302,6 +321,7 @@ impl FileWindows {
         hint: Hint,
         spec: WindowSpec,
         max_audio_secs: Option<f64>,
+        channel: ChannelSelect,
     ) -> Result<Self> {
         let mut format = symphonia::default::get_probe()
             .probe(
@@ -394,12 +414,46 @@ impl FileWindows {
                     buf_start_abs: 0,
                     decoded_16k_total: 0,
                     spec,
+                    channel,
                     next_start: 0,
                     first: true,
                     done: false,
                 })
             }
         }
+    }
+
+    /// Open a shared [`Bytes`] buffer for windowed decode of **one** channel.
+    ///
+    /// The per-channel twin of [`FileWindows::from_bytes`], for the
+    /// `channels=split` path: channel `k` is extracted in the packet loop and
+    /// resampled on its own, so peak memory is one window rather than every
+    /// channel of the whole file.
+    ///
+    /// The samples are the ones the whole-buffer per-channel decode produced —
+    /// same packet cadence, same resampler, same staging — so the windows the
+    /// decoder sees are unchanged.
+    // Same as `ChannelSelect::One`: tested, wired by the next step.
+    #[allow(dead_code)]
+    pub(crate) fn from_bytes_channel(
+        data: Bytes,
+        spec: WindowSpec,
+        max_audio_secs: Option<f64>,
+        channel: usize,
+    ) -> Result<Self> {
+        if let Some(result) = try_decode_g722_wav(&data, max_audio_secs) {
+            // G.722-in-WAV is mono by construction; there is no channel to pick.
+            return Ok(Self::eager(result?, spec));
+        }
+        let source = BytesMediaSource::new(data);
+        let mss = MediaSourceStream::new(Box::new(source), Default::default());
+        Self::from_mss(
+            mss,
+            Hint::new(),
+            spec,
+            max_audio_secs,
+            ChannelSelect::One(channel),
+        )
     }
 
     /// Build an eager source over an already-decoded 16 kHz buffer.
@@ -413,6 +467,7 @@ impl FileWindows {
             buf_start_abs: 0,
             decoded_16k_total: total,
             spec,
+            channel: ChannelSelect::Mono,
             next_start: 0,
             first: true,
             done: false,
@@ -450,6 +505,7 @@ impl FileWindows {
     /// samples to `buf`. Enforces the source-rate length budget incrementally with
     /// the exact same error string as the whole-buffer path.
     fn fill_to(&mut self, target: usize) -> Result<()> {
+        let channel = self.channel;
         let Source::Streaming {
             format,
             decoder,
@@ -486,14 +542,29 @@ impl FileWindows {
                 interleaved.clear();
                 decoded.copy_to_vec_interleaved(interleaved);
                 let stage = resampler.stage();
-                for frame in 0..num_frames {
-                    let mut sum = 0.0_f32;
-                    for c in 0..ch {
-                        sum += interleaved[frame * ch + c];
+                match channel {
+                    ChannelSelect::Mono => {
+                        for frame in 0..num_frames {
+                            let mut sum = 0.0_f32;
+                            for c in 0..ch {
+                                sum += interleaved[frame * ch + c];
+                            }
+                            stage.push(sum / ch as f32);
+                        }
                     }
-                    stage.push(sum / ch as f32);
+                    // A packet that is short of the requested channel
+                    // contributes nothing rather than shifting the timeline.
+                    ChannelSelect::One(k) if k < ch => {
+                        for frame in 0..num_frames {
+                            stage.push(interleaved[frame * ch + k]);
+                        }
+                    }
+                    ChannelSelect::One(_) => {}
                 }
-            } else {
+            } else if matches!(channel, ChannelSelect::Mono | ChannelSelect::One(0)) {
+                // Single-channel packet: it *is* channel 0. Asking for a higher
+                // index contributes nothing, rather than silently handing back
+                // channel 0's audio under another channel's name.
                 let stage = resampler.stage();
                 let offset = stage.len();
                 stage.resize(offset + num_frames, 0.0);
@@ -874,6 +945,59 @@ mod file_windows_tests {
         // resample + SliceWindows: the staged chunk sequence is the same either
         // way, so every resampled sample matches.
         assert_eq!(got, slice_seq(&flat, spec));
+    }
+
+    /// The load-bearing claim for streaming `channels=split`: pulling channel
+    /// `k` through the packet loop yields the *same samples* the whole-buffer
+    /// per-channel decode produced. Checked at 16 kHz (resampler passthrough)
+    /// and 48 kHz (real resampling), for both channels of a genuine stereo
+    /// stream whose channels differ.
+    #[test]
+    fn test_file_windows_channel_select_matches_batch_per_channel_decode() {
+        for rate in [16_000u32, 48_000] {
+            let n = rate as usize * 3;
+            let left = signal(n, 0.3);
+            let right = signal(n, 2.1);
+            let wav = stereo_wav_pcm16(&left, &right, rate);
+            let batch = crate::inference::audio::decode_audio_bytes_shared_channels(
+                Bytes::copy_from_slice(&wav),
+            )
+            .expect("batch per-channel decode");
+            assert_eq!(batch.len(), 2, "expected a stereo decode at {rate}Hz");
+            // The channels must actually differ, or the test proves nothing.
+            assert_ne!(batch[0], batch[1]);
+
+            for (k, want) in batch.iter().enumerate() {
+                let streamed = FileWindows::from_bytes_channel(
+                    Bytes::copy_from_slice(&wav),
+                    WindowSpec::flat(),
+                    None,
+                    k,
+                )
+                .expect("open channel")
+                .drain_to_vec()
+                .expect("drain channel");
+                assert_eq!(&streamed, want, "rate={rate} channel={k}");
+            }
+        }
+    }
+
+    /// Selecting a channel the stream does not have yields nothing rather than
+    /// silently falling back to another channel's audio.
+    #[test]
+    fn test_file_windows_channel_select_out_of_range_is_empty() {
+        let src = signal(16_000, 1.0);
+        let wav = encode_wav_pcm16(&src, 16000); // mono
+        let streamed = FileWindows::from_bytes_channel(
+            Bytes::copy_from_slice(&wav),
+            WindowSpec::flat(),
+            None,
+            5,
+        )
+        .expect("open")
+        .drain_to_vec()
+        .expect("drain");
+        assert!(streamed.is_empty(), "got {} samples", streamed.len());
     }
 
     #[test]

--- a/crates/gigastt-core/src/inference/audio/tests.rs
+++ b/crates/gigastt-core/src/inference/audio/tests.rs
@@ -1919,3 +1919,98 @@ fn test_dual_mono_detector_uses_the_overlap_only() {
     let batch = super::decode::normalized_correlation_for_test(&a[..3], &b);
     assert!((det.correlation() - batch).abs() < 1e-9);
 }
+
+// --- One-pass channel scan (channels=split decision) ---
+
+/// Two-channel PCM16 WAV with the given channels.
+#[cfg(feature = "file-decode")]
+fn stereo_wav(left: &[f32], right: &[f32], rate: u32) -> bytes::Bytes {
+    let frames = left.len().min(right.len());
+    let data_bytes = (frames * 4) as u32;
+    let mut w = Vec::with_capacity(44 + data_bytes as usize);
+    w.extend_from_slice(b"RIFF");
+    w.extend_from_slice(&(36 + data_bytes).to_le_bytes());
+    w.extend_from_slice(b"WAVE");
+    w.extend_from_slice(b"fmt ");
+    w.extend_from_slice(&16u32.to_le_bytes());
+    w.extend_from_slice(&1u16.to_le_bytes());
+    w.extend_from_slice(&2u16.to_le_bytes());
+    w.extend_from_slice(&rate.to_le_bytes());
+    w.extend_from_slice(&(rate * 4).to_le_bytes());
+    w.extend_from_slice(&4u16.to_le_bytes());
+    w.extend_from_slice(&16u16.to_le_bytes());
+    w.extend_from_slice(b"data");
+    w.extend_from_slice(&data_bytes.to_le_bytes());
+    let q = |s: f32| (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+    for i in 0..frames {
+        w.extend_from_slice(&q(left[i]).to_le_bytes());
+        w.extend_from_slice(&q(right[i]).to_le_bytes());
+    }
+    bytes::Bytes::from(w)
+}
+
+/// The scan replaces "decode every channel of the whole file, then correlate".
+/// Its verdict picks between transcribing two speakers and mixing to mono, so
+/// it must match the batch answer exactly — checked at both a passthrough and a
+/// resampling rate, on dual-mono and on genuine stereo.
+#[test]
+fn test_scan_channels_matches_batch_dual_mono_verdict() {
+    for rate in [16_000u32, 48_000] {
+        let n = rate as usize * 2;
+        let a: Vec<f32> = (0..n)
+            .map(|i| 0.5 * ((i as f32) * 0.011).sin() + 0.15 * ((i as f32) * 0.0009).cos())
+            .collect();
+        let b: Vec<f32> = (0..n)
+            .map(|i| 0.45 * ((i as f32) * 0.029 + 0.9).sin())
+            .collect();
+
+        for (label, left, right) in [
+            ("identical", a.clone(), a.clone()),
+            ("attenuated", a.clone(), a.iter().map(|v| v * 0.8).collect()),
+            ("stereo", a.clone(), b.clone()),
+        ] {
+            let wav = stereo_wav(&left, &right, rate);
+            let batch = decode_audio_bytes_shared_channels(wav.clone()).expect("batch");
+            let want = is_dual_mono(&batch);
+            let scan = scan_channels(wav, None).expect("scan");
+            assert_eq!(scan.channels, 2, "{label} @{rate}");
+            assert_eq!(
+                scan.dual_mono, want,
+                "{label} @{rate}: scan verdict diverged from batch"
+            );
+            assert_eq!(
+                scan.mono_fallback_reason().is_some(),
+                want,
+                "{label} @{rate}"
+            );
+        }
+    }
+}
+
+/// Anything that is not exactly two channels is decided from the header, so the
+/// scan must not need to decode — and must report the same fallback the
+/// whole-buffer path chose.
+#[test]
+fn test_scan_channels_non_stereo_is_header_only() {
+    let mono = encode_wav_pcm16(&vec![0.2f32; 16_000], 16000);
+    let scan = scan_channels(bytes::Bytes::from(mono), None).expect("scan mono");
+    assert_eq!(scan.channels, 1);
+    assert!(!scan.dual_mono);
+    assert_eq!(scan.mono_fallback_reason(), Some("mono audio"));
+}
+
+#[test]
+fn test_channel_scan_fallback_reasons() {
+    let r = |channels, dual_mono| {
+        ChannelScan {
+            channels,
+            dual_mono,
+        }
+        .mono_fallback_reason()
+    };
+    assert_eq!(r(0, false), Some("no channels"));
+    assert_eq!(r(1, false), Some("mono audio"));
+    assert_eq!(r(2, true), Some("dual-mono audio"));
+    assert_eq!(r(2, false), None);
+    assert_eq!(r(6, false), Some("more than two channels"));
+}

--- a/crates/gigastt-core/src/inference/audio/tests.rs
+++ b/crates/gigastt-core/src/inference/audio/tests.rs
@@ -1953,6 +1953,7 @@ fn stereo_wav(left: &[f32], right: &[f32], rate: u32) -> bytes::Bytes {
 /// Its verdict picks between transcribing two speakers and mixing to mono, so
 /// it must match the batch answer exactly — checked at both a passthrough and a
 /// resampling rate, on dual-mono and on genuine stereo.
+#[cfg(feature = "file-decode")]
 #[test]
 fn test_scan_channels_matches_batch_dual_mono_verdict() {
     for rate in [16_000u32, 48_000] {
@@ -1990,6 +1991,7 @@ fn test_scan_channels_matches_batch_dual_mono_verdict() {
 /// Anything that is not exactly two channels is decided from the header, so the
 /// scan must not need to decode — and must report the same fallback the
 /// whole-buffer path chose.
+#[cfg(feature = "file-decode")]
 #[test]
 fn test_scan_channels_non_stereo_is_header_only() {
     let mono = encode_wav_pcm16(&vec![0.2f32; 16_000], 16000);
@@ -1999,6 +2001,7 @@ fn test_scan_channels_non_stereo_is_header_only() {
     assert_eq!(scan.mono_fallback_reason(), Some("mono audio"));
 }
 
+#[cfg(feature = "file-decode")]
 #[test]
 fn test_channel_scan_fallback_reasons() {
     let r = |channels, dual_mono| {

--- a/crates/gigastt-core/src/inference/audio/tests.rs
+++ b/crates/gigastt-core/src/inference/audio/tests.rs
@@ -1823,3 +1823,99 @@ fn test_telephony_raw_streaming_matches_whole_buffer_resample() {
     let streamed = decode_telephony_raw(&encoded, TelephonyCodec::Pcmu, 8_000).unwrap();
     assert_matches_whole_buffer(&streamed, &reference, "pcmu 8k");
 }
+
+// --- Streaming dual-mono detection ---
+
+/// The streaming detector must agree with the batch pair
+/// (`normalized_correlation` behind `is_dual_mono`) on both the value and, more
+/// importantly, the *verdict*: it decides whether `channels=split` transcribes
+/// two speakers or falls back to a mono mix, so a flip would change output.
+#[test]
+fn test_dual_mono_detector_matches_batch_correlation() {
+    // Deterministic, no rand: a base signal plus independent-ish perturbations.
+    let n = 40_000;
+    let base: Vec<f32> = (0..n)
+        .map(|i| 0.5 * ((i as f32) * 0.013).sin() + 0.2 * ((i as f32) * 0.0007).cos())
+        .collect();
+    let other: Vec<f32> = (0..n)
+        .map(|i| 0.5 * ((i as f32) * 0.031 + 1.7).sin() - 0.3 * ((i as f32) * 0.0021).cos())
+        .collect();
+
+    let cases: Vec<(&str, Vec<f32>, Vec<f32>)> = vec![
+        // Identical: the PBX-recorded-the-mix case the check exists for.
+        ("identical", base.clone(), base.clone()),
+        // Same content, slightly attenuated — still dual-mono.
+        (
+            "attenuated",
+            base.clone(),
+            base.iter().map(|v| v * 0.85).collect(),
+        ),
+        // Same content plus a small amount of the other — near the threshold.
+        (
+            "mostly-same",
+            base.clone(),
+            base.iter()
+                .zip(&other)
+                .map(|(l, r)| l * 0.9 + r * 0.1)
+                .collect(),
+        ),
+        // Genuine stereo: two different sources.
+        ("independent", base.clone(), other.clone()),
+        // Phase-inverted: strongly anti-correlated, must not read as dual-mono.
+        ("inverted", base.clone(), base.iter().map(|v| -v).collect()),
+        // One channel silent.
+        ("right-silent", base.clone(), vec![0.0; n]),
+        // Both silent.
+        ("both-silent", vec![0.0; n], vec![0.0; n]),
+        // DC offset on both: the case naive power sums would lose.
+        (
+            "dc-offset",
+            base.iter().map(|v| v + 0.7).collect(),
+            base.iter().map(|v| v + 0.7).collect(),
+        ),
+    ];
+
+    for (label, left, right) in cases {
+        let batch = super::decode::normalized_correlation_for_test(&left, &right);
+        // Feed in irregular blocks so the recurrence is exercised across pushes.
+        let mut det = DualMonoDetector::new();
+        let mut i = 0;
+        let mut step = 1;
+        while i < left.len() {
+            let end = (i + step).min(left.len());
+            det.push(&left[i..end], &right[i..end]);
+            i = end;
+            step = step % 1_237 + 1;
+        }
+        assert!(
+            (det.correlation() - batch).abs() < 1e-6,
+            "{label}: streaming {} vs batch {batch}",
+            det.correlation()
+        );
+        let want = is_dual_mono(&[left, right]);
+        assert_eq!(det.is_dual_mono(), want, "{label}: verdict diverged");
+    }
+}
+
+#[test]
+fn test_dual_mono_detector_empty_is_not_dual_mono() {
+    let det = DualMonoDetector::new();
+    assert!(!det.is_dual_mono());
+    assert_eq!(det.correlation(), 0.0);
+    // An empty push keeps it empty.
+    let mut det = DualMonoDetector::new();
+    det.push(&[], &[]);
+    assert!(!det.is_dual_mono());
+}
+
+/// Mismatched block lengths count only the overlap, mirroring `is_dual_mono`'s
+/// `min(len)` truncation.
+#[test]
+fn test_dual_mono_detector_uses_the_overlap_only() {
+    let a = vec![0.3f32, -0.4, 0.5, 0.9, -0.1];
+    let b = vec![0.3f32, -0.4, 0.5];
+    let mut det = DualMonoDetector::new();
+    det.push(&a, &b);
+    let batch = super::decode::normalized_correlation_for_test(&a[..3], &b);
+    assert!((det.correlation() - batch).abs() < 1e-9);
+}

--- a/crates/gigastt-core/src/inference/engine.rs
+++ b/crates/gigastt-core/src/inference/engine.rs
@@ -1687,6 +1687,16 @@ impl Engine {
                 req.diarization_outcome.as_deref(),
                 ctl,
             ),
+            #[cfg(feature = "file-decode")]
+            TranscribeSource::ChannelStreams { data, channels } => self.transcribe_channel_streams(
+                data,
+                channels,
+                max_audio_secs,
+                triplet,
+                &req.overrides,
+                req.hotwords,
+                ctl.abort_only(),
+            ),
             TranscribeSource::Channels(channels) => self.transcribe_channels_inner(
                 channels,
                 triplet,
@@ -1978,6 +1988,62 @@ impl Engine {
                 text: String::new(),
                 words,
                 duration_s,
+            });
+        }
+
+        let merged = merge_channel_results(per_channel);
+        Ok(self.finish_transcribe_result(merged.words, merged.duration_s, overrides))
+    }
+
+    /// Streaming twin of the `channels=split` decode.
+    ///
+    /// Each channel of `data` runs through the windowed loop the mono file path
+    /// uses, so
+    /// peak audio memory is one window instead of every channel of the whole
+    /// file — which is what kept channel splitting on a duration ceiling. The
+    /// per-channel results are merged exactly as the whole-buffer twin merges
+    /// them.
+    ///
+    /// The caller decides *whether* to split; use
+    /// [`scan_channels`](crate::inference::audio::scan_channels), which answers
+    /// that in one pass without materializing anything.
+    ///
+    /// No progress sink is threaded through: each channel restarts the sample
+    /// clock, so a shared monotonic counter would go backwards — the same
+    /// reason the whole-buffer twin passes `abort_only`.
+    // Bundling these behind `&TranscribeRequest` is what one would want, but the
+    // caller's match moves `data` out of `req.source`, so the request cannot be
+    // borrowed whole afterwards. Same shape as `run_inference` above.
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "file-decode")]
+    fn transcribe_channel_streams(
+        &self,
+        data: bytes::Bytes,
+        channels: usize,
+        max_audio_secs: Option<f64>,
+        triplet: &mut SessionTriplet,
+        overrides: &TranscribeOverrides,
+        hotwords: Option<&HotwordOverride>,
+        ctl: DecodeControls,
+    ) -> Result<TranscribeResult, GigasttError> {
+        let request_biaser = hotwords.and_then(|hw| self.build_request_biaser(hw));
+        let biaser: Option<&bias::Biaser> = match hotwords {
+            None => self.biaser.as_ref(),
+            Some(_) => request_biaser.as_ref(),
+        };
+
+        let spec = window_spec(self.ane_encoder);
+        let mut per_channel = Vec::with_capacity(channels);
+        for k in 0..channels {
+            let mut windows =
+                audio::FileWindows::from_bytes_channel(data.clone(), spec, max_audio_secs, k)
+                    .map_err(audio::decode_error)?;
+            let words = self.decode_words_streaming(&mut windows, triplet, biaser, ctl)?;
+            per_channel.push(TranscribeResult {
+                confidence: aggregate_confidence(&words),
+                text: String::new(),
+                words,
+                duration_s: windows.total_16k_samples() as f64 / 16000.0,
             });
         }
 

--- a/crates/gigastt-core/src/inference/types.rs
+++ b/crates/gigastt-core/src/inference/types.rs
@@ -264,6 +264,21 @@ pub enum TranscribeSource<'a> {
     /// `--stereo-speakers`). Channel index becomes the speaker label;
     /// [`TranscribeRequest::diarization`] is ignored for this source.
     Channels(&'a [Vec<f32>]),
+    /// `channels=split` over a container that is **not** materialized: each
+    /// channel is pulled through the windowed decode in turn, so peak audio
+    /// memory is one window rather than every channel of the whole file.
+    ///
+    /// Prefer this over [`TranscribeSource::Channels`] when the caller has the
+    /// encoded bytes: that variant needs every channel decoded up front, which
+    /// is what puts a duration ceiling on the split path. Decide the channel
+    /// count — and whether splitting is right at all — with
+    /// [`scan_channels`](crate::inference::audio::scan_channels).
+    ChannelStreams {
+        /// Encoded container bytes; cloned per channel (a refcount bump).
+        data: bytes::Bytes,
+        /// Channels to decode, each transcribed as its own speaker.
+        channels: usize,
+    },
 }
 
 /// Unified file-transcription request (builder-friendly).

--- a/crates/gigastt-core/src/inference/types.rs
+++ b/crates/gigastt-core/src/inference/types.rs
@@ -273,6 +273,7 @@ pub enum TranscribeSource<'a> {
     /// is what puts a duration ceiling on the split path. Decide the channel
     /// count — and whether splitting is right at all — with
     /// [`scan_channels`](crate::inference::audio::scan_channels).
+    #[cfg(feature = "file-decode")]
     ChannelStreams {
         /// Encoded container bytes; cloned per channel (a refcount bump).
         data: bytes::Bytes,

--- a/crates/gigastt/src/server/file_transcribe.rs
+++ b/crates/gigastt/src/server/file_transcribe.rs
@@ -163,22 +163,13 @@ pub(crate) fn run_file_transcribe_blocking(
     };
 
     if opts.split_channels {
-        let channels = gigastt_core::inference::audio::decode_audio_bytes_shared_channels_bounded(
-            body.clone(),
-            opts.max_audio_secs,
-        )
-        .map_err(map_decode_error)?;
-        let fallback_reason = match channels.len() {
-            0 => Some("no channels"),
-            1 => Some("mono audio"),
-            2 if gigastt_core::inference::audio::is_dual_mono(&channels) => Some("dual-mono audio"),
-            n if n > 2 => Some("more than two channels"),
-            _ => None,
-        };
-        if let Some(reason) = fallback_reason {
-            // The mono path re-decodes from `body`; release the split channels
-            // first so both copies are never resident at once.
-            drop(channels);
+        // Deciding whether to split used to mean decoding every channel of the
+        // whole file and correlating two of them, which is what pinned this
+        // path to a duration ceiling. The scan answers it in one pass — from
+        // the header alone unless the file is exactly stereo.
+        let scan = gigastt_core::inference::audio::scan_channels(body.clone(), opts.max_audio_secs)
+            .map_err(map_decode_error)?;
+        if let Some(reason) = scan.mono_fallback_reason() {
             tracing::warn!(
                 "channels=split requested but {reason} detected; falling back to mono transcription"
             );
@@ -189,11 +180,32 @@ pub(crate) fn run_file_transcribe_blocking(
                     .with_max_audio_secs(opts.max_audio_secs),
                 reservation,
             )
-        } else {
+        } else if engine.has_vad() && opts.overrides.vad.unwrap_or(true) {
+            // The per-channel VAD pass still needs each channel resident, so a
+            // VAD-enabled server keeps the whole-buffer split (and its ceiling)
+            // until the VAD itself runs inside the window loop.
+            let channels =
+                gigastt_core::inference::audio::decode_audio_bytes_shared_channels_bounded(
+                    body.clone(),
+                    opts.max_audio_secs,
+                )
+                .map_err(map_decode_error)?;
             engine.transcribe_request(
                 TranscribeRequest::new(TranscribeSource::Channels(&channels))
                     .with_abort(opts.abort.clone())
                     .with_max_audio_secs(opts.max_audio_secs),
+                reservation,
+            )
+        } else {
+            engine.transcribe_request(
+                TranscribeRequest::new(TranscribeSource::ChannelStreams {
+                    data: body,
+                    channels: scan.channels,
+                })
+                .with_overrides(opts.overrides)
+                .with_hotwords(opts.hotwords.as_ref())
+                .with_abort(opts.abort.clone())
+                .with_max_audio_secs(opts.max_audio_secs),
                 reservation,
             )
         }

--- a/docs/api.md
+++ b/docs/api.md
@@ -633,11 +633,13 @@ default 50 MiB ≈ 26 min of 16 kHz mono WAV); raise it for larger single files.
 Operators who want an explicit duration limit can start the server with
 `--max-audio-secs <N>` (env `GIGASTT_MAX_AUDIO_SECS`, default `0` = unlimited);
 audio longer than `N` seconds is rejected with `413 Payload Too Large` and code
-`audio_too_long` before any inference runs. VAD segmentation, speaker
-diarization, `channels=split`, and telephony/Opus decoding hold the whole
-decoded buffer in memory, so those paths always enforce a fixed ~30-minute
-safety ceiling regardless of `--max-audio-secs`, returning the same
-`audio_too_long` code. A batch worker should gate on `GET /ready` (not just
+`audio_too_long` before any inference runs. `?channels=split` streams too — the
+stereo-vs-dual-mono decision is made in one pass and each channel is then
+decoded in windows — except on a VAD-enabled server, where it keeps the
+whole-buffer path. VAD segmentation, speaker diarization, and telephony/Opus
+decoding hold the whole decoded buffer in memory, so those paths always enforce
+a fixed ~30-minute safety ceiling regardless of `--max-audio-secs`, returning
+the same `audio_too_long` code. A batch worker should gate on `GET /ready` (not just
 `/health`) so it backs off on `503` pool saturation instead of failing
 mid-job.
 


### PR DESCRIPTION
Toward #236. Branched from `main`, independent of #252 / #253 / #254 / #255.

## Why

`?channels=split` held the file twice over. It decoded **every channel of the whole upload** into its own buffer, and it decided *whether* to split by correlating the two channels **end to end**. So a 35-minute stereo call was refused:

```
413 {"code":"audio_too_long","error":"audio too long: 1800s exceeds the maximum of 1800s"}
```

## What

Three commits, each verified on its own.

**1. `DualMonoDetector` — the decision, in one pass.** `is_dual_mono` is what forces both channels resident: it tells a genuine stereo recording from a PBX that wrote the same mix to both channels, and getting it wrong either duplicates every word or silently drops the speaker split — so it cannot be decided on a prefix.

The detector computes the same statistic over six `f64` accumulators using Welford's co-moment recurrence, deliberately not raw power sums (`Σab − ΣaΣb/n`): the naive form loses the covariance to cancellation once `n` is in the tens of millions, exactly the regime a long file puts it in, feeding a knife-edge threshold.

Pinned to the batch statistic on the value *and* the verdict across identical, attenuated, near-threshold, independent, phase-inverted, silent and DC-offset pairs, fed in irregular blocks.

**2. `ChannelSelect` — per-channel windowed decode.** `FileWindows` can pull one channel through the packet loop. Asserted equal to `decode_audio_bytes_shared_channels` for both channels of a stereo stream whose channels differ, at 16 kHz (passthrough) and 48 kHz (real resampling).

> Writing that test caught a real footgun in the first cut: the packet loop's single-channel branch ignored the selector, so asking a mono file for channel 5 silently handed back channel 0's audio under another channel's name.

**3. `scan_channels` + wiring.** The decision is header-only unless the file is exactly stereo; only that case reads audio. Each channel is then decoded through the windowed loop via an additive `TranscribeSource::ChannelStreams`, so the caller uses the same request builder as every other path — no new public entry point.

One subtlety that would have moved the verdict silently: the correlation is taken on the **16 kHz resampled** channels, on the same per-packet staging cadence the whole-buffer decode used. Correlating the source-rate samples instead would have been a different number.

## Measured

35-minute genuine-stereo upload:

| | before | after |
|---|---|---|
| result | `413 audio_too_long` | **200 OK** |
| peak RSS | — | **578 MiB** |
| wall | — | 2:50 |
| output | — | 3094 words, both speakers labeled (1311 / 1783) |

Fallback intact: a dual-mono file still returns no speaker labels and logs the mono fallback.

## Remaining limit, named not papered over

`channels=split` **on a VAD-enabled server** keeps the whole-buffer path and its ceiling: the per-channel VAD pass still needs each channel resident. That lifts once the VAD runs inside the window loop (#252's `VadWindows`, composed per channel). Documented in `docs/api.md` and the CHANGELOG.

## Verification

- `cargo test --workspace --lib --bins` — all pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `scripts/check-docs-drift.py` — clean
- `cargo semver-checks -p gigastt-core --default-features --baseline-rev origin/main` — no bump; the `TranscribeSource` variant is additive (`#[non_exhaustive]`)
- E2E with the model: `e2e_rest` 46 passed (includes the three `channels=split` tests), `e2e_http_cov` 4 passed