### PR TITLE
fix(ci): restore isolation and docs-drift after the module split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,21 @@ jobs:
 
           violations = []
           candle_violations = []
+          def is_test_path(path):
+              # Dedicated test files after the home-tests split, plus
+              # conventional tests/ directories.
+              name = path.name
+              return (
+                  "tests" in path.parts
+                  or name == "tests.rs"
+                  or name.endswith("_tests.rs")
+              )
+
           for path in Path("crates").rglob("*.rs"):
               if any(a == "runtime" and b == "ort"
                      for a, b in zip(path.parts, path.parts[1:])):
                   continue
-              if "tests" in path.parts:
+              if is_test_path(path):
                   continue
 
               is_candle = any(a == "runtime" and b == "candle"
@@ -136,7 +146,7 @@ jobs:
           for path in Path("crates").rglob("*.rs"):
               is_coreml = any(a == "runtime" and b == "coreml"
                               for a, b in zip(path.parts, path.parts[1:]))
-              if is_coreml:
+              if is_coreml or is_test_path(path):
                   continue
               lines = path.read_text(encoding="utf-8").splitlines()
               test_indices = test_line_indices(lines)

--- a/scripts/check-docs-drift.py
+++ b/scripts/check-docs-drift.py
@@ -4,9 +4,9 @@
 Ten axes, all stdlib-only (no third-party deps, no network):
 
   1. CLI flags/envs: every clap flag + GIGASTT_* env in the CLI sources
-     (crates/gigastt/src/{main,serve,transcribe_cmd}.rs) is documented in
-     docs/cli.md, and cli.md names no flag/env that does not exist
-     (intentional exceptions live in scripts/check-docs-drift.allowlist).
+     (crates/gigastt/src/{main,serve,serve/bind,transcribe_cmd}.rs) is
+     documented in docs/cli.md, and cli.md names no flag/env that does not
+     exist (intentional exceptions live in scripts/check-docs-drift.allowlist).
   2. WS error codes: the enum in docs/asyncapi.yaml == the table in docs/api.md
      == the codes emitted under crates/gigastt/src/server/ws/ (plus allowlisted
      doc-only entries).
@@ -24,7 +24,7 @@ Ten axes, all stdlib-only (no third-party deps, no network):
      and packaging/**/README* resolves to an existing file/directory, and
      #anchors resolve to a heading in the target file.
   7. OpenAPI paths: every `paths:` key in docs/openapi.yaml is registered in
-     crates/gigastt/src/server/{mod,router}.rs (or is the separate metrics listener),
+     crates/gigastt/src/server/{mod,router,listen}.rs (or is the separate metrics listener),
      and OpenAPI must not resurrect a stale unconditional duration-cap claim
      now that the default file-transcription path has no duration limit.
   8. SECURITY.md supported-version table marks the workspace Cargo.toml major.minor
@@ -55,12 +55,14 @@ ROOT = Path(__file__).resolve().parent.parent
 CLI_SOURCES = (
     ROOT / "crates/gigastt/src/main.rs",
     ROOT / "crates/gigastt/src/serve.rs",
+    ROOT / "crates/gigastt/src/serve/bind.rs",
     ROOT / "crates/gigastt/src/transcribe_cmd.rs",
 )
 WS_DIR = ROOT / "crates/gigastt/src/server/ws"
 SERVER_ROUTE_SOURCES = (
     ROOT / "crates/gigastt/src/server/mod.rs",
     ROOT / "crates/gigastt/src/server/router.rs",
+    ROOT / "crates/gigastt/src/server/listen.rs",
 )
 # Codec marker lives in the decode module after the audio/ feature split.
 AUDIO_RS = ROOT / "crates/gigastt-core/src/inference/audio/decode.rs"


### PR DESCRIPTION
Main CI after #290 failed two gates:

- **Runtime Isolation** — comments in `punctuation/tests.rs` mention `OrtRuntime`. The guard skipped `tests/` directories but not sibling `tests.rs` files from the home-tests split.
- **Docs Drift** — `/health` and `/ready` live in `server/listen.rs`; `GIGASTT_ALLOW_BIND_ANY` is read in `serve/bind.rs`. The checker still only scanned the old files.

Public APIs unchanged. Drift and isolation checks pass locally.