### PR TITLE
chore: bump version to 2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versions 0.1.0 and 0.1.1 were published to crates.io on 2026-04-09 and yanked
 
 ## [Unreleased]
 
+## [2.21.0] - 2026-09-06
+
 ### Added
 
 - **Optional long-form window parallelism (`--file-window-concurrency`).** File
@@ -2672,7 +2674,8 @@ _Release candidate for v0.9.0 — bundles five P0 fixes plus two supporting item
 - Multi-format audio support: WAV, MP3, M4A/AAC, OGG/Vorbis, FLAC (via symphonia).
 - 39 unit tests (tokenizer, features, decode, inference, protocol).
 
-[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.20.0...HEAD
+[Unreleased]: https://github.com/ekhodzitsky/gigastt/compare/v2.21.0...HEAD
+[2.21.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.20.0...v2.21.0
 [2.20.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.19.0...v2.20.0
 [2.19.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.18.0...v2.19.0
 [2.18.0]: https://github.com/ekhodzitsky/gigastt/compare/v2.17.0...v2.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-core"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "anyhow",
  "audio-codec",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-ffi"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "cbindgen",
  "gigastt-core",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-node"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "gigastt-core",
  "napi",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-quantize"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "anyhow",
  "prost",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "gigastt-uniffi"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "gigastt-core",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["crates/gigastt"]
 resolver = "3"
 
 [workspace.package]
-version = "2.20.0"
+version = "2.21.0"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $ gigastt serve
 
 ## Requirements
 
-Rust **1.94+**, `protoc` on `PATH` (build-time only — the quantizer crate regenerates ONNX types). macOS 14+ (Apple Silicon, CoreML), Linux x86_64 (optional NVIDIA CUDA 12+ via the GHCR `:cuda` image), Linux aarch64, or Windows x86_64 CPU (prebuilt tarball). **~250–400 MB disk** for the lean INT8 install + binary (optional punct/VAD side models extra), ~66 MB resident RAM at the default `--pool-size 2` (~46 MB single-session; `ps` RSS reads ~510 / ~277 MB because it counts the shared memory-mapped model). The `gigastt-core` crate has no server dependencies — embed it directly: `gigastt-core = "2.20"`.
+Rust **1.94+**, `protoc` on `PATH` (build-time only — the quantizer crate regenerates ONNX types). macOS 14+ (Apple Silicon, CoreML), Linux x86_64 (optional NVIDIA CUDA 12+ via the GHCR `:cuda` image), Linux aarch64, or Windows x86_64 CPU (prebuilt tarball). **~250–400 MB disk** for the lean INT8 install + binary (optional punct/VAD side models extra), ~66 MB resident RAM at the default `--pool-size 2` (~46 MB single-session; `ps` RSS reads ~510 / ~277 MB because it counts the shared memory-mapped model). The `gigastt-core` crate has no server dependencies — embed it directly: `gigastt-core = "2.21"`.
 
 ## License
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -133,7 +133,7 @@ $ gigastt serve
 
 ## Требования
 
-Rust **1.94+**, `protoc` в `PATH` (только на этапе сборки — крейт quantize регенерирует ONNX-типы). macOS 14+ (Apple Silicon, CoreML), Linux x86_64 (опц. NVIDIA CUDA 12+ через образ GHCR `:cuda`), Linux aarch64 или Windows x86_64 CPU (готовый tarball). **~250–400 МБ диска** для lean INT8 + бинарника (опциональные punct/VAD — отдельно), ~66 МБ resident RAM при дефолтном `--pool-size 2` (~46 МБ на одну сессию; `ps` RSS показывает ~510 / ~277 МБ из-за общего memory-mapped образа модели). Крейт `gigastt-core` без серверных зависимостей: `gigastt-core = "2.20"`.
+Rust **1.94+**, `protoc` в `PATH` (только на этапе сборки — крейт quantize регенерирует ONNX-типы). macOS 14+ (Apple Silicon, CoreML), Linux x86_64 (опц. NVIDIA CUDA 12+ через образ GHCR `:cuda`), Linux aarch64 или Windows x86_64 CPU (готовый tarball). **~250–400 МБ диска** для lean INT8 + бинарника (опциональные punct/VAD — отдельно), ~66 МБ resident RAM при дефолтном `--pool-size 2` (~46 МБ на одну сессию; `ps` RSS показывает ~510 / ~277 МБ из-за общего memory-mapped образа модели). Крейт `gigastt-core` без серверных зависимостей: `gigastt-core = "2.21"`.
 
 ## Лицензия
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported |
 |---------|-----------|
-| 2.20.x  | Yes (current)  |
-| 2.19.x  | Yes (previous) |
-| < 2.19  | No             |
+| 2.21.x  | Yes (current)  |
+| 2.20.x  | Yes (previous) |
+| < 2.20  | No             |
 
 ## Reporting a Vulnerability
 

--- a/crates/gigastt-core/Cargo.toml
+++ b/crates/gigastt-core/Cargo.toml
@@ -91,7 +91,7 @@ ryf = { version = "0.7", optional = true }
 # this crate (decoder only — the encoder is not used).
 opus-rs = { version = "0.1", optional = true }
 bytes = "1"
-gigastt-quantize = { version = "2.20.0", path = "../gigastt-quantize", optional = true }
+gigastt-quantize = { version = "2.21.0", path = "../gigastt-quantize", optional = true }
 polyvoice = { version = "0.18.0", features = ["onnx"], optional = true }
 parking_lot = "0.12"
 libc = "0.2"

--- a/crates/gigastt-core/README.md
+++ b/crates/gigastt-core/README.md
@@ -8,7 +8,7 @@ Runtime is **INT8 only**. Default `rnnt` / `e2e_rnnt` files come from GitHub Rel
 
 ```toml
 [dependencies]
-gigastt-core = "2.20"
+gigastt-core = "2.21"
 ```
 
 ```rust,ignore
@@ -63,7 +63,7 @@ the engine work out of the box. For a lean embedded build that side-loads
 INT8 models and feeds raw PCM, disable defaults:
 
 ```toml
-gigastt-core = { version = "2.20", default-features = false }
+gigastt-core = { version = "2.21", default-features = false }
 ```
 
 That drops `tokio`, `reqwest`/HTTP, `symphonia`, `ryf`, and the quantizer (`protoc`)

--- a/crates/gigastt-node/package.json
+++ b/crates/gigastt-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gigastt",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "On-device Russian speech-to-text (GigaAM v3) — Node.js binding",
   "license": "MIT",
   "repository": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ gigastt is a **6-crate** Cargo workspace:
 | [`gigastt-uniffi`](../crates/gigastt-uniffi) | lib (cdylib) | UniFFI bindings (Python wheels / Swift / Kotlin path) |
 | [`gigastt-node`](../crates/gigastt-node) | lib (cdylib) | napi-rs Node.js / Electron binding |
 
-Embed inference in any Rust project with `gigastt-core = "2.20"`. For a lean embedded build, disable defaults (`default-features = false`) to drop `tokio` / `reqwest` / `symphonia` / `ryf` / polyvoice; opt capabilities back in via the `net`, `async-pool`, `file-decode`, `diarization`, and `quantize` features (`quantize` is packaging-only — the INT8 quantizer, not a runtime path).
+Embed inference in any Rust project with `gigastt-core = "2.21"`. For a lean embedded build, disable defaults (`default-features = false`) to drop `tokio` / `reqwest` / `symphonia` / `ryf` / polyvoice; opt capabilities back in via the `net`, `async-pool`, `file-decode`, `diarization`, and `quantize` features (`quantize` is packaging-only — the INT8 quantizer, not a runtime path).
 
 Server surfaces (single process, one primary port unless metrics is enabled):
 

--- a/docs/workbook/en/src/01-getting-started.md
+++ b/docs/workbook/en/src/01-getting-started.md
@@ -62,7 +62,7 @@ publishes tarballs for `x86_64-unknown-linux-gnu` and
 `aarch64-unknown-linux-gnu`:
 
 ```sh
-# Resolve the latest release tag (or set TAG=v2.20.0 by hand):
+# Resolve the latest release tag (or set TAG=v2.21.0 by hand):
 TAG=$(curl -fsSL https://api.github.com/repos/ekhodzitsky/gigastt/releases/latest \
       | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
 VER=${TAG#v}
@@ -105,7 +105,7 @@ Every release publishes `x86_64-pc-windows-msvc` tarballs (CPU). PowerShell
 
 ```powershell
 $rel = Invoke-RestMethod https://api.github.com/repos/ekhodzitsky/gigastt/releases/latest
-$TAG = $rel.tag_name          # e.g. v2.20.0
+$TAG = $rel.tag_name          # e.g. v2.21.0
 $VER = $TAG.TrimStart('v')
 $asset = "gigastt-$VER-x86_64-pc-windows-msvc.tar.gz"
 $base = "https://github.com/ekhodzitsky/gigastt/releases/download/$TAG"
@@ -166,7 +166,7 @@ curl -F file=@recording.wav http://127.0.0.1:9876/v1/transcribe
 **Verify:** `/health` returns
 
 ```json
-{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.20.0","punctuation":true,"itn":true}
+{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.21.0","punctuation":true,"itn":true}
 ```
 
 (the `version` field reflects the image you pulled), and the POST returns a

--- a/docs/workbook/en/src/05-desktop-embedded.md
+++ b/docs/workbook/en/src/05-desktop-embedded.md
@@ -197,8 +197,8 @@ gracefully.
    Connection-refused means the process is dead or not yet spawned — not that
    it is stuck.
 6. **Version handshake over HTTP.** `GET /health` returns 200 in *both*
-   phases — `{"status":"ok","model":"loading","version":"2.20.0"}` during
-   bootstrap, then `{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.20.0","punctuation":true,"itn":true}`.
+   phases — `{"status":"ok","model":"loading","version":"2.21.0"}` during
+   bootstrap, then `{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.21.0","punctuation":true,"itn":true}`.
    Gate your minimum engine version on the `version` field instead of running
    `gigastt --version` in a subprocess.
 7. **Transcribe.** For live partial results open a WebSocket session on

--- a/docs/workbook/ru/src/01-getting-started.md
+++ b/docs/workbook/ru/src/01-getting-started.md
@@ -63,7 +63,7 @@ $ gigastt transcribe recording.wav
 `aarch64-unknown-linux-gnu`:
 
 ```sh
-# Определить тег последнего релиза (или задайте TAG=v2.20.0 вручную):
+# Определить тег последнего релиза (или задайте TAG=v2.21.0 вручную):
 TAG=$(curl -fsSL https://api.github.com/repos/ekhodzitsky/gigastt/releases/latest \
       | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
 VER=${TAG#v}
@@ -107,7 +107,7 @@ stdout, а `ls ~/.gigastt/models/` показывает файлы модели 
 
 ```powershell
 $rel = Invoke-RestMethod https://api.github.com/repos/ekhodzitsky/gigastt/releases/latest
-$TAG = $rel.tag_name          # например v2.20.0
+$TAG = $rel.tag_name          # например v2.21.0
 $VER = $TAG.TrimStart('v')
 $asset = "gigastt-$VER-x86_64-pc-windows-msvc.tar.gz"
 $base = "https://github.com/ekhodzitsky/gigastt/releases/download/$TAG"
@@ -168,7 +168,7 @@ curl -F file=@recording.wav http://127.0.0.1:9876/v1/transcribe
 **Проверка:** `/health` возвращает
 
 ```json
-{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.20.0","punctuation":true,"itn":true}
+{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.21.0","punctuation":true,"itn":true}
 ```
 
 (поле `version` отражает скачанный образ), а POST возвращает JSON с

--- a/docs/workbook/ru/src/05-desktop-embedded.md
+++ b/docs/workbook/ru/src/05-desktop-embedded.md
@@ -201,8 +201,8 @@ Runtime — отдельный рантайм бандлить не нужно. 
    Connection-refused означает, что процесс мёртв или ещё не запущен, — а не
    что он завис.
 6. **Версионное рукопожатие по HTTP.** `GET /health` возвращает 200 в *обеих*
-   фазах — `{"status":"ok","model":"loading","version":"2.20.0"}` во время
-   bootstrap, затем `{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.20.0","punctuation":true,"itn":true}`.
+   фазах — `{"status":"ok","model":"loading","version":"2.21.0"}` во время
+   bootstrap, затем `{"status":"ok","model":"gigaam-v3-rnnt","variant":"rnnt","version":"2.21.0","punctuation":true,"itn":true}`.
    Гейт минимальной версии движка делайте по полю `version`, а не запуском
    `gigastt --version` подпроцессом.
 7. **Транскрибация.** Для live-частичных результатов откройте


### PR DESCRIPTION
## Summary
Version bump to **2.21.0**.

- Optional long-form window parallelism (`--file-window-concurrency`).
- ryf 0.7.2: GSM 06.10 in WAV (wav49) decodes natively.

## Test plan
- [x] `scripts/check-docs-drift.py`
- [x] pre-commit unit tests
- [ ] CI on this PR