### PR TITLE
fix(ci): rust 1.98 clippy and h2 RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1091,7 +1091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1739,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2537,7 +2537,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3473,7 +3473,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3532,7 +3532,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3852,7 +3852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4186,7 +4186,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5165,7 +5165,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/gigastt-core/src/inference/audio/pcm.rs
+++ b/crates/gigastt-core/src/inference/audio/pcm.rs
@@ -45,8 +45,8 @@ pub fn parse_pcm16_with_carry_into(data: &[u8], pending: &mut Option<u8>, out: &
         }
     } else {
         out.reserve(data.len() / 2);
-        for chunk in data.chunks_exact(2) {
-            out.push(i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / 32768.0);
+        for chunk in data.as_chunks::<2>().0 {
+            out.push(i16::from_le_bytes(*chunk) as f32 / 32768.0);
         }
     }
 }

--- a/crates/gigastt-core/src/inference/audio/tests/opus.rs
+++ b/crates/gigastt-core/src/inference/audio/tests/opus.rs
@@ -276,8 +276,10 @@ fn test_decode_audio_bytes_opus_ogg_matches_ffmpeg_reference() {
     let reference_pcm = include_bytes!("../../../../tests/fixtures/opus/opus_tone_ffmpeg.pcm");
     let ours = decode_audio_bytes(ogg).expect("OGG/Opus must decode");
     let reference: Vec<f32> = reference_pcm
-        .chunks_exact(2)
-        .map(|c| f32::from(i16::from_le_bytes([c[0], c[1]])) / 32768.0)
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| f32::from(i16::from_le_bytes(*c)) / 32768.0)
         .collect();
     // 3 s of tone at 16 kHz; the untrimmed pre-skip on our side and the
     // resampler's FIR delay shift the exact count by a few hundred.
