### PR TITLE
fix(core): keep Windows same_file on stable MetadataExt

### DIFF
--- a/crates/gigastt-core/src/model/cache.rs
+++ b/crates/gigastt-core/src/model/cache.rs
@@ -409,24 +409,11 @@ fn same_file(a: &Path, b: &Path) -> Result<bool> {
         use std::os::unix::fs::MetadataExt;
         Ok(ma.dev() == mb.dev() && ma.ino() == mb.ino())
     }
-    #[cfg(windows)]
+    #[cfg(not(unix))]
     {
-        use std::os::windows::fs::MetadataExt;
-        Ok(
-            match (
-                ma.volume_serial_number(),
-                mb.volume_serial_number(),
-                ma.file_index(),
-                mb.file_index(),
-            ) {
-                (Some(va), Some(vb), Some(ia), Some(ib)) => va == vb && ia == ib,
-                _ => false,
-            },
-        )
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        // Best-effort: identical size is not enough; always attempt hardlink.
+        // Stable `MetadataExt` on Windows does not expose file index / volume
+        // serial (those APIs are still `windows_by_handle`). Treat as "not
+        // known to be the same" so the caller still attempts a hardlink.
         let _ = (ma, mb);
         Ok(false)
     }

--- a/crates/gigastt-core/src/model/cache/tests.rs
+++ b/crates/gigastt-core/src/model/cache/tests.rs
@@ -267,6 +267,8 @@ fn test_dedupe_hardlinks_exact_copies() {
     let report = dedupe_model_dir(dir, false).unwrap();
     assert_eq!(report.groups, 1);
     assert_eq!(report.hardlinked, 1);
+    // `same_file` is inode-based and always returns false on stable Windows.
+    #[cfg(unix)]
     assert!(same_file(&a, &b).unwrap());
     assert_eq!(std::fs::read(&a).unwrap(), payload);
     assert_eq!(std::fs::read(&b).unwrap(), payload);


### PR DESCRIPTION
## Why

#301 Windows unit tests failed to *compile*: `MetadataExt::volume_serial_number` / `file_index` are still `#![feature(windows_by_handle)]` on stable.

## What

- Revert `same_file` on non-Unix to the stable "unknown → try hardlink" path.
- Assert inode identity only on Unix. The Windows test still checks `hardlinked == 1` and byte contents.

## Verify

- `cargo test --workspace --lib --bins`
- `cargo clippy`