### PR TITLE
fix(cli): quantize no-ops when INT8 already present without FP32

### DIFF
--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -1244,23 +1244,28 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Commands::Quantize { model_dir, force } => {
-            // Packaging tool: requires a local FP32 encoder as source. Does not
-            // download FP32 or run inference on FP32 — product runtime is INT8-only.
+            // Packaging tool: requires a local FP32 encoder as source when it
+            // actually has to produce INT8. Does not download FP32 or run
+            // inference on FP32 — product runtime is INT8-only.
+            //
+            // Order matters for lean INT8 installs: if INT8 is already present
+            // and `--force` is off, no-op without looking for FP32 (CI/e2e and
+            // operators who only have the prequantized bundle).
             let dir = std::path::Path::new(&model_dir);
             let resolved = model::ModelVariant::detect_in_dir(dir).unwrap_or_default();
             let input = dir.join(resolved.encoder_file());
             let output = dir.join(resolved.encoder_int8_file());
+            if output.exists() && !force {
+                tracing::info!("INT8 model already exists: {}", output.display());
+                tracing::info!("Use --force to re-quantize.");
+                return Ok(());
+            }
             if !input.is_file() {
                 anyhow::bail!(
                     "FP32 encoder not found at {} — `quantize` needs the FP32 ONNX as packaging source. \
                      For runtime, use `gigastt download` (lean INT8 only).",
                     input.display()
                 );
-            }
-            if output.exists() && !force {
-                tracing::info!("INT8 model already exists: {}", output.display());
-                tracing::info!("Use --force to re-quantize.");
-                return Ok(());
             }
             gigastt_core::quantize::quantize_model(&input, &output)?;
             tracing::info!("Quantized model saved to {}", output.display());


### PR DESCRIPTION
## Summary
- `gigastt quantize` now treats an existing INT8 encoder as a successful no-op **before** requiring an FP32 source ONNX.
- Fixes Coverage(E2E) / lean CI installs where only `*_encoder_int8.onnx` is present (no FP32) — `cli_quantize_existing_is_noop` was failing on main after #283.

## Why
Product path is INT8-only; packaging `quantize` should not demand FP32 when the INT8 artifact is already on disk unless `--force` is set.

## Test plan
- [x] Local commit of reorder: INT8 exists && !force → ok; else require FP32
- [ ] CI unit + Coverage(E2E) green (esp. `cli_quantize_existing_is_noop`)
- [ ] main green after merge