@@ -304,8 +306,10 @@ fn test_decode_audio_bytes_opus_code3_multiframe_matches_ffmpeg_reference() {
     let reference_pcm = include_bytes!("../../../../tests/fixtures/opus/opus_tone_60ms_ffmpeg.pcm");
     let ours = decode_audio_bytes(ogg).expect("multi-frame OGG/Opus must decode");
     let reference: Vec<f32> = reference_pcm
-        .chunks_exact(2)
-        .map(|c| f32::from(i16::from_le_bytes([c[0], c[1]])) / 32768.0)
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| f32::from(i16::from_le_bytes(*c)) / 32768.0)
         .collect();
     assert!(
         ours.len() > 46_000 && ours.len() < 50_000,
@@ -332,8 +336,10 @@ fn test_decode_audio_bytes_webm_opus_live_matches_ffmpeg_reference() {
         include_bytes!("../../../../tests/fixtures/opus/opus_tone_webm_live_ffmpeg.pcm");
     let ours = decode_audio_bytes(webm).expect("live WebM/Opus must decode");
     let reference: Vec<f32> = reference_pcm
-        .chunks_exact(2)
-        .map(|c| f32::from(i16::from_le_bytes([c[0], c[1]])) / 32768.0)
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| f32::from(i16::from_le_bytes(*c)) / 32768.0)
         .collect();
     assert!(
         ours.len() > 46_000 && ours.len() < 50_000,

--- a/crates/gigastt-core/src/inference/audio/tests/stream.rs
+++ b/crates/gigastt-core/src/inference/audio/tests/stream.rs
@@ -9,8 +9,10 @@ fn fixture_tone_pcm() -> Vec<i16> {
     let wav = include_bytes!("../../../../tests/fixtures/telephony/tone_src.wav");
     let data = crate::inference::audio::telephony::find_riff_chunk(wav, b"data")
         .expect("fixture data chunk");
-    data.chunks_exact(2)
-        .map(|b| i16::from_le_bytes([b[0], b[1]]))
+    data.as_chunks::<2>()
+        .0
+        .iter()
+        .map(|b| i16::from_le_bytes(*b))
         .collect()
 }
 

--- a/crates/gigastt-core/src/inference/audio/tests/telephony.rs
+++ b/crates/gigastt-core/src/inference/audio/tests/telephony.rs
@@ -220,8 +220,10 @@ fn test_decode_audio_bytes_g722_wav_ffmpeg_fixture_matches_reference() {
     let reference_pcm = include_bytes!("../../../../tests/fixtures/telephony/g722_tone_ffmpeg.pcm");
     let ours = decode_audio_bytes(wav).expect("ffmpeg G.722 WAV must decode");
     let reference: Vec<f32> = reference_pcm
-        .chunks_exact(2)
-        .map(|c| f32::from(i16::from_le_bytes([c[0], c[1]])) / 32768.0)
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| f32::from(i16::from_le_bytes(*c)) / 32768.0)
         .collect();
     assert_eq!(
         ours.len(),

--- a/crates/gigastt-core/src/runtime/coreml/bridge/tests.rs
+++ b/crates/gigastt-core/src/runtime/coreml/bridge/tests.rs
@@ -140,8 +140,10 @@ fn read_f32(path: &Path) -> Vec<f32> {
     let bytes = fs::read(path).expect("read f32 file");
     assert_eq!(bytes.len() % 4, 0, "f32 file length not a multiple of 4");
     bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|c| f32::from_le_bytes(*c))
         .collect()
 }
 

--- a/crates/gigastt-ffi/src/lib.rs
+++ b/crates/gigastt-ffi/src/lib.rs
@@ -392,8 +392,10 @@ pub unsafe extern "C" fn gigastt_stream_process_chunk(
     // Convert PCM16 LE bytes → f32 samples.
     let bytes = unsafe { std::slice::from_raw_parts(pcm16_bytes, len) };
     let pcm16: Vec<i16> = bytes
-        .chunks_exact(2)
-        .map(|c| i16::from_le_bytes([c[0], c[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| i16::from_le_bytes(*c))
         .collect();
     let mut samples_f32: Vec<f32> = pcm16.iter().map(|&s| s as f32 / 32768.0).collect();
 

--- a/crates/gigastt-node/src/lib.rs
+++ b/crates/gigastt-node/src/lib.rs
@@ -239,8 +239,10 @@ impl Task for ProcessChunkTask {
 
         let mut samples: Vec<f32> = self
             .pcm16
-            .chunks_exact(2)
-            .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| i16::from_le_bytes(*c) as f32 / 32768.0)
             .collect();
 
         if self.sample_rate != 16000 {

--- a/crates/gigastt-quantize/src/tests.rs
+++ b/crates/gigastt-quantize/src/tests.rs
@@ -565,8 +565,10 @@ fn test_quantize_model_conv_chain() {
         .raw_data
         .as_deref()
         .unwrap()
-        .chunks_exact(8)
-        .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
+        .as_chunks::<8>()
+        .0
+        .iter()
+        .map(|c| i64::from_le_bytes(*c))
         .collect();
     assert_eq!(shape_vals, vec![1, c_out, 1]);
 }

--- a/crates/gigastt-quantize/src/weights.rs
+++ b/crates/gigastt-quantize/src/weights.rs
@@ -29,8 +29,8 @@ pub(crate) fn extract_float_data(tensor: &TensorProto) -> Result<Vec<f32>> {
         );
         let num_floats = raw.len() / 4;
         let mut data = Vec::with_capacity(num_floats);
-        for chunk in raw.chunks_exact(4) {
-            data.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+        for chunk in raw.as_chunks::<4>().0 {
+            data.push(f32::from_le_bytes(*chunk));
         }
         return Ok(data);
     }

--- a/crates/gigastt-uniffi/src/lib.rs
+++ b/crates/gigastt-uniffi/src/lib.rs
@@ -199,8 +199,10 @@ impl Stream {
         let StreamInner { state, reservation } = &mut *guard;
 
         let mut samples: Vec<f32> = pcm16
-            .chunks_exact(2)
-            .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| i16::from_le_bytes(*c) as f32 / 32768.0)
             .collect();
 
         if sample_rate != 16000 {

--- a/crates/gigastt/src/server/http/error.rs
+++ b/crates/gigastt/src/server/http/error.rs
@@ -9,14 +9,69 @@ use super::super::config::{RuntimeLimits, pool_retry_after_ms, pool_retry_after_
 /// Error response produced by the REST handlers. Using `Response` directly
 /// (rather than a `(StatusCode, Json<_>)` tuple) lets timeout paths attach
 /// a `Retry-After` header without changing the handler signatures.
-pub(super) type ApiError = Response;
+///
+/// Boxed so `Result<T, ApiError>` stays under clippy's `result_large_err`
+/// threshold (`Response` is ≥128 bytes on axum 0.8).
+pub struct ApiError(Box<Response>);
+
+impl ApiError {
+    pub(super) fn from_response(response: Response) -> Self {
+        Self(Box::new(response))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_parts(self) -> (axum::http::response::Parts, axum::body::Body) {
+        (*self.0).into_parts()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_body(self) -> axum::body::Body {
+        (*self.0).into_body()
+    }
+}
+
+impl std::fmt::Debug for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiError")
+            .field("status", &self.0.status())
+            .finish()
+    }
+}
+
+impl std::ops::Deref for ApiError {
+    type Target = Response;
+
+    fn deref(&self) -> &Response {
+        &self.0
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        *self.0
+    }
+}
+
+impl From<Response> for ApiError {
+    fn from(response: Response) -> Self {
+        Self::from_response(response)
+    }
+}
+
+impl From<Box<Response>> for ApiError {
+    fn from(response: Box<Response>) -> Self {
+        Self(response)
+    }
+}
 
 pub(super) fn api_error(status: StatusCode, msg: &str, code: &str) -> ApiError {
-    (
-        status,
-        Json(serde_json::json!({"error": msg, "code": code})),
+    ApiError::from_response(
+        (
+            status,
+            Json(serde_json::json!({"error": msg, "code": code})),
+        )
+            .into_response(),
     )
-        .into_response()
 }
 
 /// 503 response for pool-saturation backpressure: carries both the standard
@@ -24,33 +79,37 @@ pub(super) fn api_error(status: StatusCode, msg: &str, code: &str) -> ApiError {
 /// `retry_after_ms` field in the JSON body so clients on either surface can
 /// back off with the same hint.
 pub(super) fn api_timeout_error(limits: &RuntimeLimits) -> ApiError {
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        [(
-            header::RETRY_AFTER,
-            pool_retry_after_secs(limits).to_string(),
-        )],
-        Json(serde_json::json!({
-            "error": "Server busy, try again later",
-            "code": "timeout",
-            "retry_after_ms": pool_retry_after_ms(limits),
-        })),
+    ApiError::from_response(
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(
+                header::RETRY_AFTER,
+                pool_retry_after_secs(limits).to_string(),
+            )],
+            Json(serde_json::json!({
+                "error": "Server busy, try again later",
+                "code": "timeout",
+                "retry_after_ms": pool_retry_after_ms(limits),
+            })),
+        )
+            .into_response(),
     )
-        .into_response()
 }
 
 /// 503 response for the case where the pool was closed (graceful shutdown
 /// in progress). Distinct from `timeout` so clients can decide whether to
 /// retry: a closed pool is not coming back, so no `retry_after_ms` hint.
 pub(super) fn api_pool_closed_error() -> ApiError {
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(serde_json::json!({
-            "error": "Server is shutting down",
-            "code": "pool_closed",
-        })),
+    ApiError::from_response(
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "Server is shutting down",
+                "code": "pool_closed",
+            })),
+        )
+            .into_response(),
     )
-        .into_response()
 }
 
 /// 504 response for a single inference run that exceeded the per-request

--- a/crates/gigastt/src/server/http/jobs_api.rs
+++ b/crates/gigastt/src/server/http/jobs_api.rs
@@ -98,7 +98,8 @@ pub async fn submit_job(
                 "retry_after_ms": pool_retry_after_ms(&limits),
             })),
         )
-            .into_response());
+            .into_response()
+            .into());
     }
     let split_channels = params.channels.as_deref() == Some("split");
     let request_diarization = params.diarization == Some(true);

