### PR TITLE
ci: drop temporary semver major override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,12 +467,6 @@ jobs:
           # implementation detail, not a semver contract — adding config fields
           # to it must not force a workspace-wide major bump.
           exclude: gigastt
-          # One-shot for the gigastt-quantize extract: public paths
-          # (`quantize::quantize_model`, `onnx_proto::*`) are preserved via
-          # re-export and still resolve for dependents, but cargo-semver-checks
-          # treats foreign-crate re-exports as removals. Self-baseline of the
-          # re-export tree is clean. Remove this after the extract is on main.
-          release-type: major
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Follow-up to #280: remove the one-shot `release-type: major` on Semver Checks now that the quantize re-export tree is on `main` (self-baseline is clean again).

## Test plan

- [ ] CI Semver Checks green without `release-type: major`