### PR TITLE
deps(core): migrate to rubato 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`rubato` moved to 4.0.** Two API changes: `SincInterpolationParameters::f_cutoff`
+  became `Option<f32>`, and the chunk-resize hook moved out of `Resampler` into a
+  new `Resizable` trait. The cutoff is passed as `Some(0.95)` rather than left
+  `None` on purpose — `None` derives a cutoff from `sinc_len` and the window
+  instead, which is a *different filter*, so it would change the resampled
+  samples and with them every transcript from a source that is not already
+  16 kHz. Both 3.x and 4.0 scale the cutoff by the resample ratio when
+  downsampling, so `Some(0.95)` is the filter 3.x built. Verified transcript-neutral
+  on 13 clips: 8 / 11.025 / 22.05 / 32 / 44.1 / 96 kHz WAV (8 kHz being the
+  upsampling branch, where the cutoff is *not* scaled), four 48 kHz OGG/Opus
+  fixtures including a stereo one, and real 48 kHz speech — byte-identical output
+  in every case.
+
 - **CLI contract change: `gigastt transcribe-batch` no longer fails on long
   files.** Running `transcribe-batch` over a corpus that includes files
   longer than 30 minutes now exits `0` instead of `1`, because those files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,9 @@ checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
 
 [[package]]
 name = "audioadapter"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+checksum = "c75c3943c6c7279bb25a449a8d1727480730ab2efd7b6fd5d6ca51927096e6e4"
 dependencies = [
  "audio-core",
  "num-traits",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "audioadapter-buffers"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+checksum = "ece3390b6eb40379094843a1da5aaccc34bc0d85a8cbf68d09fe092fee6de29e"
 dependencies = [
  "audioadapter",
  "audioadapter-sample",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "audioadapter-sample"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+checksum = "1592f90413568e259413c21a41a3d571feb1774255c209e7966d98f9db708c90"
 dependencies = [
  "audio-core",
  "num-traits",
@@ -3465,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "rubato"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
+checksum = "f57c655d11e929f05a8663b323ff553f8d9773be05dfdc087795955bedeb8d92"
 dependencies = [
  "audioadapter",
  "audioadapter-buffers",
@@ -4829,7 +4829,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -4874,7 +4874,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "uniffi_meta",
 ]
 

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -82,7 +82,7 @@ thiserror = "2"
 sha2 = "0.11"
 hex = "0.4"
 rustfft = "6"
-rubato = "3.0"
+rubato = "4.0"
 symphonia = { version = "0.6", features = ["aac", "isomp4", "mp3", "ogg", "flac", "pcm", "wav"], optional = true }
 # Telephony codecs (G.711 A/μ-law tables, G.722 ADPCM) for RTP dumps and
 # Asterisk-style raw captures. `default-features = false` drops the opus

--- a/crates/gigastt-core/src/inference/audio/resample.rs
+++ b/crates/gigastt-core/src/inference/audio/resample.rs
@@ -3,7 +3,8 @@
 #[cfg(feature = "file-decode")]
 use anyhow::Context;
 use anyhow::Result;
-use rubato::Resampler;
+// rubato 4 split the chunk-resize hook out of `Resampler` into `Resizable`.
+use rubato::{Resampler, Resizable};
 
 /// Sample rate in Hz. Invariant: `rate > 0`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -58,7 +59,12 @@ pub fn resample(samples: &[f32], from_rate: SampleRate, to_rate: SampleRate) -> 
 
     let params = SincInterpolationParameters {
         sinc_len: 256,
-        f_cutoff: 0.95,
+        // rubato 4 made this `Option`; `None` would derive a cutoff from
+        // `sinc_len` and the window instead of using this one, which is a
+        // different filter and so a different transcript. Both versions scale
+        // it by the resample ratio when downsampling, so `Some(0.95)` is the
+        // same filter 3.x built.
+        f_cutoff: Some(0.95),
         interpolation: SincInterpolationType::Linear,
         oversampling_factor: 256,
         window: WindowFunction::BlackmanHarris2,
@@ -145,7 +151,12 @@ pub fn resample_with_cache(
         };
         let params = SincInterpolationParameters {
             sinc_len: 256,
-            f_cutoff: 0.95,
+            // rubato 4 made this `Option`; `None` would derive a cutoff from
+            // `sinc_len` and the window instead of using this one, which is a
+            // different filter and so a different transcript. Both versions scale
+            // it by the resample ratio when downsampling, so `Some(0.95)` is the
+            // same filter 3.x built.
+            f_cutoff: Some(0.95),
             interpolation: SincInterpolationType::Linear,
             oversampling_factor: 256,
             window: WindowFunction::BlackmanHarris2,


### PR DESCRIPTION
Supersedes #232, which is a bare version bump that does not compile.

## Two API changes

**`SincInterpolationParameters::f_cutoff` became `Option<f32>`.** Passing `None` is the tempting one-character fix and would have been wrong: 4.0 then derives the cutoff from `sinc_len` and the window instead of using ours — a *different filter*, so different resampled samples, and a different transcript for every source that is not already 16 kHz. It is `Some(0.95)`.

Reading both crates' sources confirms the value means the same thing across the bump — they apply the identical scaling:

```rust
// rubato 3.0.0 asynchro_sinc.rs:144      // rubato 4.0.0 asynchro_sinc.rs:227
let f_cutoff = if resample_ratio >= 1.0 { f_cutoff } else { f_cutoff * resample_ratio as f32 };
```

**The chunk-resize hook moved out of `Resampler` into a new `Resizable` trait**, so that is imported too. It still preserves FIR history and fractional phase across a resize, which is what keeps variable-sized streaming frames seamless.

## Measured, not assumed

The 24 resampler unit tests pass — but they compare streaming against whole-buffer *within one version*, so they could not catch a filter change on their own. So I compared the old binary against the new one directly:

| input | result |
|---|---|
| 8 kHz WAV | identical |
| 11.025 kHz WAV | identical |
| 22.05 kHz WAV | identical |
| 32 kHz WAV | identical |
| 44.1 kHz WAV | identical |
| 96 kHz WAV | identical |
| `speech_16k.ogg` (48 kHz Opus) | identical |
| `speech_telegram.ogg` (48 kHz Opus) | identical |
| `speech.opus` (48 kHz stereo Opus) | identical |
| 4 × real 48 kHz speech WAV | identical |

**13/13 byte-identical transcripts.** 8 kHz is in there deliberately: upsampling takes the branch where the cutoff is *not* scaled by the ratio, so it exercises the other half of the code above.

## Verification

- `cargo test --workspace --lib --bins` — all pass; 24 resampler tests included
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check`, `cargo check -p gigastt-core --no-default-features` — clean
- `cargo semver-checks -p gigastt-core --default-features --baseline-rev origin/main` — no bump required
- E2E with the model: `e2e_rest` 47 passed, `e2e_ws` 33 passed (the WS suite covers the configurable input rates, which drive the streaming resampler)

Note the WER Benchmark job only runs on push to `main`, never on a PR — so this comparison, not CI, is the quality evidence here.