### PR TITLE
fix(server): recognize typed invalid-audio errors in job sanitizer

### DIFF
--- a/crates/gigastt/src/server/jobs/queue.rs
+++ b/crates/gigastt/src/server/jobs/queue.rs
@@ -295,19 +295,27 @@ pub(crate) fn sanitize_job_error(e: &anyhow::Error) -> String {
     // `--max-audio-secs` or split) from "corrupt" — the same distinction the REST
     // path answers with 413. The blocking result reaches us via
     // `anyhow::Error::from`, so the concrete variant survives the downcast.
-    if let Some(gigastt_core::error::GigasttError::AudioTooLong {
-        observed_secs,
-        limit_secs,
-    }) = e.downcast_ref::<gigastt_core::error::GigasttError>()
-    {
-        return format!(
-            "Audio too long: {observed_secs:.0}s exceeds the maximum of {limit_secs:.0}s."
-        );
+    if let Some(err) = e.downcast_ref::<gigastt_core::error::GigasttError>() {
+        match err {
+            gigastt_core::error::GigasttError::AudioTooLong {
+                observed_secs,
+                limit_secs,
+            } => {
+                return format!(
+                    "Audio too long: {observed_secs:.0}s exceeds the maximum of {limit_secs:.0}s."
+                );
+            }
+            gigastt_core::error::GigasttError::InvalidAudio { .. } => {
+                return "Failed to decode audio file. Check format.".into();
+            }
+            _ => {}
+        }
     }
     let msg = format!("{e:#}");
-    if msg.contains("inference_timeout") {
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("inference_timeout") {
         "Inference timed out.".into()
-    } else if msg.contains("Invalid audio") {
+    } else if lower.contains("invalid audio") {
         "Failed to decode audio file. Check format.".into()
     } else {
         "Transcription failed.".into()

--- a/crates/gigastt/src/server/jobs/tests/events.rs
+++ b/crates/gigastt/src/server/jobs/tests/events.rs
@@ -10,6 +10,15 @@ fn test_sanitize_job_error_maps_known_errors() {
         sanitize_job_error(&anyhow::anyhow!("Invalid audio: unsupported format")),
         "Failed to decode audio file. Check format."
     );
+    // Typed InvalidAudio displays as lowercase "invalid audio: …".
+    let decode: anyhow::Error = gigastt_core::error::GigasttError::InvalidAudio {
+        reason: "unsupported format".into(),
+    }
+    .into();
+    assert_eq!(
+        sanitize_job_error(&decode),
+        "Failed to decode audio file. Check format."
+    );
     assert_eq!(
         sanitize_job_error(&anyhow::anyhow!("some internal onnx path /foo/bar")),
         "Transcription failed."


### PR DESCRIPTION
## Why

Main E2E (`e2e_jobs::test_job_invalid_audio_fails_with_sanitized_error`) failed after #302. A corrupt upload became `"Transcription failed."` instead of the sanitized decode message.

`GigasttError::InvalidAudio` displays as lowercase `invalid audio: …`. The job sanitizer only matched title-case `"Invalid audio"`.

## What

- Downcast `GigasttError::InvalidAudio` the same way as `AudioTooLong`.
- Match the display string case-insensitively as a fallback.
- Cover the typed lowercase error in the unit test.

## Verify

- `cargo test --workspace --lib --bins`
- `cargo clippy`
- `cargo test -p gigastt --lib jobs::tests::events`