### PR TITLE
deps(core): bump polyvoice 0.14.0 → 0.18.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -742,22 +742,32 @@ jobs:
           if [ "$rc" -ne 0 ]; then
             if echo "$out" | grep -q 'no matching package named `gigastt-quantize`'; then
               echo "note: gigastt-quantize not yet on crates.io — core dry-run skipped until first release"
+            elif echo "$out" | grep -Eq 'git dependenc|does not have a version `0\.18'; then
+              echo "note: polyvoice 0.18 is git-pinned until crates.io publish — core dry-run skipped"
             else
               exit "$rc"
             fi
           fi
-          cargo publish --dry-run -p gigastt --locked --no-verify
+          set +e
+          out=$(cargo publish --dry-run -p gigastt --locked --no-verify 2>&1)
+          rc=$?
+          set -e
+          echo "$out"
+          if [ "$rc" -ne 0 ]; then
+            if echo "$out" | grep -Eq 'git dependenc|does not have a version `0\.18|no matching package named `polyvoice`'; then
+              echo "note: polyvoice 0.18 is git-pinned until crates.io publish — gigastt dry-run skipped"
+            else
+              exit "$rc"
+            fi
+          fi
 
   msrv:
     runs-on: ubuntu-latest
-    name: MSRV (1.88)
+    name: MSRV (1.94)
     steps:
       - uses: actions/checkout@v7
-      # MSRV floor: edition 2024 needs >=1.85, is_multiple_of needs >=1.87,
-      # ort 2.0.0-rc.12 declares rust-version 1.88. NB: a warm cargo cache can
-      # mask a too-new dependency MSRV here — the ort 1.88 floor was only
-      # caught by the cold-registry Docker build, while this job stayed green.
-      - uses: dtolnay/rust-toolchain@1.88
+      # MSRV floor: polyvoice 0.18 (rten-simd) declares rust-version 1.94.
+      - uses: dtolnay/rust-toolchain@1.94
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ packaging tool that needs a local FP32 ONNX as source (not a runtime path).
 
 ## Technology Stack
 
-- **Language**: Rust 2024 edition, stable toolchain (1.88+)
+- **Language**: Rust 2024 edition, stable toolchain (1.94+)
 - **ONNX Runtime**: `ort` pinned to exactly `2.0.0-rc.13`
 - **Async runtime**: tokio (full features)
 - **HTTP + WebSocket server**: axum 0.8 (`ws`, `multipart`)
@@ -73,7 +73,7 @@ this means `--features diarization` is redundant, and opting *out* is the meanin
 
 ## Build Requirements
 
-- Rust 1.88+ (stable)
+- Rust 1.94+ (stable)
 - `protoc` (Protocol Buffers compiler) on `PATH` — required by `build.rs` which
   regenerates ONNX protobuf types via `prost-build`
   - macOS: `brew install protobuf`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ were released without a git tag, so their headings carry no compare link.
 
 ## [Unreleased]
 
