### PR TITLE
Memory-map the optimized encoder cache: per-session RAM ~310 MB → ~20 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,27 @@ were released without a git tag, so their headings carry no compare link.
   process start → `/ready` drops from ~1.1 s to ~0.7 s; transcription output is
   byte-identical to the previous behavior.
 
+- **Per-session encoder memory collapses: the optimized cache is now an ORT
+  flatbuffer model, memory-mapped, with zero-copy initializers and no
+  prepacking.** Every CPU encoder session used to carry its own private copy
+  of the INT8 weights plus the parsed protobuf graph of the optimized ONNX
+  cache — roughly 250–300 MB of anonymous memory per pool slot, so the
+  default `--pool-size 2` idled near ~650 MB before serving a single request.
+  The cache is now written as `<stem>_optimized.ort` and read back with
+  ORT 1.28's `session.use_memory_mapped_ort_model` +
+  `session.use_ort_model_bytes_for_initializers`: all sessions reference the
+  weights in one shared read-only file mapping (page-cache backed, reclaimable
+  under pressure), and the flatbuffer graph skips the protobuf object graph
+  entirely. Prepacking is disabled on this path because for this model it only
+  duplicated the weights into ~145 MB of per-session buffers with no RTF
+  benefit. Measured on an M-series MacBook (`--pool-size 2`, INT8 rnnt,
+  at `/ready`): physical footprint ~650 MB → ~60 MB, per-session marginal
+  ~310 MB → ~20 MB; steady-state RTF on the Golos fixture set unchanged
+  (0.045–0.053 both before and after); cold start unchanged at ~1.0 s.
+  Transcription output is byte-identical. Legacy `*_optimized.onnx` caches
+  are treated as zombies by `cache-gc` and are regenerated in the new format
+  on the next boot that finds them stale or missing.
+
 ### Added
 
 - **Hotword biasing now works on the multilingual CTC heads**, via a prefix beam

--- a/crates/gigastt-core/src/model/cache.rs
+++ b/crates/gigastt-core/src/model/cache.rs
@@ -41,11 +41,12 @@ pub(crate) fn coreml_cache_dir(model_dir: &Path) -> PathBuf {
 }
 
 /// Basename of the optimized graph ORT would open for `model_path`'s stem:
-/// `{file_stem}_optimized.onnx`.
+/// `{file_stem}_optimized.ort` (ORT flatbuffer format — loaded via mmap,
+/// see `runtime::ort::session`).
 pub fn optimized_cache_basename(encoder_path: &Path) -> Option<String> {
     encoder_path
         .file_stem()
-        .map(|s| format!("{}_optimized.onnx", s.to_string_lossy()))
+        .map(|s| format!("{}_optimized.ort", s.to_string_lossy()))
 }
 
 /// Preferred encoder path on disk for `variant`: INT8 when present, else FP32