--- a/crates/gigastt/src/server/openai/mod.rs
+++ b/crates/gigastt/src/server/openai/mod.rs
@@ -273,26 +273,26 @@ pub use sse::{OpenAITranscriptDelta, OpenAITranscriptDone};
 /// Parse an OpenAI-style multipart body into a typed request.
 pub async fn parse_openai_multipart(
     mut multipart: Multipart,
-) -> Result<OpenAITranscriptionRequest, Response> {
+) -> Result<OpenAITranscriptionRequest, Box<Response>> {
     let mut file: Option<Bytes> = None;
     let mut options = OpenAITranscriptionOptions::default();
 
     while let Some(field) = multipart.next_field().await.map_err(|e| {
         tracing::error!("OpenAI multipart parse failed: {e:#}");
-        openai_error(
+        Box::new(openai_error(
             StatusCode::BAD_REQUEST,
             "Invalid multipart body",
             "invalid_multipart",
-        )
+        ))
     })? {
         let name = field.name().unwrap_or("").to_string();
         let data = field.bytes().await.map_err(|e| {
             tracing::error!("OpenAI multipart field read failed: {e:#}");
-            openai_error(
+            Box::new(openai_error(
                 StatusCode::BAD_REQUEST,
                 "Invalid multipart body",
                 "invalid_multipart",
-            )
+            ))
         })?;
         if name == "file" {
             file = Some(data);
@@ -308,31 +308,31 @@ pub async fn parse_openai_multipart(
             } else {
                 "invalid_multipart"
             };
-            return Err(openai_error(StatusCode::BAD_REQUEST, &msg, code));
+            return Err(Box::new(openai_error(StatusCode::BAD_REQUEST, &msg, code)));
         }
     }
 
     if let Err(msg) = finalize_openai_options(&mut options) {
-        return Err(openai_error(
+        return Err(Box::new(openai_error(
             StatusCode::BAD_REQUEST,
             &msg,
             "invalid_stream_options",
-        ));
+        )));
     }
 
     let file = file.ok_or_else(|| {
-        openai_error(
+        Box::new(openai_error(
             StatusCode::BAD_REQUEST,
             "Missing required form field: file",
             "missing_file",
-        )
+        ))
     })?;
     if file.is_empty() {
-        return Err(openai_error(
+        return Err(Box::new(openai_error(
             StatusCode::BAD_REQUEST,
             "Empty request body",
             "empty_body",
-        ));
+        )));
     }
 
     Ok(OpenAITranscriptionRequest { file, options })

--- a/crates/gigastt/src/server/openai/tests.rs
+++ b/crates/gigastt/src/server/openai/tests.rs
@@ -277,7 +277,7 @@ async fn test_parse_multipart_full_form() {
                     });
                     (StatusCode::OK, Json(v)).into_response()
                 }
