### PR TITLE
fix(ci): match cargo version-select error in publish dry-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,7 +734,11 @@ jobs:
           set -euo pipefail
 
           unpublished_workspace_dep() {
-            grep -Eq 'no matching package named `gigastt-(quantize|core)`|failed to select a version for the requirement `gigastt-(quantize|core)`'
+            # Cargo prints `gigastt-quantize = "^2.19.0"` (name, space, version)
+            # not a closing backtick right after the crate name — do not require
+            # one. Strip ANSI so CARGO_TERM_COLOR=always cannot hide the match.
+            sed $'s/\x1b\\[[0-9;]*[mK]//g' | grep -Eq \
+              'no matching package named `gigastt-(quantize|core)`|failed to select a version for the requirement `gigastt-(quantize|core)'
           }
 
           dry_run() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ Versions 0.1.0 and 0.1.1 were published to crates.io on 2026-04-09 and yanked
   crates.io (so the old "no matching package" exception never fired), but
   `cargo publish --dry-run` for `gigastt-core` / `gigastt` still cannot
   resolve the just-bumped workspace version until that crate is actually
-  published. The job now accepts that version-select miss as well.
+  published. The job now accepts that version-select miss as well (match
+  `gigastt-quantize = "^X.Y.Z"`, not a closing backtick right after the
+  crate name).
 
 ### Changed
 


### PR DESCRIPTION
## Why

#324 landed the exception for unpublished workspace versions, but Publish Dry Run is still red on `main`. Cargo prints:

```
failed to select a version for the requirement `gigastt-quantize = "^2.19.0"`
```

The grep required a closing backtick immediately after the crate name (as in `no matching package named \`gigastt-quantize\``). That never matches the ` = "^X.Y.Z"` form, so the job still exited 101.

## What

- Match `requirement \`gigastt-(quantize|core)` without a closing backtick right after the name.
- Strip ANSI so `CARGO_TERM_COLOR=always` cannot hide the crate name.

Do not merge until **Publish Dry Run** is green on this PR.