### PR TITLE
test: mock engine so HTTP/WS/jobs run without the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ were released without a git tag, so their headings carry no compare link.
 
 ## [Unreleased]
 
+### Added
+
+- **Model-free mock engine for unit tests.** `gigastt_core::test_support`
+  (behind the private `__internals` feature) loads a scripted INT8 rnnt
+  engine whose encoder accepts any audio length. HTTP, WebSocket, jobs,
+  OpenAI transcriptions, and CLI helpers now run in `cargo test
+  --workspace --lib --bins` without the 225 MB model.
+- In-process live tests: `/health`, `/v1/audio/transcriptions`, and
+  `/v1/ws` (Ready → configure → audio → Stop → Final, plus invalid
+  sample-rate rejection) against the mock engine.
+- Unit coverage of packaging (`quantize` no-op / missing FP32,
+  `cache-gc`), job HTTP handlers, `RealJobExecutor`, engine file/bytes/
+  channels/cancel wrappers, and `transcribe` batch helpers.
+
+### Changed
+
+- Codecov patch target raised from 80% to 90%. Previously `#[ignore]`d
+  HTTP handler tests now run on every PR.
+
 ## [2.18.0] - 2026-08-14
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3370,12 +3380,15 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -4655,6 +4668,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,12 +10,13 @@
 # coverage (~75%) until Coverage (E2E) finishes (~20+ min later), and the
 # badge dips even though real merged coverage is unchanged.
 #
-# Merged line coverage of production paths is ~90–91%. The remaining
-# uncovered lines are dominated by fault-injection-only paths (ONNX-runtime
-# internal failures, network model-download errors, forced panics /
-# inference timeouts, OS-signal handlers) and defensive guards that are
-# unreachable in normal operation — deliberately left untested rather than
-# covered with brittle mocks.
+# Unit coverage (`--lib --bins`) is ~78% after the mock-engine layer
+# (HTTP / WS / jobs / OpenAI / CLI helpers run without the INT8 model).
+# Merged with the e2e flag (main-push) is the number on the badge.
+# Remaining uncovered lines are dominated by fault-injection-only paths
+# (ONNX-runtime internal failures, network model-download errors, forced
+# panics / inference timeouts, OS-signal handlers) and `process::exit`
+# / SIGINT arms that cannot return to the test harness.
 
 codecov:
   require_ci_to_pass: true
@@ -34,8 +35,10 @@ coverage:
         informational: false
     patch:
       default:
-        # New / changed lines should be well covered.
-        target: 80%
+        # New / changed lines should be well covered. Mock-engine tests
+        # make HTTP / WS / jobs / OpenAI paths unit-testable, so the
+        # bar is the SOTA floor rather than a model-gated 80%.
+        target: 90%
         threshold: 0%
         informational: false
 

