### PR TITLE
feat(core): bias hotwords on the CTC heads via prefix beam search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ were released without a git tag, so their headings carry no compare link.
 
 ### Added
 
+- **Hotword biasing now works on the multilingual CTC heads**, via a prefix beam
+  search that replaces the greedy decode whenever a glossary is present. Greedy
+  CTC picks a per-frame argmax and has no continuation to steer, which is why a
+  glossary was inert on `ml_ctc` / `ml_ctc_large` and the previous release could
+  only say so out loud. A beam gives the boost something to act on and, as
+  importantly, gives a wrong guess somewhere to lose.
+
+  Two properties keep it from inventing words. A hypothesis that walks into a
+  hotword and abandons it is refunded every bit of boost it was granted, so a
+  partial match wins nothing; and a phrase is worth one boost however long it
+  is, spread across its tokens. Without that second rule a nine-letter phrase
+  earned nine times the boost — enough that `любовницы` displaced `люк кейдж` on
+  real audio.
+
+  Measured on 62 s of Russian speech with a three-phrase glossary, `ml_ctc`
+  corrected every one of them (`ростоу`→`ростов`, `гетта`→`гетто`,
+  `любовница`→`любовницы`) and split a run-together `развалиныищи`, with the rest
+  of the transcript untouched. With no glossary the greedy path runs exactly as
+  before, so output for everyone else is unchanged.
+
 - **WebM/Opus uploads**, the container a browser's `MediaRecorder` produces and
   the only one it offers a page (#263). A recording made in Chromium or Electron
   now posts straight to `/v1/transcribe` instead of needing a client-side remux

--- a/crates/gigastt-core/src/inference/bias.rs
+++ b/crates/gigastt-core/src/inference/bias.rs
@@ -55,13 +55,50 @@ fn encode_representable(tokenizer: &Tokenizer, phrase: &str) -> Option<Vec<usize
 struct TrieNode {
     /// Edges keyed by token id → child node index.
     children: std::collections::HashMap<usize, usize>,
+    /// True when a hotword phrase ends here. Only the beam search reads it: a
+    /// finished phrase keeps the boost it was granted, an abandoned one does
+    /// not.
+    is_end: bool,
+    /// Token length of the shortest phrase running through this node, used to
+    /// spread one phrase's worth of boost across its tokens.
+    shortest_phrase: usize,
 }
 
 impl TrieNode {
     fn new() -> Self {
         Self {
             children: std::collections::HashMap::new(),
+            is_end: false,
+            shortest_phrase: usize::MAX,
         }
+    }
+}
+
+/// Where one beam sits in the hotword trie, and how much boost it has been
+/// granted for a phrase it has not finished.
+///
+/// The greedy transducer path cannot take a bonus back — it has already emitted
+/// the token — so it lives with a rationed boost instead
+/// ([`super::decode::greedy_decode`]). A beam search can: a hypothesis that
+/// walked halfway into a hotword and then left is refunded, so a partial match
+/// wins nothing and only a phrase actually spoken keeps its advantage.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct BiasPath {
+    /// Current trie node; 0 is the root.
+    node: usize,
+    /// Boost granted so far for the unfinished phrase under way.
+    pending: f32,
+}
+
+impl BiasPath {
+    /// Boost this path has been granted for a phrase it has not finished.
+    ///
+    /// Owed back: a hypothesis still mid-phrase when the audio runs out never
+    /// earned it, so the final ranking has to discount it. During the search
+    /// the amount stays credited — that is what keeps a half-matched phrase in
+    /// the beam long enough to finish.
+    pub(crate) fn pending(&self) -> f32 {
+        self.pending
     }
 }
 
@@ -90,6 +127,7 @@ impl Biaser {
                 continue;
             }
             phrase_count += 1;
+            let len = seq.len();
             let mut node = 0usize;
             for tok in seq {
                 node = match nodes[node].children.get(&tok) {
@@ -101,7 +139,9 @@ impl Biaser {
                         child
                     }
                 };
+                nodes[node].shortest_phrase = nodes[node].shortest_phrase.min(len);
             }