-                Err(resp) => resp,
+                Err(resp) => *resp,
             }
         }),
     );
@@ -332,7 +332,7 @@ async fn test_parse_multipart_missing_file() {
         post(|multipart: Multipart| async move {
             match parse_openai_multipart(multipart).await {
                 Ok(_) => StatusCode::OK.into_response(),
-                Err(resp) => resp,
+                Err(resp) => *resp,
             }
         }),
     );
@@ -370,7 +370,7 @@ async fn test_parse_multipart_invalid_format() {
         post(|multipart: Multipart| async move {
             match parse_openai_multipart(multipart).await {
                 Ok(_) => StatusCode::OK.into_response(),
-                Err(resp) => resp,
+                Err(resp) => *resp,
             }
         }),
     );
@@ -414,7 +414,7 @@ async fn test_parse_multipart_empty_file() {
         post(|multipart: Multipart| async move {
             match parse_openai_multipart(multipart).await {
                 Ok(_) => StatusCode::OK.into_response(),
-                Err(resp) => resp,
+                Err(resp) => *resp,
             }
         }),
     );


### PR DESCRIPTION
## Why

`main` CI is red on stable 1.98:

- Clippy / ANE / Candle-Metal: `clippy::chunks_exact_to_as_chunks` and `clippy::result_large_err` (`ApiError` was an axum `Response`).
- Cargo Deny / Security Audit: `RUSTSEC-2026-0258` in `h2` 0.4.14 (fixed in ≥0.4.16).

## What

- Replace first-party constant `chunks_exact(N)` with `as_chunks::<N>()` (MSRV 1.88).
- Box `ApiError` so handler `Result<_, ApiError>` stays under the large-err threshold.
- `h2` 0.4.14 → 0.4.19.

Local: `cargo clippy --workspace --all-targets -- -D warnings`, candle/ane clippy, `cargo deny check advisories`.