### PR TITLE
fix(ci): rustdoc links and Windows unit tests after the module split

### DIFF
--- a/crates/gigastt-core/src/model/cache.rs
+++ b/crates/gigastt-core/src/model/cache.rs
@@ -409,7 +409,22 @@ fn same_file(a: &Path, b: &Path) -> Result<bool> {
         use std::os::unix::fs::MetadataExt;
         Ok(ma.dev() == mb.dev() && ma.ino() == mb.ino())
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        Ok(
+            match (
+                ma.volume_serial_number(),
+                mb.volume_serial_number(),
+                ma.file_index(),
+                mb.file_index(),
+            ) {
+                (Some(va), Some(vb), Some(ia), Some(ib)) => va == vb && ia == ib,
+                _ => false,
+            },
+        )
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         // Best-effort: identical size is not enough; always attempt hardlink.
         let _ = (ma, mb);

--- a/crates/gigastt-core/src/model/tests/ane.rs
+++ b/crates/gigastt-core/src/model/tests/ane.rs
@@ -212,7 +212,11 @@ fn test_require_ane_tar_checksum_resolves_pinned_and_bails_unpinned() {
 fn test_fetch_offline_models_script_pins_match_crate_constants() {
     let script_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../scripts/fetch_offline_models.sh");
-    let script = std::fs::read_to_string(&script_path).expect("read fetch_offline_models.sh");
+    let script = std::fs::read_to_string(&script_path)
+        .expect("read fetch_offline_models.sh")
+        // Windows checkouts may use CRLF; join-continuations below match on `\n`.
+        .replace("\r\n", "\n")
+        .replace('\r', "\n");
 
     assert!(
         script.contains(PREQUANT_RELEASE_BASE),

--- a/crates/gigastt-core/src/runtime/factory.rs
+++ b/crates/gigastt-core/src/runtime/factory.rs
@@ -7,7 +7,7 @@ pub trait RuntimeFactory: Send + Sync + 'static {
     /// Returns a CPU-only factory suitable for small auxiliary models.
     fn cpu_fallback(&self) -> Box<dyn RuntimeFactory>;
 
-    /// Whether [`Engine::load`] should refuse files whose SHA-256 does not
+    /// Whether [`crate::inference::Engine::load`] should refuse files whose SHA-256 does not
     /// match the pinned table. Production factories leave this `true`. The
     /// mock factory returns `false` so unit tests can load empty placeholder
     /// ONNX files.

--- a/crates/gigastt-core/src/vad/regions.rs
+++ b/crates/gigastt-core/src/vad/regions.rs
@@ -6,7 +6,7 @@ use super::VadConfig;
 /// speech-sample spans. Pure (no model) so it is unit-testable on synthetic
 /// probabilities.
 ///
-/// `frame_samples` is the samples-per-probability stride ([`VAD_FRAME_SAMPLES`]
+/// `frame_samples` is the samples-per-probability stride ([`crate::vad::VAD_FRAME_SAMPLES`]
 /// in production); `total_samples` clamps the final span to the real signal
 /// length. Applies, in order: threshold, min-silence merge (gaps shorter than
 /// `min_silence_ms` do not split a region), min-speech drop, and symmetric

--- a/crates/gigastt/src/server/listen.rs
+++ b/crates/gigastt/src/server/listen.rs
@@ -84,7 +84,7 @@ where
     run_with_config_loading_reloadable(config, shutdown, load, None).await
 }
 
-/// Like [`run_with_config_loading`], but also carries the [`EngineBuilder`]
+/// Like [`run_with_config_loading`], but also carries the [`http::EngineBuilder`]
 /// recipe so the server that starts after the model loads exposes a working
 /// `POST /v1/admin/reload`. The `load` future typically calls the *same*
 /// builder once to produce the boot engine, so boot and reload share one recipe.
@@ -200,7 +200,7 @@ pub async fn run_with_config_listener(
     run_with_config_listener_reloadable(engine, config, shutdown, listener, None).await
 }
 
-/// Like [`run_with_config_listener`], but also accepts the [`EngineBuilder`]
+/// Like [`run_with_config_listener`], but also accepts the [`http::EngineBuilder`]
 /// recipe that `POST /v1/admin/reload` uses to rebuild the engine in place.
 /// `None` disables the reload endpoint (`reload_unsupported`) — the thin
 /// `run` / `run_with_shutdown` and test entry points take that path.


### PR DESCRIPTION
## Why

Main CI after #290/#299 is still red for two jobs that the isolation/docs-drift fix did not cover:

- **Doc Build** (`RUSTDOCFLAGS=-D warnings`): intra-doc links left dangling when code moved (`Engine::load` from `runtime/factory.rs`, `VAD_FRAME_SAMPLES` from `vad/regions.rs`, `EngineBuilder` from `server/listen.rs`).
- **Unit Tests (Windows)**: `same_file` always returned `false` off Unix, so the hardlink dedupe test could not observe a successful link; the offline fetch-script pin check failed to join `\` continuations on CRLF checkouts.

## What

- Point rustdoc links at the public paths (`crate::inference::Engine::load`, `crate::vad::VAD_FRAME_SAMPLES`, `http::EngineBuilder`).
- Implement `same_file` on Windows via `volume_serial_number` + `file_index`.
- Normalize CRLF before joining backslash-continued `fetch` lines.

## Verify

- `cargo test --workspace --lib --bins`
- `cargo clippy`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace`