### PR TITLE
fix(ci): green publish dry-run and audio-codec 0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,27 +726,39 @@ jobs:
       # (at real release time quantize then core are published first).
       # --no-verify still exercises `cargo package` (manifest, metadata,
       # file inclusion); the compile itself is covered by the build/test jobs.
+      #
+      # After a workspace version bump, cargo also fails to *select* a version
+      # (quantize/core already exist on crates.io, just not at this version).
+      # Accept only that packaging-order miss.
       - run: |
           set -euo pipefail
-          # New workspace crate: full dry-run (compile + package).
-          cargo publish --dry-run -p gigastt-quantize --locked
-          # core depends on gigastt-quantize via path. Until quantize is on
-          # crates.io (first release after this lands), `cargo publish` cannot
-          # resolve it from the registry. Accept that transitional error;
-          # anything else is a real packaging break.
-          set +e
-          out=$(cargo publish --dry-run -p gigastt-core --locked --no-verify 2>&1)
-          rc=$?
-          set -e
-          echo "$out"
-          if [ "$rc" -ne 0 ]; then
-            if echo "$out" | grep -q 'no matching package named `gigastt-quantize`'; then
-              echo "note: gigastt-quantize not yet on crates.io — core dry-run skipped until first release"
-            else
-              exit "$rc"
+
+          unpublished_workspace_dep() {
+            grep -Eq 'no matching package named `gigastt-(quantize|core)`|failed to select a version for the requirement `gigastt-(quantize|core)`'
+          }
+
+          dry_run() {
+            local pkg="$1"
+            shift
+            set +e
+            local out rc
+            out=$(cargo publish --dry-run -p "$pkg" --locked "$@" 2>&1)
+            rc=$?
+            set -e
+            printf '%s\n' "$out"
+            if [ "$rc" -eq 0 ]; then
+              return 0
             fi
-          fi
-          cargo publish --dry-run -p gigastt --locked --no-verify
+            if printf '%s\n' "$out" | unpublished_workspace_dep; then
+              echo "note: $pkg dry-run skipped — workspace dependency not yet on crates.io at this version"
+              return 0
+            fi
+            exit "$rc"
+          }
+
+          cargo publish --dry-run -p gigastt-quantize --locked
+          dry_run gigastt-core --no-verify
+          dry_run gigastt --no-verify
 
   msrv:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ Versions 0.1.0 and 0.1.1 were published to crates.io on 2026-04-09 and yanked
 
 ## [Unreleased]
 
+### Fixed
+
+- **Publish dry-run after a version bump.** `gigastt-quantize` is on
+  crates.io (so the old "no matching package" exception never fired), but
+  `cargo publish --dry-run` for `gigastt-core` / `gigastt` still cannot
+  resolve the just-bumped workspace version until that crate is actually
+  published. The job now accepts that version-select miss as well.
+
+### Changed
+
+- **audio-codec 0.3 → 0.4.** Telephony G.711/G.722 decode uses the
+  heap-free `decode_into` / `encode_into` API (`Decoder`/`Encoder` are
+  traits; the allocating `decode`/`encode` helpers need the `std`
+  feature, which we keep off so we do not pull a second Opus).
+
 ## [2.19.0] - 2026-08-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,12 +182,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "audio-codec"
-version = "0.3.40"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1affd3ba1faa8ae5c47c98f6c5e36eb321f4cb4567d7a7e1a8f3452fe40d57a"
+checksum = "81c2b027ac91f3fb0c9c001e43538ea4523c7c3e2bc3feb4f380abac07604490"
 dependencies = [
- "anyhow",
  "g729-sys",
+ "libm",
 ]
 
 [[package]]