@@ -105,8 +106,10 @@ pub struct DedupeReport {
 
 /// Drop non-active optimized graphs under `model_dir/optimized_cache/`.
 ///
-/// Keeps only `{preferred_encoder_stem}_optimized.onnx` for the variant
-/// detected in `model_dir` (INT8 preferred). When no head is detected, the
+/// Keeps only `{preferred_encoder_stem}_optimized.ort` for the variant
+/// detected in `model_dir` (INT8 preferred). Legacy `*_optimized.onnx`
+/// graphs (written by versions before the switch to the ORT flatbuffer
+/// format) count as zombies and are pruned. When no head is detected, the
 /// cache is left untouched so a half-installed tree is not wiped.
 ///
 /// With `dry_run`, reports what would be deleted without removing files.
@@ -142,8 +145,9 @@ pub fn prune_optimized_cache(model_dir: &Path, dry_run: bool) -> Result<Optimize
         }
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        // Only touch ORT optimized graphs; leave unrelated files alone.
-        if !name.ends_with("_optimized.onnx") {
+        // Only touch ORT optimized graphs (current `.ort` and legacy
+        // `.onnx`); leave unrelated files alone.
+        if !name.ends_with("_optimized.ort") && !name.ends_with("_optimized.onnx") {
             continue;
         }
         if name.as_ref() == keep_name {
@@ -416,7 +420,7 @@ mod tests {
         let p = Path::new("/m/v3_rnnt_encoder_int8.onnx");
         assert_eq!(
             optimized_cache_basename(p).as_deref(),
-            Some("v3_rnnt_encoder_int8_optimized.onnx")
+            Some("v3_rnnt_encoder_int8_optimized.ort")
         );
     }
 
@@ -429,14 +433,14 @@ mod tests {
             write_file(&dir.join(f), b"stub");
         }
         let cache = dir.join("optimized_cache");
-        let keep = cache.join("v3_rnnt_encoder_int8_optimized.onnx");
+        let keep = cache.join("v3_rnnt_encoder_int8_optimized.ort");
+        let legacy_active = cache.join("v3_rnnt_encoder_int8_optimized.onnx");
         let fp32 = cache.join("v3_rnnt_encoder_optimized.onnx");
-        let e2e = cache.join("v3_e2e_rnnt_encoder_int8_optimized.onnx");
-        let legacy = cache.join("encoder_optimized.onnx");
+        let e2e = cache.join("v3_e2e_rnnt_encoder_int8_optimized.ort");
         write_file(&keep, &[1u8; 100]);
-        write_file(&fp32, &[2u8; 200]);
-        write_file(&e2e, &[3u8; 300]);
-        write_file(&legacy, &[4u8; 400]);
+        write_file(&legacy_active, &[2u8; 200]);
+        write_file(&fp32, &[3u8; 300]);
+        write_file(&e2e, &[4u8; 400]);
         // Unrelated file must stay.
         write_file(&cache.join("notes.txt"), b"keep me");
 
@@ -444,9 +448,9 @@ mod tests {
         assert_eq!(report.kept, vec![keep.clone()]);
         assert_eq!(report.removed.len(), 3);
         assert!(keep.exists());
+        assert!(!legacy_active.exists());
         assert!(!fp32.exists());
         assert!(!e2e.exists());
-        assert!(!legacy.exists());
         assert!(cache.join("notes.txt").exists());
         assert_eq!(report.freed_bytes, 200 + 300 + 400);
     }

--- a/crates/gigastt-core/src/model/cache.rs
+++ b/crates/gigastt-core/src/model/cache.rs
@@ -41,8 +41,8 @@ pub(crate) fn coreml_cache_dir(model_dir: &Path) -> PathBuf {
 }
 
 /// Basename of the optimized graph ORT would open for `model_path`'s stem:
-/// `{file_stem}_optimized.ort` (ORT flatbuffer format — loaded via mmap,
-/// see `runtime::ort::session`).
+/// `{file_stem}_optimized.ort` (ORT flatbuffer format — loaded via mmap
+/// by the encoder session loader).
 pub fn optimized_cache_basename(encoder_path: &Path) -> Option<String> {
     encoder_path
         .file_stem()

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -75,7 +75,7 @@ fn optimized_cache_is_fresh(cache_path: &Path, source_path: &Path) -> bool {
 /// the file we write here is exactly the one `cache-gc` keeps.
 fn optimized_cache_path(cache_dir: &Path, model_path: &Path) -> std::path::PathBuf {
     let basename = crate::model::optimized_cache_basename(model_path)
-        .unwrap_or_else(|| "encoder_optimized.onnx".into());
+        .unwrap_or_else(|| "encoder_optimized.ort".into());
     cache_dir.join(basename)
 }
 
@@ -124,6 +124,16 @@ impl OrtRuntime {
     /// Returns `None` when the fast path does not apply or the cached graph
     /// fails to load (the broken entry is deleted so the next boot rewrites
     /// it cleanly).
+    ///
+    /// The cache is an ORT flatbuffer model (`.ort`), loaded with
+    /// `session.use_memory_mapped_ort_model` +
+    /// `session.use_ort_model_bytes_for_initializers`: sessions reference
+    /// the encoder weights directly from a shared read-only file mapping
+    /// instead of copying them into per-session anonymous memory, and the
+    /// flatbuffer graph avoids retaining a parsed ModelProto object graph.
+    /// Prepacking is disabled on this path — for this model it only
+    /// duplicated the weights into per-session buffers (~145 MiB each) with
+    /// no measurable RTF benefit.
     fn try_load_cached_encoder(&self, model_path: &Path) -> Option<Result<Session, RuntimeError>> {
         if !self.provider.is_cpu() {
             return None;
@@ -136,6 +146,18 @@ impl OrtRuntime {
         let result = self
             .session_builder(model_path, true)
             .and_then(|mut builder| {
+                builder = builder
+                    .with_config_entry("session.load_model_format", "ORT")
+                    .map_err(|e| load_failed(&cache_path, e))?;
+                builder = builder
+                    .with_config_entry("session.use_memory_mapped_ort_model", "1")
+                    .map_err(|e| load_failed(&cache_path, e))?;
+                builder = builder
+                    .with_config_entry("session.use_ort_model_bytes_for_initializers", "1")
+                    .map_err(|e| load_failed(&cache_path, e))?;
+                builder = builder
+                    .with_prepacking(false)
+                    .map_err(|e| load_failed(&cache_path, e))?;
                 builder
                     .commit_from_file(&cache_path)
                     .map_err(|e| load_failed(&cache_path, e))
@@ -194,6 +216,11 @@ impl Runtime for OrtRuntime {
             );
             builder = builder
                 .with_optimized_model_path(&cache_path)
+                .map_err(|e| load_failed(model_path, e))?;
+            // Persist the optimized graph in ORT flatbuffer format so the
+            // next boot can memory-map it (see `try_load_cached_encoder`).
+            builder = builder
+                .with_config_entry("session.save_model_format", "ORT")
                 .map_err(|e| load_failed(model_path, e))?;
         }
 
@@ -266,7 +293,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         let source = dir.join("v3_rnnt_encoder_int8.onnx");
-        let cache = dir.join("optimized_cache/v3_rnnt_encoder_int8_optimized.onnx");
+        let cache = dir.join("optimized_cache/v3_rnnt_encoder_int8_optimized.ort");
         write_file(&source, b"source");
         write_file(&cache, b"optimized");
         assert!(optimized_cache_is_fresh(&cache, &source));
@@ -277,7 +304,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         let source = dir.join("encoder.onnx");
-        let cache = dir.join("optimized_cache/encoder_optimized.onnx");
+        let cache = dir.join("optimized_cache/encoder_optimized.ort");
         write_file(&source, b"source");
 
         // Missing cache file → not fresh.
@@ -297,7 +324,7 @@ mod tests {
         let encoder = Path::new("/models/v3_rnnt_encoder_int8.onnx");
         assert_eq!(
             optimized_cache_path(cache_dir, encoder),
-            Path::new("/models/optimized_cache/v3_rnnt_encoder_int8_optimized.onnx")
+            Path::new("/models/optimized_cache/v3_rnnt_encoder_int8_optimized.ort")
         );
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -322,7 +322,7 @@ gigastt cache-gc [OPTIONS]
   --dry-run              Report reclaimable files without deleting / hardlinking
   --dedupe               Also hardlink content-identical files (SHA-256 groups)
 
-  Removes non-active optimized_cache/*_optimized.onnx graphs, keeping only the
-  graph for the preferred encoder of the detected head (INT8 when present).
+  Removes non-active optimized_cache/*_optimized.{ort,onnx} graphs, keeping only
+  the graph for the preferred encoder of the detected head (INT8 when present).
   Safe on accuracy: leftovers are pure disk waste from FP32 runs or head switches.
 ```


### PR DESCRIPTION
## What

The optimized encoder cache (reused since the previous PR) is now persisted in **ORT flatbuffer format** and loaded with `session.use_memory_mapped_ort_model` + `session.use_ort_model_bytes_for_initializers`, with prepacking disabled on that path:

- Sessions reference encoder weights directly from a shared read-only **file mapping** instead of copying them into per-session anonymous memory
- The flatbuffer graph avoids retaining a parsed ModelProto object graph per session
- Prepacking turned out to be the hidden multiplier: for this INT8 QDQ model it copied **~145 MB of weights per session with zero measurable RTF benefit**

## Measured (Apple M1, INT8 rnnt, physical footprint at /ready)

| | pool 1 | pool 2 | RTF | cold-start |
|---|---|---|---|---|
| main (before) | 333 MB (349 after fixtures) | 643 MB (657) | 0.043–0.053 | 0.64–1.00 s |
| this PR | **35 MB (55 after)** | **59 MB (73)** | 0.039–0.056 | 0.57–1.01 s |

Per-session marginal cost: **~310 MB → ~20 MB**. Transcription byte-identical for `rnnt`, `e2e_rnnt`, `ml_ctc`.

## Behavior notes

- Stale/broken cache: unchanged self-healing fallback (delete, reload from source `.onnx`, rewrite cache). First-boot conversion is heavier once: ~1.1 GB peak, ~2.7 s per model update.
- `cache-gc` keeps the active `.ort` and prunes legacy `.onnx` optimized caches (a dry run on the dev machine shows ~858 MiB reclaimable).
- RSS accounting caveat: `ps` RSS counts the shared mapping per-mapping, so the server's `memory_after_load` line will *under*-read at boot and grow as pages fault in; physical footprint is the honest metric (documented in the PR discussion).
- Not measured on x86/Linux: `disable_prepacking` cost nothing on arm64 for this model; MLAS VNNI kernels on x86 could theoretically differ — worth watching the nightly soak.

## Verification

`cargo test --workspace --lib --bins`, clippy `-D warnings`, fmt, check-docs-drift, pre-commit hook — all green. Unit tests updated for the `.ort` cache naming.