--- a/crates/gigastt-core/src/inference/engine/tests/mod.rs
+++ b/crates/gigastt-core/src/inference/engine/tests/mod.rs
@@ -10,5 +10,6 @@ pub(super) fn word(text: &str, start: f64, end: f64) -> WordInfo {
 mod backends;
 mod load;
 mod mock;
+mod paths;
 mod stream;
 mod transcribe;

--- a/crates/gigastt-core/src/inference/engine/tests/paths.rs
+++ b/crates/gigastt-core/src/inference/engine/tests/paths.rs
@@ -1,0 +1,180 @@
+//! File / bytes / channels / cancel paths on the mock engine.
+
+use super::*;
+use crate::inference::{TranscribeOverrides, TranscribeRequest, TranscribeSource};
+use crate::model::ModelVariant;
+use crate::test_support;
+use crate::vad::VadConfig;
+
+#[test]
+fn test_engine_config_getters_and_builders() {
+    let (engine, _tmp) = test_support::rnnt_engine();
+    assert!(engine.is_int8());
+    assert_eq!(engine.variant(), ModelVariant::Rnnt);
+    assert_eq!(engine.vocab_size(), 2);
+    assert!(!engine.has_punctuator());
+    assert!(!engine.has_itn());
+    assert!(!engine.has_vad());
+    assert!(!engine.has_hotwords());
+    assert_eq!(engine.endpoint_mode(), crate::inference::EndpointMode::Auto);
+
+    let engine = engine
+        .with_itn(true)
+        .with_punctuator(None)
+        .with_vad(None, VadConfig::default())
+        .with_endpoint_mode(crate::inference::EndpointMode::Assistant)
+        .with_hotwords(&[], 5.0);
+    assert!(engine.has_itn());
+    assert!(!engine.has_punctuator());
+    assert!(!engine.has_vad());
+    assert!(!engine.has_hotwords());
+    assert_eq!(
+        engine.endpoint_mode(),
+        crate::inference::EndpointMode::Assistant
+    );
+    assert_eq!(
+        engine.vad_config().threshold,
+        VadConfig::default().threshold
+    );
+    assert_eq!(
+        engine.apply_text_postprocess("двадцать один".into(), true, false),
+        "21"
+    );
+    assert_eq!(
+        engine.apply_text_postprocess("двадцать один".into(), false, true),
+        "двадцать один"
+    );
+}
+
+#[test]
+fn test_transcribe_bytes_and_file_wrappers() {
+    let (engine, tmp) = test_support::rnnt_engine();
+    let mut guard = engine.pool.checkout_blocking().expect("checkout");
+    let wav = test_support::pcm16_wav(&[0i16; 320], 16_000);
+
+    let from_bytes = engine
+        .transcribe_bytes(&wav, &mut guard)
+        .expect("bytes wrapper");
+    assert!(from_bytes.text.is_empty());
+    assert!((from_bytes.duration_s - 320.0 / 16_000.0).abs() < 1e-6);
+
+    let shared = engine
+        .transcribe_bytes_shared(bytes::Bytes::from(wav.clone()), &mut guard)
+        .expect("shared bytes");
+    assert_eq!(shared.duration_s, from_bytes.duration_s);
+
+    let with_overrides = engine
+        .transcribe_bytes_shared_with_overrides(
+            bytes::Bytes::from(wav.clone()),
+            &mut guard,
+            &TranscribeOverrides::default(),
+        )
+        .expect("bytes overrides");
+    assert_eq!(with_overrides.duration_s, from_bytes.duration_s);
+
+    let diarized = engine
+        .transcribe_bytes_shared_with_overrides_diarized(
+            bytes::Bytes::from(wav.clone()),
+            &mut guard,
+            &TranscribeOverrides::default(),
+        )
+        .expect("diarized wrapper degrades without a speaker model");
+    assert_eq!(diarized.duration_s, from_bytes.duration_s);
+
+    let path = tmp.path().join("clip.wav");
+    std::fs::write(&path, &wav).expect("write wav");
+    let from_file = engine
+        .transcribe_file(path.to_str().expect("utf8"), &mut guard)
+        .expect("file wrapper");
+    assert!((from_file.duration_s - from_bytes.duration_s).abs() < 1e-6);
+
+    let file_overrides = engine
+        .transcribe_file_with_overrides(
+            path.to_str().expect("utf8"),
+            &mut guard,
+            &TranscribeOverrides {
+                itn: Some(false),
+                ..Default::default()
+            },
+        )
+        .expect("file overrides");
+    assert!((file_overrides.duration_s - from_bytes.duration_s).abs() < 1e-6);
+}
+
+#[test]
+fn test_transcribe_channels_empty_and_one_channel() {
+    let (engine, _tmp) = test_support::rnnt_engine();
+    let mut guard = engine.pool.checkout_blocking().expect("checkout");
+
+    let empty = engine
+        .transcribe_channels(&[], &mut guard)
+        .expect("empty channels");
+    assert!(empty.text.is_empty());
+    assert!(empty.words.is_empty());
+    assert_eq!(empty.duration_s, 0.0);
+
+    let one = vec![vec![0.0f32; 160]];
+    let result = engine
+        .transcribe_channels(&one, &mut guard)
+        .expect("one channel");
+    assert!((result.duration_s - 160.0 / 16_000.0).abs() < 1e-6);
+}
+
+#[test]
+fn test_decode_speech_regions_empty_is_noop() {
+    let (engine, _tmp) = test_support::rnnt_engine();
+    let mut guard = engine.pool.checkout_blocking().expect("checkout");
+    let words = engine
+        .decode_speech_regions(
+            &[0.0; 320],
+            &[],
+            &mut guard,
+            None,
+            DecodeControls::default(),
+        )
+        .expect("empty regions");
+    assert!(words.is_empty());
+}
+
+#[test]
+fn test_decode_words_honours_abort_before_single_pass() {
+    let (engine, _tmp) = test_support::rnnt_engine();
+    let mut guard = engine.pool.checkout_blocking().expect("checkout");
+    let aborted = DecodeControls {
+        abort: Some(&|| true),
+        on_progress: None,
+    };
+    let err = engine
+        .decode_words(&[0.0; 100], &mut guard, None, aborted)
+        .expect_err("cancelled single-pass");
+    assert!(matches!(err, crate::error::GigasttError::Cancelled));
+}
+
+#[test]
+fn test_transcribe_request_abort_flag() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let (engine, _tmp) = test_support::rnnt_engine();
+    let mut guard = engine.pool.checkout_blocking().expect("checkout");
+    let flag = Arc::new(AtomicBool::new(true));
+    let samples = vec![0.0f32; 100];
+    let req = TranscribeRequest::new(TranscribeSource::Samples(&samples)).with_abort(Some(flag));
+    let err = engine
+        .transcribe_request(req, &mut guard)
+        .expect_err("aborted request");
+    assert!(matches!(err, crate::error::GigasttError::Cancelled));
+
+    let flag = Arc::new(AtomicBool::new(false));
+    flag.store(false, Ordering::Relaxed);
+    let req = TranscribeRequest::new(TranscribeSource::Samples(&samples)).with_abort(Some(flag));
+    engine
+        .transcribe_request(req, &mut guard)
+        .expect("not aborted");
+}
+
+#[test]
+fn test_stream_eligible_without_diarization_request() {
+    let (engine, _tmp) = test_support::rnnt_engine();
+    assert!(engine.stream_eligible(false));
+}

--- a/crates/gigastt-core/src/inference/engine/tests/transcribe.rs
+++ b/crates/gigastt-core/src/inference/engine/tests/transcribe.rs
@@ -1,14 +1,12 @@
-use super::*;
 use crate::inference::windows::CHUNK_THRESHOLD_SAMPLES;
+use crate::test_support;
 
 #[test]
