### PR TITLE
fix(core): cache-gc keeps optimized graphs of every installed head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ were released without a git tag, so their headings carry no compare link.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cache-gc` no longer prunes the optimized graph of a served head.** With
+  several heads installed in one model directory, the prune kept only the
+  auto-detected head's `.ort` and deleted the rest — including the graph a
+  running server had memory-mapped, forcing a multi-GiB rebuild on next boot.
+  The prune now keeps `{stem}_optimized.ort` for every head whose encoder
+  weights are present; it still drops legacy `*_optimized.onnx` graphs and
+  `.ort` graphs whose encoder is not installed.
+
 ## [2.17.0] - 2026-08-10
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ were released without a git tag, so their headings carry no compare link.
   auto-detected head's `.ort` and deleted the rest — including the graph a
   running server had memory-mapped, forcing a multi-GiB rebuild on next boot.
   The prune now keeps `{stem}_optimized.ort` for every head whose encoder
-  weights are present; it still drops legacy `*_optimized.onnx` graphs and
-  `.ort` graphs whose encoder is not installed.
+  weights are present (including a custom encoder named by `manifest.toml`);
+  it still drops legacy `*_optimized.onnx` graphs and `.ort` graphs whose
+  encoder is not installed.
 
 ## [2.17.0] - 2026-08-10
 

--- a/crates/gigastt-core/src/model/cache.rs
+++ b/crates/gigastt-core/src/model/cache.rs
@@ -108,8 +108,9 @@ pub struct DedupeReport {
 /// `model_dir/optimized_cache/`.
 ///
 /// Keeps `{preferred_encoder_stem}_optimized.ort` for **every** head whose
-/// encoder weights are present in `model_dir` (INT8 preferred): each installed
-/// head is one a `serve --model-variant` can start, so its graph must survive
+/// encoder weights are present in `model_dir` (INT8 preferred), plus the
+/// encoder named by a `manifest.toml` when one is installed: every installed
+/// head can be started with `serve --model-variant`, so its graph must survive
 /// a GC run — even while a running server has it memory-mapped. Legacy
 /// `*_optimized.onnx` graphs (written by versions before the switch to the ORT
 /// flatbuffer format) and `.ort` graphs whose encoder is not installed count
@@ -127,11 +128,19 @@ pub fn prune_optimized_cache(model_dir: &Path, dry_run: bool) -> Result<Optimize
         return Ok(report);
     }
 
-    let keep_names: std::collections::HashSet<String> = ModelVariant::ALL
+    let mut keep_names: std::collections::HashSet<String> = ModelVariant::ALL
         .into_iter()
         .filter_map(|v| preferred_encoder_path(v, model_dir))
         .filter_map(|p| optimized_cache_basename(&p))
         .collect();
+
+    // A manifest install may rename the encoder away from the hardcoded
+    // variant basenames; the engine loads that name, so keep its graph too.
+    if let Some(manifest) = super::manifest::ModelManifest::load(model_dir)?
+        && let Some(name) = optimized_cache_basename(&manifest.preferred_encoder_path(model_dir))
+    {
+        keep_names.insert(name);
+    }
 
     if keep_names.is_empty() {
         tracing::info!(
@@ -494,6 +503,85 @@ mod tests {
         assert!(!ml.exists());
         assert!(!legacy.exists());
         assert_eq!(report.freed_bytes, 300 + 400);
+    }
+
+    #[test]
+    fn test_prune_optimized_cache_keeps_ctc_head_dotted_stem() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // ml_ctc-only install: dotted stem (`multilingual_ctc.int8`) must
+        // survive `file_stem` handling on the keep path.
+        for f in ModelVariant::MlCtc.prequantized_files() {
+            write_file(&dir.join(f), b"stub");
+        }
+        let cache = dir.join("optimized_cache");
+        let keep = cache.join("multilingual_ctc.int8_optimized.ort");
+        let zombie = cache.join("v3_rnnt_encoder_int8_optimized.ort");
+        write_file(&keep, &[1u8; 100]);
+        write_file(&zombie, &[2u8; 200]);
+
+        let report = prune_optimized_cache(dir, false).unwrap();
+        assert_eq!(report.kept, vec![keep.clone()]);
+        assert_eq!(report.removed, vec![zombie.clone()]);
+        assert!(keep.exists());
+        assert!(!zombie.exists());
+        assert_eq!(report.freed_bytes, 200);
+    }
+
+    #[test]
+    fn test_prune_optimized_cache_keeps_fp32_only_head() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // FP32-only install (no INT8): the FP32 stem's graph is the one a
+        // cache-miss rebuild would write, so keep it.
+        write_file(&dir.join(ModelVariant::Rnnt.encoder_file()), b"stub");
+        let cache = dir.join("optimized_cache");
+        let keep = cache.join("v3_rnnt_encoder_optimized.ort");
+        let zombie = cache.join("v3_rnnt_encoder_int8_optimized.ort");
+        write_file(&keep, &[1u8; 100]);
+        write_file(&zombie, &[2u8; 200]);
+
+        let report = prune_optimized_cache(dir, false).unwrap();
+        assert_eq!(report.kept, vec![keep.clone()]);
+        assert!(keep.exists());
+        assert!(!zombie.exists(), "no INT8 encoder installed: zombie");
+    }
+
+    #[test]
+    fn test_prune_optimized_cache_keeps_manifest_named_encoder() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // Manifest install with a custom encoder basename; the engine loads
+        // that name, so its graph must survive alongside a hardcoded head.
+        write_file(
+            &dir.join("manifest.toml"),
+            br#"architecture = "ml_ctc"
+[files]
+encoder = "custom_enc.onnx"
+encoder_int8 = "custom_enc_int8.onnx"
+vocab = "custom_vocab.txt"
+"#,
+        );
+        write_file(&dir.join("custom_enc_int8.onnx"), b"stub");
+        for f in ModelVariant::Rnnt.prequantized_files() {
+            write_file(&dir.join(f), b"stub");
+        }
+        let cache = dir.join("optimized_cache");
+        let custom = cache.join("custom_enc_int8_optimized.ort");
+        let rnnt = cache.join("v3_rnnt_encoder_int8_optimized.ort");
+        write_file(&custom, &[1u8; 100]);
+        write_file(&rnnt, &[2u8; 200]);
+
+        let report = prune_optimized_cache(dir, false).unwrap();
+        assert_eq!(report.kept.len(), 2);
+        assert!(report.kept.contains(&custom));
+        assert!(report.kept.contains(&rnnt));
+        assert!(
+            custom.exists(),
+            "manifest-named graph must survive cache-gc"
+        );
+        assert!(rnnt.exists());
+        assert!(report.removed.is_empty());
     }
 
     #[test]

--- a/crates/gigastt-core/src/model/cache.rs
+++ b/crates/gigastt-core/src/model/cache.rs
@@ -69,7 +69,7 @@ pub fn preferred_encoder_path(variant: ModelVariant, dir: &Path) -> Option<PathB
 /// Result of pruning `model_dir/optimized_cache/`.
 #[derive(Debug, Default, Clone)]
 pub struct OptimizedCachePruneReport {
-    /// Active optimized graph retained (0 or 1 paths).
+    /// Optimized graphs retained: one per installed head (may be empty).
     pub kept: Vec<PathBuf>,
     /// Paths removed (or that would be removed under `dry_run`).
     pub removed: Vec<PathBuf>,
@@ -104,13 +104,17 @@ pub struct DedupeReport {
     pub dry_run: bool,
 }
 
-/// Drop non-active optimized graphs under `model_dir/optimized_cache/`.
+/// Drop optimized graphs that no installed head can load from
+/// `model_dir/optimized_cache/`.
 ///
-/// Keeps only `{preferred_encoder_stem}_optimized.ort` for the variant
-/// detected in `model_dir` (INT8 preferred). Legacy `*_optimized.onnx`
-/// graphs (written by versions before the switch to the ORT flatbuffer
-/// format) count as zombies and are pruned. When no head is detected, the
-/// cache is left untouched so a half-installed tree is not wiped.
+/// Keeps `{preferred_encoder_stem}_optimized.ort` for **every** head whose
+/// encoder weights are present in `model_dir` (INT8 preferred): each installed
+/// head is one a `serve --model-variant` can start, so its graph must survive
+/// a GC run — even while a running server has it memory-mapped. Legacy
+/// `*_optimized.onnx` graphs (written by versions before the switch to the ORT
+/// flatbuffer format) and `.ort` graphs whose encoder is not installed count
+/// as zombies and are pruned. When no head is detected, the cache is left
+/// untouched so a half-installed tree is not wiped.
 ///
 /// With `dry_run`, reports what would be deleted without removing files.
 pub fn prune_optimized_cache(model_dir: &Path, dry_run: bool) -> Result<OptimizedCachePruneReport> {
@@ -123,17 +127,19 @@ pub fn prune_optimized_cache(model_dir: &Path, dry_run: bool) -> Result<Optimize
         return Ok(report);
     }
 
-    let keep_name = ModelVariant::detect_in_dir(model_dir)
-        .and_then(|v| preferred_encoder_path(v, model_dir))
-        .and_then(|p| optimized_cache_basename(&p));
+    let keep_names: std::collections::HashSet<String> = ModelVariant::ALL
+        .into_iter()
+        .filter_map(|v| preferred_encoder_path(v, model_dir))
+        .filter_map(|p| optimized_cache_basename(&p))
+        .collect();
 
-    let Some(keep_name) = keep_name else {
+    if keep_names.is_empty() {
         tracing::info!(
             "optimized_cache prune: no usable encoder in {}; leaving cache untouched",
             model_dir.display()
         );
         return Ok(report);
-    };
+    }
 
     for entry in std::fs::read_dir(&cache_dir)
         .with_context(|| format!("failed to read optimized_cache at {}", cache_dir.display()))?
@@ -150,7 +156,7 @@ pub fn prune_optimized_cache(model_dir: &Path, dry_run: bool) -> Result<Optimize
         if !name.ends_with("_optimized.ort") && !name.ends_with("_optimized.onnx") {
             continue;
         }
-        if name.as_ref() == keep_name {
+        if keep_names.contains(name.as_ref()) {
             report.kept.push(path);
             continue;
         }
@@ -453,6 +459,41 @@ mod tests {
         assert!(!e2e.exists());
         assert!(cache.join("notes.txt").exists());
         assert_eq!(report.freed_bytes, 200 + 300 + 400);
+    }
+
+    #[test]
+    fn test_prune_optimized_cache_keeps_every_installed_head() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // Two heads installed (rnnt + e2e_rnnt); ml_ctc is not.
+        for f in ModelVariant::Rnnt.prequantized_files() {
+            write_file(&dir.join(f), b"stub");
+        }
+        for f in ModelVariant::E2eRnnt.prequantized_files() {
+            write_file(&dir.join(f), b"stub");
+        }
+        let cache = dir.join("optimized_cache");
+        let rnnt = cache.join("v3_rnnt_encoder_int8_optimized.ort");
+        let e2e = cache.join("v3_e2e_rnnt_encoder_int8_optimized.ort");
+        // Graph for a head whose weights are absent: zombie.
+        let ml = cache.join("multilingual_ctc.int8_optimized.ort");
+        // Legacy pre-flatbuffer graphs: zombies even for installed heads.
+        let legacy = cache.join("v3_rnnt_encoder_int8_optimized.onnx");
+        write_file(&rnnt, &[1u8; 100]);
+        write_file(&e2e, &[2u8; 200]);
+        write_file(&ml, &[3u8; 300]);
+        write_file(&legacy, &[4u8; 400]);
+
+        let report = prune_optimized_cache(dir, false).unwrap();
+        assert_eq!(report.kept.len(), 2);
+        assert!(report.kept.contains(&rnnt));
+        assert!(report.kept.contains(&e2e));
+        assert_eq!(report.removed.len(), 2);
+        assert!(rnnt.exists());
+        assert!(e2e.exists(), "installed head's graph must survive cache-gc");
+        assert!(!ml.exists());
+        assert!(!legacy.exists());
+        assert_eq!(report.freed_bytes, 300 + 400);
     }
 
     #[test]

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -674,8 +674,8 @@ impl ModelVariant {
 
     /// Detect which variant's files are present in `dir` by probing for the
     /// encoder file (FP32 or generated INT8). Returns `None` when neither
-    /// variant's encoder is present. `Rnnt` takes precedence when (anomalously)
-    /// both encoders coexist, mirroring the engine's default.
+    /// variant's encoder is present. `Rnnt` takes precedence when several
+    /// heads' encoders coexist, mirroring the engine's default.
     pub fn detect_in_dir(dir: &Path) -> Option<Self> {
         Self::ALL.into_iter().find(|&variant| {
             dir.join(variant.encoder_file()).exists()
@@ -2546,6 +2546,24 @@ mod tests {
     #[test]
     fn test_model_variant_default_is_rnnt() {
         assert_eq!(ModelVariant::default(), ModelVariant::Rnnt);
+    }
+
+    #[test]
+    fn test_model_variant_all_covers_every_variant() {
+        // Compile-time guard: the match is exhaustive within this crate
+        // (`#[non_exhaustive]` only binds downstream), so adding a head
+        // without extending `ModelVariant::ALL` fails the build here —
+        // the keep-set in `cache-gc` and `detect_in_dir` both derive from it.
+        let mut count = 0;
+        for v in ModelVariant::ALL {
+            match v {
+                ModelVariant::Rnnt
+                | ModelVariant::E2eRnnt
+                | ModelVariant::MlCtc
+                | ModelVariant::MlCtcLarge => count += 1,
+            }
+        }
+        assert_eq!(count, 4);
     }
 
     #[test]

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -504,6 +504,15 @@ pub enum ModelVariant {
 }
 
 impl ModelVariant {
+    /// All known recognition heads, in auto-detection precedence order
+    /// (`Rnnt` first, mirroring the engine's default).
+    pub const ALL: [ModelVariant; 4] = [
+        ModelVariant::Rnnt,
+        ModelVariant::E2eRnnt,
+        ModelVariant::MlCtc,
+        ModelVariant::MlCtcLarge,
+    ];
+
     /// Basename of the FP32 encoder ONNX file for this variant.
     pub fn encoder_file(self) -> &'static str {
         match self {
@@ -668,14 +677,7 @@ impl ModelVariant {
     /// variant's encoder is present. `Rnnt` takes precedence when (anomalously)
     /// both encoders coexist, mirroring the engine's default.
     pub fn detect_in_dir(dir: &Path) -> Option<Self> {
-        [
-            ModelVariant::Rnnt,
-            ModelVariant::E2eRnnt,
-            ModelVariant::MlCtc,
-            ModelVariant::MlCtcLarge,
-        ]
-        .into_iter()
-        .find(|&variant| {
+        Self::ALL.into_iter().find(|&variant| {
             dir.join(variant.encoder_file()).exists()
                 || dir.join(variant.encoder_int8_file()).exists()
         })

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -317,7 +317,8 @@ gigastt cache-gc [OPTIONS]
   --dry-run              Report reclaimable files without deleting / hardlinking
   --dedupe               Also hardlink content-identical files (SHA-256 groups)
 
-  Removes non-active optimized_cache/*_optimized.{ort,onnx} graphs, keeping only
-  the graph for the preferred encoder of the detected head (INT8 when present).
+  Removes optimized_cache/*_optimized.{ort,onnx} graphs that no installed head
+  can load, keeping the graph for the preferred encoder of every head whose
+  weights are present in the directory (INT8 preferred).
   Safe on accuracy: leftovers are pure disk waste from FP32 runs or head switches.
 ```


### PR DESCRIPTION
## Summary

Fixes #287.

With several heads installed in one model directory, `cache-gc` kept only the auto-detected head's `.ort` graph and pruned the rest — including the graph a running server had memory-mapped, forcing a multi-GiB rebuild (and a possible OOM kill) on next boot.

## Changes

- `prune_optimized_cache` now keeps `{preferred_encoder_stem}_optimized.ort` for **every** head whose encoder weights are present (INT8 preferred), plus the custom encoder named by a `manifest.toml`. Legacy `*_optimized.onnx` graphs and `.ort` graphs with no installed encoder are still pruned; a dir with no detected head is still left untouched.
- New `ModelVariant::ALL` is the single enumeration behind both `detect_in_dir` and the GC keep-set, with a compile-time guard (exhaustive in-crate match) so adding a head without extending it breaks the build.
- Tests: multi-head keep (the #287 scenario), dotted CTC stem on the keep path, FP32-only install, manifest-named encoder. Updated `docs/cli.md` wording and CHANGELOG.

## Verification

- `cargo test --workspace --lib --bins` — all suites green
- `cargo clippy --workspace --all-targets` — zero warnings
- `cargo fmt --check`, `scripts/check-docs-drift.py` — clean
- Three-agent audit of the diff (correctness/races, test coverage, docs consistency); findings addressed in the second commit