### PR TITLE
fix(serve): boot with a read-only model dir by relocating the ORT optimized-graph cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,6 +440,7 @@ reference: [`docs/cli.md`](docs/cli.md) (enforced by `scripts/check-docs-drift.p
 | `GIGASTT_METRICS` | `--metrics` | false |
 | `GIGASTT_METRICS_LISTEN` | `--metrics-listen` | 127.0.0.1:9090 |
 | `GIGASTT_MODEL_VARIANT` | `--model-variant` | rnnt (fresh installs) |
+| `GIGASTT_OPTIMIZED_CACHE_DIR` | `--optimized-cache-dir` (also on `cache-gc`) | `<model-dir>/optimized_cache` |
 | `GIGASTT_PUNCTUATION` | `--punctuation` | auto |
 | `GIGASTT_PUNCT_MODEL_DIR` | `--punct-model-dir` | `~/.gigastt/models/punct/` |
 | `GIGASTT_ITN` | `--itn` | auto |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ Versions 0.1.0 and 0.1.1 were published to crates.io on 2026-04-09 and yanked
 
 ## [Unreleased]
 
+### Added
+
+- **`--optimized-cache-dir <PATH>`** (env `GIGASTT_OPTIMIZED_CACHE_DIR`) on
+  `serve` and `cache-gc`: where the CPU encoder writes/reads the ORT
+  optimized-graph cache (`*_optimized.ort`). Default unchanged:
+  `<model-dir>/optimized_cache`. `cache-gc` prunes the directory given here.
+
+### Fixed
+
+- **Boot failure with a read-only model directory** (#336). The shipped
+  systemd unit installs models under `/usr/share/gigastt/models` with
+  `ProtectSystem=strict`, but the CPU encoder load path wrote the ORT
+  optimized-graph cache into `<model-dir>/optimized_cache` and a failed
+  `create_dir_all` was fatal — the service restart-looped with EROFS. The
+  unit now sets `CacheDirectory=gigastt` and passes
+  `--optimized-cache-dir /var/cache/gigastt`, and the loader degrades
+  gracefully: when the cache directory cannot be created or is not writable,
+  the server logs a warning and starts without the cache (slower cold start,
+  higher per-session RAM) instead of failing.
+
 ## [2.21.0] - 2026-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ Versions 0.1.0 and 0.1.1 were published to crates.io on 2026-04-09 and yanked
   `ProtectSystem=strict`, but the CPU encoder load path wrote the ORT
   optimized-graph cache into `<model-dir>/optimized_cache` and a failed
   `create_dir_all` was fatal — the service restart-looped with EROFS. The
-  unit now sets `CacheDirectory=gigastt` and passes
-  `--optimized-cache-dir /var/cache/gigastt`, and the loader degrades
+  unit now sets `CacheDirectory=gigastt` and points the cache there via
+  `Environment=GIGASTT_OPTIMIZED_CACHE_DIR=/var/cache/gigastt` (overridable
+  in `/etc/gigastt/gigastt.env`), and the loader degrades
   gracefully: when the cache directory cannot be created or is not writable,
   the server logs a warning and starts without the cache (slower cold start,
   higher per-session RAM) instead of failing.

--- a/crates/gigastt-core/src/inference/engine/load.rs
+++ b/crates/gigastt-core/src/inference/engine/load.rs
@@ -109,7 +109,7 @@ impl Engine {
     /// override for the CPU encoder's ORT optimized-graph cache directory.
     /// `None` keeps the default `<model_dir>/optimized_cache`; `Some(dir)`
     /// relocates the cache (e.g. a writable cache directory when the model
-    /// dir is read-only). Ignored by the CoreML / CUDA / candle builds.
+    /// dir is read-only). Only used by the CPU ort backend.
     #[allow(clippy::too_many_arguments)]
     pub fn load_with_pools_threads_variant_cache(
         model_dir: &str,

--- a/crates/gigastt-core/src/inference/engine/load.rs
+++ b/crates/gigastt-core/src/inference/engine/load.rs
@@ -94,6 +94,32 @@ impl Engine {
         batch_pool_size: usize,
         encoder_intra_threads: usize,
     ) -> Result<Self, GigasttError> {
+        Self::load_with_pools_threads_variant_cache(
+            model_dir,
+            variant,
+            pool_size,
+            min_size,
+            batch_pool_size,
+            encoder_intra_threads,
+            None,
+        )
+    }
+
+    /// Like [`Engine::load_with_pools_threads_variant`], with an optional
+    /// override for the CPU encoder's ORT optimized-graph cache directory.
+    /// `None` keeps the default `<model_dir>/optimized_cache`; `Some(dir)`
+    /// relocates the cache (e.g. a writable cache directory when the model
+    /// dir is read-only). Ignored by the CoreML / CUDA / candle builds.
+    #[allow(clippy::too_many_arguments)]
+    pub fn load_with_pools_threads_variant_cache(
+        model_dir: &str,
+        variant: Option<ModelVariant>,
+        pool_size: usize,
+        min_size: usize,
+        batch_pool_size: usize,
+        encoder_intra_threads: usize,
+        optimized_cache_dir: Option<PathBuf>,
+    ) -> Result<Self, GigasttError> {
         let dir = Path::new(model_dir);
         // Resolve the head once, up front: an explicit `variant` wins, else
         // manifest.toml architecture, else detect from disk (rnnt precedence).
@@ -117,7 +143,8 @@ impl Engine {
         let encoder_intra_threads =
             Self::clamp_encoder_intra_threads(pool_size, encoder_intra_threads, logical_cpus);
 
-        let factory = production_factory_variant(dir, Some(variant));
+        let factory =
+            production_factory_variant_with_cache(dir, Some(variant), optimized_cache_dir);
         Self::load_with_factory(
             dir,
             Some(variant),

--- a/crates/gigastt-core/src/inference/engine/mod.rs
+++ b/crates/gigastt-core/src/inference/engine/mod.rs
@@ -1,13 +1,13 @@
 //! ONNX Runtime inference engine for GigaAM v3.
 
 use anyhow::Context;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::GigasttError;
 use crate::model::ModelVariant;
 #[allow(unused_imports)]
 use crate::runtime::factory::RuntimeFactory;
-use crate::runtime::production_factory_variant;
+use crate::runtime::production_factory_variant_with_cache;
 use crate::runtime::tensor::{Shape, TensorDataView};
 
 use super::audio;

--- a/crates/gigastt-core/src/model/cache.rs
+++ b/crates/gigastt-core/src/model/cache.rs
@@ -119,11 +119,22 @@ pub struct DedupeReport {
 ///
 /// With `dry_run`, reports what would be deleted without removing files.
 pub fn prune_optimized_cache(model_dir: &Path, dry_run: bool) -> Result<OptimizedCachePruneReport> {
+    prune_optimized_cache_dir(&model_dir.join("optimized_cache"), model_dir, dry_run)
+}
+
+/// Like [`prune_optimized_cache`], but prunes an explicit cache directory
+/// instead of the default `model_dir/optimized_cache` — for installs where
+/// the cache was relocated via `--optimized-cache-dir`. Keep names are still
+/// resolved from the installed heads under `model_dir`.
+pub fn prune_optimized_cache_dir(
+    cache_dir: &Path,
+    model_dir: &Path,
+    dry_run: bool,
+) -> Result<OptimizedCachePruneReport> {
     let mut report = OptimizedCachePruneReport {
         dry_run,
         ..Default::default()
     };
-    let cache_dir = model_dir.join("optimized_cache");
     if !cache_dir.is_dir() {
         return Ok(report);
     }
@@ -150,7 +161,7 @@ pub fn prune_optimized_cache(model_dir: &Path, dry_run: bool) -> Result<Optimize
         return Ok(report);
     }
 
-    for entry in std::fs::read_dir(&cache_dir)
+    for entry in std::fs::read_dir(cache_dir)
         .with_context(|| format!("failed to read optimized_cache at {}", cache_dir.display()))?
     {
         let entry = entry.context("failed to read optimized_cache entry")?;

--- a/crates/gigastt-core/src/model/cache/tests.rs
+++ b/crates/gigastt-core/src/model/cache/tests.rs
@@ -196,6 +196,33 @@ fn test_prune_optimized_cache_no_head_leaves_cache() {
 }
 
 #[test]
+fn test_prune_optimized_cache_dir_prunes_explicit_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    // Active rnnt INT8 install with a relocated cache (e.g. systemd
+    // CacheDirectory) outside the model dir.
+    for f in ModelVariant::Rnnt.prequantized_files() {
+        write_file(&dir.join(f), b"stub");
+    }
+    let cache = tmp.path().join("relocated_cache");
+    let keep = cache.join("v3_rnnt_encoder_int8_optimized.ort");
+    let zombie = cache.join("v3_e2e_rnnt_encoder_int8_optimized.ort");
+    write_file(&keep, &[1u8; 100]);
+    write_file(&zombie, &[2u8; 200]);
+
+    let report = prune_optimized_cache_dir(&cache, dir, false).unwrap();
+    assert_eq!(report.kept, vec![keep.clone()]);
+    assert_eq!(report.removed, vec![zombie.clone()]);
+    assert!(keep.exists());
+    assert!(!zombie.exists());
+
+    // A missing explicit cache dir is a no-op, same as the default path.
+    let report = prune_optimized_cache_dir(&tmp.path().join("absent"), dir, false).unwrap();
+    assert!(report.kept.is_empty());
+    assert!(report.removed.is_empty());
+}
+
+#[test]
 fn test_prune_coreml_cache_keeps_current_version_drops_stale() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path();

--- a/crates/gigastt-core/src/model/mod.rs
+++ b/crates/gigastt-core/src/model/mod.rs
@@ -22,7 +22,7 @@ mod variant;
 pub(crate) use cache::coreml_cache_dir;
 pub use cache::{
     CoremlCachePruneReport, DedupeReport, OptimizedCachePruneReport, dedupe_model_dir,
-    optimized_cache_basename, prune_coreml_cache, prune_optimized_cache,
+    optimized_cache_basename, prune_coreml_cache, prune_optimized_cache, prune_optimized_cache_dir,
 };
 pub use manifest::{MANIFEST_FILE, ManifestFiles, ModelManifest};
 

--- a/crates/gigastt-core/src/runtime/mod.rs
+++ b/crates/gigastt-core/src/runtime/mod.rs
@@ -29,7 +29,7 @@ pub fn ane_factory() -> Box<dyn RuntimeFactory> {
 pub use error::RuntimeError;
 #[allow(unused_imports)]
 pub use factory::{Runtime, RuntimeFactory};
-pub(crate) use ort::factory::production_factory_variant;
+pub(crate) use ort::factory::production_factory_variant_with_cache;
 #[allow(unused_imports)]
 pub use ort::factory::{cpu_factory, production_factory};
 #[allow(unused_imports)]

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -275,6 +275,19 @@ pub(crate) fn production_factory_variant(
     model_dir: &Path,
     variant: Option<crate::model::ModelVariant>,
 ) -> Box<dyn RuntimeFactory> {
+    production_factory_variant_with_cache(model_dir, variant, None)
+}
+
+/// Like [`production_factory_variant`], with an optional override for the CPU
+/// encoder's ORT optimized-graph cache directory. `None` keeps the default
+/// `<model_dir>/optimized_cache`; `Some(dir)` relocates it (e.g. a writable
+/// `CacheDirectory` when the model dir is read-only under systemd
+/// `ProtectSystem=strict`).
+pub(crate) fn production_factory_variant_with_cache(
+    model_dir: &Path,
+    variant: Option<crate::model::ModelVariant>,
+    optimized_cache_dir: Option<PathBuf>,
+) -> Box<dyn RuntimeFactory> {
     let backend = select_backend(variant);
     // The Candle/ANE backends are rnnt-only (34-token char vocab,
     // `EncoderConfig::v3_rnnt()`); for any other head they would produce wrong
@@ -307,11 +320,13 @@ pub(crate) fn production_factory_variant(
         // Remeasure the pool-1→2 RSS after ORT upgrades. Safe no-op if unused.
         let prepacked = std::sync::Arc::new(ort::session::builder::PrepackedWeights::new());
         OrtFactory::cpu()
-            .with_optimized_cache_dir(model_dir.join("optimized_cache"))
+            .with_optimized_cache_dir(
+                optimized_cache_dir.unwrap_or_else(|| model_dir.join("optimized_cache")),
+            )
             .with_prepacked_weights(prepacked)
     };
     #[cfg(any(feature = "coreml", feature = "cuda"))]
-    let _ = model_dir;
+    let _ = (model_dir, optimized_cache_dir);
     Box::new(factory)
 }
 

--- a/crates/gigastt-core/src/runtime/ort/factory.rs
+++ b/crates/gigastt-core/src/runtime/ort/factory.rs
@@ -224,7 +224,7 @@ pub fn cpu_factory() -> Box<dyn RuntimeFactory> {
 /// disk-cache layout used by the engine before the runtime abstraction.
 ///
 /// Public, stable 1-arg form: selects the backend from the variant detected on
-/// disk. The engine calls the crate-internal `production_factory_variant`
+/// disk. The engine calls the crate-internal `production_factory_variant_with_cache`
 /// instead, passing the head it has already resolved so an explicit
 /// `--model-variant` is honored.
 pub fn production_factory(model_dir: &Path) -> Box<dyn RuntimeFactory> {

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -79,6 +79,40 @@ fn optimized_cache_path(cache_dir: &Path, model_path: &Path) -> std::path::PathB
     cache_dir.join(basename)
 }
 
+/// Decide whether the ORT optimized-graph cache under `cache_dir` is usable:
+/// the directory must be creatable and writable. Read-only model installs
+/// (e.g. systemd `ProtectSystem=strict` with models under `/usr/share`) make
+/// either step fail with `EROFS`; boot must degrade to a cache-less load
+/// (slower cold start, higher per-session RAM) instead of failing, so both
+/// failures only warn and return `None`. Writability is probed by creating
+/// and deleting a temp file — an existing-but-read-only dir passes
+/// `create_dir_all` yet still cannot hold the cache.
+fn usable_optimized_cache_dir(cache_dir: &Path) -> Option<std::path::PathBuf> {
+    if let Err(e) = std::fs::create_dir_all(cache_dir) {
+        tracing::warn!(
+            path = %cache_dir.display(),
+            error = %e,
+            "encoder: optimized graph cache directory cannot be created; loading source model without the cache"
+        );
+        return None;
+    }
+    let probe = cache_dir.join(format!(".write-probe-{}", std::process::id()));
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            Some(cache_dir.to_path_buf())
+        }
+        Err(e) => {
+            tracing::warn!(
+                path = %cache_dir.display(),
+                error = %e,
+                "encoder: optimized graph cache directory is not writable; loading source model without the cache"
+            );
+            None
+        }
+    }
+}
+
 impl OrtRuntime {
     /// Assemble the session builder with prepacked weights, execution
     /// providers, and (CPU-only) thread counts. Cheap: no model parsing
@@ -206,10 +240,12 @@ impl Runtime for OrtRuntime {
 
         if self.provider.is_cpu()
             && is_encoder
-            && let Some(cache_dir) = &self.optimized_cache_dir
+            && let Some(cache_dir) = self
+                .optimized_cache_dir
+                .as_deref()
+                .and_then(usable_optimized_cache_dir)
         {
-            std::fs::create_dir_all(cache_dir).map_err(|e| load_failed(model_path, e))?;
-            let cache_path = optimized_cache_path(cache_dir, model_path);
+            let cache_path = optimized_cache_path(&cache_dir, model_path);
             tracing::info!(
                 path = %cache_path.display(),
                 "encoder: loading source model and refreshing optimized graph cache"
@@ -326,5 +362,49 @@ mod tests {
             optimized_cache_path(cache_dir, encoder),
             Path::new("/models/optimized_cache/v3_rnnt_encoder_int8_optimized.ort")
         );
+    }
+
+    #[test]
+    fn test_usable_optimized_cache_dir_creates_and_returns_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("optimized_cache");
+        assert!(!cache_dir.exists());
+        assert_eq!(
+            usable_optimized_cache_dir(&cache_dir),
+            Some(cache_dir.clone())
+        );
+        assert!(cache_dir.is_dir());
+        // The write probe must not leave files behind.
+        assert_eq!(std::fs::read_dir(&cache_dir).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn test_usable_optimized_cache_dir_uncreatable_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A path under a regular file fails `create_dir_all` (ENOTDIR) on
+        // every platform and privilege level — no reliance on permissions.
+        let blocker = tmp.path().join("blocker");
+        write_file(&blocker, b"not a dir");
+        let cache_dir = blocker.join("optimized_cache");
+        assert_eq!(usable_optimized_cache_dir(&cache_dir), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_usable_optimized_cache_dir_read_only_returns_none() {
+        // Root bypasses directory write permission bits, so the probe would
+        // succeed and this test cannot exercise the read-only path.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("optimized_cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::set_permissions(&cache_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+        // An existing-but-read-only dir passes `create_dir_all` yet cannot
+        // hold the cache: the write probe must degrade to `None`.
+        assert_eq!(usable_optimized_cache_dir(&cache_dir), None);
+        std::fs::set_permissions(&cache_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 }

--- a/crates/gigastt-core/src/runtime/ort/session.rs
+++ b/crates/gigastt-core/src/runtime/ort/session.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use ort::session::Session;
 
@@ -15,6 +15,12 @@ pub struct OrtRuntime {
     provider: OrtExecutionProvider,
     prepacked: Option<Arc<ort::session::builder::PrepackedWeights>>,
     optimized_cache_dir: Option<std::path::PathBuf>,
+    /// Once-per-runtime result of the cache-dir writability probe. Pool
+    /// triplets load concurrently on this shared runtime, so probing per
+    /// `load_session` would repeat the probe (and its warning) pool-size
+    /// times at every boot. Admin reload builds a fresh `OrtRuntime`, so
+    /// re-probing on reload is preserved.
+    usable_cache_dir: OnceLock<Option<std::path::PathBuf>>,
 }
 
 impl OrtRuntime {
@@ -29,6 +35,7 @@ impl OrtRuntime {
             provider,
             prepacked,
             optimized_cache_dir,
+            usable_cache_dir: OnceLock::new(),
         }
     }
 }
@@ -92,7 +99,7 @@ fn usable_optimized_cache_dir(cache_dir: &Path) -> Option<std::path::PathBuf> {
         tracing::warn!(
             path = %cache_dir.display(),
             error = %e,
-            "encoder: optimized graph cache directory cannot be created; loading source model without the cache"
+            "encoder: optimized graph cache directory cannot be created; loading source model without the cache (slower cold start, higher per-session RAM)"
         );
         return None;
     }
@@ -106,7 +113,7 @@ fn usable_optimized_cache_dir(cache_dir: &Path) -> Option<std::path::PathBuf> {
             tracing::warn!(
                 path = %cache_dir.display(),
                 error = %e,
-                "encoder: optimized graph cache directory is not writable; loading source model without the cache"
+                "encoder: optimized graph cache directory is not writable; loading source model without the cache (slower cold start, higher per-session RAM)"
             );
             None
         }
@@ -238,20 +245,33 @@ impl Runtime for OrtRuntime {
 
         let mut builder = self.session_builder(model_path, is_encoder)?;
 
-        if self.provider.is_cpu()
-            && is_encoder
-            && let Some(cache_dir) = self
-                .optimized_cache_dir
-                .as_deref()
-                .and_then(usable_optimized_cache_dir)
-        {
-            let cache_path = optimized_cache_path(&cache_dir, model_path);
+        // Compute the cache path up front (probing writability once per
+        // runtime via the OnceLock), then commit with the fallback: a
+        // writable directory does not guarantee the ~224 MiB cache *file*
+        // write succeeds (stale root-owned entry, ENOSPC mid-write), and ORT
+        // treats that failure as fatal to `commit_from_file` — so on error
+        // retry with a freshly built, cache-less builder (builders are cheap,
+        // see `session_builder`).
+        let cache_path = if self.provider.is_cpu() && is_encoder {
+            self.usable_cache_dir
+                .get_or_init(|| {
+                    self.optimized_cache_dir
+                        .as_deref()
+                        .and_then(usable_optimized_cache_dir)
+                })
+                .as_ref()
+                .map(|dir| optimized_cache_path(dir, model_path))
+        } else {
+            None
+        };
+
+        if let Some(cache_path) = cache_path.as_ref() {
             tracing::info!(
                 path = %cache_path.display(),
                 "encoder: loading source model and refreshing optimized graph cache"
             );
             builder = builder
-                .with_optimized_model_path(&cache_path)
+                .with_optimized_model_path(cache_path)
                 .map_err(|e| load_failed(model_path, e))?;
             // Persist the optimized graph in ORT flatbuffer format so the
             // next boot can memory-map it (see `try_load_cached_encoder`).
@@ -260,9 +280,22 @@ impl Runtime for OrtRuntime {
                 .map_err(|e| load_failed(model_path, e))?;
         }
 
-        let session = builder
-            .commit_from_file(model_path)
-            .map_err(|e| load_failed(model_path, e))?;
+        let session = match builder.commit_from_file(model_path) {
+            Ok(session) => session,
+            Err(e) => {
+                let Some(cache_path) = cache_path.as_ref() else {
+                    return Err(load_failed(model_path, e));
+                };
+                tracing::warn!(
+                    path = %cache_path.display(),
+                    error = %e,
+                    "encoder: optimized graph cache write failed; retrying without the cache (slower cold start, higher per-session RAM)"
+                );
+                self.session_builder(model_path, is_encoder)?
+                    .commit_from_file(model_path)
+                    .map_err(|e| load_failed(model_path, e))?
+            }
+        };
         Ok(Box::new(OrtSession {
             session: Mutex::new(session),
         }))
@@ -395,6 +428,10 @@ mod tests {
         // Root bypasses directory write permission bits, so the probe would
         // succeed and this test cannot exercise the read-only path.
         if unsafe { libc::geteuid() } == 0 {
+            eprintln!(
+                "test_usable_optimized_cache_dir_read_only_returns_none: running as root, \
+                 skipping (root bypasses write permission bits) — vacuous pass"
+            );
             return;
         }
         use std::os::unix::fs::PermissionsExt;
@@ -404,7 +441,32 @@ mod tests {
         std::fs::set_permissions(&cache_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
         // An existing-but-read-only dir passes `create_dir_all` yet cannot
         // hold the cache: the write probe must degrade to `None`.
-        assert_eq!(usable_optimized_cache_dir(&cache_dir), None);
+        // Capture the result and restore permissions BEFORE asserting, so a
+        // failing assert does not strand a 0o555 dir that tempdir's Drop
+        // cannot remove (masking the real failure).
+        let result = usable_optimized_cache_dir(&cache_dir);
         std::fs::set_permissions(&cache_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_usable_optimized_cache_dir_concurrent_probes() {
+        // Pool triplets load concurrently on the same runtime, so the probe
+        // can race with itself within one process: the shared probe file name
+        // (.write-probe-<pid>) must tolerate create/delete races and every
+        // caller must still see a usable dir with no leftovers.
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("optimized_cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::thread::scope(|s| {
+            let handles: Vec<_> = (0..4)
+                .map(|_| s.spawn(|| usable_optimized_cache_dir(&cache_dir)))
+                .collect();
+            for h in handles {
+                assert_eq!(h.join().unwrap(), Some(cache_dir.clone()));
+            }
+        });
+        let leftover: Vec<_> = std::fs::read_dir(&cache_dir).unwrap().collect();
+        assert!(leftover.is_empty(), "probe left files behind: {leftover:?}");
     }
 }

--- a/crates/gigastt/src/boot.rs
+++ b/crates/gigastt/src/boot.rs
@@ -125,6 +125,10 @@ pub struct EngineRecipe {
     /// Max pooled triplets one file decode may hold for overlapping-window
     /// parallelism. `1` keeps the serial loop (default).
     pub file_window_concurrency: usize,
+    /// Override for the CPU encoder's ORT optimized-graph cache directory
+    /// (serve `--optimized-cache-dir`). `None` keeps the default
+    /// `<model_dir>/optimized_cache`.
+    pub optimized_cache_dir: Option<String>,
 }
 
 impl EngineRecipe {
@@ -170,6 +174,7 @@ impl EngineRecipe {
             stream_max_window_secs: None,
             stream_stable_prefix: false,
             file_window_concurrency: 1,
+            optimized_cache_dir: None,
         }
     }
 
@@ -227,13 +232,16 @@ impl EngineRecipe {
                 .map(|n| n.get())
                 .unwrap_or(1),
         );
-        let mut engine = inference::Engine::load_with_pools_threads_variant(
+        let mut engine = inference::Engine::load_with_pools_threads_variant_cache(
             &self.model_dir,
             Some(resolved),
             self.pool_size,
             self.pool_min_size,
             self.batch_pool_size,
             resolved_intra_threads,
+            self.optimized_cache_dir
+                .as_deref()
+                .map(std::path::PathBuf::from),
         )?
         .with_punctuator(punctuator)
         .with_itn(resolve_itn(self.itn, resolved))

--- a/crates/gigastt/src/cli_tests/download.rs
+++ b/crates/gigastt/src/cli_tests/download.rs
@@ -36,6 +36,8 @@ fn test_cli_cache_gc_parsing() {
         "/tmp/models",
         "--dry-run",
         "--dedupe",
+        "--optimized-cache-dir",
+        "/var/cache/gigastt",
     ])
     .expect("parse cache-gc");
     match cli.command {
@@ -43,10 +45,56 @@ fn test_cli_cache_gc_parsing() {
             model_dir,
             dry_run,
             dedupe,
+            optimized_cache_dir,
         } => {
             assert_eq!(model_dir, "/tmp/models");
             assert!(dry_run);
             assert!(dedupe);
+            assert_eq!(optimized_cache_dir.as_deref(), Some("/var/cache/gigastt"));
+        }
+        _ => panic!("expected CacheGc"),
+    }
+}
+
+#[test]
+fn test_cli_cache_gc_optimized_cache_dir_defaults_to_none() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let _restore = EnvRestore(
+        "GIGASTT_OPTIMIZED_CACHE_DIR",
+        std::env::var("GIGASTT_OPTIMIZED_CACHE_DIR").ok(),
+    );
+    unsafe {
+        std::env::remove_var("GIGASTT_OPTIMIZED_CACHE_DIR");
+    }
+    let cli = Cli::try_parse_from(["gigastt", "cache-gc"]).expect("parse cache-gc");
+    match cli.command {
+        Commands::CacheGc {
+            optimized_cache_dir,
+            ..
+        } => {
+            assert_eq!(optimized_cache_dir, None);
+        }
+        _ => panic!("expected CacheGc"),
+    }
+}
+
+#[test]
+fn test_cli_cache_gc_optimized_cache_dir_env_var() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let _restore = EnvRestore(
+        "GIGASTT_OPTIMIZED_CACHE_DIR",
+        std::env::var("GIGASTT_OPTIMIZED_CACHE_DIR").ok(),
+    );
+    unsafe {
+        std::env::set_var("GIGASTT_OPTIMIZED_CACHE_DIR", "/var/cache/gigastt");
+    }
+    let cli = Cli::try_parse_from(["gigastt", "cache-gc"]).expect("parse cache-gc");
+    match cli.command {
+        Commands::CacheGc {
+            optimized_cache_dir,
+            ..
+        } => {
+            assert_eq!(optimized_cache_dir.as_deref(), Some("/var/cache/gigastt"));
         }
         _ => panic!("expected CacheGc"),
     }

--- a/crates/gigastt/src/cli_tests/serve.rs
+++ b/crates/gigastt/src/cli_tests/serve.rs
@@ -42,6 +42,53 @@ fn test_cli_serve_profile_edge_defaults_pool_and_vad_flags() {
 }
 
 #[test]
+fn test_cli_serve_optimized_cache_dir_flag_and_env() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let _restore = EnvRestore(
+        "GIGASTT_OPTIMIZED_CACHE_DIR",
+        std::env::var("GIGASTT_OPTIMIZED_CACHE_DIR").ok(),
+    );
+    unsafe {
+        std::env::remove_var("GIGASTT_OPTIMIZED_CACHE_DIR");
+    }
+    // Unset → None: the engine keeps `<model-dir>/optimized_cache`.
+    let cli = Cli::parse_from(["gigastt", "serve"]);
+    match cli.command {
+        Commands::Serve(ServeArgs {
+            optimized_cache_dir,
+            ..
+        }) => assert_eq!(optimized_cache_dir, None),
+        _ => panic!("expected Serve"),
+    }
+    // Explicit flag wins.
+    let cli = Cli::parse_from([
+        "gigastt",
+        "serve",
+        "--optimized-cache-dir",
+        "/var/cache/gigastt",
+    ]);
+    match cli.command {
+        Commands::Serve(ServeArgs {
+            optimized_cache_dir,
+            ..
+        }) => assert_eq!(optimized_cache_dir.as_deref(), Some("/var/cache/gigastt")),
+        _ => panic!("expected Serve"),
+    }
+    // Env var fallback.
+    unsafe {
+        std::env::set_var("GIGASTT_OPTIMIZED_CACHE_DIR", "/tmp/gigastt-cache");
+    }
+    let cli = Cli::parse_from(["gigastt", "serve"]);
+    match cli.command {
+        Commands::Serve(ServeArgs {
+            optimized_cache_dir,
+            ..
+        }) => assert_eq!(optimized_cache_dir.as_deref(), Some("/tmp/gigastt-cache")),
+        _ => panic!("expected Serve"),
+    }
+}
+
+#[test]
 fn test_cli_serve_encoder_intra_threads_default() {
     // Unset → None, so the default resolves from the pool size at load time.
     let _guard = ENV_LOCK.lock().unwrap();

--- a/crates/gigastt/src/main.rs
+++ b/crates/gigastt/src/main.rs
@@ -113,6 +113,13 @@ enum Commands {
         /// (SHA-256 groups). Off by default — optimized_cache prune always runs.
         #[arg(long, default_value_t = false)]
         dedupe: bool,
+
+        /// Directory of the ORT optimized-graph cache to prune. Defaults to
+        /// `<model-dir>/optimized_cache`; set this when the cache was
+        /// relocated via `serve --optimized-cache-dir`. Env:
+        /// GIGASTT_OPTIMIZED_CACHE_DIR.
+        #[arg(long, env = "GIGASTT_OPTIMIZED_CACHE_DIR", value_name = "PATH")]
+        optimized_cache_dir: Option<String>,
     },
 
     /// Transcribe an audio file (offline)
@@ -386,8 +393,9 @@ async fn main() -> anyhow::Result<()> {
             model_dir,
             dry_run,
             dedupe,
+            optimized_cache_dir,
         } => {
-            run_cache_gc(model_dir, dry_run, dedupe)?;
+            run_cache_gc(model_dir, dry_run, dedupe, optimized_cache_dir)?;
         }
         Commands::Transcribe {
             file,

--- a/crates/gigastt/src/packaging.rs
+++ b/crates/gigastt/src/packaging.rs
@@ -30,9 +30,19 @@ pub(crate) fn run_quantize(model_dir: String, force: bool) -> anyhow::Result<()>
 }
 
 /// Prune optimized/CoreML caches and optionally content-hash-dedupe the model dir.
-pub(crate) fn run_cache_gc(model_dir: String, dry_run: bool, dedupe: bool) -> anyhow::Result<()> {
+pub(crate) fn run_cache_gc(
+    model_dir: String,
+    dry_run: bool,
+    dedupe: bool,
+    optimized_cache_dir: Option<String>,
+) -> anyhow::Result<()> {
     let dir = std::path::Path::new(&model_dir);
-    let prune = model::prune_optimized_cache(dir, dry_run)?;
+    let prune = match optimized_cache_dir {
+        Some(cache_dir) => {
+            model::prune_optimized_cache_dir(std::path::Path::new(&cache_dir), dir, dry_run)?
+        }
+        None => model::prune_optimized_cache(dir, dry_run)?,
+    };
     let action = if dry_run { "would free" } else { "freed" };
     println!(
         "optimized_cache: kept {} graph(s), removed {} ({} {:.1} MiB)",
@@ -192,7 +202,32 @@ mod tests {
     #[test]
     fn test_run_cache_gc_empty_dir_is_ok() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        run_cache_gc(tmp.path().display().to_string(), true, true).expect("empty dry-run");
-        run_cache_gc(tmp.path().display().to_string(), false, false).expect("empty prune");
+        run_cache_gc(tmp.path().display().to_string(), true, true, None).expect("empty dry-run");
+        run_cache_gc(tmp.path().display().to_string(), false, false, None).expect("empty prune");
+    }
+
+    #[test]
+    fn test_run_cache_gc_prunes_explicit_optimized_cache_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let model_dir = tmp.path().join("models");
+        // rnnt INT8 stub so the prune has a keep-name.
+        std::fs::create_dir_all(&model_dir).unwrap();
+        std::fs::write(model_dir.join("v3_rnnt_encoder_int8.onnx"), b"int8").unwrap();
+        let cache_dir = tmp.path().join("elsewhere");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let keep = cache_dir.join("v3_rnnt_encoder_int8_optimized.ort");
+        let zombie = cache_dir.join("v3_e2e_rnnt_encoder_int8_optimized.ort");
+        std::fs::write(&keep, b"keep").unwrap();
+        std::fs::write(&zombie, b"zombie").unwrap();
+
+        run_cache_gc(
+            model_dir.display().to_string(),
+            false,
+            false,
+            Some(cache_dir.display().to_string()),
+        )
+        .expect("prune explicit cache dir");
+        assert!(keep.exists());
+        assert!(!zombie.exists());
     }
 }

--- a/crates/gigastt/src/serve.rs
+++ b/crates/gigastt/src/serve.rs
@@ -147,6 +147,15 @@ pub(crate) struct ServeArgs {
     #[arg(long, env = "GIGASTT_VAD_MODEL_DIR", default_value_t = model::default_vad_model_dir())]
     pub(crate) vad_model_dir: String,
 
+    /// Directory for the CPU encoder's ORT optimized-graph cache
+    /// (`*_optimized.ort`). Defaults to `<model-dir>/optimized_cache`; set this
+    /// (e.g. to a systemd `CacheDirectory`) when the model directory is
+    /// read-only. An unwritable cache dir is skipped with a warning instead of
+    /// failing boot. No effect on CoreML / CUDA builds. Env:
+    /// GIGASTT_OPTIMIZED_CACHE_DIR.
+    #[arg(long, env = "GIGASTT_OPTIMIZED_CACHE_DIR", value_name = "PATH")]
+    pub(crate) optimized_cache_dir: Option<String>,
+
     /// Streaming utterance-end policy for WebSocket sessions.
     /// `auto` (default): VAD silence if `--vad`, else decoder blank-run (~0.6 s).
     /// `assistant`: only VAD silence ends utterances (use with `--vad`); blank-run
@@ -443,6 +452,7 @@ pub(crate) async fn run_serve(
         stream_max_window_secs: Some(args.stream_max_window_secs),
         stream_stable_prefix: args.stream_stable_prefix,
         file_window_concurrency: args.file_window_concurrency.max(1),
+        optimized_cache_dir: args.optimized_cache_dir,
     };
     let build_engine: server::EngineBuilder = {
         let recipe = recipe.clone();

--- a/crates/gigastt/src/serve.rs
+++ b/crates/gigastt/src/serve.rs
@@ -151,7 +151,7 @@ pub(crate) struct ServeArgs {
     /// (`*_optimized.ort`). Defaults to `<model-dir>/optimized_cache`; set this
     /// (e.g. to a systemd `CacheDirectory`) when the model directory is
     /// read-only. An unwritable cache dir is skipped with a warning instead of
-    /// failing boot. No effect on CoreML / CUDA builds. Env:
+    /// failing boot. Only used by the CPU ort backend. Env:
     /// GIGASTT_OPTIMIZED_CACHE_DIR.
     #[arg(long, env = "GIGASTT_OPTIMIZED_CACHE_DIR", value_name = "PATH")]
     pub(crate) optimized_cache_dir: Option<String>,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,6 +31,14 @@ gigastt serve [OPTIONS]
   --port <PORT>             Listen port [default: 9876]
   --host <HOST>             Bind address [default: 127.0.0.1]
   --model-dir <DIR>         Model directory [default: ~/.gigastt/models]
+  --optimized-cache-dir <PATH>  ORT optimized-graph cache directory
+                            [default: <model-dir>/optimized_cache]. Where the
+                            CPU encoder writes/reads its *_optimized.ort graphs.
+                            If the directory cannot be created or is not
+                            writable, the server logs a warning and starts
+                            without the cache (slower cold start, higher
+                            per-session RAM) instead of failing.
+                            Env: GIGASTT_OPTIMIZED_CACHE_DIR.
   --model-variant <V>       Recognition head: rnnt | e2e_rnnt | ml_ctc | ml_ctc_large.
                             Omit to use the model already installed; fresh installs
                             default to rnnt (lower WER, no punctuation). e2e_rnnt keeps
@@ -343,10 +351,17 @@ gigastt quantize [OPTIONS]          # packaging only (needs local FP32 source)
 
 gigastt cache-gc [OPTIONS]
   --model-dir <DIR>      Model directory [default: ~/.gigastt/models]
+  --optimized-cache-dir <PATH>  ORT optimized-graph cache directory to prune
+                         [default: <model-dir>/optimized_cache]. Pass the same
+                         path `serve` uses (e.g. /var/cache/gigastt under the
+                         shipped systemd unit) so stale *_optimized.ort graphs
+                         are pruned from the right place.
+                         Env: GIGASTT_OPTIMIZED_CACHE_DIR.
   --dry-run              Report reclaimable files without deleting / hardlinking
   --dedupe               Also hardlink content-identical files (SHA-256 groups)
 
-  Removes optimized_cache/*_optimized.{ort,onnx} graphs that no installed head
+  Removes optimized_cache/ (or --optimized-cache-dir) *_optimized.{ort,onnx}
+  graphs that no installed head
   can load, keeping the graph for the preferred encoder of every head whose
   weights are present in the directory (INT8 preferred). Also prunes stale
   CoreML compiled-model caches under coreml_cache/: keeps only the current

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -360,9 +360,9 @@ gigastt cache-gc [OPTIONS]
   --dry-run              Report reclaimable files without deleting / hardlinking
   --dedupe               Also hardlink content-identical files (SHA-256 groups)
 
-  Removes optimized_cache/ (or --optimized-cache-dir) *_optimized.{ort,onnx}
-  graphs that no installed head
-  can load, keeping the graph for the preferred encoder of every head whose
+  Removes *_optimized.{ort,onnx} graphs (from optimized_cache/, or the
+  --optimized-cache-dir directory when given) that no installed head can
+  load, keeping the graph for the preferred encoder of every head whose
   weights are present in the directory (INT8 preferred). Also prunes stale
   CoreML compiled-model caches under coreml_cache/: keeps only the current
   ort-<minor>/ version dir, removes dirs left by other ONNX Runtime builds

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -362,6 +362,18 @@ Optional side models (not required for core ASR):
 Runtime never loads FP32. `gigastt quantize` is packaging-only (needs a local
 FP32 ONNX as source). `gigastt cache-gc` drops stale ORT optimized graphs.
 
+Under the shipped systemd unit the ORT optimized-graph cache
+(`*_optimized.ort`, written by the CPU encoder on first load) lives in
+`/var/cache/gigastt` (systemd `CacheDirectory=gigastt` + `--optimized-cache-dir`),
+not in the model directory — `/usr/share/gigastt/models` stays read-only
+under `ProtectSystem=strict`. Pass `--optimized-cache-dir` (env
+`GIGASTT_OPTIMIZED_CACHE_DIR`) to relocate it. Read-only model dirs are
+supported either way: if the cache directory cannot be created or is not
+writable, the server logs a warning and starts without the cache (slower
+cold start, higher per-session RAM) instead of failing. When relocating the
+cache, pass the same path to `gigastt cache-gc` so it prunes the right
+directory.
+
 ## Air-gapped / offline installation
 
 For hosts with no internet access, every release publishes a self-contained

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -364,10 +364,14 @@ FP32 ONNX as source). `gigastt cache-gc` drops stale ORT optimized graphs.
 
 Under the shipped systemd unit the ORT optimized-graph cache
 (`*_optimized.ort`, written by the CPU encoder on first load) lives in
-`/var/cache/gigastt` (systemd `CacheDirectory=gigastt` + `--optimized-cache-dir`),
-not in the model directory — `/usr/share/gigastt/models` stays read-only
-under `ProtectSystem=strict`. Pass `--optimized-cache-dir` (env
-`GIGASTT_OPTIMIZED_CACHE_DIR`) to relocate it. Read-only model dirs are
+`/var/cache/gigastt` (systemd `CacheDirectory=gigastt` plus the unit's
+`Environment=GIGASTT_OPTIMIZED_CACHE_DIR=/var/cache/gigastt`), not in the
+model directory — `/usr/share/gigastt/models` stays read-only under
+`ProtectSystem=strict`. To relocate it under systemd, set
+`GIGASTT_OPTIMIZED_CACHE_DIR` in `/etc/gigastt/gigastt.env` (the
+`EnvironmentFile=` is processed after the unit's `Environment=` and wins);
+outside systemd, pass `--optimized-cache-dir` (env
+`GIGASTT_OPTIMIZED_CACHE_DIR`). Read-only model dirs are
 supported either way: if the cache directory cannot be created or is not
 writable, the server logs a warning and starts without the cache (slower
 cold start, higher per-session RAM) instead of failing. When relocating the

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -11,6 +11,7 @@ Operator-facing guidance for gigastt in production: graceful shutdown, session c
 | SIGTERM takes 30+ seconds to exit | In-flight spawn_blocking inferences can't be cancelled mid-chunk | Wait or lower `GIGASTT_SHUTDOWN_DRAIN_SECS`; process will still finish the current chunk |
 | `Close(1008 Policy Violation)` unexpected | session-duration cap fired | Double check `max_session_secs` is set high enough for your use case |
 | `Close(1001 Going Away)` seen by clients | Expected on SIGTERM — not a bug | None — clients should reconnect |
+| WARN `optimized graph cache directory cannot be created / is not writable` | Cache dir missing or unwritable (e.g. read-only model dir) | Service still works — see [ORT cache warnings](#ort-optimized-graph-cache-warnings) |
 | REST `503` `timeout` / WS error `timeout` (`retry_after_ms`) | Pool saturated — every triplet busy | Raise `--pool-size`; isolate batch with `--batch-pool-size`; see [Pool exhaustion](#pool-exhaustion--backpressure) |
 | `inference_timeout` (REST `504` / WS close) | A run made no progress for `--inference-timeout-secs` (default 600 s) | Not a length limit — the deadline resets on every decode window, so long files never trip it. Investigate a wedged ONNX run |
 | Server won't start, model errors | Missing / corrupt model files | See [Model download failures](#model-download-failures) |
@@ -126,6 +127,28 @@ within one window, so a hung run no longer wedges a slot until restart.
    inputs are legitimately long.
 3. If saturation is steady, scale `--pool-size` (watch RSS and single-job RTF)
    or add replicas.
+
+## ORT optimized-graph cache warnings
+
+The CPU encoder writes an ORT optimized-graph cache (`*_optimized.ort`,
+~224 MiB) to `--optimized-cache-dir` (default `<model-dir>/optimized_cache`;
+`/var/cache/gigastt` under the shipped systemd unit).
+
+**Symptoms** — WARN lines in the journal (once per engine load):
+- `optimized graph cache directory cannot be created; loading source model without the cache (slower cold start, higher per-session RAM)`
+- `optimized graph cache directory is not writable; loading source model without the cache (slower cold start, higher per-session RAM)`
+- `optimized graph cache write failed; retrying without the cache (slower cold start, higher per-session RAM)` — the directory is writable but the cache *file* write failed (stale root-owned `*_optimized.ort`, ENOSPC mid-write).
+
+**Effect** — the service starts and transcribes correctly either way; only
+cold start is slower (the graph is re-optimized on every boot) and
+per-session RAM is higher (no shared memory-mapped weights).
+
+**Fix** — point `GIGASTT_OPTIMIZED_CACHE_DIR` at a writable directory
+(under systemd, set it in `/etc/gigastt/gigastt.env` — the `EnvironmentFile=`
+overrides the unit's built-in `Environment=` default) or fix
+ownership/permissions on the existing one (e.g.
+`chown -R gigastt:gigastt /var/cache/gigastt`, removing a stale root-owned
+`*_optimized.ort` if present).
 
 ## Model download failures
 

--- a/packaging/offline/README-OFFLINE.md
+++ b/packaging/offline/README-OFFLINE.md
@@ -71,6 +71,7 @@ Inside the bundle, `install.sh` re-verifies every binary/model payload file
 | Models | `/usr/share/gigastt/models/` (+ `models/punct/`) |
 | systemd unit | `/etc/systemd/system/gigastt.service` |
 | Env overrides | `/etc/gigastt/gigastt.env` |
+| ORT optimized-graph cache | `/var/cache/gigastt/` (systemd `CacheDirectory=`) |
 | Service account | `gigastt` (system user, nologin) |
 
 The unit binds `127.0.0.1:9876` (loopback only), restarts on failure, and

--- a/packaging/systemd/gigastt.env
+++ b/packaging/systemd/gigastt.env
@@ -23,9 +23,11 @@ GIGASTT_OFFLINE=1
 # Usually auto-detected from the installed model files; set only to pin it.
 #GIGASTT_MODEL_VARIANT=rnnt
 
-# ORT optimized-graph cache directory. The shipped unit already passes
-# --optimized-cache-dir /var/cache/gigastt (CacheDirectory); set this only to
-# relocate the cache. Unwritable dir → cache skipped with a warning.
+# ORT optimized-graph cache directory. The shipped unit sets
+# GIGASTT_OPTIMIZED_CACHE_DIR=/var/cache/gigastt (CacheDirectory) via
+# Environment=; this file is processed after that and overrides it, so set
+# here only to relocate the cache. Unwritable dir → cache skipped with a
+# warning.
 #GIGASTT_OPTIMIZED_CACHE_DIR=/var/cache/gigastt
 
 # Punctuation/casing restoration and inverse text normalization: on|off|auto.

--- a/packaging/systemd/gigastt.env
+++ b/packaging/systemd/gigastt.env
@@ -23,6 +23,11 @@ GIGASTT_OFFLINE=1
 # Usually auto-detected from the installed model files; set only to pin it.
 #GIGASTT_MODEL_VARIANT=rnnt
 
+# ORT optimized-graph cache directory. The shipped unit already passes
+# --optimized-cache-dir /var/cache/gigastt (CacheDirectory); set this only to
+# relocate the cache. Unwritable dir → cache skipped with a warning.
+#GIGASTT_OPTIMIZED_CACHE_DIR=/var/cache/gigastt
+
 # Punctuation/casing restoration and inverse text normalization: on|off|auto.
 #GIGASTT_PUNCTUATION=auto
 #GIGASTT_ITN=auto

--- a/packaging/systemd/gigastt.service
+++ b/packaging/systemd/gigastt.service
@@ -4,8 +4,9 @@
 # (see packaging/offline/ and docs/deployment.md, "Air-gapped / offline
 # installation").
 #
-# Compatibility: every directive below is available in systemd 241 or older,
-# so the unit works on Astra Linux, RED OS and ALT without modification.
+# Compatibility: every directive below is available in systemd 241 or older
+# (CacheDirectory since 235), so the unit works on Astra Linux, RED OS and
+# ALT without modification.
 # Do NOT add directives introduced after 241 (e.g. ProtectProc, ProtectClock,
 # ProtectHostname, RestrictSUIDSGID) — they break on those targets.
 
@@ -26,7 +27,10 @@ EnvironmentFile=-/etc/gigastt/gigastt.env
 # Model and punctuation-model directories are passed explicitly: the gigastt
 # user has no $HOME, so the default ~/.gigastt/models lookup would not work.
 # Both directories are read-only at runtime (all models are pre-installed);
-# gigastt never writes to them once the files are present.
+# gigastt never writes to them once the files are present. The ORT
+# optimized-graph cache is the one write the CPU encoder needs — it is
+# redirected to /var/cache/gigastt via --optimized-cache-dir and
+# CacheDirectory below, keeping the model dir genuinely read-only.
 #
 # The server binds 127.0.0.1:9876 by default (loopback only). Do NOT add
 # --bind-all here; expose the API through a reverse proxy instead
@@ -34,13 +38,20 @@ EnvironmentFile=-/etc/gigastt/gigastt.env
 # with `systemctl edit gigastt` instead of editing this file.
 ExecStart=/usr/bin/gigastt serve \
     --model-dir /usr/share/gigastt/models \
-    --punct-model-dir /usr/share/gigastt/models/punct
+    --punct-model-dir /usr/share/gigastt/models/punct \
+    --optimized-cache-dir /var/cache/gigastt
+
+# Writable scratch for the ORT optimized-graph cache (systemd 235+): systemd
+# creates /var/cache/gigastt owned by the gigastt user and keeps it writable
+# despite ProtectSystem=strict below.
+CacheDirectory=gigastt
 
 Restart=on-failure
 RestartSec=5
 
-# Hardening. The server needs no capabilities, no writable filesystem (models
-# are pre-installed, logs go to the journal), and no devices/kernel knobs.
+# Hardening. The server needs no capabilities, no writable filesystem beyond
+# the CacheDirectory above (models are pre-installed, logs go to the
+# journal), and no devices/kernel knobs.
 NoNewPrivileges=true
 CapabilityBoundingSet=
 ProtectSystem=strict

--- a/packaging/systemd/gigastt.service
+++ b/packaging/systemd/gigastt.service
@@ -29,8 +29,9 @@ EnvironmentFile=-/etc/gigastt/gigastt.env
 # Both directories are read-only at runtime (all models are pre-installed);
 # gigastt never writes to them once the files are present. The ORT
 # optimized-graph cache is the one write the CPU encoder needs — it is
-# redirected to /var/cache/gigastt via --optimized-cache-dir and
-# CacheDirectory below, keeping the model dir genuinely read-only.
+# redirected to /var/cache/gigastt via CacheDirectory and
+# GIGASTT_OPTIMIZED_CACHE_DIR below, keeping the model dir genuinely
+# read-only.
 #
 # The server binds 127.0.0.1:9876 by default (loopback only). Do NOT add
 # --bind-all here; expose the API through a reverse proxy instead
@@ -38,13 +39,18 @@ EnvironmentFile=-/etc/gigastt/gigastt.env
 # with `systemctl edit gigastt` instead of editing this file.
 ExecStart=/usr/bin/gigastt serve \
     --model-dir /usr/share/gigastt/models \
-    --punct-model-dir /usr/share/gigastt/models/punct \
-    --optimized-cache-dir /var/cache/gigastt
+    --punct-model-dir /usr/share/gigastt/models/punct
 
 # Writable scratch for the ORT optimized-graph cache (systemd 235+): systemd
 # creates /var/cache/gigastt owned by the gigastt user and keeps it writable
 # despite ProtectSystem=strict below.
 CacheDirectory=gigastt
+# Point the cache there via the env var, not an ExecStart flag: a CLI flag
+# beats the env var in clap, which would make the documented
+# GIGASTT_OPTIMIZED_CACHE_DIR override in /etc/gigastt/gigastt.env a silent
+# no-op. Per systemd.exec(5), EnvironmentFile= is processed after
+# Environment=, so the env file overrides this default.
+Environment=GIGASTT_OPTIMIZED_CACHE_DIR=/var/cache/gigastt
 
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Problem

The shipped systemd unit (`packaging/systemd/gigastt.service`) installs models under `/usr/share/gigastt/models` with `ProtectSystem=strict`, but the CPU encoder load path writes the ORT optimized-graph cache to `<model-dir>/optimized_cache`, and a failed `create_dir_all` was fatal — the service restart-looped with `EROFS (os error 30)` (fixes #336).

## Fix

- **New flag** `--optimized-cache-dir <PATH>` (env `GIGASTT_OPTIMIZED_CACHE_DIR`) on `serve` and `cache-gc`. Default unchanged: `<model-dir>/optimized_cache`.
- **systemd unit**: adds `CacheDirectory=gigastt` (systemd 235+, within the unit's stated ≤241 compatibility) and passes `--optimized-cache-dir /var/cache/gigastt`, so the model dir stays genuinely read-only — matching the promise in the unit's comments.
- **Graceful degradation**: when the cache dir cannot be created or is not writable (probed with a temp file — an existing-but-read-only dir passes `create_dir_all`), the loader logs a warning and starts without the cache (slower cold start, higher per-session RAM) instead of failing. This keeps immutable/container deployments working.
- `cache-gc --optimized-cache-dir` prunes the relocated cache dir via the new `prune_optimized_cache_dir`.

## Implementation notes

- Public API stays backward compatible: `Engine::load`/`production_factory` signatures unchanged; new `Engine::load_with_pools_threads_variant_cache` and `prune_optimized_cache_dir` alongside.
- Docs updated: `docs/cli.md`, `docs/deployment.md`, `packaging/systemd/gigastt.env`, `AGENTS.md` env table, CHANGELOG. `scripts/check-docs-drift.py` passes.

## Validation

- `cargo fmt --check`, `cargo clippy --workspace --all-targets` (zero warnings), `cargo test --workspace --lib --bins` — all green locally.
- New unit tests: cache-dir usability probe (creatable / uncreatable / read-only), explicit-dir prune, CLI flag+env parsing for `serve` and `cache-gc`.
- `cargo check --no-default-features` and FFI/Node/UniFFI crates compile.