+### Changed
+
+- **polyvoice 0.14.0 → 0.18.0** via git tag `v0.18.0` (not on crates.io:
+  the 0.18 release gate failed compiling Linux `polyvoice-kernels`).
+  Diarization still uses `features = ["onnx"]` with `FbankOnnxExtractor` /
+  `LegacyPipeline` / CPU `ExecutionProvider`. **MSRV 1.88 → 1.94**
+  (`rten-simd`).
+
 ### Added
 
 - **Streaming WER + TTFP corpus harness.** `benchmark.py --mode batch|stream|both`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2924,9 +2924,8 @@ dependencies = [
 
 [[package]]
 name = "polyvoice"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641c28a7011e831ca8139f5c40ac4324b7ac466a9d9f9edac3df74c0f49a283f"
+version = "0.18.0"
+source = "git+https://github.com/ekhodzitsky/polyvoice?tag=v0.18.0#3ece4ea95ae997443d0348f7507dd7e9f3a2aac9"
 dependencies = [
  "anyhow",
  "hound",
@@ -3473,7 +3472,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3532,7 +3531,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4186,7 +4185,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5165,7 +5164,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 [workspace.package]
 version = "2.18.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.94"
 license = "MIT"
 repository = "https://github.com/ekhodzitsky/gigastt"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@
 # Pinned to the workspace MSRV (`rust-version` in Cargo.toml) so the image
 # build doubles as an MSRV check; bump both together. `--locked` keeps the
 # image on the audited Cargo.lock graph — a fresh resolve could pull deps
-# with a newer MSRV (exactly how ort rc.12 silently raised the floor to 1.88).
+# with a newer MSRV (polyvoice 0.18 raised the floor to 1.94).
 # trixie (not bookworm): ort's prebuilt onnxruntime statics are compiled with
 # gcc >= 13 and reference `__cxa_call_terminate` (CXXABI_1.3.15), which
 # bookworm's libstdc++ 12 lacks — the final link fails there.
-FROM rust:1.88-trixie AS builder
+FROM rust:1.94-trixie AS builder
 
 # `prost-build` (via build.rs) requires `protoc` at compile time; without it
 # the build aborts with "prost-build failed to compile gigastt-quantize proto/onnx.proto".

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -15,7 +15,7 @@ FROM nvidia/cuda:12.6.3-devel-ubuntu24.04 AS builder
 # bump both together. `--locked` rationale — see Dockerfile.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl build-essential pkg-config libssl-dev protobuf-compiler && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0 && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.94.0 && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $ gigastt serve
 
 ## Requirements
 
-Rust **1.88+**, `protoc` on `PATH` (build-time only — the quantizer crate regenerates ONNX types). macOS 14+ (Apple Silicon, CoreML), Linux x86_64 (optional NVIDIA CUDA 12+ via the GHCR `:cuda` image), Linux aarch64, or Windows x86_64 CPU (prebuilt tarball). **~250–400 MB disk** for the lean INT8 install + binary (optional punct/VAD side models extra), ~66 MB resident RAM at the default `--pool-size 2` (~46 MB single-session; `ps` RSS reads ~510 / ~277 MB because it counts the shared memory-mapped model). The `gigastt-core` crate has no server dependencies — embed it directly: `gigastt-core = "2.18"`.
+Rust **1.94+**, `protoc` on `PATH` (build-time only — the quantizer crate regenerates ONNX types). macOS 14+ (Apple Silicon, CoreML), Linux x86_64 (optional NVIDIA CUDA 12+ via the GHCR `:cuda` image), Linux aarch64, or Windows x86_64 CPU (prebuilt tarball). **~250–400 MB disk** for the lean INT8 install + binary (optional punct/VAD side models extra), ~66 MB resident RAM at the default `--pool-size 2` (~46 MB single-session; `ps` RSS reads ~510 / ~277 MB because it counts the shared memory-mapped model). The `gigastt-core` crate has no server dependencies — embed it directly: `gigastt-core = "2.18"`.
 
 ## License
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -133,7 +133,7 @@ $ gigastt serve
 
 ## Требования
 
-Rust **1.88+**, `protoc` в `PATH` (только на этапе сборки — крейт quantize регенерирует ONNX-типы). macOS 14+ (Apple Silicon, CoreML), Linux x86_64 (опц. NVIDIA CUDA 12+ через образ GHCR `:cuda`), Linux aarch64 или Windows x86_64 CPU (готовый tarball). **~250–400 МБ диска** для lean INT8 + бинарника (опциональные punct/VAD — отдельно), ~66 МБ resident RAM при дефолтном `--pool-size 2` (~46 МБ на одну сессию; `ps` RSS показывает ~510 / ~277 МБ из-за общего memory-mapped образа модели). Крейт `gigastt-core` без серверных зависимостей: `gigastt-core = "2.18"`.
+Rust **1.94+**, `protoc` в `PATH` (только на этапе сборки — крейт quantize регенерирует ONNX-типы). macOS 14+ (Apple Silicon, CoreML), Linux x86_64 (опц. NVIDIA CUDA 12+ через образ GHCR `:cuda`), Linux aarch64 или Windows x86_64 CPU (готовый tarball). **~250–400 МБ диска** для lean INT8 + бинарника (опциональные punct/VAD — отдельно), ~66 МБ resident RAM при дефолтном `--pool-size 2` (~46 МБ на одну сессию; `ps` RSS показывает ~510 / ~277 МБ из-за общего memory-mapped образа модели). Крейт `gigastt-core` без серверных зависимостей: `gigastt-core = "2.18"`.
 
 ## Лицензия
 

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -92,7 +92,9 @@ audio-codec = { version = "0.3", default-features = false, optional = true }
 opus-rs = { version = "0.1", optional = true }
 bytes = "1"
 gigastt-quantize = { version = "2.18.0", path = "../gigastt-quantize", optional = true }
-polyvoice = { version = "0.14.0", features = ["onnx"], optional = true }
+# 0.18.0 is tagged but not on crates.io yet (polyvoice release gate failed
+# compiling Linux kernels). Revisit when 0.18.0 is published.
+polyvoice = { git = "https://github.com/ekhodzitsky/polyvoice", tag = "v0.18.0", features = ["onnx"], optional = true }
 parking_lot = "0.12"
 libc = "0.2"
 tar = { version = "0.4", optional = true }

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -94,7 +94,7 @@ bytes = "1"
 gigastt-quantize = { version = "2.18.0", path = "../gigastt-quantize", optional = true }
 # 0.18.0 is tagged but not on crates.io yet (polyvoice release gate failed
 # compiling Linux kernels). Revisit when 0.18.0 is published.
-polyvoice = { git = "https://github.com/ekhodzitsky/polyvoice", tag = "v0.18.0", features = ["onnx"], optional = true }
+polyvoice = { version = "0.18.0", git = "https://github.com/ekhodzitsky/polyvoice", tag = "v0.18.0", features = ["onnx"], optional = true }
 parking_lot = "0.12"
 libc = "0.2"
 tar = { version = "0.4", optional = true }

--- a/crates/gigastt-core/README.md
+++ b/crates/gigastt-core/README.md
@@ -91,7 +91,7 @@ from the dependency graph. Opt features back in as needed.
 
 ## Requirements
 
-- Rust 1.88+ (edition 2024)
+- Rust 1.94+ (edition 2024)
 - `protoc` on PATH only when the `quantize` feature is on (`brew install protobuf` / `apt install protobuf-compiler`)
 
 ## License

--- a/deny.toml
+++ b/deny.toml
@@ -43,3 +43,8 @@ wildcards = "deny"
 unknown-git = "deny"
 unknown-registry = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+    # polyvoice 0.18 is tagged but not published (release gate failed on
+    # Linux polyvoice-kernels). Drop this once 0.18.0 is on crates.io.
+    "https://github.com/ekhodzitsky/polyvoice",
+]

--- a/docs/workbook/en/src/01-getting-started.md
+++ b/docs/workbook/en/src/01-getting-started.md
@@ -20,7 +20,7 @@ you should not need any other document to get here.
   (`.opus`), WebM/Opus, or FLAC. The repo ships a 4 s Russian fixture:
   `crates/gigastt/tests/fixtures/golos_00.wav`. Any short Russian recording
   works. Files → this chapter / REST. Live partials → [Streaming](04-streaming-ws.md).
-- Only for `cargo install` (build from source): Rust 1.88+ and `protoc` on
+- Only for `cargo install` (build from source): Rust 1.94+ and `protoc` on
   `PATH` (`brew install protobuf` / `apt install protobuf-compiler`).
 
 Pick **one** recipe below — macOS, Linux, Windows, Docker, or air-gapped — then
@@ -79,7 +79,7 @@ sudo install -m 0755 gigastt /usr/local/bin/gigastt
 `aarch64-unknown-linux-gnu`. Homebrew on Linux x86_64 — `brew install
 gigastt` after the tap from the macOS recipe — works too.)
 
