### PR TITLE
feat(benchmark): measure streaming WER and TTFP p50/p95

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,23 @@ jobs:
           print("OK: objc2 is isolated")
           PY
 
+  benchmark-pytest:
+    runs-on: ubuntu-latest
+    name: Benchmark harness tests
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test deps
+        run: python -m pip install pytest websockets
+      - name: Run benchmark unit tests
+        working-directory: benchmark
+        run: |
+          python -m pytest tests/test_streaming.py tests/test_latency.py \
+            tests/test_benchmark.py tests/test_common.py tests/test_histograms.py \
+            tests/test_cache.py -q --tb=short
+
   clippy:
     runs-on: ubuntu-latest
     name: Clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ were released without a git tag, so their headings carry no compare link.
   `cache-gc`), job HTTP handlers, `RealJobExecutor`, engine file/bytes/
   channels/cancel wrappers, and `transcribe` batch helpers.
 
+### Fixed
+
+- Candle/Metal CI: mock-engine getter test no longer asserts `is_int8()`
+  (the candle loader reports FP32 safetensors even when the on-disk
+  layout uses INT8 ONNX filenames). This is what kept `Build (Candle/Metal)`
+  red on `main` after the mock-engine coverage merge.
+
 ### Changed
 
 - Codecov patch target raised from 80% to 90%. Previously `#[ignore]`d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ were released without a git tag, so their headings carry no compare link.
 
 ### Added
 