-#[ignore = "requires model"]
 fn test_transcribe_samples_silence_yields_empty_text() {
     // The single-pass file path on pure silence: the encoder runs, decode
     // produces no words, and the result text is empty with a correct
     // duration.
-    let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
-        .expect("engine should load");
+    let (engine, _tmp) = test_support::rnnt_engine();
     let mut guard = engine.pool.checkout_blocking().expect("checkout");
     let silence = vec![0.0f32; 16000 * 2]; // 2s
     let result = engine
@@ -20,15 +18,13 @@ fn test_transcribe_samples_silence_yields_empty_text() {
 }
 
 #[test]
-#[ignore = "requires model"]
 fn test_transcribe_samples_short_sub_frame_audio() {
     // Audio shorter than a single FFT frame: the mel extractor pads to one
     // zero frame and the encoder still runs — exercising the short-input
     // single-pass branch without panicking. The decode output is whatever
     // the model emits on a lone padded frame; we only assert it doesn't
     // error and the reported duration matches the (tiny) input.
-    let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
-        .expect("engine should load");
+    let (engine, _tmp) = test_support::rnnt_engine();
     let mut guard = engine.pool.checkout_blocking().expect("checkout");
     let tiny = vec![0.0f32; 100]; // < N_FFT (320)
     let result = engine
@@ -38,12 +34,10 @@ fn test_transcribe_samples_short_sub_frame_audio() {
 }
 
 #[test]
-#[ignore = "requires model"]
 fn test_transcribe_samples_below_chunk_threshold_single_pass() {
     // Just under the long-form chunk threshold (30s) takes the single-pass
     // path; pure silence still yields no words but must not error.
-    let engine = Engine::load_with_pool_size(&crate::model::default_model_dir(), 1)
-        .expect("engine should load");
+    let (engine, _tmp) = test_support::rnnt_engine();
     let mut guard = engine.pool.checkout_blocking().expect("checkout");
     let samples = vec![0.0f32; CHUNK_THRESHOLD_SAMPLES]; // exactly at threshold → single pass
     let result = engine

--- a/crates/gigastt-core/src/lib.rs
+++ b/crates/gigastt-core/src/lib.rs
@@ -73,6 +73,11 @@ mod wordpiece;
 
 pub use runtime::cpu_factory;
 
+/// Model-free mock engines for tests. Behind `__internals` (and `cfg(test)`
+/// inside this crate). Not a stable public surface.
+#[cfg(any(test, feature = "__internals"))]
+pub mod test_support;
+
 /// Runtime abstraction surface needed to drive backends directly (e.g. parity
 /// tests that construct and compare the ort and candle encoder sessions).
 pub mod runtime_api {

--- a/crates/gigastt-core/src/runtime/mock/session.rs
+++ b/crates/gigastt-core/src/runtime/mock/session.rs
@@ -87,6 +87,9 @@ pub struct MockSession {
     /// [`MockSession::with_script`]).
     script: Option<Vec<Vec<Tensor>>>,
     call_count: AtomicUsize,
+    /// When false, `run` skips input-count and shape checks so a scripted
+    /// encoder can accept any audio length (REST/SSE/jobs tests).
+    check_inputs: bool,
 }
 
 #[allow(dead_code)]
@@ -97,6 +100,20 @@ impl MockSession {
             outputs,
             script: None,
             call_count: AtomicUsize::new(0),
+            check_inputs: true,
+        }
+    }
+
+    /// Return `outputs` for every call and accept any input tensors.
+    ///
+    /// Used for encoder mocks whose time dimension follows the clip length.
+    pub fn unconstrained(outputs: Vec<Tensor>) -> Self {
+        Self {
+            expected_inputs: Vec::new(),
+            outputs,
+            script: None,
+            call_count: AtomicUsize::new(0),
+            check_inputs: false,
         }
     }
 
@@ -121,24 +138,27 @@ impl Clone for MockSession {
             outputs: self.outputs.clone(),
             script: self.script.clone(),
             call_count: AtomicUsize::new(self.call_count.load(Ordering::Relaxed)),
+            check_inputs: self.check_inputs,
         }
     }
 }
 
 impl RuntimeSession for MockSession {
     fn run(&self, inputs: &[Tensor]) -> Result<Vec<Tensor>, RuntimeError> {
-        if inputs.len() != self.expected_inputs.len() {
-            return Err(RuntimeError::InvalidInputCount {
-                expected: self.expected_inputs.len(),
-                got: inputs.len(),
-            });
-        }
-        for (actual, expected) in inputs.iter().zip(self.expected_inputs.iter()) {
-            if actual.shape() != expected {
-                return Err(RuntimeError::InvalidShape {
-                    expected: expected.clone(),
-                    got: actual.shape().clone(),
+        if self.check_inputs {
+            if inputs.len() != self.expected_inputs.len() {
+                return Err(RuntimeError::InvalidInputCount {
+                    expected: self.expected_inputs.len(),
+                    got: inputs.len(),
                 });
+            }
+            for (actual, expected) in inputs.iter().zip(self.expected_inputs.iter()) {
+                if actual.shape() != expected {
+                    return Err(RuntimeError::InvalidShape {
+                        expected: expected.clone(),
+                        got: actual.shape().clone(),
+                    });
+                }
             }
         }
         let call = self.call_count.fetch_add(1, Ordering::Relaxed);
@@ -219,6 +239,18 @@ mod tests {
         let input = Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![0.0])).unwrap();
         let outputs = session.run(&[input]).unwrap();
         assert_eq!(outputs.len(), 1);
+    }
+
+    #[test]
+    fn test_mock_session_unconstrained_accepts_any_input_shape() {
+        let session = MockSession::unconstrained(vec![
+            Tensor::new(Shape::new(vec![1]), TensorData::F32(vec![7.0])).unwrap(),
+        ]);
+        let input =
+            Tensor::new(Shape::new(vec![1, 64, 9]), TensorData::F32(vec![0.0; 576])).unwrap();
+        let outputs = session.run(&[input]).unwrap();
+        assert_eq!(outputs[0].view().data().as_f32().unwrap()[0], 7.0);
+        assert_eq!(session.call_count(), 1);
     }
 
     #[test]

--- a/crates/gigastt-core/src/test_support.rs
+++ b/crates/gigastt-core/src/test_support.rs
@@ -1,0 +1,129 @@
+//! Model-free test engines for in-crate tests and the private `__internals`
+//! feature (server / FFI unit tests).
+//!
+//! Not part of the stable public API. The encoder session accepts any audio
+//! length and emits a single blank frame so REST / SSE / jobs / file wrappers
+//! can run without ONNX weights.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::error::GigasttError;
+use crate::inference::{Engine, PRED_HIDDEN};
+use crate::runtime::mock::{MockFactory, MockSession};
+use crate::runtime::tensor::{Shape, Tensor, TensorData};
+
+const ENC_DIM: usize = 768;
+
+/// Write the INT8 rnnt filenames the engine loader expects (empty ONNX bytes).
+pub fn write_rnnt_layout(dir: &Path) -> std::io::Result<()> {
+    std::fs::write(dir.join("v3_rnnt_encoder_int8.onnx"), b"")?;
+    std::fs::write(dir.join("v3_rnnt_decoder.onnx"), b"")?;
+    std::fs::write(dir.join("v3_rnnt_joint.onnx"), b"")?;
+    std::fs::write(dir.join("v3_vocab.txt"), "\u{2581}hi\n<blk>\n")?;
+    Ok(())
+}
+
+/// PCM16 mono WAV with a standard 44-byte header.
+pub fn pcm16_wav(samples: &[i16], sample_rate: u32) -> Vec<u8> {
+    let data_size = (samples.len() * 2) as u32;
+    let file_size = 36 + data_size;
+    let mut wav = Vec::with_capacity(44 + samples.len() * 2);
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&file_size.to_le_bytes());
+    wav.extend_from_slice(b"WAVE");
+    wav.extend_from_slice(b"fmt ");
+    wav.extend_from_slice(&16u32.to_le_bytes());
+    wav.extend_from_slice(&1u16.to_le_bytes());
+    wav.extend_from_slice(&1u16.to_le_bytes());
+    wav.extend_from_slice(&sample_rate.to_le_bytes());
+    wav.extend_from_slice(&(sample_rate * 2).to_le_bytes());
+    wav.extend_from_slice(&2u16.to_le_bytes());
+    wav.extend_from_slice(&16u16.to_le_bytes());
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&data_size.to_le_bytes());
+    for s in samples {
+        wav.extend_from_slice(&s.to_le_bytes());
+    }
+    wav
+}
+
+/// Scripted rnnt factory: unconstrained encoder (any T) + fixed decoder/joiner.
+pub fn rnnt_factory() -> MockFactory {
+    let mut sessions: HashMap<String, Arc<MockSession>> = HashMap::new();
+    sessions.insert(
+        "v3_rnnt_encoder_int8".into(),
+        Arc::new(MockSession::unconstrained(vec![
+            Tensor::new(
+                Shape::new(vec![1, ENC_DIM, 1]),
+                TensorData::F32(vec![0.0; ENC_DIM]),
+            )
+            .expect("encoder out"),
+            Tensor::new(Shape::new(vec![1]), TensorData::I64(vec![1])).expect("enc len"),
+        ])),
+    );
+    sessions.insert(
+        "v3_rnnt_decoder".into(),
+        Arc::new(MockSession::new(
+            vec![
+                Shape::new(vec![1, 1]),
+                Shape::new(vec![1, 1, PRED_HIDDEN]),
+                Shape::new(vec![1, 1, PRED_HIDDEN]),
+            ],
+            vec![
+                Tensor::new(
+                    Shape::new(vec![1, 1, PRED_HIDDEN]),
+                    TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                )
+                .expect("dec h"),
+                Tensor::new(
+                    Shape::new(vec![1, 1, PRED_HIDDEN]),
+                    TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                )
+                .expect("dec c"),
+                Tensor::new(
+                    Shape::new(vec![1, 1, PRED_HIDDEN]),
+                    TensorData::F32(vec![0.0; PRED_HIDDEN]),
+                )
+                .expect("dec out"),
+            ],
+        )),
+    );
+    sessions.insert(
+        "v3_rnnt_joint".into(),
+        Arc::new(MockSession::new(
+            vec![
+                Shape::new(vec![1, ENC_DIM, 1]),
+                Shape::new(vec![1, PRED_HIDDEN, 1]),
+            ],
+            vec![
+                Tensor::new(Shape::new(vec![1, 1, 2]), TensorData::F32(vec![0.0; 2]))
+                    .expect("joint"),
+            ],
+        )),
+    );
+    MockFactory::new(sessions)
+}
+
+/// Load an INT8 rnnt engine from `dir` (must already hold [`write_rnnt_layout`]).
+pub fn load_rnnt_engine(dir: &Path, pool_size: usize) -> Result<Engine, GigasttError> {
+    Engine::load_with_factory(
+        dir,
+        None,
+        pool_size.max(1),
+        1,
+        0,
+        Box::new(rnnt_factory()),
+        1,
+    )
+}
+
+/// Convenience for this crate's own unit tests (`tempfile` is a dev-dep).
+#[cfg(test)]
+pub fn rnnt_engine() -> (Engine, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_rnnt_layout(tmp.path()).expect("rnnt layout");
+    let engine = load_rnnt_engine(tmp.path(), 1).expect("mock rnnt engine");
+    (engine, tmp)
+}

--- a/crates/gigastt/Cargo.toml
+++ b/crates/gigastt/Cargo.toml
@@ -76,10 +76,20 @@ parking_lot = "0.12"
 uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]
+# Extra `__internals` feature exposes `gigastt_core::test_support` so HTTP /
+# jobs / CLI unit tests can drive a mock engine without the INT8 model.
+gigastt-core = { version = "2.13.0", path = "../gigastt-core", default-features = false, features = [
+    "net",
+    "async-pool",
+    "file-decode",
+    "quantize",
+    "diarization",
+    "__internals",
+] }
 tempfile = "3"
 # `test-util` (paused clock) is test-only; it unifies with the production tokio
 # dependency's features only when building tests, keeping it out of the binary.
 tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread"] }
 tokio-tungstenite = "0.30"
 proptest = "1"
-reqwest = { version = "0.13", features = ["stream"] }
+reqwest = { version = "0.13", features = ["stream", "json", "multipart"] }

--- a/crates/gigastt/src/packaging.rs
+++ b/crates/gigastt/src/packaging.rs
@@ -164,3 +164,35 @@ pub(crate) async fn run_download(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_quantize_noops_when_int8_already_present() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("v3_rnnt_encoder_int8.onnx"), b"int8").unwrap();
+        run_quantize(tmp.path().display().to_string(), false).expect("existing INT8 is a no-op");
+        assert!(!tmp.path().join("v3_rnnt_encoder.onnx").exists());
+    }
+
+    #[test]
+    fn test_run_quantize_errors_when_fp32_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let err = run_quantize(tmp.path().display().to_string(), true)
+            .expect_err("force still needs FP32");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("FP32 encoder not found"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_run_cache_gc_empty_dir_is_ok() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        run_cache_gc(tmp.path().display().to_string(), true, true).expect("empty dry-run");
+        run_cache_gc(tmp.path().display().to_string(), false, false).expect("empty prune");
+    }
+}