+            nodes[node].is_end = true;
         }
         if phrase_count == 0 {
             return None;
@@ -158,6 +198,72 @@ impl Biaser {
     /// Number of hotword phrases compiled into the trie.
     pub fn phrase_count(&self) -> usize {
         self.phrase_count
+    }
+
+    /// Score emitting `tok` from `path`, returning the log-domain delta to add
+    /// to the hypothesis and the path that follows.
+    ///
+    /// Three cases, and the middle one is why this exists:
+    /// - the token continues the phrase under way — grant the boost;
+    /// - it does not, but starts some phrase — refund everything the abandoned
+    ///   partial match was granted, then grant the boost for the new start;
+    /// - it is not a hotword token at all — refund and return to the root.
+    ///
+    /// A node that ends a phrase clears the pending amount: the phrase was
+    /// spoken, so its boost is earned and is never taken back.
+    pub(crate) fn score_token(&self, path: BiasPath, tok: usize) -> (f32, BiasPath) {
+        // A phrase is worth `boost` however long it is, so each of its tokens
+        // is granted a share rather than the whole amount.
+        //
+        // A character vocabulary makes the difference stark: paid per token, a
+        // nine-letter phrase would earn nine times the boost and outrank
+        // whatever was actually said — `любовницы` really did displace
+        // `люк кейдж` that way. Clawing the excess back on completion is worse
+        // still: the correction lands as one large negative step and the
+        // hypothesis that just finished the phrase gets pruned for it. Granting
+        // the right amount from the start keeps every step small.
+        let enter = |from: BiasPath, child: usize| {
+            let share = self.boost / self.nodes[child].shortest_phrase.max(1) as f32;
+            (
+                share,
+                BiasPath {
+                    node: child,
+                    // A finished phrase owes nothing back; an unfinished one
+                    // owes everything it has been granted so far.
+                    pending: if self.nodes[child].is_end {
+                        0.0
+                    } else {
+                        from.pending + share
+                    },
+                },
+            )
+        };
+
+        if let Some(&child) = self.nodes[path.node].children.get(&tok) {
+            return enter(path, child);
+        }
+
+        // The phrase under way dies here: take back what it was granted, and
+        // let a fresh phrase start on the same token.
+        let refund = -path.pending;
+        match self.nodes[0].children.get(&tok) {
+            Some(&child) => {
+                let (delta, next) = enter(BiasPath::default(), child);
+                (refund + delta, next)
+            }
+            None => (refund, BiasPath::default()),
+        }
+    }
+
+    /// Token ids that would extend the phrase `path` is in, plus every phrase
+    /// start. A beam search hands these to the candidate set so a boosted
+    /// continuation can be considered even when the acoustic model ranks it
+    /// below the pruning cut — which is the entire point of biasing.
+    pub(crate) fn continuations(&self, path: BiasPath, out: &mut Vec<usize>) {
+        out.extend(self.nodes[path.node].children.keys().copied());
+        if path.node != 0 {
+            out.extend(self.nodes[0].children.keys().copied());
+        }
     }
 
     /// Create a fresh per-decode prefix-tracking state rooted at the trie root.
@@ -301,6 +407,49 @@ mod tests {
             "<blk>".to_string(),
         ];
         Tokenizer::from_tokens(tokens)
+    }
+
+    #[test]
+    fn a_phrase_earns_one_boost_however_long_it_is() {
+        // Paid per token, a nine-letter phrase would be worth nine boosts and
+        // outrank whatever was actually said — that is how `любовницы`
+        // displaced `люк кейдж` on real audio. Length must not buy rank.
+        for len in [1usize, 3, 9] {
+            let seq: Vec<usize> = (1..=len).collect();
+            let b = Biaser::from_sequences(vec![seq.clone()], 6.0).expect("biaser");
+            let mut path = BiasPath::default();
+            let mut earned = 0.0;
+            for &tok in &seq {
+                let (delta, next) = b.score_token(path, tok);
+                earned += delta;
+                path = next;
+            }
+            assert!(
+                (earned - 6.0).abs() < 1e-4,
+                "a {len}-token phrase earned {earned}, expected the boost once"
+            );
+            assert_eq!(path.pending(), 0.0, "a finished phrase owes nothing back");
+        }
+    }
+
+    #[test]
+    fn an_abandoned_phrase_earns_nothing() {
+        // Credit accrues while a phrase is under way so the beam keeps it
+        // alive; walking away has to give all of it back, or a partial match
+        // would be rewarded for going nowhere.
+        let b = Biaser::from_sequences(vec![vec![1, 2, 3, 4]], 6.0).expect("biaser");
+        let mut path = BiasPath::default();
+        let mut earned = 0.0;
+        for tok in [1usize, 2] {
+            let (delta, next) = b.score_token(path, tok);
+            earned += delta;
+            path = next;
+        }
+        assert!(path.pending() > 0.0, "mid-phrase credit is outstanding");
+        let (delta, path) = b.score_token(path, 99);
+        earned += delta;
+        assert!(earned.abs() < 1e-4, "abandoned phrase netted {earned}");
+        assert_eq!(path.pending(), 0.0);
     }
 
     #[test]

--- a/crates/gigastt-core/src/inference/ctc.rs
+++ b/crates/gigastt-core/src/inference/ctc.rs
@@ -10,9 +10,283 @@
 //! axis, the vocab the inner. This differs from the RNN-T encoder's channels-first
 //! `[1, D, T]` layout (see [`super::decode::extract_encoder_frame`]).
 
+use super::bias::{BiasPath, Biaser};
 use super::decode::{TokenInfo, argmax_with_confidence};
 use super::tokenizer::{Tokenizer, WORD_BOUNDARY};
 use super::{SECONDS_PER_FRAME, WordInfo};
+
+/// Hypotheses kept per frame by [`ctc_prefix_beam_decode`].
+///
+/// Small on purpose: the vocabulary is 71 classes and biasing needs breadth
+/// only where a hotword competes with what the model heard, not everywhere.
+const BEAM_WIDTH: usize = 8;
+
+/// Acoustic candidates considered per frame before hotword continuations are
+/// added. Everything below this rank is too unlikely to survive pruning anyway.
+const BEAM_TOP_K: usize = 6;
+
+/// `ln(exp(a) + exp(b))`, stable for the log-domain accumulation below.
+fn log_add_exp(a: f32, b: f32) -> f32 {
+    if a == f32::NEG_INFINITY {
+        return b;
+    }
+    if b == f32::NEG_INFINITY {
+        return a;
+    }
+    let (hi, lo) = if a > b { (a, b) } else { (b, a) };
+    hi + (lo - hi).exp().ln_1p()
+}
+
+/// One prefix under consideration, with the two probabilities CTC prefix search
+/// has to keep apart: paths that end in a blank and paths that end in the
+/// prefix's own last label. Collapsing them would lose the distinction between
+/// "aa" written as one label and as two.
+struct Hypothesis {
+    /// Log-probability of paths reaching this prefix and ending in blank.
+    p_blank: f32,
+    /// Log-probability of paths reaching this prefix and ending in its last label.
+    p_nonblank: f32,
+    /// Emitted labels with the frame and confidence that produced them; word
+    /// timestamps downstream are built from these, so a prefix has to carry its
+    /// alignment rather than just its text.
+    tokens: Vec<TokenInfo>,
+    /// Where this hypothesis sits in the hotword trie.
+    bias: BiasPath,
+    /// Probability of the contribution that supplied `tokens` and `bias`. When
+    /// two extensions land on the same prefix, the better-supported alignment
+    /// is the one worth keeping.
+    anchor: f32,
+}
+
+impl Hypothesis {
+    fn total(&self) -> f32 {
+        log_add_exp(self.p_blank, self.p_nonblank)
+    }
+
+    /// Score with any un-earned hotword boost taken back.
+    ///
+    /// Pruning uses [`Self::total`], boost included — that credit is what keeps
+    /// a half-matched phrase alive long enough to finish. Choosing the winner
+    /// uses this instead: a hypothesis still inside a phrase when the audio ran
+    /// out never finished it, and paying it for the attempt is how a glossary
+    /// starts inventing words that were not said.
+    fn settled_total(&self) -> f32 {
+        self.total() - self.bias.pending()
+    }
+}
+
+/// Contextual CTC decoding by prefix beam search.
+///
+/// Greedy CTC takes a per-frame argmax and has no continuation state, so there
+/// is nothing for a hotword boost to steer — biasing was inert on these heads.
+/// A beam keeps competing prefixes alive, which gives a boost something to act
+/// on and, just as importantly, gives a wrong guess somewhere to lose: a
+/// hypothesis that walks into a hotword and abandons it is refunded the boost
+/// it was granted (see [`Biaser::score_token`]), so only a phrase the audio
+/// actually supports keeps its advantage.
+///
+/// Arguments match [`ctc_greedy_decode`]; `log_probs` is likewise the raw
+/// encoder output, normalized per frame here.
+pub(crate) fn ctc_prefix_beam_decode(
+    log_probs: &[f32],
+    t_len: usize,
+    vocab: usize,
+    blank_id: usize,
+    biaser: &Biaser,
+) -> Vec<TokenInfo> {
+    if vocab == 0 {
+        return Vec::new();
+    }
+    let usable = t_len.min(log_probs.len() / vocab);
+
+    // The empty prefix, reached by a blank-only path with probability 1.
+    let mut beams: Vec<(Vec<usize>, Hypothesis)> = vec![(
+        Vec::new(),
+        Hypothesis {
+            p_blank: 0.0,
+            p_nonblank: f32::NEG_INFINITY,
+            tokens: Vec::new(),
+            bias: BiasPath::default(),
+            anchor: 0.0,
+        },
+    )];
+
+    let mut lp = vec![0.0_f32; vocab];
+    let mut candidates: Vec<usize> = Vec::new();
+
+    for t in 0..usable {
+        log_softmax(&log_probs[t * vocab..(t + 1) * vocab], &mut lp);
+
+        // Candidates: the most likely classes this frame, plus every token that
+        // could extend a hotword any live beam is inside. The second half is
+        // what lets a boosted continuation be considered at all when the model
+        // ranks it below the cut.
+        candidates.clear();
+        top_k_into(&lp, BEAM_TOP_K, &mut candidates);
+        if !candidates.contains(&blank_id) {
+            candidates.push(blank_id);
+        }
+        for (_, hyp) in &beams {
+            biaser.continuations(hyp.bias, &mut candidates);
+        }
+        // A hotword compiled against a different vocabulary can name a token id
+        // this head does not have; drop those rather than index past the frame.
+        candidates.retain(|&c| c < vocab);
+        candidates.sort_unstable();
+        candidates.dedup();
+
+        let mut next: Vec<(Vec<usize>, Hypothesis)> = Vec::new();
+        for (labels, hyp) in &beams {
+            for &c in &candidates {
+                if lp[c] == f32::NEG_INFINITY {
+                    continue;
+                }
+                if c == blank_id {
+                    // No label emitted: the prefix is unchanged and the path
+                    // now ends in blank.
+                    let p = hyp.total() + lp[c];
+                    merge(&mut next, labels, hyp, Emission::Blank(p));
+                    continue;
+                }
+                if labels.last() == Some(&c) {
+                    // Repeat of the last label. Without an intervening blank it
+                    // collapses into the same prefix; with one it emits a
+                    // second copy.
+                    let same = hyp.p_nonblank + lp[c];
+                    merge(&mut next, labels, hyp, Emission::Repeat(same));
+                    let (bonus, bias) = biaser.score_token(hyp.bias, c);
+                    let extended = hyp.p_blank + lp[c] + bonus;
+                    merge_extension(&mut next, labels, hyp, c, extended, bias, t, lp[c].exp());
+                    continue;
+                }
+                let (bonus, bias) = biaser.score_token(hyp.bias, c);
+                let extended = hyp.total() + lp[c] + bonus;
+                merge_extension(&mut next, labels, hyp, c, extended, bias, t, lp[c].exp());
+            }
+        }
+
+        if next.is_empty() {
+            break;
+        }
+        next.sort_by(|a, b| b.1.total().total_cmp(&a.1.total()));
+        next.truncate(BEAM_WIDTH);
+        beams = next;
+    }
+
+    beams
+        .into_iter()
+        .max_by(|a, b| a.1.settled_total().total_cmp(&b.1.settled_total()))
+        .map(|(_, hyp)| hyp.tokens)
+        .unwrap_or_default()
+}
+
+/// A contribution to a prefix that emits no new label.
+enum Emission {
+    /// Path ends in blank.
+    Blank(f32),
+    /// Path ends in the prefix's own last label.
+    Repeat(f32),
+}
+
+/// Fold a same-prefix contribution into `next`.
+fn merge(
+    next: &mut Vec<(Vec<usize>, Hypothesis)>,
+    labels: &[usize],
+    from: &Hypothesis,
+    emission: Emission,
+) {
+    let slot = match next.iter_mut().find(|(l, _)| l == labels) {
+        Some((_, hyp)) => hyp,
+        None => {
+            next.push((
+                labels.to_vec(),
+                Hypothesis {
+                    p_blank: f32::NEG_INFINITY,
+                    p_nonblank: f32::NEG_INFINITY,
+                    tokens: from.tokens.clone(),
+                    bias: from.bias,
+                    anchor: from.anchor,
+                },
+            ));
+            &mut next.last_mut().expect("just pushed").1
+        }
+    };
+    match emission {
+        Emission::Blank(p) => slot.p_blank = log_add_exp(slot.p_blank, p),
+        Emission::Repeat(p) => slot.p_nonblank = log_add_exp(slot.p_nonblank, p),
+    }
+}
+
+/// Fold an extension by `token` into `next`, keeping the alignment of whichever
+/// contribution is best supported.
+#[allow(clippy::too_many_arguments)]
+fn merge_extension(
+    next: &mut Vec<(Vec<usize>, Hypothesis)>,
+    labels: &[usize],
+    from: &Hypothesis,
+    token: usize,
+    p: f32,
+    bias: BiasPath,
+    frame: usize,
+    confidence: f32,
+) {
+    if p == f32::NEG_INFINITY {
+        return;
+    }
+    let mut extended = Vec::with_capacity(labels.len() + 1);
+    extended.extend_from_slice(labels);
+    extended.push(token);
+
+    let build = |from: &Hypothesis| {
+        let mut tokens = Vec::with_capacity(from.tokens.len() + 1);
+        tokens.extend_from_slice(&from.tokens);
+        tokens.push(TokenInfo {
+            token_id: token,
+            frame_index: frame,
+            confidence,
+        });
+        tokens
+    };
+
+    match next.iter_mut().find(|(l, _)| *l == extended) {
+        Some((_, hyp)) => {
+            hyp.p_nonblank = log_add_exp(hyp.p_nonblank, p);
+            if p > hyp.anchor {
+                hyp.tokens = build(from);
+                hyp.bias = bias;
+                hyp.anchor = p;
+            }
+        }
+        None => next.push((
+            extended,
+            Hypothesis {
+                p_blank: f32::NEG_INFINITY,
+                p_nonblank: p,
+                tokens: build(from),
+                bias,
+                anchor: p,
+            },
+        )),
+    }
+}
+
+/// Normalize one frame of encoder output into log-probabilities.
+fn log_softmax(row: &[f32], out: &mut [f32]) {
+    let max = row.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let sum: f32 = row.iter().map(|&l| (l - max).exp()).sum();
+    let log_sum = max + sum.ln();
+    for (o, &l) in out.iter_mut().zip(row) {
+        *o = l - log_sum;
+    }
+}
+
+/// Indices of the `k` largest values in `lp`, appended to `out`.
+fn top_k_into(lp: &[f32], k: usize, out: &mut Vec<usize>) {
+    let mut idx: Vec<usize> = (0..lp.len()).collect();
+    let k = k.min(idx.len());
+    idx.select_nth_unstable_by(k.saturating_sub(1), |&a, &b| lp[b].total_cmp(&lp[a]));
+    out.extend_from_slice(&idx[..k]);
+}
 
 /// Greedy CTC decode over a flat `log_probs` buffer of shape `[t_total, vocab]`
 /// (row-major). Returns the collapsed, blank-stripped tokens with a per-token
@@ -178,6 +452,109 @@ mod tests {
         let toks = ctc_greedy_decode(&lp, 2, 3, 2);
         assert_eq!(toks.len(), 2);
         assert_eq!(toks[1].frame_index, 1);
+    }
+
+    /// Two-class-plus-blank frames where `ids[t]` leads by `margin` nats over
+    /// every other class. A small margin is what a boost can overturn.
+    fn logits_with_margin(ids: &[usize], vocab: usize, margin: f32) -> Vec<f32> {
+        let mut lp = vec![0.0f32; ids.len() * vocab];
+        for (t, &id) in ids.iter().enumerate() {
+            lp[t * vocab + id] = margin;
+        }
+        lp
+    }
+
+    fn ids_of(tokens: &[TokenInfo]) -> Vec<usize> {
+        tokens.iter().map(|t| t.token_id).collect()
+    }
+
+    #[test]
+    fn beam_without_a_hotword_hit_matches_greedy() {
+        // The biaser names a token this vocabulary does not have, so nothing is
+        // ever boosted and the beam must land where the argmax does — including
+        // the collapse rules.
+        let b = Biaser::from_sequences(vec![vec![99]], 5.0).expect("biaser");
+        for ids in [
+            vec![0usize, 0, 2, 1],
+            vec![0, 0, 2, 0],
+            vec![1, 2, 2, 1, 0],
+            vec![2, 2, 2],
+        ] {
+            let lp = logits(&ids, 3);
+            let beam = ctc_prefix_beam_decode(&lp, ids.len(), 3, 2, &b);
+            let greedy = ctc_greedy_decode(&lp, ids.len(), 3, 2);
+            assert_eq!(
+                ids_of(&beam),
+                ids_of(&greedy),
+                "beam diverged from greedy on {ids:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn beam_keeps_the_frame_of_each_emitted_label() {
+        // Word timestamps are built from these, so a prefix has to carry its
+        // alignment, not just its text.
+        let b = Biaser::from_sequences(vec![vec![99]], 5.0).expect("biaser");
+        let lp = logits(&[0, 0, 2, 1], 3);
+        let beam = ctc_prefix_beam_decode(&lp, 4, 3, 2, &b);
+        let greedy = ctc_greedy_decode(&lp, 4, 3, 2);
+        assert_eq!(
+            beam.iter().map(|t| t.frame_index).collect::<Vec<_>>(),
+            greedy.iter().map(|t| t.frame_index).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn boost_recovers_a_hotword_the_model_narrowly_missed() {
+        // vocab: 0, 1, 2 are labels, 3 is blank. Frame 0 is label 0; on frame 1
+        // the model puts label 2 narrowly ahead of label 1. The hotword is
+        // [0, 1] — the phrase the model just missed.
+        let vocab = 4;
+        let mut lp = logits_with_margin(&[0, 2], vocab, 5.0);
+        lp[vocab + 1] = 4.6; // frame 1: label 1 just behind label 2
+
+        let inert = Biaser::from_sequences(vec![vec![99]], 3.0).expect("biaser");
+        let unbiased = ids_of(&ctc_prefix_beam_decode(&lp, 2, vocab, 3, &inert));
+        assert_eq!(unbiased, vec![0, 2], "model's own pick");
+
+        let hot = Biaser::from_sequences(vec![vec![0, 1]], 3.0).expect("biaser");
+        let biased = ids_of(&ctc_prefix_beam_decode(&lp, 2, vocab, 3, &hot));
+        assert_eq!(biased, vec![0, 1], "boost recovers the hotword");
+    }
+
+    #[test]
+    fn abandoned_partial_match_is_refunded() {
+        // The hotword is [0, 1, 1, 1] but the audio only supports its first
+        // token, so no beam can finish the phrase. The refund must leave the
+        // transcript exactly where the unbiased decode put it — a partial match
+        // that wins would be the greedy path's failure mode all over again.
+        let lp = logits(&[0, 2, 1, 2, 0], 3);
+        let inert = Biaser::from_sequences(vec![vec![99]], 8.0).expect("biaser");
+        let hot = Biaser::from_sequences(vec![vec![0, 1, 1, 1]], 8.0).expect("biaser");
+        assert_eq!(
+            ids_of(&ctc_prefix_beam_decode(&lp, 5, 3, 2, &hot)),
+            ids_of(&ctc_prefix_beam_decode(&lp, 5, 3, 2, &inert)),
+            "an unfinishable hotword must not bend the transcript"
+        );
+    }
+
+    #[test]
+    fn beam_tolerates_a_hotword_token_outside_the_vocab() {
+        // A glossary compiled against another head can name ids this one does
+        // not have. Those must be dropped, not indexed.
+        let b = Biaser::from_sequences(vec![vec![0, 250]], 5.0).expect("biaser");
+        let lp = logits(&[0, 1], 3);
+        let out = ctc_prefix_beam_decode(&lp, 2, 3, 2, &b);
+        assert_eq!(ids_of(&out), vec![0, 1]);
+    }
+
+    #[test]
+    fn beam_honours_t_len_truncation() {
+        let b = Biaser::from_sequences(vec![vec![99]], 5.0).expect("biaser");
+        let lp = logits(&[0, 1, 0], 3);
+        let out = ctc_prefix_beam_decode(&lp, 2, 3, 2, &b);
+        assert_eq!(ids_of(&out), vec![0, 1]);
     }
 
     #[test]

--- a/crates/gigastt-core/src/inference/engine.rs
+++ b/crates/gigastt-core/src/inference/engine.rs
@@ -522,7 +522,7 @@ impl Engine {
     /// Unrepresentable phrases are dropped by [`Biaser::from_phrases`]; if none
     /// survive, returns `None` (decode continues without biasing).
     fn build_request_biaser(&self, hw: &HotwordOverride) -> Option<bias::Biaser> {
-        if hw.phrases.is_empty() || self.hotwords_unsupported() {
+        if hw.phrases.is_empty() {
             return None;
         }
         let boost = hw.boost.unwrap_or(DEFAULT_HOTWORDS_BOOST);
@@ -554,7 +554,7 @@ impl Engine {
     /// the active vocab, the biaser resolves to `None` and the decode path stays
     /// byte-for-byte unchanged. Replaces any previously attached biaser.
     pub fn with_hotwords(mut self, phrases: &[(String, f32)], boost: f32) -> Self {
-        self.biaser = if phrases.is_empty() || self.hotwords_unsupported() {
+        self.biaser = if phrases.is_empty() {
             None
         } else {
             bias::Biaser::from_phrases(&self.tokenizer, phrases, boost)
@@ -566,25 +566,6 @@ impl Engine {
             );
         }
         self
-    }
-
-    /// Whether the loaded head has nowhere to apply a hotword boost, warning
-    /// once if a glossary was supplied anyway.
-    ///
-    /// Biasing is shallow fusion over the transducer's continuation scores. A
-    /// charwise-CTC head decodes by per-frame argmax with no continuation state
-    /// to steer, so a glossary is inert there — and saying "biasing enabled"
-    /// anyway is how a user ends up trusting a glossary that never ran.
-    fn hotwords_unsupported(&self) -> bool {
-        if !self.variant.is_ctc() {
-            return false;
-        }
-        tracing::warn!(
-            "Hotword biasing is not applied on the {:?} head: it decodes with greedy CTC, \
-             which has no continuation state to bias. The glossary is ignored.",
-            self.variant
-        );
-        true
     }
 
     /// Whether a hotword biaser is attached (biasing active).
@@ -2577,21 +2558,35 @@ impl Engine {
         tracing::debug!("Encoder output: {} frames", enc_len);
 
         // CTC head: the single encoder emits per-frame class log-probs
-        // (`[1, T', 71]`, row-major). Greedy-decode them directly — there is no
+        // (`[1, T', 71]`, row-major). Decode them directly — there is no
         // prediction network / joiner, so we return before the RNN-T block
         // borrows `encoder_outputs` for the decode loop.
+        //
+        // A glossary switches the decode to a prefix beam, which is the only
+        // form that can act on one: a per-frame argmax has no continuation
+        // state to steer. Without hotwords the greedy path runs untouched, so
+        // output for everyone else is byte-for-byte what it was.
         if self.variant.is_ctc() {
             let log_probs = encoder_outputs[0]
                 .view()
                 .data()
                 .as_f32()
                 .context("CTC log_probs tensor is not f32")?;
-            let tokens = ctc::ctc_greedy_decode(
-                log_probs,
-                enc_len,
-                self.tokenizer.vocab_size(),
-                self.tokenizer.blank_id(),
-            );
+            let tokens = match biaser {
+                Some(b) => ctc::ctc_prefix_beam_decode(
+                    log_probs,
+                    enc_len,
+                    self.tokenizer.vocab_size(),
+                    self.tokenizer.blank_id(),
+                    b,
+                ),
+                None => ctc::ctc_greedy_decode(
+                    log_probs,
+                    enc_len,
+                    self.tokenizer.vocab_size(),
+                    self.tokenizer.blank_id(),
+                ),
+            };
             let words = ctc::ctc_tokens_to_words(&self.tokenizer, &tokens, frame_offset);
             return Ok((words, false)); // CTC has no endpoint signal
         }
@@ -5618,27 +5613,27 @@ vocab = "pack_vocab.txt"
         }
 
         #[test]
-        fn test_ctc_head_reports_hotwords_as_off() {
+        fn test_ctc_head_attaches_a_biaser() {
             use crate::inference::HotwordOverride;
             use crate::model::ModelVariant;
 
-            // A charwise-CTC head decodes by per-frame argmax and never reads a
-            // biaser, so attaching one and logging "biasing enabled" told users
-            // their glossary was live when nothing applied it. Both the boot
-            // biaser and the per-request one must now report the truth.
+            // A glossary used to be inert here: greedy CTC has no continuation
+            // state, so the biaser was refused outright to stop the engine
+            // claiming otherwise. The prefix beam gives it somewhere to act, so
+            // both the boot biaser and the per-request one attach again.
             let (mut engine, _tmp) = tiny_mock_engine();
             engine.variant = ModelVariant::MlCtc;
 
             let engine = engine.with_hotwords(&[("hi".into(), 1.0)], 5.0);
             assert!(
-                !engine.has_hotwords(),
-                "a CTC head must not claim an active biaser"
+                engine.has_hotwords(),
+                "a CTC head biases through the prefix beam"
             );
 
             let per_request = HotwordOverride::new(vec!["hi".into()], Some(7.0));
             assert!(
-                engine.build_request_biaser(&per_request).is_none(),
-                "a per-request glossary is inert on a CTC head too"
+                engine.build_request_biaser(&per_request).is_some(),
+                "a per-request glossary applies on a CTC head too"
             );
         }
 

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -84,9 +84,7 @@ struct OfflineEngineArgs {
     itn: ItnMode,
 
     /// Contextual hotword biasing: path to a file of phrases to boost (one
-    /// phrase per line, optional `\t<weight>` suffix). Applies to the rnnt and
-    /// e2e_rnnt heads only; the multilingual CTC heads ignore it.
-    /// Env: GIGASTT_HOTWORDS_FILE.
+    /// phrase per line, optional `\t<weight>` suffix). Env: GIGASTT_HOTWORDS_FILE.
     #[arg(long, env = "GIGASTT_HOTWORDS_FILE")]
     hotwords_file: Option<String>,
 
@@ -265,8 +263,7 @@ enum Commands {
 
         /// Contextual hotword biasing: path to a file of phrases to boost during
         /// recognition (one phrase per line, optional `\t<weight>` suffix; blank
-        /// lines and `#` comments ignored). Off when unset. Applies to the rnnt
-        /// and e2e_rnnt heads only; the multilingual CTC heads ignore it. Env:
+        /// lines and `#` comments ignored). Off when unset. Env:
         /// GIGASTT_HOTWORDS_FILE.
         #[arg(long, env = "GIGASTT_HOTWORDS_FILE")]
         hotwords_file: Option<String>,
@@ -636,8 +633,7 @@ enum Commands {
 
         /// Contextual hotword biasing: path to a file of phrases to boost during
         /// recognition (one phrase per line, optional `\t<weight>` suffix; blank
-        /// lines and `#` comments ignored). Off when unset. Applies to the rnnt
-        /// and e2e_rnnt heads only; the multilingual CTC heads ignore it. Env:
+        /// lines and `#` comments ignored). Off when unset. Env:
         /// GIGASTT_HOTWORDS_FILE.
         #[arg(long, env = "GIGASTT_HOTWORDS_FILE")]
         hotwords_file: Option<String>,

--- a/docs/api.md
+++ b/docs/api.md
@@ -480,10 +480,11 @@ impossible combination fails fast instead of holding a triplet:
   `409 vad_not_loaded` if the server was started without `--vad`.
 - `hotwords` (string) — comma-separated phrases to bias the decoder toward.
   `409 too_many_hotwords` above 64 phrases, `409 hotword_phrase_too_long` above
-  64 characters in one phrase. Biasing is shallow fusion over the transducer's
-  continuation scores, so it applies to the `rnnt` and `e2e_rnnt` heads only —
-  a `ml_ctc` / `ml_ctc_large` server accepts the parameter and ignores it,
-  logging a warning at startup.
+  64 characters in one phrase. The `rnnt` and `e2e_rnnt` heads bias their greedy
+  transducer decode directly; the `ml_ctc` / `ml_ctc_large` heads switch to a
+  prefix beam search when a glossary is present, since a per-frame argmax has no
+  continuation to steer. Without hotwords those heads decode greedily exactly as
+  before.
 - `hotwords_boost` (number) — strength of that bias.
 - `variant` (string) — forward-compatibility guard naming the expected recognition
   head. A single-variant engine cannot switch, so any value other than the loaded

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,8 +51,7 @@ gigastt serve [OPTIONS]
                             e2e_rnnt]. Runs before punctuation. Env: GIGASTT_ITN.
   --hotwords-file <FILE>    Contextual hotword biasing: file of phrases to boost
                             (one per line, optional `\t<weight>` suffix). Off when
-                            unset. rnnt / e2e_rnnt only; the multilingual CTC
-                            heads ignore it. Env: GIGASTT_HOTWORDS_FILE.
+                            unset. Env: GIGASTT_HOTWORDS_FILE.
   --hotwords-default        Also bias the built-in Russian brand/acronym lexicon.
                             Env: GIGASTT_HOTWORDS_DEFAULT.
   --hotwords-boost <N>      Additive logit boost for hotword continuation tokens
@@ -207,7 +206,7 @@ gigastt transcribe [OPTIONS] <FILE>
                               auto | on | off [default: auto = on for rnnt, off for
                               e2e_rnnt]. Runs before punctuation. Env: GIGASTT_ITN.
   --hotwords-file <FILE>      Hotword biasing: file of phrases to boost (one per
-                              line, optional `\t<weight>`). rnnt / e2e_rnnt only.
+                              line, optional `\t<weight>`).
                               Env: GIGASTT_HOTWORDS_FILE.
   --hotwords-default          Also bias the built-in brand/acronym lexicon.
                               Env: GIGASTT_HOTWORDS_DEFAULT.


### PR DESCRIPTION
Follow-up to #262, which could only make the engine stop *claiming* hotword
biasing worked on `ml_ctc` / `ml_ctc_large`. This makes it work.

## Why greedy CTC could not be biased

A per-frame argmax carries no continuation state, so there is nothing for a
boost to steer. A prefix beam keeps competing hypotheses alive, which gives the
boost something to act on and — the half that matters — gives a wrong guess
somewhere to lose, instead of one path being dragged off course the way the
transducer's greedy loop was in #262.

The beam replaces the greedy decode **only when a glossary is present**. Without
hotwords the greedy path runs untouched, so `ml_ctc` output is byte-for-byte
what it was and no WER re-measurement is owed for users who never asked for
biasing.

## Two rules that keep it from inventing words

**A partial match wins nothing.** A hypothesis that walks into a hotword and
abandons it is refunded every bit of boost it was granted. Credit still accrues
while the phrase is under way — that is what keeps it in the beam long enough to
finish — and any credit still outstanding when the audio ends is discounted
before the winner is picked.

**A phrase is worth one boost however long it is**, spread across its tokens.
This one was found the hard way on real audio: paid per token, a nine-letter
phrase earned nine times the boost and simply outranked what was said —
`любовницы` displaced `люк кейдж`. The obvious repair, clawing the excess back on
completion, was worse: the correction lands as one large negative step and prunes
the hypothesis that just finished the phrase, which cost whole spans of
transcript. Granting the right share from the start keeps every step small.

Both rules are pinned by unit tests on the scoring function itself, so the
invariants survive future changes to the search.

## Timestamps

Prefix beams merge paths, which normally loses alignment. Each hypothesis
carries the frame and confidence of every label it emitted rather than just its
text, so `ctc_tokens_to_words` keeps producing word timestamps unchanged.

## Verification

62 s of Russian speech, `ml_ctc`, three-phrase glossary
(`ростов`, `гетто`, `любовницы`):

| | greedy (before) | beam (after) |
|---|---|---|
| `ростоу` | ✗ | **ростов** |
| `гетта` | ✗ | **гетто** |
| `любовница` | ✗ | **любовницы** |
| `развалиныищи` | ✗ | **развалины ищи** |
| `люк кейдж` | ✓ | ✓ (no false insertion) |

All three glossary terms corrected, a run-together word split as a side effect
of the search, and the rest of the transcript untouched. With no glossary the
output matches `main` exactly.

Cost is negligible: 71 classes, beam of 8, ~6 acoustic candidates per frame plus
hotword continuations — invisible next to the encoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)