+- **Streaming WER + TTFP corpus harness.** `benchmark.py --mode batch|stream|both`
+  runs the live `/v1/ws` path (16 kHz PCM16, 100 ms real-time chunks) next to
+  REST batch and writes paired **Δ = WER_stream − WER_batch** with a bootstrap
+  CI. `benchmark_latency.py --dataset` reports TTFP / TTFS p50–p95. Protocol
+  is pinned in [`docs/benchmarks.md`](docs/benchmarks.md#streaming-measurement-protocol).
+  First 100-clip measurement (M1 Pro, CPU INT8): crowd Δ **+14.5 pp**
+  (4.97 → 19.46), far-field **+10.6 pp** (4.82 → 15.42); TTFP p50
+  **820 ms** far-field / **1653 ms** crowd; per-partial lag p50 **41–51 ms**.
 - **Model-free mock engine for unit tests.** `gigastt_core::test_support`
   (behind the private `__internals` feature) loads a scripted INT8 rnnt
   engine whose encoder accepts any audio length. HTTP, WebSocket, jobs,

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,7 +23,9 @@ Reproducible benchmark comparing **gigastt** against popular open-source ASR eng
 
 RTF is measured against a **pre-warmed engine** so that model-load time is not unfairly charged to any runner:
 
-- **gigastt** is measured via HTTP POST to a `gigastt serve` process that stays up for the whole benchmark. WebSocket streaming was evaluated but abandoned for WER benchmarking: when inference is slower than real-time, the streaming endpoint finalizes on incomplete audio and returns truncated transcripts.
+- **gigastt (batch)** is measured via HTTP POST to a `gigastt serve` process that stays up for the whole benchmark.
+- **gigastt (stream)** (`--mode stream` / `--mode both`) uses the same process over `/v1/ws`: 16 kHz mono PCM16, 100 ms real-time chunks, Stop at EOF. Protocol: [`docs/benchmarks.md` § Streaming measurement protocol](../docs/benchmarks.md#streaming-measurement-protocol). `--mode both` emits `stream_vs_batch` (Δ = WER_stream − WER_batch, paired files, bootstrap 95% CI). Stream **RTF** in the results table is paced wall-clock (≈ 1.0 + drain), not encoder compute — do not compare it to REST ~0.10. The runner starts `serve` with the default `--pool-size 2`; published TTFP rows use a separately started `--pool-size 1` server.
+- A 2026-06 attempt to use WebSocket for the *cross-engine* WER table was abandoned when the then-streaming path could not keep up with real-time audio and truncated finals. The stride (0.8 s) path is real-time on CPU; stream WER is now a first-class mode, not a replacement for the REST competitor table.
 - **faster-whisper** and **Vosk** load their models once in `is_available()` and reuse them for every sample.
 - **whisper.cpp** runs in **server mode** (`whisper-server`). The model is loaded once when the server starts; each sample is sent as an HTTP POST to `/inference` and the wall-clock request latency is used as `processing_time`. This replaces the previous per-sample `whisper-cli` invocation that re-loaded the ~3 GB model on every file and produced an artificially high RTF.
 
@@ -99,6 +101,13 @@ python benchmark.py --max-samples 0 --output results_full.json
 
 # Run only specific engines
 python benchmark.py --runners gigastt,whisper_cpp
+
+# Streaming WER vs REST batch on the same gigastt server (Δ in results JSON)
+python benchmark.py --mode both --runners gigastt --dataset golos_crowd --max-samples 100 \
+  --output results_stream_wer.json
+
+# TTFP / TTFS p50–p95 (start `gigastt serve --port 9877 --pool-size 1` first)
+python benchmark_latency.py --dataset golos_crowd --max-samples 100 --output results_latency_corpus.json
 
 # Use environment variable for limit
 GIGASTT_BENCHMARK_MAX_SAMPLES=50 python benchmark.py

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -32,11 +32,13 @@ from runners import (
     GigasttMlCtcLargeRunner,
     GigasttMlCtcRunner,
     GigasttRunner,
+    GigasttStreamRunner,
     TOneRunner,
     VoskRunner,
     Vosk054Runner,
     WhisperCppRunner,
 )
+from streaming import paired_delta
 
 
 PROFILE_PATH = "benchmark.prof"
@@ -44,6 +46,7 @@ PROGRESS_INTERVAL = 10
 
 ALL_RUNNERS = [
     GigasttRunner,
+    GigasttStreamRunner,
     GigasttMlCtcRunner,
     GigasttMlCtcLargeRunner,
     WhisperCppRunner,
@@ -53,6 +56,8 @@ ALL_RUNNERS = [
     Vosk054Runner,
     TOneRunner,
 ]
+
+STREAM_RUNNER_NAMES = {"gigastt-stream"}
 
 
 def run_benchmark(
@@ -231,13 +236,43 @@ def print_histograms(results: list[dict]):
                 )
 
 
+def _stream_vs_batch(results: list[dict]) -> Optional[dict]:
+    by_name = {r["name"]: r for r in results}
+    batch = by_name.get("gigastt")
+    stream = by_name.get("gigastt-stream")
+    if batch is None or stream is None:
+        return None
+    return paired_delta(batch.get("details") or [], stream.get("details") or [])
+
+
+def print_stream_delta(delta: dict) -> None:
+    print("\n--- Streaming vs batch (gigastt) ---")
+    print(
+        f"  paired={delta['paired']}  "
+        f"WER_batch={delta['wer_batch']:.2f}%  "
+        f"WER_stream={delta['wer_stream']:.2f}%  "
+        f"Δ={delta['delta_pp']:+.2f} pp  "
+        f"95% CI [{delta['ci_low']:.2f}, {delta['ci_high']:.2f}]"
+    )
+    print("  Δ = WER_stream − WER_batch on the same files (positive ⇒ streaming costs accuracy).")
+    print("  Stream RTF in the table above is paced wall-clock, not compute.")
+
+
 def _parse_args(argv=None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Cross-ASR benchmark")
     parser.add_argument("--max-samples", type=int, default=int(os.environ.get("GIGASTT_BENCHMARK_MAX_SAMPLES", "100")),
                         help="Maximum samples to process (0 = unlimited)")
     parser.add_argument("--output", type=str, default="results.json", help="Output JSON path")
     parser.add_argument("--runners", type=str, default="all",
-                        help="Comma-separated list: gigastt,whisper_cpp,faster_whisper,vosk (or 'all')")
+                        help="Comma-separated list: gigastt,gigastt-stream,whisper_cpp,faster_whisper,vosk (or 'all')")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=("batch", "stream", "both"),
+        default="batch",
+        help="batch = REST (default); stream = gigastt WebSocket only; "
+        "both = REST + WS and print Δ = WER_stream − WER_batch",
+    )
     parser.add_argument("--dataset", type=str, default=os.environ.get("GIGASTT_BENCHMARK_DATASET", "golos_crowd"),
                         help="Dataset manifest name (e.g. golos_crowd, golos_farfield)")
     parser.add_argument(
@@ -291,11 +326,22 @@ def _main(args: Optional[argparse.Namespace] = None):
     for runner_or_cls in ALL_RUNNERS:
         r = runner_or_cls() if isinstance(runner_or_cls, type) else runner_or_cls
         normalized = r.name.replace(".", "_").replace("-", "_")
-        if "all" in requested or normalized in requested or r.name in requested:
-            if r.is_available():
-                active_runners.append(r)
-            else:
-                print(f"Skipping {r.name} (not available)")
+        is_stream = r.name in STREAM_RUNNER_NAMES
+        if args.mode == "batch" and is_stream:
+            continue
+        if args.mode == "stream" and not is_stream:
+            continue
+        selected = "all" in requested or normalized in requested or r.name in requested
+        if args.mode == "stream" and is_stream:
+            selected = True
+        if args.mode == "both" and is_stream:
+            selected = True
+        if not selected:
+            continue
+        if r.is_available():
+            active_runners.append(r)
+        else:
+            print(f"Skipping {r.name} (not available)")
 
     if not active_runners:
         print("No runners available. Install dependencies:")
@@ -312,6 +358,9 @@ def _main(args: Optional[argparse.Namespace] = None):
 
     print_results_table(results)
     print_histograms(results)
+    stream_vs_batch = _stream_vs_batch(results)
+    if stream_vs_batch is not None:
+        print_stream_delta(stream_vs_batch)
     if cache.enabled:
         total_cached = sum(r.get("cached_hits", 0) for r in results)
         print(f"Total cache hits: {total_cached}")
@@ -320,12 +369,15 @@ def _main(args: Optional[argparse.Namespace] = None):
     total_failures = sum(r["failures"] for r in results)
     output = {
         "dataset": args.dataset,
+        "mode": args.mode,
         "manifest_samples": len(manifest) + skipped_empty_refs,
         "skipped_empty_refs": skipped_empty_refs,
         "total_failures": total_failures,
         "runners": results,
         "metadata": collect_repro_metadata(active_runners, dataset_name=args.dataset),
     }
+    if stream_vs_batch is not None:
+        output["stream_vs_batch"] = stream_vs_batch
     with open(args.output, "w", encoding="utf-8") as f:
         json.dump(output, f, ensure_ascii=False, indent=2)
     print(f"\nResults written to {args.output}")

--- a/benchmark/benchmark_latency.py
+++ b/benchmark/benchmark_latency.py
@@ -1,136 +1,130 @@
 #!/usr/bin/env python3
-"""Measure streaming latency: time-to-first-partial and finalization lag."""
+"""Measure streaming latency: TTFP / TTFS p50–p95 and finalization lag.
+
+Single clip (legacy):
+    python benchmark_latency.py --wav path.wav --port 9877
+
+Corpus (p50/p95):
+    python benchmark_latency.py --dataset golos_crowd --max-samples 100 --port 9877
+
+The server must already be running (warm, `--pool-size 1` for the published
+protocol). Clock starts on the first audio frame after Ready + configure.
+"""
+
+from __future__ import annotations
 
 import argparse
-import asyncio
 import json
-import time
-import wave
 from pathlib import Path
 
-import websockets
+from common import load_manifest
+from streaming import STREAM_CHUNK_MS, STREAM_PROTOCOL_VERSION, STREAM_SAMPLE_RATE, summarize_latency, transcribe_ws
 
 
-class GigasttLatencyClient:
-    def __init__(self, port: int = 9877):
-        self.port = port
-        self.url = f"ws://127.0.0.1:{port}/v1/ws"
-
-    async def measure(self, wav_path: str, chunk_ms: int = 100) -> dict:
-        # Pre-load and validate the clip up front so the sender just paces already
-        # decoded PCM frames out over the socket while the reader runs concurrently.
-        with wave.open(wav_path, "rb") as wf:
-            channels = wf.getnchannels()
-            width = wf.getsampwidth()
-            rate = wf.getframerate()
-            if channels != 1 or width != 2 or rate != 16000:
-                raise ValueError("gigastt WebSocket streaming expects 16kHz mono 16-bit WAV")
-            frames_per_chunk = int(rate * chunk_ms / 1000)
-            audio_duration_ms = wf.getnframes() / rate * 1000.0
-            chunks = []
-            while True:
-                data = wf.readframes(frames_per_chunk)
-                if not data:
-                    break
-                chunks.append(data)
-
-        first_partial_at = None
-        final_at = None
-        # Wall-clock when the most recent audio chunk left the client. Because the sender is
-        # real-time paced, it also marks that audio's position in the stream, so a partial's
-        # delay relative to it approximates the server's per-chunk response (compute) lag.
-        last_sent_at = None
-        partial_lags = []  # seconds: (partial arrival - last_sent_at), one per partial
-
-        async with websockets.connect(self.url) as ws:
-            # Consume the ready message and tell the server we are streaming 16kHz PCM.
-            await ws.recv()
-            await ws.send(json.dumps({"type": "configure", "sample_rate": 16000}))
-
-            async def _read_loop():
-                # Runs concurrently with the sender, so a partial emitted mid-stream is
-                # timestamped when it actually arrives — not after the whole clip is sent.
-                nonlocal first_partial_at, final_at
-                async for msg in ws:
-                    now = time.perf_counter()
-                    obj = json.loads(msg)
-                    kind = obj.get("type")
-                    if kind == "partial":
-                        if last_sent_at is not None:
-                            partial_lags.append(now - last_sent_at)
-                        if first_partial_at is None:
-                            first_partial_at = now
-                    elif kind == "final":
-                        final_at = now
-                        return
-
-            # Start the reader before any audio leaves the client, then stamp started_at
-            # on the first chunk (handshake + configure already done) so TTFP is measured
-            # against the audio stream, not the connection setup.
-            reader = asyncio.create_task(_read_loop())
-            started_at = time.perf_counter()
-            last_sent_at = started_at
-            for data in chunks:
-                await ws.send(data)
-                last_sent_at = time.perf_counter()
-                await asyncio.sleep(chunk_ms / 1000.0)
-            await ws.send(json.dumps({"type": "stop"}))
-            send_done_at = time.perf_counter()
-
-            # The sender is real-time paced (~clip length); give the reader a bounded
-            # window after `stop` to observe the final segment, then stop waiting.
-            try:
-                await asyncio.wait_for(reader, timeout=30.0)
-            except asyncio.TimeoutError:
-                reader.cancel()
-
-        ttfp_ms = round((first_partial_at - started_at) * 1000, 1) if first_partial_at else None
-        result = {
-            "time_to_first_partial_ms": ttfp_ms,
-            "first_partial_after_audio_ms": ttfp_ms,
-            "finalization_lag_ms": round((final_at - started_at) * 1000, 1) if final_at else None,
-            "audio_duration_ms": round(audio_duration_ms, 1),
-            "total_audio_sent_ms": round((send_done_at - started_at) * 1000, 1),
-        }
-        # Per-chunk server response lag: delay of each partial relative to the most recently
-        # sent audio chunk. Isolates compute (+queue) latency from real-time pacing and from
-        # where the first word happens to fall in the clip — this is the number comparable to
-        # "incremental streaming latency". NOTE: it is an UPPER-bounded approximation and is
-        # under-estimated when per-chunk compute >= chunk_ms (a newer chunk is sent before the
-        # prior partial arrives, resetting last_sent_at); cross-check against the server log's
-        # `encoder_inference elapsed_ms`.
-        if partial_lags:
-            ordered = sorted(partial_lags)
-            n = len(ordered)
-            result["partial_response_lag_ms"] = {
+def evaluate_gigastt(wav_path: str, port: int = 9877, chunk_ms: int = STREAM_CHUNK_MS) -> dict:
+    """One clip. Keeps the legacy JSON keys used by older notes."""
+    _text, _elapsed, session = transcribe_ws(wav_path, port=port, chunk_ms=chunk_ms, pace=True)
+    lags = session.get("partial_lags_ms") or []
+    ordered = sorted(lags)
+    n = len(ordered)
+    return {
+        "time_to_first_partial_ms": session["ttfp_ms"],
+        "first_partial_after_audio_ms": session["ttfp_ms"],
+        "ttfs_ms": session["ttfs_ms"],
+        "finalization_lag_ms": session["finalization_lag_ms"],
+        "audio_duration_ms": session["audio_duration_ms"],
+        "total_audio_sent_ms": session["total_audio_sent_ms"],
+        "timed_out": session["timed_out"],
+        "no_partial": session["no_partial"],
+        "onset_s": session["onset_s"],
+        "ttfp_ms": session["ttfp_ms"],
+        "partial_lags_ms": lags,
+        "partial_response_lag_ms": (
+            {
                 "count": n,
-                "min": round(ordered[0] * 1000, 1),
-                "median": round(ordered[n // 2] * 1000, 1),
-                "max": round(ordered[-1] * 1000, 1),
+                "min": ordered[0],
+                "median": ordered[n // 2],
+                "max": ordered[-1],
             }
-        else:
-            result["partial_response_lag_ms"] = None
-        return result
+            if ordered
+            else None
+        ),
+        "wav": wav_path,
+        "engine": "gigastt",
+        "protocol": {
+            "sample_rate": STREAM_SAMPLE_RATE,
+            "chunk_ms": chunk_ms,
+            "version": STREAM_PROTOCOL_VERSION,
+        },
+    }
 
 
-def evaluate_gigastt(wav_path: str, port: int = 9877) -> dict:
-    return asyncio.run(GigasttLatencyClient(port).measure(wav_path))
+def evaluate_corpus(samples: list[dict], port: int, chunk_ms: int) -> dict:
+    rows = []
+    for idx, sample in enumerate(samples):
+        wav_path = sample["filename"]
+        try:
+            row = evaluate_gigastt(wav_path, port=port, chunk_ms=chunk_ms)
+            row["ok"] = True
+        except Exception as e:
+            print(f"  [{idx + 1}/{len(samples)}] ERROR {Path(wav_path).name}: {e}")
+            row = {
+                "wav": wav_path,
+                "ttfp_ms": None,
+                "ttfs_ms": None,
+                "finalization_lag_ms": None,
+                "timed_out": False,
+                "no_partial": True,
+                "partial_lags_ms": [],
+                "ok": False,
+                "error": str(e),
+            }
+        # summarize_latency reads ttfp_ms / timed_out / no_partial
+        if "ttfp_ms" not in row:
+            row["ttfp_ms"] = row.get("time_to_first_partial_ms")
+        if row.get("partial_response_lag_ms") and "partial_lags_ms" not in row:
+            # single-clip helper stores a summary; corpus rollup wants the list
+            row["partial_lags_ms"] = []
+        rows.append(row)
+        print(
+            f"  [{idx + 1}/{len(samples)}] TTFP={row.get('ttfp_ms')}  "
+            f"TTFS={row.get('ttfs_ms')}  {Path(wav_path).name}"
+        )
+    return {
+        "engine": "gigastt",
+        "port": port,
+        "chunk_ms": chunk_ms,
+        "summary": summarize_latency(rows),
+        "clips": rows,
+    }
 
 
 def main():
     parser = argparse.ArgumentParser(description="Streaming latency benchmark")
-    parser.add_argument("--wav", required=True, help="16kHz mono 16-bit WAV file")
+    parser.add_argument("--wav", help="Single 16 kHz (or resampled) WAV")
+    parser.add_argument("--dataset", help="Manifest name (e.g. golos_crowd)")
+    parser.add_argument("--max-samples", type=int, default=100, help="0 = all (dataset mode)")
     parser.add_argument("--output", default="results_latency.json")
     parser.add_argument("--port", type=int, default=9877)
+    parser.add_argument("--chunk-ms", type=int, default=STREAM_CHUNK_MS)
     args = parser.parse_args()
 
-    result = evaluate_gigastt(args.wav, port=args.port)
-    result["engine"] = "gigastt"
-    result["wav"] = args.wav
+    if bool(args.wav) == bool(args.dataset):
+        parser.error("provide exactly one of --wav or --dataset")
+
+    if args.wav:
+        result = evaluate_gigastt(args.wav, port=args.port, chunk_ms=args.chunk_ms)
+    else:
+        max_samples = args.max_samples if args.max_samples > 0 else None
+        manifest = load_manifest(max_samples=max_samples, dataset=args.dataset)
+        print(f"Loaded {len(manifest['samples'])} samples from '{args.dataset}'")
+        result = evaluate_corpus(manifest["samples"], port=args.port, chunk_ms=args.chunk_ms)
+        result["dataset"] = args.dataset
 
     with open(args.output, "w", encoding="utf-8") as f:
         json.dump(result, f, ensure_ascii=False, indent=2)
-    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print(json.dumps(result if args.wav else result["summary"], ensure_ascii=False, indent=2))
+    print(f"\nWrote {args.output}")
 
 
 if __name__ == "__main__":

--- a/benchmark/results_full/stream_protocol_v1_100.json
+++ b/benchmark/results_full/stream_protocol_v1_100.json
@@ -1,0 +1,48 @@
+{
+  "protocol": "1.0",
+  "measured": "2026-08-14",
+  "machine": "Apple M1 Pro, CPU INT8, rnnt",
+  "note": "First 100 clips of each committed manifest. WER used default --pool-size 2. Latency used --pool-size 1. Not the 1000-row competitor table.",
+  "wer": {
+    "golos_crowd_1k": {
+      "n": 100,
+      "wer_batch": 4.97,
+      "wer_stream": 19.46,
+      "delta_pp": 14.49,
+      "ci_low": 10.91,
+      "ci_high": 18.24,
+      "stream_failures": 2
+    },
+    "golos_farfield": {
+      "n": 100,
+      "wer_batch": 4.82,
+      "wer_stream": 15.42,
+      "delta_pp": 10.6,
+      "ci_low": 6.53,
+      "ci_high": 15.09,
+      "stream_failures": 0
+    }
+  },
+  "latency": {
+    "golos_crowd_1k": {
+      "n": 100,
+      "n_timeout": 0,
+      "n_no_partial": 2,
+      "n_error": 2,
+      "ttfp_ms": {"n": 98, "p50": 1652.5, "p95": 2627.9, "max": 3044.8},
+      "ttfs_ms": {"n": 89, "p50": 802.5, "p95": 2513.7, "max": 3044.8},
+      "partial_lag_ms": {"n": 452, "p50": 51.4, "p95": 100.2, "max": 298.1},
+      "finalization_lag_ms": {"n": 98, "p50": 4284.2, "p95": 7324.9, "max": 10753.8}
+    },
+    "golos_farfield": {
+      "n": 100,
+      "n_timeout": 0,
+      "n_no_partial": 0,
+      "n_error": 0,
+      "ttfp_ms": {"n": 100, "p50": 819.8, "p95": 828.8, "max": 1704.3},
+      "ttfs_ms": {"n": 42, "p50": 500.1, "p95": 656.1, "max": 731.0, "note": "non-negative only; 45 no onset, 13 onset-after-partial dropped"},
+      "partial_lag_ms": {"n": 310, "p50": 41.4, "p95": 113.7, "max": 442.9},
+      "finalization_lag_ms": {"n": 100, "p50": 2786.7, "p95": 5442.6, "max": 7453.9}
+    }
+  }
+}

--- a/benchmark/runners/__init__.py
+++ b/benchmark/runners/__init__.py
@@ -1,6 +1,7 @@
 """ASR benchmark runners."""
 
 from .gigastt import GigasttRunner, GigasttCoreMLRunner
+from .gigastt_stream import GigasttStreamRunner
 from .gigastt_ml_ctc import GigasttMlCtcRunner, GigasttMlCtcLargeRunner
 from .whisper_cpp import WhisperCppRunner
 from .faster_whisper import FasterWhisperRunner
@@ -11,6 +12,7 @@ from .t_one import TOneRunner
 
 __all__ = [
     "GigasttRunner",
+    "GigasttStreamRunner",
     "GigasttCoreMLRunner",
     "GigasttMlCtcRunner",
     "GigasttMlCtcLargeRunner",

--- a/benchmark/runners/gigastt_stream.py
+++ b/benchmark/runners/gigastt_stream.py
@@ -1,0 +1,56 @@
+"""gigastt WebSocket streaming runner (same server as REST, different cache key)."""
+
+from streaming import STREAM_CHUNK_MS, STREAM_PROTOCOL_VERSION, STREAM_SAMPLE_RATE, transcribe_ws
+
+from .gigastt import GIGASTT_CACHE_SCHEMA_VERSION, GigasttRunner
+
+
+class GigasttStreamRunner(GigasttRunner):
+    """Live `/v1/ws` path: real-time 100 ms PCM16 chunks, then Stop.
+
+    Shares process start/stop with :class:`GigasttRunner`. ``name`` and
+    ``cache_config`` differ so REST hypotheses never poison the stream cache.
+    """
+
+    name = "gigastt-stream"
+
+    def __init__(
+        self,
+        model_dir: str | None = None,
+        use_int8: bool = True,
+        port: int = 9877,
+        manage_server: bool = True,
+        pace: bool = True,
+    ):
+        super().__init__(model_dir=model_dir, use_int8=use_int8, port=port)
+        self.manage_server = manage_server
+        self.pace = pace
+
+    @property
+    def cache_config(self) -> str:
+        return (
+            f"{self.model_dir}:{self.use_int8}:{GIGASTT_CACHE_SCHEMA_VERSION}:"
+            f"stream:{STREAM_PROTOCOL_VERSION}:chunk{STREAM_CHUNK_MS}:sr{STREAM_SAMPLE_RATE}"
+        )
+
+    def is_available(self) -> bool:
+        # Do not start a server here. GigasttRunner.is_available() binds
+        # :9877 during runner selection; a second serve on the same port
+        # would race `--mode both` (REST then WS, sequential).
+        return self._find_binary()
+
+    def _start_server(self):
+        if not self.manage_server:
+            return
+        super()._start_server()
+
+    def _stop_server(self):
+        if not self.manage_server:
+            return
+        super()._stop_server()
+
+    def transcribe(self, wav_path: str) -> tuple[str, float]:
+        text, elapsed, _session = transcribe_ws(
+            wav_path, port=self.port, chunk_ms=STREAM_CHUNK_MS, pace=self.pace
+        )
+        return text, elapsed

--- a/benchmark/streaming.py
+++ b/benchmark/streaming.py
@@ -1,0 +1,419 @@
+"""Shared WebSocket streaming protocol for WER and TTFP measurement.
+
+Canonical knobs (do not change without bumping STREAM_PROTOCOL_VERSION and
+rewriting the tables in docs/benchmarks.md):
+
+- 16 kHz mono PCM16 over `/v1/ws`
+- `configure` with `sample_rate=16000` after Ready, before any audio
+- real-time paced `chunk_ms=100` frames
+- TTFP clock starts on the first audio frame (after Ready + configure)
+- empty / whitespace `partial`s are ignored
+- every `final` is kept until the socket closes (mid-stream + Stop flush)
+- a clip with no counted partial before timeout stays in the corpus as `no_partial`
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+import wave
+from pathlib import Path
+from typing import Any, Optional
+
+STREAM_SAMPLE_RATE = 16000
+STREAM_CHUNK_MS = 100
+STREAM_PROTOCOL_VERSION = "1.0"
+
+
+def chunk_pcm16(
+    pcm: bytes,
+    chunk_ms: int = STREAM_CHUNK_MS,
+    sample_rate: int = STREAM_SAMPLE_RATE,
+) -> list[bytes]:
+    """Split mono PCM16 into `chunk_ms` frames (last frame may be short)."""
+    if not pcm:
+        return []
+    frame_bytes = max(1, int(sample_rate * chunk_ms / 1000) * 2)
+    return [pcm[i : i + frame_bytes] for i in range(0, len(pcm), frame_bytes)]
+
+
+def should_count_partial(msg: dict) -> bool:
+    """True for a non-empty `partial`. Empty partials do not start the TTFP clock."""
+    if msg.get("type") != "partial":
+        return False
+    return bool(str(msg.get("text") or "").strip())
+
+
+def join_transcripts(*, finals: list[str], last_partial: str) -> str:
+    """Committed streaming text: finals in order, plus a live tail if it is new.
+
+    After a `final`, the session sets `last_partial` to that same text, so the
+    tail is not double-counted. A later non-empty partial is the next
+    utterance and must be kept if Stop never flushed it (timeout).
+    """
+    parts = [t.strip() for t in finals if t and t.strip()]
+    tail = (last_partial or "").strip()
+    if parts:
+        if tail and tail != parts[-1]:
+            parts.append(tail)
+        return " ".join(parts)
+    return tail
+
+
+def energy_onset_s(
+    pcm: bytes,
+    sample_rate: int = STREAM_SAMPLE_RATE,
+    frame_ms: int = 10,
+    rel_threshold: float = 0.02,
+    abs_threshold: float = 200.0,
+) -> Optional[float]:
+    """First frame whose RMS exceeds a fraction of the clip peak (or `abs_threshold`).
+
+    Used for TTFS (time-to-first-partial after speech onset) without a VAD model.
+    All-silence clips return None.
+    """
+    n = len(pcm) // 2
+    if n == 0:
+        return None
+    samples = struct.unpack("<" + "h" * n, pcm[: n * 2])
+    peak = max(abs(s) for s in samples)
+    if peak == 0:
+        return None
+    thresh = max(abs_threshold, rel_threshold * peak)
+    hop = max(1, int(sample_rate * frame_ms / 1000))
+    for start in range(0, n, hop):
+        window = samples[start : start + hop]
+        if not window:
+            continue
+        mean_sq = sum(s * s for s in window) / len(window)
+        rms = mean_sq**0.5
+        if rms >= thresh:
+            return start / sample_rate
+    return None
+
+
+def percentile(xs: list[float], p: float) -> Optional[float]:
+    """Linear-interpolation percentile. `p` is in [0, 100]. Empty → None."""
+    if not xs:
+        return None
+    ordered = sorted(xs)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    rank = (len(ordered) - 1) * (p / 100.0)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return float(ordered[lo] * (1.0 - frac) + ordered[hi] * frac)
+
+
+def paired_delta(batch_details: list[dict], stream_details: list[dict]) -> dict:
+    """WER_stream − WER_batch on files present in both runs, plus bootstrap CI on Δ."""
+    by_batch = {d["file"]: d for d in batch_details}
+    pairs: list[tuple[int, int, int]] = []
+    for s in stream_details:
+        b = by_batch.get(s["file"])
+        if b is None:
+            continue
+        ref = int(s.get("ref_words") or b.get("ref_words") or 0)
+        pairs.append((ref, int(b.get("errors") or 0), int(s.get("errors") or 0)))
+
+    if not pairs:
+        return {
+            "paired": 0,
+            "wer_batch": 0.0,
+            "wer_stream": 0.0,
+            "delta_pp": 0.0,
+            "ci_low": 0.0,
+            "ci_high": 0.0,
+        }
+
+    ref_sum = sum(p[0] for p in pairs)
+    batch_err = sum(p[1] for p in pairs)
+    stream_err = sum(p[2] for p in pairs)
+    wer_batch = (batch_err / ref_sum * 100.0) if ref_sum else 0.0
+    wer_stream = (stream_err / ref_sum * 100.0) if ref_sum else 0.0
+    delta = wer_stream - wer_batch
+    lo, hi = _bootstrap_delta_ci(pairs)
+    return {
+        "paired": len(pairs),
+        "wer_batch": round(wer_batch, 2),
+        "wer_stream": round(wer_stream, 2),
+        "delta_pp": round(delta, 2),
+        "ci_low": round(lo, 2),
+        "ci_high": round(hi, 2),
+    }
+
+
+def _bootstrap_delta_ci(
+    pairs: list[tuple[int, int, int]],
+    iterations: int = 1000,
+) -> tuple[float, float]:
+    """95% CI for (WER_stream − WER_batch) by resampling paired clips."""
+    n = len(pairs)
+    rng = 123456789
+    mask = (1 << 64) - 1
+    deltas: list[float] = []
+    for _ in range(iterations):
+        ref_sum = 0
+        batch_err = 0
+        stream_err = 0
+        for _ in range(n):
+            rng = (rng * 6364136223846793005 + 1) & mask
+            idx = (rng >> 32) % n
+            ref, b_err, s_err = pairs[idx]
+            ref_sum += ref
+            batch_err += b_err
+            stream_err += s_err
+        if ref_sum == 0:
+            deltas.append(0.0)
+        else:
+            deltas.append((stream_err / ref_sum - batch_err / ref_sum) * 100.0)
+    deltas.sort()
+    return deltas[(iterations * 25) // 1000], deltas[(iterations * 975) // 1000]
+
+
+def summarize_latency(rows: list[dict]) -> dict:
+    """Corpus rollup: p50/p95 TTFP/TTFS/finalization, timeout counts."""
+    ttfp = [r["ttfp_ms"] for r in rows if r.get("ttfp_ms") is not None]
+    ttfs = [
+        r["ttfs_ms"]
+        for r in rows
+        if r.get("ttfs_ms") is not None and r["ttfs_ms"] >= 0
+    ]
+    fin = [r["finalization_lag_ms"] for r in rows if r.get("finalization_lag_ms") is not None]
+    lags: list[float] = []
+    for r in rows:
+        lags.extend(r.get("partial_lags_ms") or [])
+
+    def _block(xs: list[float]) -> dict:
+        return {
+            "n": len(xs),
+            "p50": None if not xs else round(percentile(xs, 50) or 0.0, 1),
+            "p95": None if not xs else round(percentile(xs, 95) or 0.0, 1),
+            "max": None if not xs else round(max(xs), 1),
+        }
+
+    return {
+        "n": len(rows),
+        "n_timeout": sum(1 for r in rows if r.get("timed_out")),
+        "n_no_partial": sum(1 for r in rows if r.get("no_partial")),
+        "n_error": sum(
+            1 for r in rows if r.get("ok") is False and not r.get("timed_out")
+        ),
+        "ttfp_ms": _block(ttfp),
+        "ttfs_ms": _block(ttfs),
+        "finalization_lag_ms": _block(fin),
+        "partial_lag_ms": _block(lags),
+        "protocol": {
+            "sample_rate": STREAM_SAMPLE_RATE,
+            "chunk_ms": STREAM_CHUNK_MS,
+            "version": STREAM_PROTOCOL_VERSION,
+        },
+    }
+
+
+def load_pcm16_16k(path: str) -> tuple[bytes, float]:
+    """Load a WAV as mono PCM16 @ 16 kHz. Returns `(pcm, duration_s)`."""
+    with wave.open(path, "rb") as wf:
+        channels = wf.getnchannels()
+        width = wf.getsampwidth()
+        rate = wf.getframerate()
+        nframes = wf.getnframes()
+        raw = wf.readframes(nframes)
+    if channels == 1 and width == 2 and rate == STREAM_SAMPLE_RATE:
+        return raw, nframes / float(STREAM_SAMPLE_RATE)
+    return _resample_to_pcm16_16k(path)
+
+
+def _resample_to_pcm16_16k(path: str) -> tuple[bytes, float]:
+    try:
+        import numpy as np
+        import soundfile as sf
+    except ImportError as e:
+        raise ValueError(
+            f"{path} is not 16 kHz mono PCM16; install soundfile+numpy to resample"
+        ) from e
+    samples, rate = sf.read(path, always_2d=True, dtype="float32")
+    mono = samples.mean(axis=1)
+    if rate != STREAM_SAMPLE_RATE and len(mono) > 1:
+        n_out = max(1, int(round(len(mono) * STREAM_SAMPLE_RATE / rate)))
+        x = np.linspace(0.0, 1.0, num=len(mono), endpoint=False)
+        xi = np.linspace(0.0, 1.0, num=n_out, endpoint=False)
+        mono = np.interp(xi, x, mono)
+    clipped = np.clip(mono, -1.0, 1.0)
+    pcm = (clipped * 32767.0).astype("<i2").tobytes()
+    return pcm, len(clipped) / float(STREAM_SAMPLE_RATE)
+
+
+async def stream_session(
+    url: str,
+    pcm: bytes,
+    *,
+    chunk_ms: int = STREAM_CHUNK_MS,
+    pace: bool = True,
+    timeout_s: float = 60.0,
+) -> dict[str, Any]:
+    """One WS session: Ready → configure → paced PCM → Stop → collect finals.
+
+    Returns hypothesis text plus latency fields. Does not raise on a missing
+    final: `timed_out` / `no_partial` are set instead so the clip stays in p95.
+    """
+    import websockets
+    from websockets.exceptions import ConnectionClosed
+
+    chunks = chunk_pcm16(pcm, chunk_ms=chunk_ms)
+    duration_s = (len(pcm) // 2) / float(STREAM_SAMPLE_RATE)
+    onset_s = energy_onset_s(pcm)
+
+    first_partial_at: Optional[float] = None
+    final_at: Optional[float] = None
+    last_sent_at: Optional[float] = None
+    partial_lags: list[float] = []
+    finals: list[str] = []
+    last_partial = ""
+    empty_skipped = 0
+    timed_out = False
+    started_at: Optional[float] = None
+    send_done_at: Optional[float] = None
+
+    try:
+        async with websockets.connect(url, open_timeout=min(10.0, timeout_s)) as ws:
+            try:
+                ready_raw = await asyncio.wait_for(ws.recv(), timeout=min(10.0, timeout_s))
+            except asyncio.TimeoutError as e:
+                raise RuntimeError("timed out waiting for Ready") from e
+            ready = json.loads(ready_raw if isinstance(ready_raw, str) else ready_raw.decode())
+            if ready.get("type") != "ready":
+                raise RuntimeError(f"expected Ready, got {ready!r}")
+            await ws.send(json.dumps({"type": "configure", "sample_rate": STREAM_SAMPLE_RATE}))
+
+            async def _read() -> None:
+                # Mid-stream finals are committed utterances (VAD / blank). Stop
+                # then emits one more Final (possibly empty) and closes. Collect
+                # every final until the socket ends — returning on the first one
+                # drops the rest of the clip from WER. The server Breaks after
+                # the Stop Final and may drop TCP without a close frame.
+                nonlocal first_partial_at, final_at, last_partial, empty_skipped
+                try:
+                    async for raw in ws:
+                        now = asyncio.get_running_loop().time()
+                        if isinstance(raw, bytes):
+                            try:
+                                raw = raw.decode()
+                            except UnicodeDecodeError:
+                                continue
+                        try:
+                            obj = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        kind = obj.get("type")
+                        if kind == "partial":
+                            if not should_count_partial(obj):
+                                empty_skipped += 1
+                                continue
+                            last_partial = str(obj.get("text") or "")
+                            if last_sent_at is not None:
+                                partial_lags.append(now - last_sent_at)
+                            if first_partial_at is None:
+                                first_partial_at = now
+                        elif kind == "final":
+                            text = str(obj.get("text") or "").strip()
+                            if text:
+                                finals.append(text)
+                                last_partial = text
+                            final_at = now
+                        elif kind == "error":
+                            raise RuntimeError(
+                                obj.get("message") or obj.get("code") or "ws error"
+                            )
+                except ConnectionClosed:
+                    return
+
+            reader = asyncio.create_task(_read())
+            loop = asyncio.get_running_loop()
+            started_at = loop.time()
+            last_sent_at = started_at
+            try:
+                for chunk in chunks:
+                    await ws.send(chunk)
+                    last_sent_at = loop.time()
+                    if pace:
+                        await asyncio.sleep(chunk_ms / 1000.0)
+                await ws.send(json.dumps({"type": "stop"}))
+                await asyncio.wait_for(reader, timeout=timeout_s)
+            except asyncio.TimeoutError:
+                timed_out = True
+                reader.cancel()
+                try:
+                    await reader
+                except (asyncio.CancelledError, ConnectionClosed):
+                    pass
+            except Exception:
+                reader.cancel()
+                try:
+                    await reader
+                except (asyncio.CancelledError, ConnectionClosed):
+                    pass
+                raise
+            send_done_at = loop.time()
+    except ConnectionClosed:
+        if started_at is None:
+            raise
+
+    ttfp_ms = (
+        round((first_partial_at - started_at) * 1000.0, 1)
+        if first_partial_at is not None and started_at is not None
+        else None
+    )
+    ttfs_ms = None
+    if ttfp_ms is not None and onset_s is not None:
+        raw_ttfs = ttfp_ms - onset_s * 1000.0
+        # Energy onset after the first partial (common on far-field / noise)
+        # is not a latency; leave TTFS unset instead of publishing a negative.
+        if raw_ttfs >= 0:
+            ttfs_ms = round(raw_ttfs, 1)
+    no_partial = first_partial_at is None
+    return {
+        "text": join_transcripts(finals=finals, last_partial=last_partial),
+        "ttfp_ms": ttfp_ms,
+        "ttfs_ms": ttfs_ms,
+        "finalization_lag_ms": (
+            round((final_at - started_at) * 1000.0, 1)
+            if final_at is not None and started_at is not None
+            else None
+        ),
+        "audio_duration_ms": round(duration_s * 1000.0, 1),
+        "total_audio_sent_ms": (
+            round((send_done_at - started_at) * 1000.0, 1) if started_at is not None else None
+        ),
+        "partial_count": len(partial_lags) if first_partial_at is None else max(len(partial_lags), 1),
+        "empty_partials_skipped": empty_skipped,
+        "partial_lags_ms": [round(x * 1000.0, 1) for x in partial_lags],
+        "onset_s": None if onset_s is None else round(onset_s, 3),
+        "timed_out": timed_out,
+        "no_partial": no_partial,
+    }
+
+
+def transcribe_ws(
+    wav_path: str,
+    *,
+    port: int = 9877,
+    chunk_ms: int = STREAM_CHUNK_MS,
+    pace: bool = True,
+) -> tuple[str, float, dict[str, Any]]:
+    """Sync wrapper: `(hypothesis, wall_s, session_metrics)`."""
+    pcm, duration_s = load_pcm16_16k(wav_path)
+    url = f"ws://127.0.0.1:{port}/v1/ws"
+    timeout_s = max(30.0, duration_s + 30.0)
+    import time
+
+    start = time.perf_counter()
+    session = asyncio.run(
+        stream_session(url, pcm, chunk_ms=chunk_ms, pace=pace, timeout_s=timeout_s)
+    )
+    elapsed = time.perf_counter() - start
+    if session["no_partial"] and not session["text"]:
+        raise RuntimeError(f"no streaming transcript for {Path(wav_path).name}")
+    return session["text"], elapsed, session

--- a/benchmark/tests/test_benchmark.py
+++ b/benchmark/tests/test_benchmark.py
@@ -1,5 +1,6 @@
 """Unit tests for benchmark/benchmark.py orchestration."""
 
+import json
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -54,6 +55,95 @@ def _fake_result(name: str = "fake") -> dict:
         "details": [],
         "histograms": {},
     }
+
+
+def test_mode_batch_does_not_select_stream_runner(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    batch = _fake_runner("gigastt")
+    stream = _fake_runner("gigastt-stream")
+    manifest = [{"filename": "a.wav", "reference": "hello"}]
+    fake_result = {**_fake_result(), "samples": 1, "total_ref_words": 1}
+
+    with patch.object(benchmark, "ALL_RUNNERS", [batch, stream]):
+        with patch.object(benchmark, "load_manifest", return_value={"samples": manifest, "skipped_empty_refs": 0}):
+            with patch.object(benchmark, "run_benchmark", return_value=fake_result) as mock_run:
+                with patch.object(sys, "argv", [
+                    "benchmark.py",
+                    "--cache-dir", str(cache_dir),
+                    "--mode", "batch",
+                    "--output", str(tmp_path / "results.json"),
+                    "--max-samples", "1",
+                ]):
+                    benchmark._main()
+    names = [c.args[0].name for c in mock_run.call_args_list]
+    assert names == ["gigastt"]
+
+
+def test_mode_stream_selects_only_stream_runner(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    batch = _fake_runner("gigastt")
+    stream = _fake_runner("gigastt-stream")
+    manifest = [{"filename": "a.wav", "reference": "hello"}]
+    fake_result = {**_fake_result(), "samples": 1, "total_ref_words": 1}
+
+    with patch.object(benchmark, "ALL_RUNNERS", [batch, stream]):
+        with patch.object(benchmark, "load_manifest", return_value={"samples": manifest, "skipped_empty_refs": 0}):
+            with patch.object(benchmark, "run_benchmark", return_value=fake_result) as mock_run:
+                with patch.object(sys, "argv", [
+                    "benchmark.py",
+                    "--cache-dir", str(cache_dir),
+                    "--mode", "stream",
+                    "--output", str(tmp_path / "results.json"),
+                    "--max-samples", "1",
+                ]):
+                    benchmark._main()
+    names = [c.args[0].name for c in mock_run.call_args_list]
+    assert names == ["gigastt-stream"]
+
+
+def test_mode_both_selects_batch_and_stream_and_writes_delta(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    batch = _fake_runner("gigastt")
+    stream = _fake_runner("gigastt-stream")
+    whisper = _fake_runner("whisper_cpp")
+    manifest = [{"filename": "a.wav", "reference": "hello"}]
+    out = tmp_path / "results.json"
+
+    def _run(runner, *_args, **_kwargs):
+        if runner.name == "gigastt":
+            return {
+                **_fake_result("gigastt"),
+                "details": [{"file": "a.wav", "ref_words": 10, "errors": 1, "failed": False}],
+            }
+        if runner.name == "gigastt-stream":
+            return {
+                **_fake_result("gigastt-stream"),
+                "details": [{"file": "a.wav", "ref_words": 10, "errors": 2, "failed": False}],
+            }
+        return _fake_result(runner.name)
+
+    with patch.object(benchmark, "ALL_RUNNERS", [batch, stream, whisper]):
+        with patch.object(benchmark, "load_manifest", return_value={"samples": manifest, "skipped_empty_refs": 0}):
+            with patch.object(benchmark, "run_benchmark", side_effect=_run) as mock_run:
+                with patch.object(sys, "argv", [
+                    "benchmark.py",
+                    "--cache-dir", str(cache_dir),
+                    "--mode", "both",
+                    "--runners", "gigastt",
+                    "--output", str(out),
+                    "--max-samples", "1",
+                ]):
+                    benchmark._main()
+
+    names = [c.args[0].name for c in mock_run.call_args_list]
+    assert names == ["gigastt", "gigastt-stream"]
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["mode"] == "both"
+    assert payload["stream_vs_batch"]["paired"] == 1
+    assert payload["stream_vs_batch"]["delta_pp"] == pytest.approx(10.0)
 
 
 def test_runner_selection_filters_by_name(tmp_path):

--- a/benchmark/tests/test_latency.py
+++ b/benchmark/tests/test_latency.py
@@ -1,0 +1,96 @@
+"""Unit tests for benchmark_latency.py CLI and corpus rollup."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import benchmark_latency
+
+
+def test_main_requires_wav_xor_dataset(tmp_path, capsys):
+    with patch("sys.argv", ["benchmark_latency.py"]):
+        with pytest.raises(SystemExit):
+            benchmark_latency.main()
+    err = capsys.readouterr().err
+    assert "--wav" in err and "--dataset" in err
+
+    with patch("sys.argv", [
+        "benchmark_latency.py",
+        "--wav", "a.wav",
+        "--dataset", "golos_crowd",
+    ]):
+        with pytest.raises(SystemExit):
+            benchmark_latency.main()
+
+
+def test_main_single_wav_writes_legacy_keys(tmp_path):
+    wav = tmp_path / "clip.wav"
+    wav.write_bytes(b"fake")
+    out = tmp_path / "lat.json"
+    session = {
+        "ttfp_ms": 400.0,
+        "ttfs_ms": 200.0,
+        "finalization_lag_ms": 4100.0,
+        "audio_duration_ms": 4000.0,
+        "total_audio_sent_ms": 4050.0,
+        "timed_out": False,
+        "no_partial": False,
+        "onset_s": 0.2,
+        "partial_lags_ms": [80.0, 90.0],
+    }
+
+    with patch.object(benchmark_latency, "transcribe_ws", return_value=("привет", 4.1, session)):
+        with patch("sys.argv", [
+            "benchmark_latency.py",
+            "--wav", str(wav),
+            "--output", str(out),
+            "--port", "9877",
+        ]):
+            benchmark_latency.main()
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["time_to_first_partial_ms"] == 400.0
+    assert payload["ttfp_ms"] == 400.0
+    assert payload["ttfs_ms"] == 200.0
+    assert payload["engine"] == "gigastt"
+    assert payload["partial_response_lag_ms"]["count"] == 2
+    assert payload["protocol"]["version"] == "1.0"
+    assert payload["protocol"]["chunk_ms"] == 100
+
+
+def test_evaluate_corpus_keeps_errors_in_n_not_as_timeouts():
+    samples = [
+        {"filename": "/tmp/a.wav"},
+        {"filename": "/tmp/b.wav"},
+    ]
+    ok = {
+        "ttfp_ms": 500.0,
+        "ttfs_ms": 300.0,
+        "finalization_lag_ms": 4000.0,
+        "timed_out": False,
+        "no_partial": False,
+        "partial_lags_ms": [70.0],
+        "time_to_first_partial_ms": 500.0,
+        "partial_response_lag_ms": {"count": 1, "min": 70.0, "median": 70.0, "max": 70.0},
+        "wav": "/tmp/a.wav",
+        "engine": "gigastt",
+    }
+
+    def _one(path, port=9877, chunk_ms=100):
+        if path.endswith("b.wav"):
+            raise RuntimeError("connection refused")
+        return ok
+
+    with patch.object(benchmark_latency, "evaluate_gigastt", side_effect=_one):
+        result = benchmark_latency.evaluate_corpus(samples, port=9877, chunk_ms=100)
+
+    assert result["summary"]["n"] == 2
+    assert result["summary"]["n_timeout"] == 0
+    assert result["summary"]["n_error"] == 1
+    assert result["summary"]["n_no_partial"] == 1
+    assert result["summary"]["ttfp_ms"]["n"] == 1
+    assert result["clips"][1]["ok"] is False
+    assert result["clips"][1]["timed_out"] is False
+    assert Path(result["clips"][0]["wav"]).name == "a.wav"

--- a/benchmark/tests/test_runner_cache_config.py
+++ b/benchmark/tests/test_runner_cache_config.py
@@ -13,6 +13,32 @@ def test_gigastt_cache_config_excludes_binary_path():
     assert runner.cache_config == f"/models:True:{GIGASTT_CACHE_SCHEMA_VERSION}"
 
 
+def test_gigastt_stream_is_available_does_not_start_server(monkeypatch):
+    from runners.gigastt_stream import GigasttStreamRunner
+
+    runner = GigasttStreamRunner(model_dir="/models", use_int8=True)
+    started = []
+    monkeypatch.setattr(runner, "_find_binary", lambda: True)
+    monkeypatch.setattr(runner, "_start_server", lambda: started.append("start"))
+    assert runner.is_available() is True
+    assert started == []
+
+
+def test_gigastt_stream_cache_config_differs_from_rest():
+    from runners.gigastt import GIGASTT_CACHE_SCHEMA_VERSION, GigasttRunner
+    from runners.gigastt_stream import GigasttStreamRunner
+    from streaming import STREAM_CHUNK_MS, STREAM_PROTOCOL_VERSION, STREAM_SAMPLE_RATE
+
+    rest = GigasttRunner(model_dir="/models", use_int8=True)
+    stream = GigasttStreamRunner(model_dir="/models", use_int8=True)
+    assert stream.name == "gigastt-stream"
+    assert stream.cache_config != rest.cache_config
+    assert stream.cache_config == (
+        f"/models:True:{GIGASTT_CACHE_SCHEMA_VERSION}:"
+        f"stream:{STREAM_PROTOCOL_VERSION}:chunk{STREAM_CHUNK_MS}:sr{STREAM_SAMPLE_RATE}"
+    )
+
+
 def test_faster_whisper_cache_config_includes_params():
     from runners.faster_whisper import FasterWhisperRunner
 
@@ -42,7 +68,7 @@ def test_vosk_054_cache_config_is_model_name(tmp_path):
     from runners.vosk_054 import Vosk054Runner
 
     runner = Vosk054Runner(model_name="vosk-model-ru-0.54", download_dir=str(tmp_path))
-    assert runner.cache_config == "vosk-model-ru-0.54"
+    assert runner.cache_config == "vosk-model-ru-0.54:audio-load-v2"
 
 
 def test_t_one_cache_config_reflects_env(monkeypatch):

--- a/benchmark/tests/test_streaming.py
+++ b/benchmark/tests/test_streaming.py
@@ -1,0 +1,296 @@
+"""Unit tests for the streaming WER / TTFP protocol helpers."""
+
+import asyncio
+import json
+import struct
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+
+from streaming import (
+    STREAM_CHUNK_MS,
+    STREAM_SAMPLE_RATE,
+    chunk_pcm16,
+    energy_onset_s,
+    join_transcripts,
+    paired_delta,
+    percentile,
+    should_count_partial,
+    stream_session,
+    summarize_latency,
+)
+
+
+def _pcm16_silence(n_samples: int) -> bytes:
+    return b"\x00\x00" * n_samples
+
+
+def _pcm16_tone(n_samples: int, amplitude: int = 8000) -> bytes:
+    return struct.pack("<" + "h" * n_samples, *([amplitude] * n_samples))
+
+
+def test_chunk_pcm16_splits_on_100ms_frames():
+    # 0.35 s @ 16 kHz = 5600 samples → 3 full 100 ms chunks + 50 ms remainder.
+    pcm = _pcm16_silence(5600)
+    chunks = chunk_pcm16(pcm, chunk_ms=100)
+    assert [len(c) for c in chunks] == [3200, 3200, 3200, 1600]
+
+
+def test_chunk_pcm16_empty_is_empty():
+    assert chunk_pcm16(b"") == []
+
+
+def test_should_count_partial_skips_empty_and_whitespace():
+    assert should_count_partial({"type": "partial", "text": ""}) is False
+    assert should_count_partial({"type": "partial", "text": "   "}) is False
+    assert should_count_partial({"type": "partial", "text": "привет"}) is True
+    assert should_count_partial({"type": "final", "text": "привет"}) is False
+
+
+def test_join_transcripts_prefers_finals_in_order():
+    text = join_transcripts(
+        finals=["шестьдесят тысяч", "тенге"],
+        last_partial="тенге",
+    )
+    assert text == "шестьдесят тысяч тенге"
+
+
+def test_join_transcripts_appends_live_tail_after_final():
+    text = join_transcripts(
+        finals=["шестьдесят тысяч"],
+        last_partial="тенге",
+    )
+    assert text == "шестьдесят тысяч тенге"
+
+
+def test_join_transcripts_falls_back_to_last_partial():
+    assert join_transcripts(finals=[], last_partial="  привет мир  ") == "привет мир"
+    assert join_transcripts(finals=[], last_partial="") == ""
+
+
+def test_energy_onset_finds_first_speech_frame():
+    # 200 ms silence + 100 ms tone @ 16 kHz.
+    pcm = _pcm16_silence(3200) + _pcm16_tone(1600)
+    onset = energy_onset_s(pcm)
+    assert onset is not None
+    assert 0.18 <= onset <= 0.22
+
+
+def test_energy_onset_all_silence_is_none():
+    assert energy_onset_s(_pcm16_silence(1600)) is None
+
+
+def test_percentile_p50_p95():
+    xs = [float(i) for i in range(1, 101)]
+    assert percentile(xs, 50) == pytest.approx(50.5, abs=0.6)
+    assert percentile(xs, 95) == pytest.approx(95.05, abs=1.0)
+    assert percentile([], 50) is None
+
+
+def test_paired_delta_stream_minus_batch():
+    batch = [
+        {"file": "a.wav", "ref_words": 10, "errors": 1, "failed": False},
+        {"file": "b.wav", "ref_words": 10, "errors": 0, "failed": False},
+    ]
+    stream = [
+        {"file": "a.wav", "ref_words": 10, "errors": 2, "failed": False},
+        {"file": "b.wav", "ref_words": 10, "errors": 1, "failed": False},
+    ]
+    delta = paired_delta(batch, stream)
+    assert delta["paired"] == 2
+    assert delta["wer_batch"] == pytest.approx(5.0)
+    assert delta["wer_stream"] == pytest.approx(15.0)
+    assert delta["delta_pp"] == pytest.approx(10.0)
+    assert delta["ci_low"] <= delta["delta_pp"] <= delta["ci_high"]
+
+
+def test_paired_delta_skips_unmatched_files():
+    batch = [{"file": "a.wav", "ref_words": 4, "errors": 0, "failed": False}]
+    stream = [{"file": "b.wav", "ref_words": 4, "errors": 1, "failed": False}]
+    delta = paired_delta(batch, stream)
+    assert delta["paired"] == 0
+    assert delta["delta_pp"] == 0.0
+
+
+def test_summarize_latency_reports_p50_p95_and_timeouts():
+    rows = [
+        {"ttfp_ms": 400.0, "ttfs_ms": 200.0, "finalization_lag_ms": 4100.0, "timed_out": False, "no_partial": False},
+        {"ttfp_ms": 800.0, "ttfs_ms": 300.0, "finalization_lag_ms": 4200.0, "timed_out": False, "no_partial": False},
+        {"ttfp_ms": 1200.0, "ttfs_ms": 400.0, "finalization_lag_ms": 4300.0, "timed_out": False, "no_partial": False},
+        {"ttfp_ms": None, "ttfs_ms": None, "finalization_lag_ms": None, "timed_out": True, "no_partial": True},
+    ]
+    summary = summarize_latency(rows)
+    assert summary["n"] == 4
+    assert summary["n_timeout"] == 1
+    assert summary["n_no_partial"] == 1
+    assert summary["n_error"] == 0
+    assert summary["ttfp_ms"]["n"] == 3
+    assert summary["ttfp_ms"]["p50"] == pytest.approx(800.0, abs=1.0)
+    assert summary["ttfp_ms"]["p95"] >= summary["ttfp_ms"]["p50"]
+    assert STREAM_CHUNK_MS == 100
+    assert STREAM_SAMPLE_RATE == 16000
+
+
+def test_summarize_latency_drops_negative_ttfs():
+    rows = [
+        {"ttfp_ms": 800.0, "ttfs_ms": 200.0, "finalization_lag_ms": 4000.0, "timed_out": False, "no_partial": False},
+        {"ttfp_ms": 800.0, "ttfs_ms": -300.0, "finalization_lag_ms": 4000.0, "timed_out": False, "no_partial": False},
+    ]
+    summary = summarize_latency(rows)
+    assert summary["ttfs_ms"]["n"] == 1
+    assert summary["ttfs_ms"]["p50"] == pytest.approx(200.0, abs=0.1)
+
+
+class _ScriptedWS:
+    """Minimal websockets stand-in: Ready, then scripted replies as audio/Stop arrive."""
+
+    def __init__(self, *, hang_after_stop: bool = False, error_after_audio: bool = False):
+        self.sent: list = []
+        self._out: asyncio.Queue = asyncio.Queue()
+        self._audio = 0
+        self._hang_after_stop = hang_after_stop
+        self._error_after_audio = error_after_audio
+        self._out.put_nowait(
+            json.dumps(
+                {
+                    "type": "ready",
+                    "model": "mock",
+                    "sample_rate": 16000,
+                    "version": "1.0",
+                    "max_session_secs": 0,
+                    "idle_timeout_secs": 300,
+                }
+            )
+        )
+
+    async def recv(self):
+        return await self._out.get()
+
+    async def send(self, data):
+        self.sent.append(data)
+        if isinstance(data, (bytes, bytearray)):
+            self._audio += 1
+            if self._audio == 1:
+                await self._out.put(json.dumps({"type": "partial", "text": "   "}))
+                await self._out.put(json.dumps({"type": "partial", "text": "шестьдесят"}))
+            elif self._audio == 2:
+                await self._out.put(json.dumps({"type": "final", "text": "шестьдесят тысяч"}))
+            if self._error_after_audio and self._audio == 1:
+                await self._out.put(json.dumps({"type": "error", "code": "inference_error", "message": "boom"}))
+            return
+        try:
+            obj = json.loads(data)
+        except (TypeError, json.JSONDecodeError):
+            return
+        if obj.get("type") == "stop" and not self._hang_after_stop:
+            await self._out.put(json.dumps({"type": "final", "text": "тенге"}))
+            await self._out.put(None)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        item = await self._out.get()
+        if item is None:
+            raise StopAsyncIteration
+        return item
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _patch_connect(ws: _ScriptedWS):
+    @asynccontextmanager
+    async def _connect(*_args, **_kwargs):
+        yield ws
+
+    return _connect
+
+
+def test_stream_session_collects_midstream_and_stop_finals():
+    ws = _ScriptedWS()
+    pcm = _pcm16_tone(1600 * 3)
+
+    with patch("websockets.connect", _patch_connect(ws)):
+        result = asyncio.run(stream_session("ws://127.0.0.1:9/v1/ws", pcm, pace=False, timeout_s=2.0))
+
+    assert result["text"] == "шестьдесят тысяч тенге"
+    assert result["empty_partials_skipped"] == 1
+    assert result["ttfp_ms"] is not None
+    assert result["timed_out"] is False
+    assert result["no_partial"] is False
+    assert any(isinstance(s, (bytes, bytearray)) for s in ws.sent)
+    stop_msgs = [json.loads(s) for s in ws.sent if isinstance(s, str)]
+    assert {"type": "configure", "sample_rate": 16000} in stop_msgs
+    assert {"type": "stop"} in stop_msgs
+
+
+def test_stream_session_timeout_keeps_clip_in_corpus():
+    ws = _ScriptedWS(hang_after_stop=True)
+    pcm = _pcm16_tone(1600)
+
+    with patch("websockets.connect", _patch_connect(ws)):
+        result = asyncio.run(stream_session("ws://127.0.0.1:9/v1/ws", pcm, pace=False, timeout_s=0.05))
+
+    assert result["timed_out"] is True
+    assert result["text"] == "шестьдесят"
+    assert result["no_partial"] is False
+
+
+def test_stream_session_ready_timeout_raises():
+    class _HangReady:
+        async def recv(self):
+            await asyncio.sleep(10)
+
+        async def send(self, data):
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    @asynccontextmanager
+    async def _connect(*_args, **_kwargs):
+        yield _HangReady()
+
+    with patch("websockets.connect", _connect):
+        with pytest.raises(RuntimeError, match="Ready"):
+            asyncio.run(
+                stream_session("ws://127.0.0.1:9/v1/ws", _pcm16_tone(1600), pace=False, timeout_s=0.05)
+            )
+
+
+def test_stream_session_treats_unclean_close_as_end():
+    """Server Stop path often drops TCP without a close frame."""
+    from websockets.exceptions import ConnectionClosedError
+
+    class _CloseAfterStop(_ScriptedWS):
+        async def __anext__(self):
+            item = await self._out.get()
+            if item is None:
+                raise ConnectionClosedError(None, None)
+            return item
+
+    ws = _CloseAfterStop()
+    pcm = _pcm16_tone(1600 * 3)
+
+    with patch("websockets.connect", _patch_connect(ws)):
+        result = asyncio.run(stream_session("ws://127.0.0.1:9/v1/ws", pcm, pace=False, timeout_s=2.0))
+
+    assert result["text"] == "шестьдесят тысяч тенге"
+    assert result["timed_out"] is False
+
+
+def test_stream_session_error_raises():
+    ws = _ScriptedWS(error_after_audio=True)
+    pcm = _pcm16_tone(1600)
+
+    with patch("websockets.connect", _patch_connect(ws)):
+        with pytest.raises(RuntimeError, match="boom"):
+            asyncio.run(stream_session("ws://127.0.0.1:9/v1/ws", pcm, pace=False, timeout_s=1.0))

--- a/crates/gigastt-core/src/inference/engine/tests/paths.rs
+++ b/crates/gigastt-core/src/inference/engine/tests/paths.rs
@@ -9,7 +9,9 @@ use crate::vad::VadConfig;
 #[test]
 fn test_engine_config_getters_and_builders() {
     let (engine, _tmp) = test_support::rnnt_engine();
-    assert!(engine.is_int8());
+    // Candle ignores the INT8 ONNX encoder and loads FP32 safetensors, so
+    // `Engine::load` reports `is_int8() == false` under that feature.
+    assert_eq!(engine.is_int8(), !cfg!(feature = "candle"));
     assert_eq!(engine.variant(), ModelVariant::Rnnt);
     assert_eq!(engine.vocab_size(), 2);
     assert!(!engine.has_punctuator());

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -250,14 +250,99 @@ extra slot) sits below Vosk 0.54 (560 MB) and T-one greedy (672 MB). The
 resident figure is what to budget: RSS counts the shared memory-mapped model,
 whose pages the OS reclaims under pressure.
 
-## Streaming latency
+## Streaming measurement protocol
 
-Only gigastt exposes genuine incremental WebSocket streaming. Measured on `golos_00.wav`
-(4 s, fed in real time, timer from connect): **TTFP ~782 ms (CPU) / ~693 ms (CoreML)**.
-This is *buffered/chunked over an offline RNN-T*, not a natively streaming acoustic model
-— the win is "true incremental partials from a single embedded binary" vs Whisper's
-no-streaming, **not** a sub-second-latency claim. Vosk-server and T-one (300 ms chunks)
-are also genuine streaming designs.
+Streaming is **buffered/chunked over an offline RNN-T**, not a native streaming AM.
+Encoder geometry (do not change without a new protocol version): stride **0.8 s**,
+max window **2.5 s**, left context **1.5 s**. The first decode cannot run before
+~0.8 s of new audio, so end-to-end TTFP cannot honestly be “sub-200 ms” on this path.
+
+**Client (canonical, `STREAM_PROTOCOL_VERSION = 1.0`):**
+
+1. Connect `GET /v1/ws`. Wait for `Ready`.
+2. Send `{"type":"configure","sample_rate":16000}` **before** any audio.
+3. Feed **16 kHz mono PCM16**, `chunk_ms=100`, real-time `sleep` between frames.
+4. Start the TTFP clock on the **first audio frame** (after Ready + configure), not on connect.
+5. Ignore empty / whitespace `partial`s. They do not start the clock.
+6. Send `{"type":"stop"}` at EOF. Keep every `final` until the socket ends (mid-stream utterances + Stop flush); join them in order, then append a live partial only if it is not the last final. The Stop handler may drop TCP without a close frame — that is session end, not a dropped clip.
+7. A clip with no counted partial before timeout stays in the corpus as `n` / `n_timeout` / `n_no_partial`. **p50/p95 are over observed TTFPs only** (a missing partial is not imputed). Quote `n_timeout` next to p95.
+8. Warm server, INT8, CPU. Published latency rows use `--pool-size 1`. WER `--mode both` starts `serve` with the default `--pool-size 2`; do not mix those rows with the latency table. Stream RTF in `benchmark.py` is paced wall-clock (~1.0+), not encoder compute.
+
+Commands:
+
+```sh
+# Streaming WER vs the same REST batch path (same files, same normalizer)
+cd benchmark
+python benchmark.py --mode both --runners gigastt --dataset golos_crowd --max-samples 100 \
+  --output results_stream_wer.json
+
+# TTFP / TTFS p50–p95 (server must already be up)
+gigastt serve --port 9877 --pool-size 1
+python benchmark_latency.py --dataset golos_crowd --max-samples 100 \
+  --port 9877 --output results_latency_corpus.json
+```
+
+`--mode batch` is the historical REST table (default). `--mode stream` is WebSocket only.
+`--mode both` prints **Δ = WER_stream − WER_batch** with a bootstrap 95% CI on the paired clips.
+
+### Streaming vs batch WER
+
+First **100** clips of each committed manifest (not the 1000-row competitor table
+above). Apple M1 Pro, CPU INT8, `rnnt`. WER `--mode both` uses default
+`--pool-size 2`. Same files, same normalizer. Measured 2026-08-14.
+Summary artifact:
+[`benchmark/results_full/stream_protocol_v1_100.json`](../benchmark/results_full/stream_protocol_v1_100.json).
+
+| Dataset | n | WER_batch | WER_stream | Δ pp (stream − batch) | 95% CI on Δ |
+|---|--:|--:|--:|--:|---|
+| `golos_crowd_1k` | 100 | 4.97 | 19.46 | **+14.49** | [10.91, 18.24] |
+| `golos_farfield` | 100 | 4.82 | 15.42 | **+10.60** | [6.53, 15.09] |
+
+Crowd: 2 stream clips produced no transcript (counted as 100% WER). Farfield: 0
+timeouts. Typical stream errors are dropped / truncated words (`сколько` →
+`сколь`, long commands collapsed to a prefix), not substitutions of a full
+sentence.
+
+This 100-clip batch WER (4.97 / 4.82) is a **different n** from the 1000-row
+table (3.55 / 4.08). Do not splice them. The Δ is the number that matters:
+**streaming currently costs about 11–15 pp** on these slices.
+
+A single-file guard still exists: `crates/gigastt-core/tests/streaming_quality.rs` (`golos_00`, word overlap ≥ 0.5). That is not a corpus WER.
+
+### Streaming latency (p50 / p95)
+
+Older single-clip smoke (`golos_00.wav`, 4 s, real-time, timer from first audio):
+**TTFP ~782 ms (CPU) / ~693 ms (CoreML)**. That number is dominated by *where the first word
+falls* plus the 0.8 s stride — not by encoder compute (~70–100 ms/chunk).
+
+Corpus (same protocol, Apple M1 Pro, CPU INT8, warm `--pool-size 1`, 2026-08-14).
+p50/p95 are over **observed** values only. `n_timeout` / `n_no_partial` /
+`n_error` stay in the experiment count.
+
+**`golos_crowd_1k`** (n=100; 2 clips no partial / harness error):
+
+| Metric | n | p50 | p95 | max | notes |
+|---|--:|--:|--:|--:|---|
+| TTFP (first audio → first non-empty partial) | 98 | 1653 | 2628 | 3045 | clip-start; 0.8 s stride buckets |
+| TTFS (energy onset → first partial) | 89 | 803 | 2514 | 3045 | 11 clips had no onset |
+| Partial lag (send → partial) | 452 | 51 | 100 | 298 | compute + queue |
+| Finalization lag (first audio → final) | 98 | 4284 | 7325 | 10754 | includes clip duration |
+
+**`golos_farfield`** (n=100; 0 timeouts):
+
+| Metric | n | p50 | p95 | max | notes |
+|---|--:|--:|--:|--:|---|
+| TTFP | 100 | 820 | 829 | 1704 | almost all first-stride |
+| TTFS | 42 | 500 | 656 | 731 | 45 no onset; 13 dropped (onset after partial) |
+| Partial lag | 310 | 41 | 114 | 443 | compute + queue |
+| Finalization lag | 100 | 2787 | 5443 | 7454 | includes clip duration |
+
+TTFP p50 is **0.82 s (far-field) / 1.65 s (crowd)** — first-word position plus
+the 0.8 s stride, not encoder compute. Per-partial lag p50 is **41–51 ms**,
+p95 ~100–114 ms. Negative TTFS (energy onset after the first partial) is
+dropped from the percentile, not imputed.
+
+Vosk-server and T-one (300 ms chunks) are also genuine streaming designs. Whisper engines are offline. gigastt’s streaming win vs Whisper is incremental partials from one binary, **not** a lowest-latency claim, and **not** batch-equal WER on the live path.
 
 ## Edge / Raspberry Pi
 


### PR DESCRIPTION
## Summary

Streaming accuracy and latency are now measured, not claimed.

- **Protocol 1.0:** `/v1/ws`, 16 kHz PCM16, 100 ms real-time chunks, TTFP clock starts on the first audio frame after Ready+configure, empty partials ignored, all finals until socket close.
- **`benchmark.py --mode batch|stream|both`:** paired **Δ = WER_stream − WER_batch** with bootstrap 95% CI. Stream cache key is distinct from REST.
- **`benchmark_latency.py --dataset`:** TTFP / TTFS / partial-lag / finalization p50–p95. Timeouts stay in `n`; percentiles are over observed values only.
- CI job `Benchmark harness tests` runs the new pytest files (no model).

## First 100-clip numbers (M1 Pro, CPU INT8, `rnnt`)

| Dataset | n | WER_batch | WER_stream | Δ pp | 95% CI on Δ |
|---|--:|--:|--:|--:|---|
| `golos_crowd_1k` | 100 | 4.97 | 19.46 | **+14.49** | [10.91, 18.24] |
| `golos_farfield` | 100 | 4.82 | 15.42 | **+10.60** | [6.53, 15.09] |

| Dataset | TTFP p50 / p95 | TTFS p50 / p95 | partial lag p50 / p95 |
|---|---|---|---|
| crowd | 1653 / 2628 ms | 803 / 2514 ms | 51 / 100 ms |
| far-field | 820 / 829 ms | 500 / 656 ms | 41 / 114 ms |

TTFP is stride + first-word position, not encoder compute. Streaming currently costs **~11–15 pp WER** on these slices (truncated / dropped words). Artifact: `benchmark/results_full/stream_protocol_v1_100.json`.

This 100-clip batch WER is a different *n* from the published 1000-row table. Do not splice them.

## Test plan

- [x] `pytest` harness: 89 passed locally (`benchmark/tests`)
- [x] Live smoke on `golos_00.wav` (TTFP ~792 ms, unclean Stop close handled)
- [x] 100-clip crowd + far-field WER `--mode both`
- [x] 100-clip crowd + far-field latency (`--pool-size 1`)
- [x] pre-commit: fmt, clippy, unit+bin tests

Stride / window optimization is **not** in this PR. Measure first.