-**Option B — cargo** (any platform, needs Rust 1.88+ and `protoc`):
+**Option B — cargo** (any platform, needs Rust 1.94+ and `protoc`):
 
 ```sh
 sudo apt install protobuf-compiler   # Debian/Ubuntu; skip if protoc exists

--- a/docs/workbook/en/src/07-models-and-backends.md
+++ b/docs/workbook/en/src/07-models-and-backends.md
@@ -22,7 +22,7 @@ this chapter links into them. Flags are checked against `gigastt <command>
   [Getting started](01-getting-started.md).
 - Disk: **~250–400 MB** free for the lean INT8 install (the only runtime path;
   optional punct/VAD side models extra).
-- For building a non-default backend from source: Rust 1.88+ and `protoc` on
+- For building a non-default backend from source: Rust 1.94+ and `protoc` on
   `PATH` (build requirements:
   [docs/architecture.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/architecture.md)).
 

--- a/docs/workbook/ru/src/01-getting-started.md
+++ b/docs/workbook/ru/src/01-getting-started.md
@@ -21,7 +21,7 @@ GigaAM v3, транскрибировать первый аудиофайл — 
   фикстура: `crates/gigastt/tests/fixtures/golos_00.wav`. Подойдёт любая
   короткая русская запись. Файлы → эта глава / REST. Живые partials →
   [Стриминг](04-streaming-ws.md).
-- Только для `cargo install` (сборка из исходников): Rust 1.88+ и `protoc` в
+- Только для `cargo install` (сборка из исходников): Rust 1.94+ и `protoc` в
   `PATH` (`brew install protobuf` / `apt install protobuf-compiler`).
 
 Выберите **один** рецепт ниже — macOS, Linux, Windows, Docker или замкнутый контур, —
@@ -80,7 +80,7 @@ sudo install -m 0755 gigastt /usr/local/bin/gigastt
 `aarch64-unknown-linux-gnu`. Homebrew на Linux x86_64 — `brew install
 gigastt` после tap из рецепта для macOS — тоже работает.)
 
-**Вариант B — cargo** (любая платформа, нужны Rust 1.88+ и `protoc`):
+**Вариант B — cargo** (любая платформа, нужны Rust 1.94+ и `protoc`):
 
 ```sh
 sudo apt install protobuf-compiler   # Debian/Ubuntu; пропустите, если protoc есть

--- a/docs/workbook/ru/src/07-models-and-backends.md
+++ b/docs/workbook/ru/src/07-models-and-backends.md
@@ -22,7 +22,7 @@ gigastt уже работает с головой `rnnt` по умолчанию
   [Начало работы](01-getting-started.md).
 - Диск: **~250–400 МБ** свободно для lean INT8-установки (единственный
   runtime-путь; опциональные punct/VAD — отдельно).
-- Для сборки нестандартного бэкенда из исходников: Rust 1.88+ и `protoc` в
+- Для сборки нестандартного бэкенда из исходников: Rust 1.94+ и `protoc` в
   `PATH` (требования сборки:
   [docs/architecture.md](https://github.com/ekhodzitsky/gigastt/blob/main/docs/architecture.md)).
 


### PR DESCRIPTION
## Why

Pull polyvoice **0.18.0** (native INT8 kernel pipeline as polyvoice's product default). gigastt diarization stays on the library ONNX path.

## What

- Pin `polyvoice` to git tag `v0.18.0` (`features = ["onnx"]`). **Not on crates.io**: the polyvoice 0.18 [Release gate](https://github.com/ekhodzitsky/polyvoice/actions/runs/32830208888) failed compiling Linux `polyvoice-kernels` (`pack_kn_sdot16` / x86), so `crates-io` was skipped. `polyvoice-kernels` is also `publish = false`.
- API we use is unchanged: `FbankOnnxExtractor::new(..., ExecutionProvider::Cpu)`, `LegacyPipeline`, `StreamingPipeline`, `EnergyVad`.
- **MSRV 1.88 → 1.94** (`rten-simd` / polyvoice `rust-version`).
- `cargo-deny` `allow-git` for this repo until 0.18 is published.

Supersedes #311 (0.14 → 0.17).

Local: `cargo check -p gigastt-core --features diarization` and diarization unit tests against `v0.18.0` (`3ece4ea`).