@@ -1320,12 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "g729-sys"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0115766e9b2dcbc585946d207299fe2fce9bf0b8d4ba0d3592c6e0f66fe116"
-dependencies = [
- "anyhow",
-]
+checksum = "582ee481959b69a3557c190d4c038fb8c1ff2319be9ef84ea9c98faeffebbf98"
 
 [[package]]
 name = "gemm"

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -85,7 +85,7 @@ symphonia = { version = "0.6", features = ["aac", "isomp4", "mkv", "mp3", "ogg",
 # Telephony codecs (G.711 A/μ-law tables, G.722 ADPCM) for RTP dumps and
 # Asterisk-style raw captures. `default-features = false` drops the opus
 # feature so we do not pull a second Opus implementation next to opus-rs.
-audio-codec = { version = "0.3", default-features = false, optional = true }
+audio-codec = { version = "0.4", default-features = false, optional = true }
 # Pure-Rust Opus decoder (libopus port, BSD-3-Clause). Symphonia demuxes
 # OGG/Opus containers but ships no Opus decoder, so packets are decoded with
 # this crate (decoder only — the encoder is not used).

--- a/crates/gigastt-core/src/inference/audio/telephony.rs
+++ b/crates/gigastt-core/src/inference/audio/telephony.rs
@@ -4,6 +4,8 @@
 use anyhow::Context;
 #[cfg(feature = "file-decode")]
 use anyhow::Result;
+#[cfg(feature = "file-decode")]
+use audio_codec::Decoder;
 
 #[cfg(feature = "file-decode")]
 use super::resample::{RESAMPLE_STAGING_FRAMES, ResampleTo16k, SampleRate};
@@ -136,13 +138,30 @@ pub(crate) fn try_decode_g722_wav(
         return Some(Err(audio_too_long_err(num_samples, 16000, limit_secs)));
     }
     let mut decoder = audio_codec::g722::G722Decoder::new();
-    let pcm = audio_codec::Decoder::decode(&mut decoder, payload);
+    let pcm = match decode_pcm(&mut decoder, payload) {
+        Ok(p) => p,
+        Err(e) => return Some(Err(e)),
+    };
     tracing::info!(
         "Decoded G.722 WAV: {} samples at 16000Hz ({:.1}s)",
         pcm.len(),
         pcm.len() as f64 / 16000.0
     );
     Some(Ok(pcm.iter().map(|&s| f32::from(s) / 32768.0).collect()))
+}
+
+/// `audio-codec` 0.4 keeps the allocating `Decoder::decode` helper behind the
+/// `std` feature. We ship `default-features = false` (drops the bundled Opus),
+/// so production decode uses the always-on `decode_into` API.
+#[cfg(feature = "file-decode")]
+fn decode_pcm<D: Decoder>(decoder: &mut D, data: &[u8]) -> Result<Vec<i16>> {
+    let n = decoder.max_decode_samples(data.len());
+    let mut pcm = vec![0i16; n];
+    let written = decoder
+        .decode_into(data, &mut pcm)
+        .map_err(|e| anyhow::anyhow!("telephony decode failed: {e}"))?;
+    pcm.truncate(written);
+    Ok(pcm)
 }
 
 /// Headerless telephony codecs accepted for raw uploads (`?codec=` on REST,
@@ -211,21 +230,15 @@ pub fn decode_telephony_raw(
     let (pcm, rate) = match codec {
         TelephonyCodec::Pcmu => {
             let mut decoder = audio_codec::pcmu::PcmuDecoder::new();
-            (
-                audio_codec::Decoder::decode(&mut decoder, data),
-                sample_rate,
-            )
+            (decode_pcm(&mut decoder, data)?, sample_rate)
         }
         TelephonyCodec::Pcma => {
             let mut decoder = audio_codec::pcma::PcmaDecoder::new();
-            (
-                audio_codec::Decoder::decode(&mut decoder, data),
-                sample_rate,
-            )
+            (decode_pcm(&mut decoder, data)?, sample_rate)
         }
         TelephonyCodec::G722 => {
             let mut decoder = audio_codec::g722::G722Decoder::new();
-            (audio_codec::Decoder::decode(&mut decoder, data), 16000)
+            (decode_pcm(&mut decoder, data)?, 16000)
         }
     };
     let (max_samples, limit_secs) = resolve_budget(Some(WHOLE_BUFFER_MAX_AUDIO_SECS), rate);

--- a/crates/gigastt-core/src/inference/audio/tests/mod.rs
+++ b/crates/gigastt-core/src/inference/audio/tests/mod.rs
@@ -3,6 +3,31 @@
 
 pub(super) use super::*;
 
+use audio_codec::{Decoder, Encoder};
+
+/// `audio-codec` 0.4 keeps allocating `encode`/`decode` behind the `std`
+/// feature. Tests drive the heap-free `*_into` API with a sized scratch
+/// buffer so we can keep `default-features = false` (no bundled Opus).
+fn encode_telephony<E: Encoder>(encoder: &mut E, samples: &[i16]) -> Vec<u8> {
+    let n = encoder.max_encode_bytes(samples.len());
+    let mut out = vec![0u8; n];
+    let written = encoder
+        .encode_into(samples, &mut out)
+        .unwrap_or_else(|e| panic!("test encode failed: {e}"));
+    out.truncate(written);
+    out
+}
+
+fn decode_telephony_pcm<D: Decoder>(decoder: &mut D, data: &[u8]) -> Vec<i16> {
+    let n = decoder.max_decode_samples(data.len());
+    let mut pcm = vec![0i16; n];
+    let written = decoder
+        .decode_into(data, &mut pcm)
+        .unwrap_or_else(|e| panic!("test decode failed: {e}"));
+    pcm.truncate(written);
+    pcm
+}
+
 pub(super) fn make_wav_bytes(samples: &[i16], sample_rate: u32) -> Vec<u8> {
     let data_size = (samples.len() * 2) as u32;
     let file_size = 36 + data_size;

--- a/crates/gigastt-core/src/inference/audio/tests/stream.rs
+++ b/crates/gigastt-core/src/inference/audio/tests/stream.rs
@@ -317,9 +317,9 @@ fn test_telephony_raw_streaming_matches_whole_buffer_resample() {
         pcm.len()
     );
     let mut encoder = audio_codec::pcmu::PcmuEncoder::new();
-    let encoded = audio_codec::Encoder::encode(&mut encoder, &pcm);
+    let encoded = encode_telephony(&mut encoder, &pcm);
     let mut decoder = audio_codec::pcmu::PcmuDecoder::new();
-    let round_tripped = audio_codec::Decoder::decode(&mut decoder, &encoded);
+    let round_tripped = decode_telephony_pcm(&mut decoder, &encoded);
     let at_source: Vec<f32> = round_tripped
         .iter()
         .map(|&s| f32::from(s) / 32768.0)

--- a/crates/gigastt-core/src/inference/audio/tests/telephony.rs
+++ b/crates/gigastt-core/src/inference/audio/tests/telephony.rs
@@ -48,7 +48,7 @@ fn test_telephony_codec_validate_sample_rate() {
 fn test_decode_telephony_raw_pcmu_roundtrip() {
     let source = test_tone_8k(8000);
     let mut encoder = audio_codec::pcmu::PcmuEncoder::new();
-    let encoded = audio_codec::Encoder::encode(&mut encoder, &source);
+    let encoded = encode_telephony(&mut encoder, &source);
     assert_eq!(encoded.len(), source.len(), "G.711 is one byte per sample");
     let decoded = decode_telephony_raw(&encoded, TelephonyCodec::Pcmu, 8000).unwrap();
     // Resampled 8k → 16k: roughly double, minus the FIR delay slack.
@@ -87,7 +87,7 @@ fn test_decode_telephony_raw_pcmu_roundtrip() {
 fn test_decode_telephony_raw_pcma_roundtrip() {
     let source = test_tone_8k(8000);
     let mut encoder = audio_codec::pcma::PcmaEncoder::new();
-    let encoded = audio_codec::Encoder::encode(&mut encoder, &source);
+    let encoded = encode_telephony(&mut encoder, &source);
     let decoded = decode_telephony_raw(&encoded, TelephonyCodec::Pcma, 8000).unwrap();
     assert!(decoded.len() > 12_000 && decoded.len() <= 16_000);
     assert!(decoded.iter().all(|s| s.is_finite()));
@@ -100,7 +100,7 @@ fn test_decode_telephony_raw_g722_roundtrip() {
         .map(|i| ((i as f32 * 0.03).sin() * 10000.0) as i16)
         .collect();
     let mut encoder = audio_codec::g722::G722Encoder::new();
-    let encoded = audio_codec::Encoder::encode(&mut encoder, &source);
+    let encoded = encode_telephony(&mut encoder, &source);
     assert_eq!(encoded.len(), source.len() / 2, "64 kbit/s over 16 kHz");
     let decoded = decode_telephony_raw(&encoded, TelephonyCodec::G722, 8000).unwrap();
     assert_eq!(decoded.len(), source.len(), "G.722 stays at native 16 kHz");
@@ -131,7 +131,7 @@ fn test_decode_audio_bytes_g711_alaw_wav() {
     // this pins the de-facto support so it cannot silently regress.
     let source = test_tone_8k(8000);
     let mut encoder = audio_codec::pcma::PcmaEncoder::new();
-    let encoded = audio_codec::Encoder::encode(&mut encoder, &source);
+    let encoded = encode_telephony(&mut encoder, &source);
     let wav = make_compressed_wav(0x0006, 8000, 8000, &encoded);
     let decoded = decode_audio_bytes(&wav).unwrap();
     assert!(
@@ -148,7 +148,7 @@ fn test_decode_audio_bytes_g711_mulaw_wav() {
     // G.711 μ-law in WAV (tag 0x0007), same symphonia PCM path.
     let source = test_tone_8k(8000);
     let mut encoder = audio_codec::pcmu::PcmuEncoder::new();
-    let encoded = audio_codec::Encoder::encode(&mut encoder, &source);
+    let encoded = encode_telephony(&mut encoder, &source);
     let wav = make_compressed_wav(0x0007, 8000, 8000, &encoded);
     let decoded = decode_audio_bytes(&wav).unwrap();
     assert!(
@@ -167,7 +167,7 @@ fn test_decode_audio_bytes_g722_wav_fallback() {
         .map(|i| ((i as f32 * 0.03).sin() * 10000.0) as i16)
         .collect();
     let mut encoder = audio_codec::g722::G722Encoder::new();
-    let encoded = audio_codec::Encoder::encode(&mut encoder, &source);
+    let encoded = encode_telephony(&mut encoder, &source);
     for tag in [0x0064u16, 0x028F] {
         let wav = make_compressed_wav(tag, 16000, 8000, &encoded);
         let decoded = decode_audio_bytes(&wav).unwrap_or_else(|e| {
@@ -198,7 +198,7 @@ fn test_try_decode_g722_wav_malformed_inputs() {
     );
     // Truncated data payload must decode the bytes present, not panic.
     let mut enc = audio_codec::g722::G722Encoder::new();
-    let encoded = audio_codec::Encoder::encode(&mut enc, &[0i16; 320]);
+    let encoded = encode_telephony(&mut enc, &[0i16; 320]);
     let mut wav = make_compressed_wav(0x0064, 16000, 8000, &encoded);
     wav.truncate(wav.len() - 3);
     let result = try_decode_g722_wav(&wav, None);


### PR DESCRIPTION
## Why

`main` is red: **Publish Dry Run** fails after the 2.19.0 bump because `gigastt-quantize` *is* on crates.io (2.18.0 / 2.17.0), so the old `no matching package named gigastt-quantize` exception never fires. Cargo now errors with `failed to select a version for the requirement gigastt-quantize = "^2.19.0"`. The same miss would then hit `gigastt` looking for `gigastt-core` 2.19.0.

Open Dependabot PR #322 (`audio-codec` 0.3.40 → 0.4.6) is also red: 0.4 made `Decoder`/`Encoder` traits, and the allocating `decode`/`encode` helpers need the `std` feature. We keep `default-features = false` so we do not pull a second Opus.

## What

- Accept the unpublished-workspace-version miss for `gigastt-core` and `gigastt` in Publish Dry Run (package still exists, version does not).
- Bump `audio-codec` to 0.4 and decode/encode via `decode_into` / `encode_into`.

## Test plan

- [x] `cargo test --workspace --lib --bins`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] telephony G.711/G.722 roundtrips, including the ffmpeg G.722 fixture
- [ ] GitHub CI Publish Dry Run on this PR

Supersedes #322.