### PR TITLE
deps(core): take polyvoice 0.18.0 from crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -742,24 +742,11 @@ jobs:
           if [ "$rc" -ne 0 ]; then
             if echo "$out" | grep -q 'no matching package named `gigastt-quantize`'; then
               echo "note: gigastt-quantize not yet on crates.io — core dry-run skipped until first release"
-            elif echo "$out" | grep -Eq 'git dependenc|does not have a version `0\.18'; then
-              echo "note: polyvoice 0.18 is git-pinned until crates.io publish — core dry-run skipped"
             else
               exit "$rc"
             fi
           fi
-          set +e
-          out=$(cargo publish --dry-run -p gigastt --locked --no-verify 2>&1)
-          rc=$?
-          set -e
-          echo "$out"
-          if [ "$rc" -ne 0 ]; then
-            if echo "$out" | grep -Eq 'git dependenc|does not have a version `0\.18|no matching package named `polyvoice`'; then
-              echo "note: polyvoice 0.18 is git-pinned until crates.io publish — gigastt dry-run skipped"
-            else
-              exit "$rc"
-            fi
-          fi
+          cargo publish --dry-run -p gigastt --locked --no-verify
 
   msrv:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,9 @@ were released without a git tag, so their headings carry no compare link.
 
 ### Changed
 
-- **polyvoice 0.14.0 → 0.18.0** via git tag `v0.18.0` (not on crates.io:
-  the 0.18 release gate failed compiling Linux `polyvoice-kernels`).
-  Diarization still uses `features = ["onnx"]` with `FbankOnnxExtractor` /
-  `LegacyPipeline` / CPU `ExecutionProvider`. **MSRV 1.88 → 1.94**
-  (`rten-simd`).
+- **polyvoice 0.14.0 → 0.18.0** from crates.io (`features = ["onnx"]`).
+  Diarization still uses `FbankOnnxExtractor` / `LegacyPipeline` /
+  CPU `ExecutionProvider`. **MSRV 1.88 → 1.94** (`rten-simd`).
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1091,7 +1091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2537,7 +2537,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2925,7 +2925,8 @@ dependencies = [
 [[package]]
 name = "polyvoice"
 version = "0.18.0"
-source = "git+https://github.com/ekhodzitsky/polyvoice?tag=v0.18.0#3ece4ea95ae997443d0348f7507dd7e9f3a2aac9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de72d6f3051f7197768f40b6622af6c7d2ac62bb3bb401178e41f4bb3531e94"
 dependencies = [
  "anyhow",
  "hound",
@@ -3472,7 +3473,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3531,7 +3532,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3851,7 +3852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4185,7 +4186,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5164,7 +5165,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -92,9 +92,7 @@ audio-codec = { version = "0.3", default-features = false, optional = true }
 opus-rs = { version = "0.1", optional = true }
 bytes = "1"
 gigastt-quantize = { version = "2.18.0", path = "../gigastt-quantize", optional = true }
-# 0.18.0 is tagged but not on crates.io yet (polyvoice release gate failed
-# compiling Linux kernels). Revisit when 0.18.0 is published.
-polyvoice = { version = "0.18.0", git = "https://github.com/ekhodzitsky/polyvoice", tag = "v0.18.0", features = ["onnx"], optional = true }
+polyvoice = { version = "0.18.0", features = ["onnx"], optional = true }
 parking_lot = "0.12"
 libc = "0.2"
 tar = { version = "0.4", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -43,8 +43,3 @@ wildcards = "deny"
 unknown-git = "deny"
 unknown-registry = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = [
-    # polyvoice 0.18 is tagged but not published (release gate failed on
-    # Linux polyvoice-kernels). Drop this once 0.18.0 is on crates.io.
-    "https://github.com/ekhodzitsky/polyvoice",
-]


### PR DESCRIPTION
polyvoice **0.18.0** is on crates.io (checksum `7de72d6f…`, rust-version 1.94). Switch off the git tag pin from #316.

- `polyvoice = { version = \"0.18.0\", features = [\"onnx\"] }`
- drop `deny.toml` `allow-git`
- restore normal publish dry-run (no git-pin skip)

Local: `cargo check -p gigastt-core --features diarization`, diarization unit tests, `cargo deny check sources`.