### PR TITLE
ci: keep Dependabot away from the MSRV toolchain pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,8 @@ updates:
     commit-message:
       prefix: ci
       include: scope
+    # dtolnay/rust-toolchain@1.94 in the MSRV job is a deliberate pin
+    # (the tag selects the toolchain that proves the MSRV floor), not a
+    # stale action version — never bump it.
+    ignore:
+      - dependency-name: 'dtolnay/rust-toolchain'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,7 +769,9 @@ jobs:
     name: MSRV (1.94)
     steps:
       - uses: actions/checkout@v7
-      # MSRV floor: polyvoice 0.18 (rten-simd) declares rust-version 1.94.
+      # MSRV floor: polyvoice (rten-simd) declares rust-version 1.94. The
+      # toolchain tag is the pin — Dependabot must not bump it (see
+      # dependabot.yml ignore).
       - uses: dtolnay/rust-toolchain@1.94
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler


### PR DESCRIPTION
## Why

`dtolnay/rust-toolchain@1.94` in the MSRV job is a deliberate pin — the tag selects the toolchain that proves the MSRV floor (polyvoice/rten-simd declare rust-version 1.94). Dependabot bumped it to 1.120 in #334, which made the MSRV job test nothing and fail; #334 is closed unmerged.

## What

- `dependabot.yml`: ignore rule for `dtolnay/rust-toolchain` so the PR does not reappear weekly.
- `ci.yml`: refresh the stale "polyvoice 0.18" reference in the MSRV job comment (0.19 is on main now) and point at the ignore rule.