--- a/crates/gigastt/src/server/http/tests/admin.rs
+++ b/crates/gigastt/src/server/http/tests/admin.rs
@@ -29,7 +29,6 @@ fn test_peer_is_loopback_guard() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_reload_rejects_non_loopback_peer() {
     // The loopback guard fires before any engine work: a non-loopback
     // ConnectInfo yields 403 `loopback_only` even with a builder present.
@@ -62,7 +61,6 @@ async fn test_reload_rejects_non_loopback_peer() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_reload_unsupported_when_no_builder() {
     // A loopback peer with no stored builder (the thin `run_with_shutdown` /
     // test path) gets `reload_unsupported`, not a swap.

--- a/crates/gigastt/src/server/http/tests/handlers.rs
+++ b/crates/gigastt/src/server/http/tests/handlers.rs
@@ -1,7 +1,6 @@
 use super::*;
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_readiness_when_shutdown_cancelled() {
     let state = Arc::new(AppState {
         engine: engine_swap(test_engine()),
@@ -23,7 +22,6 @@ async fn test_readiness_when_shutdown_cancelled() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_readiness_when_pool_exhausted() {
     let engine = fresh_engine();
     let _guards: Vec<_> = (0..engine.pool.total())
@@ -48,7 +46,6 @@ async fn test_readiness_when_pool_exhausted() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_transcribe_payload_too_large() {
     let state = Arc::new(AppState {
         engine: engine_swap(test_engine()),
@@ -72,7 +69,6 @@ async fn test_transcribe_payload_too_large() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_transcribe_channels_split_diarization_conflict_returns_400() {
     let state = Arc::new(AppState {
         engine: engine_swap(test_engine()),
@@ -99,7 +95,6 @@ async fn test_transcribe_channels_split_diarization_conflict_returns_400() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_models_with_metrics() {
     let state = Arc::new(AppState {
         engine: engine_swap(test_engine()),
@@ -131,7 +126,6 @@ async fn test_models_with_metrics() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_readiness_with_metrics() {
     let state = Arc::new(AppState {
         engine: engine_swap(fresh_engine()),
@@ -148,7 +142,6 @@ async fn test_readiness_with_metrics() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_transcribe_pool_closed() {
     let engine = fresh_engine();
     engine.pool.close();
@@ -171,7 +164,6 @@ async fn test_transcribe_pool_closed() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_transcribe_stream_invalid_audio() {
     let state = Arc::new(AppState {
         engine: engine_swap(test_engine()),
@@ -192,7 +184,6 @@ async fn test_transcribe_stream_invalid_audio() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_transcribe_stream_payload_too_large() {
     let state = Arc::new(AppState {
         engine: engine_swap(test_engine()),
@@ -216,7 +207,6 @@ async fn test_transcribe_stream_payload_too_large() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_transcribe_stream_pool_closed() {
     let engine = fresh_engine();
     engine.pool.close();
@@ -239,7 +229,6 @@ async fn test_transcribe_stream_pool_closed() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_transcribe_with_metrics() {
     let state = Arc::new(AppState {
         engine: engine_swap(test_engine()),
@@ -259,7 +248,6 @@ async fn test_transcribe_with_metrics() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_transcribe_stream_with_metrics() {
     let state = Arc::new(AppState {
         engine: engine_swap(test_engine()),
@@ -279,7 +267,6 @@ async fn test_transcribe_stream_with_metrics() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_transcribe_segments_json() {
     // `?segments=true` on the default JSON response adds a `segments` array
     // with sane start/end ordering and per-segment words, while keeping the
@@ -318,4 +305,88 @@ async fn test_transcribe_segments_json() {
         assert!(end >= start, "segment end {end} < start {start}");
         assert!(seg["words"].is_array());
     }
+}
+
+fn bare_state(engine: Arc<Engine>) -> Arc<AppState> {
+    Arc::new(AppState {
+        engine: engine_swap(engine),
+        limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
+        metrics_registry: None,
+        engine_builder: None,
+        reload_lock: Arc::new(tokio::sync::Mutex::new(())),
+        shutdown: tokio_util::sync::CancellationToken::new(),
+        tracker: tokio_util::task::TaskTracker::new(),
+        jobs: None,
+    })
+}
+
+#[tokio::test]
+async fn test_health_reports_mock_rnnt_identity() {
+    let resp = health(State(bare_state(test_engine()))).await;
+    let json = serde_json::to_value(&*resp).unwrap();
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["variant"], "rnnt");
+    assert_eq!(json["model"], "gigaam-v3-rnnt");
+    assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
+}
+
+#[tokio::test]
+async fn test_metrics_disabled_returns_404() {
+    let resp = metrics(State(bare_state(test_engine()))).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_metrics_enabled_returns_prometheus_text() {
+    let registry = Arc::new(MetricsRegistry::new());
+    registry.counter_inc("gigastt_http_requests_total", &[], 1);
+    let state = Arc::new(AppState {
+        engine: engine_swap(test_engine()),
+        limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
+        metrics_registry: Some(registry),
+        engine_builder: None,
+        reload_lock: Arc::new(tokio::sync::Mutex::new(())),
+        shutdown: tokio_util::sync::CancellationToken::new(),
+        tracker: tokio_util::task::TaskTracker::new(),
+        jobs: None,
+    });
+    let resp = metrics(State(state)).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        text.contains("gigastt_http_requests_total"),
+        "prometheus body should include the recorded counter, got {text:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_readiness_ready_when_pool_has_a_slot() {
+    let resp = readiness(State(bare_state(fresh_engine()))).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["status"], "ready");
+    assert!(v["pool_available"].as_u64().unwrap() >= 1);
+}
+
+#[tokio::test]
+async fn test_transcribe_stream_empty_body_is_bad_request() {
+    let result = transcribe_stream(State(bare_state(test_engine())), Bytes::new()).await;
+    let resp = result.expect_err("empty body");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_transcribe_empty_body_is_bad_request() {
+    let result = transcribe(
+        State(bare_state(test_engine())),
+        Query(ExportParams::default()),
+        Bytes::new(),
+    )
+    .await;
+    let resp = result.expect_err("empty body");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }

--- a/crates/gigastt/src/server/http/tests/jobs.rs
+++ b/crates/gigastt/src/server/http/tests/jobs.rs
@@ -1,0 +1,152 @@
+//! Job HTTP handlers — model-free via the mock engine + in-memory store.
+
+use super::*;
+use crate::server::http::{
+    JobServerState, cancel_job, get_job, get_job_result, job_events, submit_job,
+};
+use crate::server::jobs::{InMemoryJobStore, Job, JobQueue, JobStatus, JobStore};
+use axum::extract::Path;
+
+fn jobs_state(engine: Arc<Engine>, limits: RuntimeLimits) -> Arc<AppState> {
+    let store: Arc<dyn crate::server::jobs::JobStore> =
+        Arc::new(InMemoryJobStore::new(limits.clone()));
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let queue = JobQueue::new(store.clone(), 1, 0, shutdown.clone());
+    Arc::new(AppState {
+        engine: engine_swap(engine),
+        limits: Arc::new(ArcSwap::from_pointee(limits)),
+        metrics_registry: None,
+        engine_builder: None,
+        reload_lock: Arc::new(tokio::sync::Mutex::new(())),
+        shutdown,
+        tracker: tokio_util::task::TaskTracker::new(),
+        jobs: Some(JobServerState { store, queue }),
+    })
+}
+
+#[tokio::test]
+async fn test_submit_job_disabled_is_404() {
+    let state = Arc::new(AppState {
+        engine: engine_swap(test_engine()),
+        limits: Arc::new(ArcSwap::from_pointee(RuntimeLimits::default())),
+        metrics_registry: None,
+        engine_builder: None,
+        reload_lock: Arc::new(tokio::sync::Mutex::new(())),
+        shutdown: tokio_util::sync::CancellationToken::new(),
+        tracker: tokio_util::task::TaskTracker::new(),
+        jobs: None,
+    });
+    let err = submit_job(State(state), Query(ExportParams::default()), short_wav())
+        .await
+        .expect_err("jobs disabled");
+    assert_eq!(err.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_submit_job_empty_body_is_400() {
+    let state = jobs_state(test_engine(), RuntimeLimits::default());
+    let err = submit_job(State(state), Query(ExportParams::default()), Bytes::new())
+        .await
+        .expect_err("empty");
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_submit_job_payload_too_large() {
+    let state = jobs_state(
+        test_engine(),
+        RuntimeLimits {
+            body_limit_bytes: 4,
+            ..RuntimeLimits::default()
+        },
+    );
+    let err = submit_job(State(state), Query(ExportParams::default()), short_wav())
+        .await
+        .expect_err("too large");
+    assert_eq!(err.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn test_submit_job_conflict_split_and_diarization() {
+    let state = jobs_state(test_engine(), RuntimeLimits::default());
+    let params = ExportParams {
+        channels: Some("split".into()),
+        diarization: Some(true),
+        ..ExportParams::default()
+    };
+    let err = submit_job(State(state), Query(params), short_wav())
+        .await
+        .expect_err("conflict");
+    assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_submit_get_cancel_job_round_trip() {
+    let state = jobs_state(test_engine(), RuntimeLimits::default());
+    let resp = submit_job(
+        State(state.clone()),
+        Query(ExportParams::default()),
+        short_wav(),
+    )
+    .await
+    .expect("submit");
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let id = v["job_id"].as_str().unwrap().to_string();
+
+    let resp = get_job(State(state.clone()), Path(id.clone()))
+        .await
+        .expect("get");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let err = get_job_result(State(state.clone()), Path(id.clone()))
+        .await
+        .expect_err("not finished");
+    assert_eq!(err.status(), StatusCode::CONFLICT);
+
+    let resp = cancel_job(State(state.clone()), Path(id.clone()))
+        .await
+        .expect("cancel");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let err = get_job(State(state.clone()), Path("missing".into()))
+        .await
+        .expect_err("missing");
+    assert_eq!(err.status(), StatusCode::NOT_FOUND);
+
+    let events = job_events(State(state), Path(id)).await.expect("events");
+    drop(events);
+}
+
+#[tokio::test]
+async fn test_get_job_result_returns_json_when_done() {
+    let limits = RuntimeLimits::default();
+    let store = Arc::new(InMemoryJobStore::new(limits.clone()));
+    let mut job = Job::queued(short_wav(), ExportParams::default());
+    job.status = JobStatus::Done;
+    job.result = Some(sample_export_result());
+    let id = store.create(job).await.expect("create");
+
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let queue = JobQueue::new(store.clone(), 1, 0, shutdown.clone());
+    let state = Arc::new(AppState {
+        engine: engine_swap(test_engine()),
+        limits: Arc::new(ArcSwap::from_pointee(limits)),
+        metrics_registry: None,
+        engine_builder: None,
+        reload_lock: Arc::new(tokio::sync::Mutex::new(())),
+        shutdown,
+        tracker: tokio_util::task::TaskTracker::new(),
+        jobs: Some(JobServerState { store, queue }),
+    });
+    let resp = get_job_result(State(state), Path(id))
+        .await
+        .expect("result");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 16)
+        .await
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["text"], "привет мир");
+}

--- a/crates/gigastt/src/server/http/tests/mod.rs
+++ b/crates/gigastt/src/server/http/tests/mod.rs
@@ -36,15 +36,19 @@ pub(super) fn test_engine() -> Arc<Engine> {
     static ENGINE: OnceLock<Arc<Engine>> = OnceLock::new();
     ENGINE
         .get_or_init(|| {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            gigastt_core::test_support::write_rnnt_layout(tmp.path()).expect("layout");
             Arc::new(
-                Engine::load_with_pool_size(&gigastt_core::model::default_model_dir(), 1).unwrap(),
+                gigastt_core::test_support::load_rnnt_engine(tmp.path(), 1).expect("mock engine"),
             )
         })
         .clone()
 }
 
 pub(super) fn fresh_engine() -> Arc<Engine> {
-    Arc::new(Engine::load_with_pool_size(&gigastt_core::model::default_model_dir(), 1).unwrap())
+    let tmp = tempfile::tempdir().expect("tempdir");
+    gigastt_core::test_support::write_rnnt_layout(tmp.path()).expect("layout");
+    Arc::new(gigastt_core::test_support::load_rnnt_engine(tmp.path(), 1).expect("mock engine"))
 }
 
 /// Wrap an engine handle in the `ArcSwap` the `AppState` now holds. Keeps
@@ -106,5 +110,6 @@ mod codec;
 mod error;
 mod export;
 mod handlers;
+mod jobs;
 mod serde_contract;
 mod sse;

--- a/crates/gigastt/src/server/jobs/tests/executor.rs
+++ b/crates/gigastt/src/server/jobs/tests/executor.rs
@@ -1,0 +1,67 @@
+use super::*;
+use crate::server::jobs::RealJobExecutor;
+use arc_swap::ArcSwap;
+use gigastt_core::inference::Engine;
+
+fn mock_engine() -> (Arc<Engine>, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    gigastt_core::test_support::write_rnnt_layout(tmp.path()).expect("layout");
+    let engine = gigastt_core::test_support::load_rnnt_engine(tmp.path(), 1).expect("engine");
+    (Arc::new(engine), tmp)
+}
+
+#[tokio::test]
+async fn test_real_executor_transcribes_short_wav() {
+    let (engine, _tmp) = mock_engine();
+    let limits = test_limits();
+    let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(limits.clone()));
+    let job = Job::queued(
+        Bytes::from(gigastt_core::test_support::pcm16_wav(&[0; 320], 16_000)),
+        ExportParams::default(),
+    );
+    let id = store.create(job).await.expect("create");
+
+    let executor = RealJobExecutor::new(
+        Arc::new(ArcSwap::new(engine)),
+        Arc::new(ArcSwap::from_pointee(limits)),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    let result = executor
+        .execute(
+            &id,
+            store.clone(),
+            Bytes::from(gigastt_core::test_support::pcm16_wav(&[0; 320], 16_000)),
+            ExportParams::default(),
+        )
+        .await
+        .expect("executor");
+    assert!(result.text.is_empty());
+    assert!(result.duration_s > 0.0);
+}
+
+#[tokio::test]
+async fn test_real_executor_rejects_unknown_variant() {
+    let (engine, _tmp) = mock_engine();
+    let limits = test_limits();
+    let store: Arc<dyn JobStore> = Arc::new(InMemoryJobStore::new(limits.clone()));
+    let params = ExportParams {
+        variant: Some("does-not-exist".into()),
+        ..ExportParams::default()
+    };
+    let job = Job::queued(Bytes::from(vec![1, 2, 3]), params.clone());
+    let id = store.create(job).await.expect("create");
+
+    let executor = RealJobExecutor::new(
+        Arc::new(ArcSwap::new(engine)),
+        Arc::new(ArcSwap::from_pointee(limits)),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    let err = executor
+        .execute(&id, store, Bytes::from(vec![1, 2, 3]), params)
+        .await
+        .expect_err("unknown variant");
+    assert!(
+        format!("{err:#}").contains("not loaded"),
+        "unexpected error: {err:#}"
+    );
+}

--- a/crates/gigastt/src/server/jobs/tests/mod.rs
+++ b/crates/gigastt/src/server/jobs/tests/mod.rs
@@ -76,5 +76,6 @@ impl JobExecution for BodyLenRecorder {
 }
 
 mod events;
+mod executor;
 mod queue;
 mod store;

--- a/crates/gigastt/src/server/router.rs
+++ b/crates/gigastt/src/server/router.rs
@@ -69,3 +69,16 @@ pub(crate) fn protected_v1_router(jobs_enabled: bool) -> Router<Arc<http::AppSta
         protected
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_protected_v1_router_builds_with_and_without_jobs() {
+        // Both branches must construct: jobs routes are only registered when
+        // the flag is on, and a panic here would be a boot-time outage.
+        let _ = protected_v1_router(false);
+        let _ = protected_v1_router(true);
+    }
+}

--- a/crates/gigastt/src/server/tests.rs
+++ b/crates/gigastt/src/server/tests.rs
@@ -90,14 +90,18 @@ fn test_json_text_fallback_on_serialization_error() {
     );
 }
 
+mod live;
+
+fn mock_engine() -> (gigastt_core::inference::Engine, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    gigastt_core::test_support::write_rnnt_layout(tmp.path()).expect("layout");
+    let engine = gigastt_core::test_support::load_rnnt_engine(tmp.path(), 1).expect("mock engine");
+    (engine, tmp)
+}
+
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_run_with_shutdown_starts_and_stops() {
-    let engine = gigastt_core::inference::Engine::load_with_pool_size(
-        &gigastt_core::model::default_model_dir(),
-        1,
-    )
-    .unwrap();
+    let (engine, _tmp) = mock_engine();
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
     let handle =
         tokio::spawn(
@@ -110,13 +114,8 @@ async fn test_run_with_shutdown_starts_and_stops() {
 }
 
 #[tokio::test]
-#[ignore = "requires model"]
 async fn test_run_with_config_listener_clamps_zero_timeout() {
-    let engine = gigastt_core::inference::Engine::load_with_pool_size(
-        &gigastt_core::model::default_model_dir(),
-        1,
-    )
-    .unwrap();
+    let (engine, _tmp) = mock_engine();
     let mut config = ServerConfig::local(0);
     config.limits.pool_checkout_timeout_secs = 0;
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();

--- a/crates/gigastt/src/server/tests/live.rs
+++ b/crates/gigastt/src/server/tests/live.rs
@@ -1,0 +1,151 @@
+//! In-process server + mock engine: WS / REST / OpenAI without the INT8 model.
+
+use super::mock_engine;
+use crate::server::{ServerConfig, run_with_config_listener};
+use futures_util::{SinkExt, StreamExt};
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+
+async fn spawn_mock_server() -> (u16, tokio::sync::oneshot::Sender<()>, tempfile::TempDir) {
+    let (engine, tmp) = mock_engine();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let config = ServerConfig::local(port);
+    tokio::spawn(async move {
+        run_with_config_listener(engine, config, Some(shutdown_rx), listener)
+            .await
+            .expect("server");
+    });
+    for _ in 0..100 {
+        if reqwest::get(format!("http://127.0.0.1:{port}/health"))
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return (port, shutdown_tx, tmp);
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("mock server did not become ready on port {port}");
+}
+
+#[tokio::test]
+async fn test_live_health_and_openai_transcriptions() {
+    let (port, shutdown, _tmp) = spawn_mock_server().await;
+    let health: serde_json::Value = reqwest::get(format!("http://127.0.0.1:{port}/health"))
+        .await
+        .expect("health")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(health["status"], "ok");
+    assert_eq!(health["variant"], "rnnt");
+
+    let wav = gigastt_core::test_support::pcm16_wav(&[0i16; 1600], 16_000);
+    let form = reqwest::multipart::Form::new().part(
+        "file",
+        reqwest::multipart::Part::bytes(wav)
+            .file_name("silence.wav")
+            .mime_str("audio/wav")
+            .expect("mime"),
+    );
+    let resp = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{port}/v1/audio/transcriptions"))
+        .multipart(form)
+        .send()
+        .await
+        .expect("openai");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.expect("openai json");
+    assert!(body.get("text").is_some(), "openai json has text: {body}");
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn test_live_ws_ready_audio_stop_final() {
+    let (port, shutdown, _tmp) = spawn_mock_server().await;
+    let (ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/v1/ws"))
+        .await
+        .expect("ws connect");
+    let (mut sink, mut stream) = ws.split();
+
+    let ready = next_json(&mut stream).await;
+    assert_eq!(ready["type"], "ready");
+    assert_eq!(ready["version"], "1.0");
+
+    sink.send(Message::Text(
+        serde_json::json!({"type": "configure", "sample_rate": 16000})
+            .to_string()
+            .into(),
+    ))
+    .await
+    .expect("configure");
+
+    let mut pcm = Vec::with_capacity(320 * 2);
+    for _ in 0..320 {
+        pcm.extend_from_slice(&0i16.to_le_bytes());
+    }
+    sink.send(Message::Binary(pcm.into())).await.expect("audio");
+    sink.send(Message::Text(
+        serde_json::json!({"type": "stop"}).to_string().into(),
+    ))
+    .await
+    .expect("stop");
+
+    let mut saw_final = false;
+    for _ in 0..8 {
+        let v = next_json(&mut stream).await;
+        match v["type"].as_str() {
+            Some("partial") => continue,
+            Some("final") => {
+                assert!(v["text"].is_string());
+                saw_final = true;
+                break;
+            }
+            other => panic!("unexpected ws message type {other:?}: {v}"),
+        }
+    }
+    assert!(saw_final, "stop must produce a final");
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn test_live_ws_invalid_sample_rate_is_rejected() {
+    let (port, shutdown, _tmp) = spawn_mock_server().await;
+    let (ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/v1/ws"))
+        .await
+        .expect("ws connect");
+    let (mut sink, mut stream) = ws.split();
+    let ready = next_json(&mut stream).await;
+    assert_eq!(ready["type"], "ready");
+
+    sink.send(Message::Text(
+        serde_json::json!({"type": "configure", "sample_rate": 12345})
+            .to_string()
+            .into(),
+    ))
+    .await
+    .expect("configure");
+
+    let err = next_json(&mut stream).await;
+    assert_eq!(err["type"], "error");
+    assert_eq!(err["code"], "invalid_sample_rate");
+    let _ = shutdown.send(());
+}
+
+async fn next_json<S>(stream: &mut S) -> serde_json::Value
+where
+    S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    let msg = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("timeout")
+        .expect("eof")
+        .expect("ws err");
+    let text = msg.into_text().expect("text");
+    serde_json::from_str(&text).unwrap_or_else(|_| panic!("json: {text}"))
+}

--- a/crates/gigastt/src/transcribe_cmd.rs
+++ b/crates/gigastt/src/transcribe_cmd.rs
@@ -434,3 +434,47 @@ pub(crate) async fn run_watch(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_batch_options_defaults() {
+        let out = BatchOutputArgs {
+            format: "txt,json".into(),
+            move_to: None,
+            delete_source: false,
+            retries: None,
+            max_chars_per_line: None,
+            max_words_per_line: None,
+            word_timestamps: false,
+        };
+        let opts = build_batch_options("/in", "/out", 2, 3, &out).expect("opts");
+        assert_eq!(opts.input_dir, std::path::PathBuf::from("/in"));
+        assert_eq!(opts.output_dir, std::path::PathBuf::from("/out"));
+        assert_eq!(opts.concurrency, 2);
+        assert_eq!(opts.retries, 3);
+        assert_eq!(opts.render_opts.max_chars_per_line, 80);
+        assert_eq!(opts.render_opts.max_words_per_line, 14);
+        assert!(!opts.delete_source);
+    }
+
+    #[test]
+    fn test_make_transcribe_fn_reads_wav() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        gigastt_core::test_support::write_rnnt_layout(tmp.path()).expect("layout");
+        let engine = std::sync::Arc::new(
+            gigastt_core::test_support::load_rnnt_engine(tmp.path(), 1).expect("engine"),
+        );
+        let wav = tmp.path().join("clip.wav");
+        std::fs::write(
+            &wav,
+            gigastt_core::test_support::pcm16_wav(&[0i16; 320], 16_000),
+        )
+        .expect("wav");
+        let f = make_transcribe_fn(engine);
+        let result = f(wav).expect("transcribe");
+        assert!(result.duration_s > 0.0);
+    }
+}


### PR DESCRIPTION
## Summary

HTTP, WebSocket, jobs, OpenAI transcriptions, and CLI helpers now run in `cargo test --workspace --lib --bins` without the 225 MB INT8 model.

- Scripted INT8 rnnt runtime (`gigastt_core::test_support`, private `__internals` feature). Encoder accepts any audio length.
- Previously `#[ignore]`d handler tests (health, ready, transcribe, SSE, admin reload) now run on every PR.
- In-process live tests: `/health`, `/v1/audio/transcriptions`, `/v1/ws` Ready → configure → audio → Stop → Final.
- Packaging (`quantize` no-op / missing FP32, `cache-gc`), `RealJobExecutor`, engine file/bytes/channels/cancel wrappers.
- Codecov **patch** target 80% → **90%**.

Unit line coverage (`llvm-cov --workspace --lib --bins`): **68% → 78.5%**.

## Test plan

- [x] `cargo test --workspace --lib --bins` (pre-commit)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Live mock WS + OpenAI + health tests